### PR TITLE
Start on board sync tasks

### DIFF
--- a/.github/workflows/sync_board.yml
+++ b/.github/workflows/sync_board.yml
@@ -1,0 +1,24 @@
+name: Sync Board
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.12'
+      - name: Install dependencies
+        run: pip install requests
+      - name: Sync project board
+        env:
+          GITHUB_TOKEN: ${{ secrets.PROJECT_PAT || github.token }}
+          GITHUB_PROJECT_ID: ${{ secrets.PROJECT_COLUMN_ID }}
+        run: python scripts/github_board_sync.py

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,8 @@
+repos:
+  - repo: local
+    hooks:
+      - id: wikilink-to-md
+        name: Convert wikilinks
+        entry: python scripts/convert_wikilinks.py
+        language: system
+        files: '\.md$'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -187,6 +187,8 @@ train_cephalon_align_lora.py
 * Use `[[Wikilinks]]` in your Obsidian workflow, but ensure they are converted to regular markdown links for compatibility. Use `#hashtags` to support the Obsidian graph view.
 * Code paths must be written like: `services/cephalon/langstream.py`
 * All new modules must have a doc stub in `/docs/`
+* See `docs/vault-config-readme.md` for tips on configuring Obsidian to export
+  GitHub-friendly markdown
 
 ---
 

--- a/docs/agile/Tasks/Document board sync workflow.md
+++ b/docs/agile/Tasks/Document board sync workflow.md
@@ -12,16 +12,16 @@ After the sync script exists, we need clear instructions on how to use it and ho
 ---
 
 ## 📦 Requirements
-- [ ] Add documentation under `docs/` describing setup
-- [ ] Include example command invocations
-- [ ] Mention required GitHub permissions
+- [x] Add documentation under `docs/` describing setup
+- [x] Include example command invocations
+- [x] Mention required GitHub permissions
 
 ---
 
 ## 📋 Subtasks
-- [ ] Write README section or new doc
-- [ ] Describe expected workflow
-- [ ] Link to the sync script
+- [x] Write README section or new doc
+- [x] Describe expected workflow
+- [x] Link to the sync script
 
 ---
 
@@ -40,3 +40,4 @@ Nothing
 
 ## 🔍 Relevant Links
 - [kanban](../boards/kanban.md)
+- [Board Sync Workflow](../../board_sync.md)

--- a/docs/agile/Tasks/Ensure GitHub-compatible markdown settings are documented.md
+++ b/docs/agile/Tasks/Ensure GitHub-compatible markdown settings are documented.md
@@ -12,16 +12,16 @@ Some Obsidian features don't render well on GitHub. We need clear guidelines so 
 ---
 
 ## 📦 Requirements
-- [ ] Add a section to `vault-config/README.md` describing recommended settings
-- [ ] Mention any plugins used to export or format markdown
+- [x] Add a section to `vault-config/README.md` describing recommended settings
+- [x] Mention any plugins used to export or format markdown
 - [ ] Include Prettier or markdownlint configuration if applicable
 
 ---
 
 ## 📋 Subtasks
-- [ ] Review current Obsidian settings
-- [ ] Summarize options that influence markdown syntax
-- [ ] Update documentation and link from `AGENTS.md`
+- [x] Review current Obsidian settings
+- [x] Summarize options that influence markdown syntax
+- [x] Update documentation and link from `AGENTS.md`
 
 ---
 

--- a/docs/agile/Tasks/Obsidian Kanban Github Project Board Mirror system.md
+++ b/docs/agile/Tasks/Obsidian Kanban Github Project Board Mirror system.md
@@ -20,7 +20,7 @@ Synchronize our local kanban board with a GitHub Projects board so tasks stay co
 ---
 
 ## 📋 Subtasks
-- [ ] [Research GitHub Projects board API](Research%20GitHub%20Projects%20board%20API.md)
+- [x] [Research GitHub Projects board API](Research%20GitHub%20Projects%20board%20API.md)
 - [ ] [Write board sync script](Write%20board%20sync%20script.md)
 - [ ] [Document board sync workflow](Document%20board%20sync%20workflow.md)
 

--- a/docs/agile/Tasks/Research GitHub Projects board API.md
+++ b/docs/agile/Tasks/Research GitHub Projects board API.md
@@ -12,13 +12,13 @@ We need to understand how to interact programmatically with GitHub Projects so o
 ---
 
 ## 📦 Requirements
-- [ ] Document relevant API endpoints
-- [ ] Summarize required auth tokens
+- [x] Document relevant API endpoints
+- [x] Summarize required auth tokens
 
 ---
 
 ## 📋 Subtasks
-- [ ] Read GitHub API documentation
+- [x] Read GitHub API documentation
 - [ ] Experiment with basic calls via `curl`
 - [ ] Outline how board data maps to GitHub structures
 

--- a/docs/agile/Tasks/Write board sync script.md
+++ b/docs/agile/Tasks/Write board sync script.md
@@ -12,17 +12,17 @@ Create a small tool that pushes updates from our Obsidian kanban board to a GitH
 ---
 
 ## 📦 Requirements
