### PR TITLE
Add Hy date_tools module

### DIFF
--- a/docs/date_tools.md
+++ b/docs/date_tools.md
@@ -1,0 +1,8 @@
+# `date_tools.hy`
+
+Utility functions for date and time manipulation in Hy.
+
+Current features:
+
+- `time-ago`: convert two datetime objects into a human-readable string.
+

--- a/shared/hy/date_tools.hy
+++ b/shared/hy/date_tools.hy
@@ -1,0 +1,20 @@
+(import [datetime [datetime timezone timedelta]])
+
+(defn time-ago [past &optional [now None]]
+  (setv now (or now (.now datetime timezone.utc)))
+  (setv delta (- now past))
+
+  (setv seconds (int (.total_seconds delta)))
+  (setv minutes (// seconds 60))
+  (setv hours (// minutes 60))
+  (setv days delta.days)
+
+  (cond
+    (< seconds 60)
+      (format "{} second{} ago" seconds (if (!= seconds 1) "s" ""))
+    (< minutes 60)
+      (format "{} minute{} ago" minutes (if (!= minutes 1) "s" ""))
+    (< hours 24)
+      (format "{} hour{} ago" hours (if (!= hours 1) "s" ""))
+    True
+      (format "{} day{} ago" days (if (!= days 1) "s" ""))))


### PR DESCRIPTION
## Summary
- add `shared/hy/date_tools.hy` translating `time_ago` from Python to Hy
- document the new Hy module in `docs/date_tools.md`

## Testing
- `pytest -q` *(fails: ConnectionError to Ollama and missing OpenVINO model)*

------
https://chatgpt.com/codex/tasks/task_e_6886b36e5b8883248592e80d8d350476