### PR TITLE
Add Eidolon tasks to kanban

### DIFF
--- a/docs/kanban.md
+++ b/docs/kanban.md
@@ -28,6 +28,14 @@ kanban-plugin: board
 - [ ] Annotate legacy code with migration tags
 - [ ] Create base `README.md` templates for each service
 
+- [ ] Build data structures for Eidolon field #codex-task #framework-core
+- [ ] Implement fragment ingestion with activation vectors #codex-task #framework-core
+- [ ] Create permission gating layer #codex-task #framework-core
+- [ ] Detect contradictions in memory #codex-task #framework-core
+- [ ] Evaluate and reward flow satisfaction #codex-task #framework-core
+- [ ] Identify ancestral resonance patterns #codex-task #framework-core
+- [ ] Suggest metaprogramming updates #codex-task #framework-core
+- [ ] Implement transcendence cascade #codex-task #framework-core
 ## 🟡 In Progress (4)
 
 	- [ ] Transferring `agents/duck/` and restructuring legacy code into `/agents/` and `/services/`


### PR DESCRIPTION
## Summary
- add new tasks based on the pseudocode in `pseudo/eidolon-field-scratchpad.lisp`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6886e8f2a5c883248ce1e5511b0169d3