### PR TITLE
Add JS/TS tests to workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,4 +1,4 @@
-name: Python Tests
+name: Test Suite
 
 on:
   pull_request:
@@ -11,14 +11,24 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+
       - uses: actions/setup-python@v4
         with:
           python-version: '3.12'
 
-      - name: Install dependencies
+      - name: Install Python dependencies
         run: |
           python -m pip install --upgrade pip
           pip install numpy inflect pytest
 
-      - name: Run tests
+      - name: Run Python tests
         run: pytest -q
+
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '20'
+
+      - name: Run JS/TS tests
+        run: |
+          cd services/cephalon && npm ci && npm test && cd ../..
+          cd services/discord-embedder && npm ci && npm test && cd ../..


### PR DESCRIPTION
## Summary
- run JS/TS tests for Cephalon and Discord Embedder
- rename GitHub workflow to *Test Suite*

## Testing
- `pytest -q`
- `npm ci` *(fails: connect ENETUNREACH 140.82.114.4:443)*

------
https://chatgpt.com/codex/tasks/task_e_68870b054a90832487badf698b830c22