### PR TITLE
Fix Cephalon converter test

### DIFF
--- a/services/cephalon/src/converter.ts
+++ b/services/cephalon/src/converter.ts
@@ -1,0 +1,21 @@
+import { Readable, PassThrough } from 'node:stream';
+import * as prism from 'prism-media';
+import * as wav from 'wav';
+
+export function convert(oggStream: Readable): PassThrough {
+    const decoder = new prism.opus.Decoder({
+        channels: 2,
+        rate: 48000,
+        frameSize: 960,
+    });
+
+    const wavWriter = new wav.Writer({
+        channels: 2,
+        sampleRate: 48000,
+        bitDepth: 16,
+    });
+
+    const output = new PassThrough();
+    oggStream.pipe(decoder).pipe(wavWriter).pipe(output);
+    return output;
+}

--- a/services/cephalon/tests/converter.ts
+++ b/services/cephalon/tests/converter.ts
@@ -1,7 +1,11 @@
 import test from 'ava';
+import { PassThrough } from 'node:stream';
+import { convert } from '../src/converter.ts';
 
-import { convert } from '../src/converter';
+// Basic sanity test: ensure convert returns a stream
 
-test('convert ogg stream to wav stream', (t) => {
-})
-
+test('convert ogg stream to wav stream', t => {
+    const input = new PassThrough();
+    const output = convert(input);
+    t.truthy(output.readable);
+});


### PR DESCRIPTION
## Summary
- add audio conversion helper in cephalon
- update converter test to import the TS module directly

## Testing
- `npm test` in `services/cephalon`

------
https://chatgpt.com/codex/tasks/task_e_6886f256f9908324a79298f88e45de97