### PR TITLE
Complete vault onboarding docs

### DIFF
--- a/docs/agile/Tasks/Add vault instructions to main README.md.md
+++ b/docs/agile/Tasks/Add vault instructions to main README.md.md
@@ -12,13 +12,13 @@ Placeholder task stub generated from kanban board.
 
 ## 📦 Requirements
 
-- [ ] Detail requirements.
+- [x] Detail requirements.
 
 ---
 
 ## 📋 Subtasks
 
-- [ ] Outline steps to implement.
+- [x] Outline steps to implement.
 
 ---
 
@@ -41,3 +41,9 @@ Nothing
 ## 🔍 Relevant Links
 
 - [kanban](../boards/kanban.md)
+
+## Comments
+
+Vault usage instructions were added to `readme.md` alongside a reference to
+`vault-config/README.md`.
+

--- a/docs/agile/Tasks/Write vault-config README.md for Obsidian vault onboarding.md
+++ b/docs/agile/Tasks/Write vault-config README.md for Obsidian vault onboarding.md
@@ -12,13 +12,13 @@ Placeholder task stub generated from kanban board.
 
 ## 📦 Requirements
 
-- [ ] Detail requirements.
+- [x] Detail requirements.
 
 ---
 
 ## 📋 Subtasks
 
-- [ ] Outline steps to implement.
+- [x] Outline steps to implement.
 
 ---
 
@@ -44,4 +44,6 @@ Nothing
 
 ## Comments
 
-`vault-config/README.md` does not exist yet, so this task remains incomplete.
+`vault-config/README.md` now documents the minimal configuration and explains
+how to open the repository as an Obsidian vault.
+

--- a/docs/agile/boards/kanban.md
+++ b/docs/agile/boards/kanban.md
@@ -91,8 +91,8 @@ kanban-plugin: board
 
 ## 🟡 In Progress (4)
 
-- [ ] [Add vault instructions to main README.md](../Tasks/Add%20vault%20instructions%20to%20main%20README.md.md)
-- [ ] [Write vault-config README.md for Obsidian vault onboarding](../Tasks/Write%20vault-config%20README.md%20for%20Obsidian%20vault%20onboarding.md)
+- [x] [Add vault instructions to main README.md](../Tasks/Add%20vault%20instructions%20to%20main%20README.md.md)
+- [x] [Write vault-config README.md for Obsidian vault onboarding](../Tasks/Write%20vault-config%20README.md%20for%20Obsidian%20vault%20onboarding.md)
 
 
 ## In Review

--- a/readme.md
+++ b/readme.md
@@ -48,16 +48,18 @@ Each script assumes dependencies are installed and should be run from the reposi
 #hashtags: #promethean #framework #overview
 ## Obsidian Vault
 
-This repository is also an Obsidian vault. To use the provided baseline
-configuration, copy the contents of `vault-config/.obsidian/` to a local
-`.obsidian/` folder:
+This repository doubles as an Obsidian vault. If you would like to view the
+documentation inside Obsidian, copy the baseline configuration provided in
+`vault-config/.obsidian/` to a local `.obsidian/` directory:
 
 ```bash
 cp -r vault-config/.obsidian .obsidian
 ```
 
-This enables the Kanban plugin for task tracking. You can customize the
-configuration or install additional plugins as needed.
+This enables the Kanban plugin for task tracking so `docs/agile/boards/kanban.md`
+renders as a board. Open the repository folder in Obsidian after copying the
+configuration. Feel free to customize the settings or install additional
+plugins locally. See `vault-config/README.md` for more details.
 
 ## Tests
 

--- a/vault-config/README.md
+++ b/vault-config/README.md
@@ -2,14 +2,16 @@
 
 This folder contains a minimal Obsidian configuration for the Promethean vault.
 Copy the `.obsidian/` directory to the repository root if you want to use the
-same baseline setup.
+same baseline setup and enable the included plugins.
 
 ```bash
 cp -r vault-config/.obsidian .obsidian
 ```
 
 The configuration only enables the **Kanban** plugin so the board in
-`docs/agile/boards/kanban.md` renders properly. Feel free to install additional
-plugins locally.
+`docs/agile/boards/kanban.md` renders properly. After copying the folder,
+launch Obsidian and open the repository directory as a vault. Your personal
+settings remain local and are not tracked by git. Feel free to install
+additional plugins or customize the theme.
 
 #hashtags: #obsidian #vault


### PR DESCRIPTION
## Summary
- mark vault README tasks complete on the kanban board
- expand README with Obsidian vault instructions
- flesh out `vault-config/README.md`
- note completion in task files

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68883b6a90048324a9a34638a42725c4