### PR TITLE
Add alignment tasks to board

### DIFF
--- a/docs/agile/Tasks/Clarify Promethean project vision.md
+++ b/docs/agile/Tasks/Clarify Promethean project vision.md
@@ -1,0 +1,42 @@
+## 🛠️ Task: Clarify Promethean project vision
+
+Summarize the long-term goals of the Promethean framework so new contributors understand the purpose and scope. Capture the intent driving agents like Duck and outline expected outcomes.
+
+---
+
+## 🎯 Goals
+- Provide a short paragraph describing the overarching vision
+- Highlight key milestones currently planned
+- Include links to core docs for further reading
+
+---
+
+## 📦 Requirements
+- [ ] Draft a one-page summary under `docs/`
+- [ ] Link summary from `readme.md`
+- [ ] Review with maintainers for accuracy
+
+---
+
+## 📋 Subtasks
+- [ ] Gather notes from existing docs (`AGENTS.md`, `MIGRATION_PLAN.md`)
+- [ ] Synthesize into coherent narrative
+- [ ] PR the summary and update links
+
+---
+
+## 🔗 Related Epics
+#framework-core
+
+---
+
+## ⛓️ Blocked By
+Nothing
+
+## ⛓️ Blocks
+- Helps shape onboarding docs
+
+---
+
+## 🔍 Relevant Links
+- [kanban](../boards/kanban.md)

--- a/docs/agile/Tasks/Document board usage guidelines.md
+++ b/docs/agile/Tasks/Document board usage guidelines.md
@@ -1,0 +1,42 @@
+## 🛠️ Task: Document board usage guidelines
+
+Provide a concise how-to for contributors on interacting with the Obsidian Kanban board. Include common conventions, WIP limits, and tips for linking tasks.
+
+---
+
+## 🎯 Goals
+- Explain how to add new tasks using the template
+- Clarify column purposes and typical transitions
+- Encourage linking to relevant docs and code
+
+---
+
+## 📦 Requirements
+- [ ] Create a guideline page under `docs/`
+- [ ] Reference `Process.md` and `AGENTS.md`
+- [ ] Mention WIP limits noted in column headings
+
+---
+
+## 📋 Subtasks
+- [ ] Draft initial guide
+- [ ] Review with maintainers
+- [ ] Add cross-links from board and README
+
+---
+
+## 🔗 Related Epics
+#framework-core
+
+---
+
+## ⛓️ Blocked By
+Nothing
+
+## ⛓️ Blocks
+- Better contributor onboarding
+
+---
+
+## 🔍 Relevant Links
+- [kanban](../boards/kanban.md)

--- a/docs/agile/boards/kanban.md
+++ b/docs/agile/boards/kanban.md
@@ -52,6 +52,8 @@ kanban-plugin: board
 - [ ] [Start Eidolon](../tasks/Start%20Eidolon.md)
 - [ ] Write meaningful tests for Cephalon
 - [ ] [Create vault-config .obsidian with Kanban and minimal vault setup](../tasks/Create%20vault-config%20.obsidian%20with%20Kanban%20and%20minimal%20vault%20setup.md)
+- [ ] [Clarify Promethean project vision](../tasks/Clarify%20Promethean%20project%20vision.md)
+- [ ] [Document board usage guidelines](../tasks/Document%20board%20usage%20guidelines.md)
 
 
 ## Agent thinking


### PR DESCRIPTION
## Summary
- create task to clarify Promethean vision
- create task to document board usage guidelines
- link the new tasks from the kanban board

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'discord')*


------
https://chatgpt.com/codex/tasks/task_e_6888749553148324a66df55f77cb2822