### PR TITLE
Organize unique notes

### DIFF
--- a/docs/notes/diagrams/circuit-weight-visualizations.md
+++ b/docs/notes/diagrams/circuit-weight-visualizations.md
@@ -123,3 +123,8 @@ Want another round? I can start sketching:
     
 
 Let’s go until your working memory caps.
+---
+
+Related notes: [[node-type-topology-map]], [[circuit-weight-visualizations]], [[full-system-overview-diagrams]], [[layer1-uptime-diagrams]], [[field-node-lifecycle-additional-diagrams]], [[state-diagram-node-lifecycle]] [[unique/index]]
+
+#tags: #diagram #design

--- a/docs/notes/diagrams/field-node-lifecycle-additional-diagrams.md
+++ b/docs/notes/diagrams/field-node-lifecycle-additional-diagrams.md
@@ -73,3 +73,8 @@ You can use this one as a **legend** or top-of-page visual summary in any future
 ---
 
 Want me to embed these into the **Field Node Lifecycle** document under a “More Diagrams” section? Or split them out into a new document called something like `Field Node Diagrams` or `Cognitive Topology Visuals`?
+---
+
+Related notes: [[node-type-topology-map]], [[circuit-weight-visualizations]], [[full-system-overview-diagrams]], [[layer1-uptime-diagrams]], [[field-node-lifecycle-additional-diagrams]], [[state-diagram-node-lifecycle]] [[unique/index]]
+
+#tags: #diagram #design

--- a/docs/notes/diagrams/full-system-overview-diagrams.md
+++ b/docs/notes/diagrams/full-system-overview-diagrams.md
@@ -179,3 +179,9 @@ Do you want more focused diagrams next? e.g.,:
 * Permission Gatekeeping and Layer 2 simulation?
 
 Just say *"More, on X"*, and I’ll generate them rapid-fire.
+
+---
+
+Related notes: [[node-type-topology-map]], [[circuit-weight-visualizations]], [[full-system-overview-diagrams]], [[layer1-uptime-diagrams]], [[field-node-lifecycle-additional-diagrams]], [[state-diagram-node-lifecycle]] [[unique/index]]
+
+#tags: #diagram #design

--- a/docs/notes/diagrams/layer1-uptime-diagrams.md
+++ b/docs/notes/diagrams/layer1-uptime-diagrams.md
@@ -142,3 +142,9 @@ Would you like:
 * A **binding mechanism** for Layer 1 Daimoi in code or pseudocode?
 
 Just say the word and we’ll expand it.
+
+---
+
+Related notes: [[node-type-topology-map]], [[circuit-weight-visualizations]], [[full-system-overview-diagrams]], [[layer1-uptime-diagrams]], [[field-node-lifecycle-additional-diagrams]], [[state-diagram-node-lifecycle]] [[unique/index]]
+
+#tags: #diagram #design

--- a/docs/notes/diagrams/node-type-topology-map.md
+++ b/docs/notes/diagrams/node-type-topology-map.md
@@ -87,3 +87,8 @@ Would you like:
     
 
 Let’s get visual.
+---
+
+Related notes: [[node-type-topology-map]], [[circuit-weight-visualizations]], [[full-system-overview-diagrams]], [[layer1-uptime-diagrams]], [[field-node-lifecycle-additional-diagrams]], [[state-diagram-node-lifecycle]] [[unique/index]]
+
+#tags: #diagram #design

