### PR TITLE
Add initial docstrings

### DIFF
--- a/shared/py/utils/__init__.py
+++ b/shared/py/utils/__init__.py
@@ -1,0 +1,1 @@
+"""Shared utility functions used across Promethean services."""

--- a/shared/py/utils/embeddings_processing.py
+++ b/shared/py/utils/embeddings_processing.py
@@ -1,13 +1,19 @@
+"""Embedding utilities such as a minimal PCA implementation."""
+
 import numpy as np
 
 
 class PCA:
-    def __init__(self, n_components=1):
+    """Minimal principal component analysis transformer."""
+
+    def __init__(self, n_components: int = 1):
+        """Initialise the transformer with ``n_components`` dimensions."""
         self.mean = None
         self.eig_vectors = None
         self.n_components = n_components
 
-    def build(self, x):
+    def build(self, x: np.ndarray) -> np.ndarray:
+        """Fit PCA to ``x`` and return the projected data."""
         m = np.mean(x, axis=0)
         xm = x - m
         cov_mat = np.cov(xm.T)
@@ -22,12 +28,14 @@ class PCA:
         self.mean = m
         return projection
 
-    def project(self, x):
+    def project(self, x: np.ndarray) -> np.ndarray:
+        """Project ``x`` using the fitted components."""
         xm = x - self.mean
         v = self.eig_vectors[:, :self.n_components]
         return xm.dot(v)
 
-    def iproject(self, z):
+    def iproject(self, z: np.ndarray) -> np.ndarray:
+        """Inverse transform ``z`` back to the original space."""
         v = self.eig_vectors[:, :self.n_components]
         x = z * v.T + self.mean
         return x

--- a/shared/py/utils/gui.py
+++ b/shared/py/utils/gui.py
@@ -1,4 +1,8 @@
+"""GUI helpers for adjusting runtime parameters."""
+
+
 def init_parameters_interactive(args):
+    """Prompt the user with a simple Tkinter window to tweak TTS settings."""
     import tkinter as tk
 
     window = tk.Tk()

--- a/shared/py/utils/numbers.py
+++ b/shared/py/utils/numbers.py
@@ -31,15 +31,18 @@ _ordinal_re = re.compile(r'[0-9]+(st|nd|rd|th)')
 _number_re = re.compile(r'[0-9]+')
 
 
-def _remove_commas(m):
+def _remove_commas(m: re.Match) -> str:
+    """Return the number string with embedded commas removed."""
     return m.group(1).replace(',', '')
 
 
-def _expand_decimal_point(m):
+def _expand_decimal_point(m: re.Match) -> str:
+    """Convert a decimal point match into words."""
     return m.group(1).replace('.', ' point ')
 
 
-def _expand_dollars(m):
+def _expand_dollars(m: re.Match) -> str:
+    """Expand a currency amount into spoken words."""
     match = m.group(1)
     parts = match.split('.')
     if len(parts) > 2:
@@ -60,11 +63,13 @@ def _expand_dollars(m):
         return 'zero dollars'
 
 
-def _expand_ordinal(m):
+def _expand_ordinal(m: re.Match) -> str:
+    """Expand an ordinal number into words."""
     return _inflect.number_to_words(m.group(0))
 
 
-def _expand_number(m):
+def _expand_number(m: re.Match) -> str:
+    """Expand a cardinal number into words."""
     num = int(m.group(0))
     if num > 1000 and num < 3000:
         if num == 2000:
@@ -79,7 +84,8 @@ def _expand_number(m):
         return _inflect.number_to_words(num, andword='')
 
 
-def normalize_numbers(text):
+def normalize_numbers(text: str) -> str:
+    """Normalize all numbers within ``text`` to their spoken forms."""
     text = re.sub(_comma_number_re, _remove_commas, text)
     text = re.sub(_pounds_re, r'\1 pounds', text)
     text = re.sub(_dollars_re, _expand_dollars, text)

--- a/shared/py/utils/split_sentances.py
+++ b/shared/py/utils/split_sentances.py
@@ -1,8 +1,31 @@
+"""Utilities for splitting text into sentence-based chunks."""
 
 import re
 
+
 def split_sentences(text, max_chunk_len=79, min_chunk_len=20):
-    print(f"Splitting text into sentence-aware chunks (max {max_chunk_len}, min {min_chunk_len}).")
+    """Return a list of sentence-like chunks from ``text``.
+
+    Parameters
+    ----------
+    text : str
+        Input paragraph to be chunked.
+    max_chunk_len : int, optional
+        Hard limit for chunk size; longer sentences are split by words.
+        Defaults to ``79``.
+    min_chunk_len : int, optional
+        Minimum chunk length. Short chunks will try to absorb following
+        sentences to reach this length. Defaults to ``20``.
+
+    Returns
+    -------
+    list[str]
+        Sequence of chunks derived from the input.
+    """
+
+    print(
+        f"Splitting text into sentence-aware chunks (max {max_chunk_len}, min {min_chunk_len})."
+    )
     print(f"Input text length: {len(text)} characters")
 
     # First pass: basic sentence splitting

--- a/shared/py/utils/wav_processing.py
+++ b/shared/py/utils/wav_processing.py
@@ -24,6 +24,7 @@ import numpy as np
 
 # for WaveRNN approach (https://github.com/fatchord/WaveRNN), first step before upsample
 def pad_tensor(x, pad, side='both'):
+    """Pad a tensor along the time dimension."""
     # NB - this is just a quick method i need right now
     # i.e., it won't generalise to other shapes/dims
     b, t, c = x.shape


### PR DESCRIPTION
## Summary
- provide module description for `utils` package
- document PCA implementation and methods
- explain `split_sentences` behaviour
- clarify GUI helper and wav helper functions
- annotate numeric helpers with brief explanations

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887eb762330832484da787e2a6224ce