### PR TITLE
Add modular agent network sketch

### DIFF
--- a/pseudo/modular-agent-network.hy
+++ b/pseudo/modular-agent-network.hy
@@ -1,0 +1,53 @@
+;; Modular Agent Network - Hy Pseudocode
+;; This file sketches an idea for coordinating multiple agents
+;; across shared cognitive services.
+
+(import [promethean.bridge [send-event]])
+
+;; --- Agent Node Object ---
+(defclass AgentNode [object]
+  [(id None)
+   (role "generic")
+   (inbox [])
+   (outbox [])])
+
+(defn process-incoming [node]
+  ;; Iterate through queued messages and spawn tasks
+  (for [msg node.inbox]
+    (case msg.type
+      "utterance" (handle-utterance node msg)
+      "directive" (schedule-action node msg)
+      (print "[AgentNode] Unknown message" msg.type))))
+
+(defn handle-utterance [node msg]
+  ;; Pass utterance to STT, Cephalon, TTS
+  (send-event "stt-input" msg.content)
+  (let [thought (send-event "cephalon-route" msg.content)]
+    (send-event "tts-output" thought)))
+
+(defn schedule-action [node msg]
+  ;; Placeholder for action scheduling
+  (append node.outbox (:action msg)))
+
+;; --- Network Supervisor ---
+(defclass NetworkSupervisor [object]
+  [(nodes {})])
+
+(defn register-node [sup node]
+  (assoc sup.nodes node.id node))
+
+(defn broadcast [sup payload]
+  (for [[_ node] (.items sup.nodes)]
+    (append node.inbox payload)))
+
+;; Example usage (would normally run inside event loop)
+(defn main []
+  (let [sup (NetworkSupervisor)
+        duck (AgentNode :id "duck" :role "assistant")
+        sparrow (AgentNode :id "sparrow" :role "observer")]
+    (register-node sup duck)
+    (register-node sup sparrow)
+    (broadcast sup {:type "directive" :action "start-up"})
+    (process-incoming duck)
+    (process-incoming sparrow)))
+


### PR DESCRIPTION
## Summary
- introduce `modular-agent-network.hy` in the pseudo folder
- outline concept for coordinating multiple agents through shared services

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6886e8fc82608324bd25d012a514eb00