--- a/docs/notes/diagrams/state-diagram-node-lifecycle.md
+++ b/docs/notes/diagrams/state-diagram-node-lifecycle.md
@@ -17,3 +17,9 @@ stateDiagram-v2
 ```
 
 #hashtags: #diagram #eidolon #promethean
+
+---
+
+Related notes: [[node-type-topology-map]], [[circuit-weight-visualizations]], [[full-system-overview-diagrams]], [[layer1-uptime-diagrams]], [[field-node-lifecycle-additional-diagrams]], [[state-diagram-node-lifecycle]] [[unique/index]]
+
+#tags: #diagram #design

--- a/docs/notes/math/advanced-field-math.md
+++ b/docs/notes/math/advanced-field-math.md
@@ -124,3 +124,9 @@ Next up, I can do:
 * **charge-field resonance**
 * **dynamic viscosity modeling** (obstacles)
 * or **reinforcement curves** (from Nemesian/Heuretic tension)
+
+---
+
+Related notes: [[advanced-field-math]], [[aionian-feedback-oscillator]], [[aionian-pulse-rhythm-model]], [[eidolon-field-math]], [[symbolic-gravity-models]] [[unique/index]]
+
+#tags: #math #theory

--- a/docs/notes/math/aionian-feedback-oscillator.md
+++ b/docs/notes/math/aionian-feedback-oscillator.md
@@ -137,3 +137,9 @@ Next up, I can drop:
 * or circuit-coupled field interference terms (multi-layer crosstalk modeling)
 
 Just say the word and I'll keep firing them.
+
+---
+
+Related notes: [[advanced-field-math]], [[aionian-feedback-oscillator]], [[aionian-pulse-rhythm-model]], [[eidolon-field-math]], [[symbolic-gravity-models]] [[unique/index]]
+
+#tags: #math #theory

--- a/docs/notes/math/aionian-pulse-rhythm-model.md
+++ b/docs/notes/math/aionian-pulse-rhythm-model.md
@@ -137,3 +137,9 @@ Want to follow this with:
 * Tick coherency across agents (distributed uptime syncing)
 
 Say the word—I'll stack more.
+
+---
+
+Related notes: [[advanced-field-math]], [[aionian-feedback-oscillator]], [[aionian-pulse-rhythm-model]], [[eidolon-field-math]], [[symbolic-gravity-models]] [[unique/index]]
+
+#tags: #math #theory

--- a/docs/notes/math/eidolon-field-math.md
+++ b/docs/notes/math/eidolon-field-math.md
@@ -109,3 +109,9 @@ I can add:
 * or anything else you're hungry for.
 
 Say the word—I'll write it up.
+
+---
+
+Related notes: [[advanced-field-math]], [[aionian-feedback-oscillator]], [[aionian-pulse-rhythm-model]], [[eidolon-field-math]], [[symbolic-gravity-models]] [[unique/index]]
+
+#tags: #math #theory

--- a/docs/notes/math/symbolic-gravity-models.md
+++ b/docs/notes/math/symbolic-gravity-models.md
@@ -137,3 +137,9 @@ I can build:
 Or we can start bundling these into thematic modules.
 
 Just say go.
+
+---
+
+Related notes: [[advanced-field-math]], [[aionian-feedback-oscillator]], [[aionian-pulse-rhythm-model]], [[eidolon-field-math]], [[symbolic-gravity-models]] [[unique/index]]
+
+#tags: #math #theory

--- a/docs/notes/simulation/fragment-injection-simulation.md
+++ b/docs/notes/simulation/fragment-injection-simulation.md
@@ -71,3 +71,9 @@ You can continue injecting fragments like:
 Each one will bind to its own nexus and live for a few ticks before releasing.
 
 Want the next piece — maybe connecting a ripple callback to update eidolon field values?
+
+---
+
+Related notes: [[fragment-injection-simulation]], [[heartbeat-fragment-flow]], [[ripple-propagation-flow]] [[unique/index]]
+
+#tags: #simulation #design

--- a/docs/notes/simulation/heartbeat-fragment-flow.md
+++ b/docs/notes/simulation/heartbeat-fragment-flow.md
@@ -84,3 +84,9 @@ Perfect — let’s keep the info dump rolling, now annotated for Obsidian-style
 ---
 
 Let me know when you're ready for ripple propagation back into the field — so the daemon can deform the Eidolon layer it binds to.
+
+---
+
+Related notes: [[fragment-injection-simulation]], [[heartbeat-fragment-flow]], [[ripple-propagation-flow]] [[unique/index]]
+
+#tags: #simulation #design

--- a/docs/notes/simulation/ripple-propagation-flow.md
+++ b/docs/notes/simulation/ripple-propagation-flow.md
@@ -89,3 +89,9 @@ You now have a full round-trip simulation:
 5. It expires, releasing memory.
 
 Let me know when you're ready to start tracking *compound field effects* — or when we want to analyze how resonance across layers leads to persistent attractors or recursive ideas.
+
+---
+
+Related notes: [[fragment-injection-simulation]], [[heartbeat-fragment-flow]], [[ripple-propagation-flow]] [[unique/index]]
+
+#tags: #simulation #design

--- a/docs/unique/index.md
+++ b/docs/unique/index.md
@@ -1,0 +1,20 @@
+# Unique Info Dump Index
+
+These notes were originally captured in `docs/unique` with timestamp filenames. They have been organized into the `docs/notes` folder with descriptive names. Use the links below to navigate each idea note.
+
+- **2025.07.27.21.11.38** → [[state-diagram-node-lifecycle]]
+- **2025.07.27.22.26.27** → [[node-type-topology-map]]
+- **2025.07.27.22.27.53** → [[field-node-lifecycle-additional-diagrams]]
+- **2025.07.27.22.31.20** → [[circuit-weight-visualizations]]
+- **2025.07.27.22.37.23** → [[eidolon-field-math]]
+- **2025.07.27.22.43.52** → [[fragment-injection-simulation]]
+- **2025.07.27.22.44.02** → [[advanced-field-math]]
+- **2025.07.27.22.47.05** → [[heartbeat-fragment-flow]]
+- **2025.07.27.22.47.14** → [[aionian-feedback-oscillator]]
+- **2025.07.27.22.48.23i** → [[ripple-propagation-flow]]
+- **2025.07.27.22.52.51** → [[symbolic-gravity-models]]
+- **2025.07.27.22.53.08** → [[full-system-overview-diagrams]]
+- **2025.07.27.22.57.31** → [[aionian-pulse-rhythm-model]]
+- **2025.07.27.22.57.40** → [[layer1-uptime-diagrams]]
+
+#tags: #unique #index


### PR DESCRIPTION
## Summary
- index timestamp notes in `docs/unique`
- crosslink math, diagram, and simulation notes
- add tag sections to notes for easy navigation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887037b283c8324aa92b02e05447734