-- [ ] Node or Python script using the GitHub API
-- [ ] Reads `kanban.md` and updates project items
-- [ ] Supports personal access token configuration
+- [x] Python script using the GitHub API
+- [x] Reads `kanban.md` and updates project items
+- [x] Supports personal access token configuration
 
 ---
 
 ## 📋 Subtasks
-- [ ] Parse kanban board data
-- [ ] Use endpoints outlined in research
-- [ ] Handle basic error reporting
-- [ ] Document usage examples
+- [x] Parse kanban board data
+- [x] Use endpoints outlined in research
+- [x] Handle basic error reporting
+- [x] Document usage examples
 
 ---
 
@@ -41,3 +41,5 @@ Create a small tool that pushes updates from our Obsidian kanban board to a GitH
 
 ## 🔍 Relevant Links
 - [kanban](../boards/kanban.md)
+- [board_sync.py](../../scripts/github_board_sync.py)
+- [Board Sync Workflow](../../board_sync.md)

--- a/docs/board_sync.md
+++ b/docs/board_sync.md
@@ -1,0 +1,30 @@
+# Board Sync Workflow
+
+This document explains how to keep the local `kanban.md` board in sync with a GitHub Projects board using `scripts/github_board_sync.py`.
+
+## Setup
+1. Obtain a GitHub personal access token with `project` and `repo` scopes.
+2. Export your project column ID as `GITHUB_PROJECT_ID`.
+3. Set `GITHUB_TOKEN` in your environment.
+
+## Usage
+Run the script from the repository root:
+
+```bash
+python scripts/github_board_sync.py
+```
+
+By default the script reads `docs/agile/boards/kanban.md` and creates note cards in the specified project column. Without environment variables it performs a dry run.
+
+## Column Mapping
+Currently only the **To Do** column is synced. Each unchecked task becomes a new card in the target column. Future work will support more columns and two-way updates.
+
+## Limitations
+- Requires a PAT for write access
+- Only creates cards; it does not update or delete existing items
+
+See `docs/research/github_projects_api.md` for API details.
+
+## Continuous Integration
+
+A GitHub Action (`.github/workflows/sync_board.yml`) runs this script whenever changes are pushed to the `main` branch. The action uses repository secrets `PROJECT_PAT` and `PROJECT_COLUMN_ID` to authenticate and update the board automatically after pull requests are merged.

--- a/docs/research/github_projects_api.md
+++ b/docs/research/github_projects_api.md
@@ -1,0 +1,30 @@
+# Research: GitHub Projects Board API
+
+This note summarizes the endpoints and references needed for synchronizing our local kanban board with a GitHub Projects board.
+
+## REST API (Classic Projects)
+- `POST /repos/{owner}/{repo}/projects` – create a project.
+- `GET /repos/{owner}/{repo}/projects` – list projects.
+- `POST /projects/{project_id}/columns` – create a column.
+- `POST /projects/columns/{column_id}/cards` – create a card from an issue or note.
+- `PATCH /projects/columns/cards/{card_id}` – update or move a card.
+
+See the official docs: <https://docs.github.com/en/rest/projects>
+
+## GraphQL API (Projects v2)
+The newer project boards use GraphQL. Key objects:
+- `projectV2` – represents a board
+- `addProjectV2ItemById` – add an issue or pull request to a board
+- `updateProjectV2ItemFieldValue` – modify fields like status or assignee
+
+Docs: <https://docs.github.com/en/graphql/overview/explorer>
+
+## Authentication
+Both APIs accept a personal access token (classic PAT or fine‑grained PAT) with `project` and `repo` scopes. For GitHub Actions, you can use the `GITHUB_TOKEN` secret, but a PAT is required for cross-repo access.
+
+## Rate Limits
+- REST: 5,000 requests per hour per authenticated user
+- GraphQL: 5,000 points per hour (query cost varies)
+
+## Recommendation
+Start with the REST API for simplicity if using classic Projects. For Projects v2, plan on using GraphQL.

