### PR TITLE
Add service README templates

### DIFF
--- a/docs/kanban.md
+++ b/docs/kanban.md
@@ -26,7 +26,6 @@ kanban-plugin: board
 - [ ] Finalize `MIGRATION_PLAN.md`
 - [ ] Set up `Makefile` for Python + JS build/test/dev
 - [ ] Annotate legacy code with migration tags
-- [ ] Create base `README.md` templates for each service
 - [ ] Build data structures for Eidolon field #codex-task #framework-core
 - [ ] Implement fragment ingestion with activation vectors #codex-task #framework-core
 - [ ] Create permission gating layer #codex-task #framework-core
@@ -40,6 +39,7 @@ kanban-plugin: board
 ## 🟡 In Progress (4)
 
 - [ ] Migrating relevant modules from `riatzukiza.github.io` to `/site/` and `/docs/`
+- [ ] Create base `README.md` templates for each service
 
 
 ## 🔵 Done

--- a/services/discord-embedder/README.md
+++ b/services/discord-embedder/README.md
@@ -1,0 +1,20 @@
+# Discord Embedder Service
+
+Enriches Discord messages by generating embeddings and storing them in ChromaDB.
+Built with Node.js and TypeScript.
+
+## Setup
+
+```bash
+npm install
+```
+
+## Usage
+
+Run in development mode:
+
+```bash
+npm run start:dev
+```
+
+#hashtags: #discord #service #promethean

--- a/services/discord-indexer/README.md
+++ b/services/discord-indexer/README.md
@@ -1,0 +1,20 @@
+# Discord Indexer Service
+
+Archives Discord messages for later processing using the Discord API.
+Implemented in Python.
+
+## Setup
+
+```bash
+pipenv install
+```
+
+## Usage
+
+Run the crawler:
+
+```bash
+pipenv run python main.py
+```
+
+#hashtags: #discord #service #promethean

--- a/services/stt/README.md
+++ b/services/stt/README.md
@@ -1,0 +1,13 @@
+# STT Service
+
+This service handles speech-to-text using Whisper models accelerated on NPU hardware.
+
+## Usage
+
+Run the service via pm2 or execute `run.sh` directly:
+
+```bash
+./run.sh
+```
+
+#hashtags: #stt #service #promethean

--- a/services/tts/README.md
+++ b/services/tts/README.md
@@ -1,0 +1,13 @@
+# TTS Service
+
+This service converts text to speech using Tacotron and WaveRNN models.
+
+## Usage
+
+Run via pm2 or execute `run.sh` directly:
+
+```bash
+./run.sh
+```
+
+#hashtags: #tts #service #promethean


### PR DESCRIPTION
## Summary
- add starter README docs for STT, TTS, Discord embedder and indexer services
- move README templates card to In Progress on the kanban board

## Testing
- `pytest -q`
- `npm test` *(fails: onnxruntime download blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68870b61ce9c8324b7260bc6d5776e76