### PR TITLE
Add text preprocessing tests

### DIFF
--- a/tests/test_numbers.py
+++ b/tests/test_numbers.py
@@ -1,0 +1,20 @@
+import os, sys
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "shared", "py"))
+
+from utils.numbers import normalize_numbers
+
+
+def test_normalize_simple_number():
+    text = "He owes me 5 dollars."
+    assert normalize_numbers(text) == "He owes me five dollars."
+
+
+def test_normalize_money_and_ordinal():
+    text = "She won $1.05 in the 1st contest."
+    expected = "She won one dollar, five cents in the first contest."
+    assert normalize_numbers(text) == expected
+
+
+def test_decimal_number():
+    text = "Pi is 3.14"
+    assert normalize_numbers(text) == "Pi is three point fourteen"

--- a/tests/test_pca.py
+++ b/tests/test_pca.py
@@ -1,0 +1,15 @@
+import os, sys
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "shared", "py"))
+
+from utils.embeddings_processing import PCA
+import numpy as np
+
+
+def test_pca_reconstruction():
+    data = np.array([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]])
+    p = PCA(n_components=1)
+    proj = p.build(data)
+    recon = p.iproject(proj)
+    assert recon.shape == data.shape
+    # Reconstruction should be close to original data
+    assert np.allclose(recon, data)

--- a/tests/test_split_sentences.py
+++ b/tests/test_split_sentences.py
@@ -17,3 +17,13 @@ def test_respects_max_length():
     )
     chunks = split_sentences(text, max_chunk_len=20, min_chunk_len=5)
     assert all(len(chunk) <= 20 for chunk in chunks)
+
+def test_appends_filler_for_short_text():
+    chunks = split_sentences('Hi.', max_chunk_len=10, min_chunk_len=5)
+    assert chunks == ['Hi. ...']
+
+
+def test_long_sentence_breaks_into_multiple_chunks():
+    text = 'This is a very long sentence that is definitely going to exceed the max limit by a considerable margin.'
+    chunks = split_sentences(text, max_chunk_len=40, min_chunk_len=5)
+    assert len(chunks) > 1

--- a/tests/test_text_preprocessing.py
+++ b/tests/test_text_preprocessing.py
@@ -1,0 +1,40 @@
+import os, sys
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "shared", "py"))
+
+import numpy as np
+
+from utils.text_preprocessing import (
+    expand_abbreviations,
+    collapse_whitespace,
+    text_to_sequence,
+    _symbols_to_sequence,
+)
+from utils.numbers import normalize_numbers
+from utils.embeddings_processing import PCA
+
+
+def test_expand_abbreviations_and_numbers():
+    text = "Dr. Smith bought 2nd house for $1.01."
+    expanded = expand_abbreviations(text.lower())
+    expanded = normalize_numbers(expanded)
+    assert expanded == "doctor smith bought second house for one dollar, one cent."
+
+
+def test_collapse_whitespace():
+    text = "Hello\n   world\t\t!"
+    assert collapse_whitespace(text) == "Hello world !"
+
+
+def test_text_to_sequence_consistency():
+    text = "Dr. Strange has 2 apples."
+    seq = text_to_sequence(text)
+    expected = _symbols_to_sequence("doctor strange has two apples.")
+    assert seq == expected
+
+
+def test_pca_round_trip():
+    data = np.array([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]])
+    pca = PCA(n_components=1)
+    proj = pca.build(data)
+    reconstructed = pca.iproject(proj)
+    assert np.allclose(reconstructed, data)


### PR DESCRIPTION
## Summary
- add test coverage for text preprocessing utilities and PCA class

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6886bb8dfe3c83248c87d7bef14ad589