### PR TITLE
Add CI workflow to run tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,24 @@
+name: Python Tests
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install numpy inflect pytest
+
+      - name: Run tests
+        run: pytest -q

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -1,0 +1,5 @@
+# Continuous Integration
+
+GitHub Actions run `pytest` on every pull request to ensure the test suite passes.
+The workflow file lives at `.github/workflows/tests.yml` and installs minimal
+dependencies before executing the tests.

--- a/readme.md
+++ b/readme.md
@@ -44,3 +44,13 @@ Scripts in `agents/scripts/` launch commonly used services:
 - `discord_indexer_run.sh` – runs the Discord indexer
 
 Each script assumes dependencies are installed and should be run from the repository root.
+
+## Tests
+
+Unit tests are located in `tests/` and run automatically on every pull request
+through [GitHub Actions](.github/workflows/tests.yml).
+To run them locally:
+
+```bash
+pytest -q
+```


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to run pytest
- document the CI process
- mention tests in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6886ec630f8c83248ae04d0615f74061