--- a/readme.md
+++ b/readme.md
@@ -60,6 +60,8 @@ This enables the Kanban plugin for task tracking so `docs/agile/boards/kanban.md
 renders as a board. Open the repository folder in Obsidian after copying the
 configuration. Feel free to customize the settings or install additional
 plugins locally. See `vault-config/README.md` for more details.
+To push tasks from the board to GitHub Projects, see `docs/board_sync.md` and the
+`github_board_sync.py` script.
 
 ## Tests
 
@@ -86,3 +88,16 @@ python scripts/kanban_to_issues.py
 
 Without a token the script performs a dry run and prints the issues that would be created.
 
+
+## Pre-commit Setup
+
+Documentation uses `[[wikilinks]]` inside the vault but they must be converted to standard markdown links before committing. A helper script `scripts/convert_wikilinks.py` runs automatically via [pre-commit](https://pre-commit.com/).
+
+Install the hook with:
+
+```bash
+pip install pre-commit
+pre-commit install
+```
+
+This ensures all modified markdown files are converted during `git commit`.

--- a/scripts/convert_wikilinks.py
+++ b/scripts/convert_wikilinks.py
@@ -1,0 +1,28 @@
+import re
+import sys
+from pathlib import Path
+
+WIKILINK_RE = re.compile(r"\[\[([^\]|]+)(\|([^\]]+))?\]\]")
+
+
+def convert_wikilinks(path: Path) -> None:
+    text = path.read_text(encoding="utf-8")
+
+    def repl(match: re.Match) -> str:
+        target = match.group(1)
+        alias = match.group(3) or target
+        link = target.replace(" ", "%20") + ".md"
+        return f"[{alias}]({link})"
+
+    new_text = WIKILINK_RE.sub(repl, text)
+    if new_text != text:
+        path.write_text(new_text, encoding="utf-8")
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print("Usage: convert_wikilinks.py <files>")
+        sys.exit(1)
+
+    for file in sys.argv[1:]:
+        convert_wikilinks(Path(file))

--- a/scripts/github_board_sync.py
+++ b/scripts/github_board_sync.py
@@ -1,0 +1,52 @@
+"""Synchronize local kanban board with a GitHub Projects board."""
+
+import os
+import requests
+from requests import HTTPError
+
+KANBAN_PATH = os.environ.get("KANBAN_PATH", "docs/agile/boards/kanban.md")
+PROJECT_ID = os.environ.get("GITHUB_PROJECT_ID")
+GITHUB_TOKEN = os.environ.get("GITHUB_TOKEN")
+API_URL = "https://api.github.com"
+
+
+def read_kanban(path: str) -> list[str]:
+    """Return a list of task titles from the To Do column."""
+    tasks = []
+    current = None
+    with open(path, "r", encoding="utf-8") as f:
+        for line in f:
+            if line.startswith("## "):
+                current = line.strip()
+            elif current and "To Do" in current and line.startswith("- [ ]"):
+                task = line.split("]", 1)[-1].strip()
+                tasks.append(task)
+    return tasks
+
+
+def add_item(title: str) -> None:
+    """Add a note card to a project column using the REST API."""
+    if not (PROJECT_ID and GITHUB_TOKEN):
+        print(f"[DRY-RUN] Would add '{title}' to project {PROJECT_ID}")
+        return
+    url = f"{API_URL}/projects/columns/{PROJECT_ID}/cards"
+    headers = {
+        "Authorization": f"token {GITHUB_TOKEN}",
+        "Accept": "application/vnd.github.inertia-preview+json",
+    }
+    try:
+        resp = requests.post(url, headers=headers, json={"note": title}, timeout=10)
+        resp.raise_for_status()
+    except HTTPError as exc:
+        print(f"Failed to add '{title}': {exc}")
+        return
+    print("Created card", resp.json().get("id"))
+
+
+def main() -> None:
+    for task in read_kanban(KANBAN_PATH):
+        add_item(task)
+
+
+if __name__ == "__main__":
+    main()

--- a/vault-config/README.md
+++ b/vault-config/README.md
@@ -14,4 +14,39 @@ launch Obsidian and open the repository directory as a vault. Your personal
 settings remain local and are not tracked by git. Feel free to install
 additional plugins or customize the theme.
 
+## GitHub-Compatible Markdown Settings
+
+Obsidian offers many conveniences that do not always render correctly on
+GitHub. To keep documentation readable in both places, enable the following
+options in **Settings → Files & Links**:
+
+* **Automatically update internal links** – keeps link paths tidy when files are
+  moved.
+* **Use [[wikilinks]]** – preferred inside the vault for graph navigation.
+* **Default location for new attachments → Same folder as current file** – avoids
+  absolute paths.
+
+Then, install the optional **Markdown Format Converter** plugin and run the
+`Convert all to Markdown` command before committing docs. This converts
+`[[wikilinks]]` to standard `[text](link.md)` syntax so everything renders on
+GitHub without broken links.
+
+If you prefer an automated approach, you can add a `markdownlint` or `Prettier`
+configuration in your editor to normalize code fences and line breaks. The repo
+does not currently enforce a style, but consistent formatting makes diffs
+cleaner.
+
 #hashtags: #obsidian #vault
+
+## Automated Wikilink Conversion
+
+A small script `scripts/convert_wikilinks.py` converts `[[wikilinks]]` to standard markdown links. The repository provides a `.pre-commit-config.yaml` that runs this script automatically before each commit.
+
+Install the `pre-commit` tool and enable the hook:
+
+```bash
+pip install pre-commit
+pre-commit install
+```
+
+From then on, any changed markdown files will have their wikilinks rewritten when you commit.


### PR DESCRIPTION
## Summary
- document GitHub-friendly markdown settings
- add board sync script and research notes
- update README links
- document workflow for syncing kanban with GitHub Projects
- add wikilink conversion pre-commit and GitHub action
- fix permission warning by limiting GITHUB_TOKEN access in workflow

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688868b419bc83248d75bea572b7a685