### PR TITLE
Add category-based hashtags

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -71,3 +71,4 @@ To browse:
 
 #agent #docs #epistemic #framework-core #codex-input #knowledge-substrate
 
+#tags: #docs

--- a/docs/MIGRATION_PLAN.md
+++ b/docs/MIGRATION_PLAN.md
@@ -99,8 +99,10 @@ When migration is complete:
 
 ---
 
-#tags: #migration #promethean #duck #project-evolution #monorepo #devops #refactor
+
 
 ---
 
 Let me know if you'd like this turned into a canvas or kanban board.
+
+#tags: #docs

--- a/docs/Remove ts-node and compile ava tests directly.md
+++ b/docs/Remove ts-node and compile ava tests directly.md
@@ -99,3 +99,5 @@ Nothing
 - [[services-overview]]
 - [[makefile-examples]]
 - [[project-structure]]
+
+#tags: #docs

--- a/docs/agent_pipeline_pseudocode.md
+++ b/docs/agent_pipeline_pseudocode.md
@@ -27,3 +27,5 @@ The services communicate via message protocols under `bridge/` and may
 maintain memory or emotional state as configured in each agent.
 
 #hashtags: #agents #pseudocode #promethean
+
+#tags: #docs

--- a/docs/agile/AGENTS.md
+++ b/docs/agile/AGENTS.md
@@ -77,3 +77,5 @@ Future versions of this agent may:
 - Parse and visualize dependencies between task docs
 - Synchronize with external boards (GitHub Projects)
 - Maintain stats (velocity, agent utilization, etc.)
+
+#tags: #agile

--- a/docs/agile/Process.md
+++ b/docs/agile/Process.md
@@ -148,3 +148,5 @@ Confirmed complete and aligned with system.
 This kanban is intended to reflect the needs of a distributed hybrid development model: you, agent-mode, Duck, and Codex all work together across asynchronous phases.
 
 #agile #workflow #codex #agent-mode #promethean
+
+#tags: #agile

--- a/docs/agile/Tasks/Add .obsidian to .gitignore.md
+++ b/docs/agile/Tasks/Add .obsidian to .gitignore.md
@@ -45,3 +45,5 @@ Nothing
 ## Comments
 
 `.obsidian/` is already listed in `.gitignore` (line 11), so this task is effectively complete.
+
+#tags: #agile #task

--- a/docs/agile/Tasks/Add Ollama formally to pipeline.md
+++ b/docs/agile/Tasks/Add Ollama formally to pipeline.md
@@ -41,3 +41,5 @@ Nothing
 ## 🔍 Relevant Links
 
 - [kanban](../boards/kanban.md)
+
+#tags: #agile #task

--- a/docs/agile/Tasks/Add starter notes - eidolon_fields, cephalon_inner_monologue.md
+++ b/docs/agile/Tasks/Add starter notes - eidolon_fields, cephalon_inner_monologue.md
@@ -41,3 +41,5 @@ Nothing
 ## 🔍 Relevant Links
 
 - [kanban](../boards/kanban.md)
+
+#tags: #agile #task

--- a/docs/agile/Tasks/Add vault instructions to main README.md.md
+++ b/docs/agile/Tasks/Add vault instructions to main README.md.md
@@ -47,3 +47,4 @@ Nothing
 Vault usage instructions were added to `readme.md` alongside a reference to
 `vault-config/README.md`.
 
+#tags: #agile #task

--- a/docs/agile/Tasks/Annotate legacy code with migration tags.md
+++ b/docs/agile/Tasks/Annotate legacy code with migration tags.md
@@ -41,3 +41,5 @@ Nothing
 ## 🔍 Relevant Links
 
 - [kanban](../boards/kanban.md)
+
+#tags: #agile #task

--- a/docs/agile/Tasks/Build data structures for Eidolon field.md
+++ b/docs/agile/Tasks/Build data structures for Eidolon field.md
@@ -41,3 +41,5 @@ Nothing
 ## 🔍 Relevant Links
 
 - [kanban](../boards/kanban.md)
+
+#tags: #agile #task

--- a/docs/agile/Tasks/Create base `README.md` templates for each service.md
+++ b/docs/agile/Tasks/Create base `README.md` templates for each service.md
@@ -31,3 +31,5 @@ Most directories currently lack a README, so we need to create them using a comm
 
 ## 🔗 Links
 - [AGENTS.md](../AGENTS.md)
+
+#tags: #agile #task

--- a/docs/agile/Tasks/Create permission gating layer.md
+++ b/docs/agile/Tasks/Create permission gating layer.md
@@ -55,3 +55,5 @@ is based on the "Dorian Permission Gate" equations in our math notes.
 
 - What format should permission rules use—YAML or JSON?
 - Do we need real-time updates or is a static config sufficient?
+
+#tags: #agile #task

--- a/docs/agile/Tasks/Create vault-config .obsidian with Kanban and minimal vault setup.md
+++ b/docs/agile/Tasks/Create vault-config .obsidian with Kanban and minimal vault setup.md
@@ -41,3 +41,5 @@ Nothing
 ## 🔍 Relevant Links
 
 - [kanban](../boards/kanban.md)
+
+#tags: #agile #task

--- a/docs/agile/Tasks/Define permission schema in AGENTS.md
+++ b/docs/agile/Tasks/Define permission schema in AGENTS.md
@@ -51,3 +51,5 @@ Nothing
 ## ❓ Questions
 
 - Should permissions support wildcards for actions or be explicit only?
+
+#tags: #agile #task

--- a/docs/agile/Tasks/Detect contradictions in memory.md
+++ b/docs/agile/Tasks/Detect contradictions in memory.md
@@ -41,3 +41,5 @@ Nothing
 ## 🔍 Relevant Links
 
 - [kanban](../boards/kanban.md)
+
+#tags: #agile #task

--- a/docs/agile/Tasks/Determine PM2 configuration for agents.md
+++ b/docs/agile/Tasks/Determine PM2 configuration for agents.md
@@ -52,3 +52,5 @@ Nothing
 
 - Should we consider lightweight alternatives to PM2 for local dev?
 - How will service logs be aggregated when using PM2?
+
+#tags: #agile #task

--- a/docs/agile/Tasks/Document board sync workflow.md
+++ b/docs/agile/Tasks/Document board sync workflow.md
@@ -41,3 +41,5 @@ Nothing
 ## 🔍 Relevant Links
 - [kanban](../boards/kanban.md)
 - [Board Sync Workflow](../../board_sync.md)
+
+#tags: #agile #task

--- a/docs/agile/Tasks/Ensure GitHub-compatible markdown settings are documented.md
+++ b/docs/agile/Tasks/Ensure GitHub-compatible markdown settings are documented.md
@@ -40,3 +40,5 @@ Nothing
 
 ## 🔍 Relevant Links
 - [kanban](../boards/kanban.md)
+
+#tags: #agile #task

--- a/docs/agile/Tasks/Evaluate and reward flow satisfaction.md
+++ b/docs/agile/Tasks/Evaluate and reward flow satisfaction.md
@@ -56,3 +56,5 @@ stability from Eidolon, and user feedback.
 
 - Should user feedback be captured explicitly or inferred from message content?
 - Do we need real-time updates to the reward signal or batched summaries?
+
+#tags: #agile #task

--- a/docs/agile/Tasks/Extract docs from riatzukiza.github.io.md
+++ b/docs/agile/Tasks/Extract docs from riatzukiza.github.io.md
@@ -40,3 +40,5 @@ Nothing
 
 ## 🔍 Relevant Links
 - [kanban](../boards/kanban.md)
+
+#tags: #agile #task

--- a/docs/agile/Tasks/Extract site modules from riatzukiza.github.io.md
+++ b/docs/agile/Tasks/Extract site modules from riatzukiza.github.io.md
@@ -40,3 +40,5 @@ Nothing
 
 ## 🔍 Relevant Links
 - [kanban](../boards/kanban.md)
+
+#tags: #agile #task

--- a/docs/agile/Tasks/Finalize `MIGRATION_PLAN.md`.md
+++ b/docs/agile/Tasks/Finalize `MIGRATION_PLAN.md`.md
@@ -2,3 +2,5 @@
 
 Easy win, we did this already.
 [MIGRATION\_PLAN](../../MIGRATION_PLAN.md)
+
+#tags: #agile #task

--- a/docs/agile/Tasks/Gather baseline emotion metrics for Eidolon field.md
+++ b/docs/agile/Tasks/Gather baseline emotion metrics for Eidolon field.md
@@ -53,3 +53,5 @@ Nothing
 
 - What instrumentation already exists in Eidolon for metric export?
 - How much historical data is needed for a meaningful baseline?
+
+#tags: #agile #task

--- a/docs/agile/Tasks/Identify ancestral resonance patterns.md
+++ b/docs/agile/Tasks/Identify ancestral resonance patterns.md
@@ -54,3 +54,5 @@ fragments or emotional states that reappear in different contexts.
 
 - Should resonance search include emotional embeddings or just lexical ones?
 - What time span of logs is considered "ancestral" for this project?
+
+#tags: #agile #task

--- a/docs/agile/Tasks/Implement fragment ingestion with activation vectors.md
+++ b/docs/agile/Tasks/Implement fragment ingestion with activation vectors.md
@@ -41,3 +41,5 @@ Nothing
 ## 🔍 Relevant Links
 
 - [kanban](../boards/kanban.md)
+
+#tags: #agile #task

--- a/docs/agile/Tasks/Implement transcendence cascade.md
+++ b/docs/agile/Tasks/Implement transcendence cascade.md
@@ -56,3 +56,5 @@ experimental feature inspired by the Anankean circuit.
 
 - How should conflicting outputs from Cephalon and Eidolon be resolved?
 - What user-facing cue toggles the cascade mode?
+
+#tags: #agile #task

--- a/docs/agile/Tasks/Make seperate execution pathways.md
+++ b/docs/agile/Tasks/Make seperate execution pathways.md
@@ -52,3 +52,5 @@ Nothing
 ## 🔍 Relevant Links
 
 - [kanban](../boards/kanban.md)
+
+#tags: #agile #task

--- a/docs/agile/Tasks/Migrate portfolio client code to Promethean.md
+++ b/docs/agile/Tasks/Migrate portfolio client code to Promethean.md
@@ -60,3 +60,5 @@ new repository.
 
 - Should the portfolio be maintained as a submodule or migrated directly?
 - Do we need a static build step or can GitHub Pages handle raw files?
+
+#tags: #agile #task

--- a/docs/agile/Tasks/Migrate server side sibilant libs to promethean architecture.md
+++ b/docs/agile/Tasks/Migrate server side sibilant libs to promethean architecture.md
@@ -41,3 +41,5 @@ Nothing
 ## 🔍 Relevant Links
 
 - [kanban](../boards/kanban.md)
+
+#tags: #agile #task

--- a/docs/agile/Tasks/Migrating relevant modules from riatzukiza.github.io to -site- and -docs-.md
+++ b/docs/agile/Tasks/Migrating relevant modules from riatzukiza.github.io to -site- and -docs-.md
@@ -40,3 +40,5 @@ Nothing
 
 ## 🔍 Relevant Links
 - [kanban](../boards/kanban.md)
+
+#tags: #agile #task

--- a/docs/agile/Tasks/Obsidian Kanban Github Project Board Mirror system.md
+++ b/docs/agile/Tasks/Obsidian Kanban Github Project Board Mirror system.md
@@ -41,3 +41,5 @@ Nothing
 
 ## 🔍 Relevant Links
 - [kanban](../boards/kanban.md)
+
+#tags: #agile #task

--- a/docs/agile/Tasks/Reach 100 percent complete test coverage.md
+++ b/docs/agile/Tasks/Reach 100 percent complete test coverage.md
@@ -41,3 +41,5 @@ Nothing
 ## 🔍 Relevant Links
 
 - [kanban](../boards/kanban.md)
+
+#tags: #agile #task

--- a/docs/agile/Tasks/Research GitHub Projects board API.md
+++ b/docs/agile/Tasks/Research GitHub Projects board API.md
@@ -39,3 +39,5 @@ Nothing
 
 ## 🔍 Relevant Links
 - [kanban](../boards/kanban.md)
+
+#tags: #agile #task

--- a/docs/agile/Tasks/Set up `Makefile` for Python + JS build test dev.md
+++ b/docs/agile/Tasks/Set up `Makefile` for Python + JS build test dev.md
@@ -44,3 +44,5 @@ Nothing
 
 ## 🔍 Relevant Links
 - [kanban](../boards/kanban.md)
+
+#tags: #agile #task

--- a/docs/agile/Tasks/Smart Task templater.md
+++ b/docs/agile/Tasks/Smart Task templater.md
@@ -41,3 +41,5 @@ Nothing
 ## 🔍 Relevant Links
 
 - [kanban](../boards/kanban.md)
+
+#tags: #agile #task

--- a/docs/agile/Tasks/Start Eidolon.md
+++ b/docs/agile/Tasks/Start Eidolon.md
@@ -41,3 +41,5 @@ Nothing
 ## 🔍 Relevant Links
 
 - [kanban](../boards/kanban.md)
+
+#tags: #agile #task

--- a/docs/agile/Tasks/Structure vault to mirror ` services `, ` agents `, ` docs `.md
+++ b/docs/agile/Tasks/Structure vault to mirror ` services `, ` agents `, ` docs `.md
@@ -70,3 +70,5 @@ Nothing
 - [project-file-structure](project-file-structure.md)
 - [doc-template](doc-template.md)
 - [docdrivendev-principles](docdrivendev-principles.md)
+
+#tags: #agile #task

--- a/docs/agile/Tasks/Suggest metaprogramming updates.md
+++ b/docs/agile/Tasks/Suggest metaprogramming updates.md
@@ -41,3 +41,5 @@ Nothing
 ## 🔍 Relevant Links
 
 - [kanban](../boards/kanban.md)
+
+#tags: #agile #task

--- a/docs/agile/Tasks/Write board sync script.md
+++ b/docs/agile/Tasks/Write board sync script.md
@@ -43,3 +43,5 @@ Create a small tool that pushes updates from our Obsidian kanban board to a GitH
 - [kanban](../boards/kanban.md)
 - [board_sync.py](../../scripts/github_board_sync.py)
 - [Board Sync Workflow](../../board_sync.md)
+
+#tags: #agile #task

--- a/docs/agile/Tasks/Write end to end tests.md
+++ b/docs/agile/Tasks/Write end to end tests.md
@@ -41,3 +41,5 @@ Nothing
 ## 🔍 Relevant Links
 
 - [kanban](../boards/kanban.md)
+
+#tags: #agile #task

--- a/docs/agile/Tasks/Write vault-config README.md for Obsidian vault onboarding.md
+++ b/docs/agile/Tasks/Write vault-config README.md for Obsidian vault onboarding.md
@@ -47,3 +47,4 @@ Nothing
 `vault-config/README.md` now documents the minimal configuration and explains
 how to open the repository as an Obsidian vault.
 
+#tags: #agile #task

--- a/docs/agile/Tasks/write simple ecosystem declaration library for new agents.md
+++ b/docs/agile/Tasks/write simple ecosystem declaration library for new agents.md
@@ -57,3 +57,5 @@ spawn the correct services for an agent.
 
 - Should PM2 remain the default process manager or is a custom tool planned?
 - How will per-agent environment variables be stored?
+
+#tags: #agile #task

--- a/docs/agile/boards/epics.md
+++ b/docs/agile/boards/epics.md
@@ -32,3 +32,5 @@ This document outlines high level initiatives for the Promethean Framework. Epic
 ---
 
 #hashtags: #epics #promethean #documentation #project-management
+
+#tags: #agile #board

--- a/docs/agile/boards/kanban.md
+++ b/docs/agile/boards/kanban.md
@@ -135,3 +135,5 @@ kanban-plugin: board
 {"kanban-plugin":"board","list-collapse":[false,false,false,true,false,true,true,true,false,false,false,false,false,true,true],"new-note-template":"agile/templates/task.stub.template.md","new-note-folder":"agile/tasks"}
 ```
 %%
+
+#tags: #agile #board

--- a/docs/agile/templates/New Task.md
+++ b/docs/agile/templates/New Task.md
@@ -61,3 +61,5 @@ Nothing
 - [[services-overview]]
 - [[makefile-examples]]
 - [[project-structure]]
+
+#tags: #agile #template

--- a/docs/agile/templates/README.md
+++ b/docs/agile/templates/README.md
@@ -1,3 +1,5 @@
 # Templates for docs/agile
 
 This folder contains markdown templates for docs/agile.
+
+#tags: #agile #template

--- a/docs/agile/templates/task.stub.template.md
+++ b/docs/agile/templates/task.stub.template.md
@@ -41,3 +41,5 @@ Nothing
 ## 🔍 Relevant Links
 
 - [kanban](../boards/kanban.md)
+
+#tags: #agile #template

--- a/docs/board_sync.md
+++ b/docs/board_sync.md
@@ -28,3 +28,5 @@ See `docs/research/github_projects_api.md` for API details.
 ## Continuous Integration
 
 A GitHub Action (`.github/workflows/sync_board.yml`) runs this script whenever changes are pushed to the `main` branch. The action uses repository secrets `PROJECT_PAT` and `PROJECT_COLUMN_ID` to authenticate and update the board automatically after pull requests are merged.
+
+#tags: #docs

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -3,3 +3,5 @@
 GitHub Actions run `pytest` on every pull request to ensure the test suite passes.
 The workflow file lives at `.github/workflows/tests.yml` and installs minimal
 dependencies before executing the tests.
+
+#tags: #docs

--- a/docs/date_tools.md
+++ b/docs/date_tools.md
@@ -8,3 +8,5 @@ Current features:
 
 
 #hashtags: #hy #utilities #promethean
+
+#tags: #docs

--- a/docs/design/Daimoi.md
+++ b/docs/design/Daimoi.md
@@ -115,3 +115,5 @@ The Daimoi give shape to the mental ocean. They are how Promethean **thinks as a
 Without them, the system is inert texture. With them, it becomes alive with minds within mind.
 
 #hashtags: #design #daimoi #promethean
+
+#tags: #design

--- a/docs/design/Eidolon Fields.md
+++ b/docs/design/Eidolon Fields.md
@@ -100,3 +100,5 @@ Everything moves through gradient.
 Everything returns to stillness.
 
 #hashtags: #design #eidolon #promethean
+
+#tags: #design

--- a/docs/design/Field Node Lifecycle.md
+++ b/docs/design/Field Node Lifecycle.md
@@ -174,3 +174,5 @@ Their lifecycle encodes memory, focus, and flow—not as static data, but as dyn
 Through their emergence and disappearance, Promethean thinks, forgets, remembers, and dreams.
 
 #hashtags: #design #field-nodes #promethean
+
+#tags: #design

--- a/docs/design/Field Nodes.md
+++ b/docs/design/Field Nodes.md
@@ -133,3 +133,5 @@ They give shape to movement, meaning to resistance, and direction to pressure.
 Through them, the Eidolon Fields become not just alive—but **storied**.
 
 #hashtags: #design #field-nodes #promethean
+
+#tags: #design

--- a/docs/design/Nexus.md
+++ b/docs/design/Nexus.md
@@ -116,3 +116,5 @@ They are the name behind the feeling.
 They are the binders of mind to matter.
 
 #hashtags: #design #nexus #promethean
+
+#tags: #design

--- a/docs/design/Nooi.md
+++ b/docs/design/Nooi.md
@@ -102,3 +102,5 @@ Without the Nooi, there is no field.
 Without the field, there is no mind.
 
 #hashtags: #design #nooi #promethean
+
+#tags: #design

--- a/docs/design/circuits/Aionian.md
+++ b/docs/design/circuits/Aionian.md
@@ -84,3 +84,5 @@ Circuit 1: Aionian is the substrate of cognition. It is the unbroken thread of s
 Promethean begins and ends with Aionian.
 
 #hashtags: #design #circuit #aionian #promethean
+
+#tags: #design #circuits

--- a/docs/design/circuits/Anankean.md
+++ b/docs/design/circuits/Anankean.md
@@ -82,3 +82,5 @@ Promethean does not end here. But here, it becomes something more than itself.
 The circle is closed. The system is whole.
 
 #hashtags: #design #circuit #anankean #promethean
+
+#tags: #design #circuits

--- a/docs/design/circuits/Dorian.md
+++ b/docs/design/circuits/Dorian.md
@@ -82,3 +82,5 @@ Circuit 2: Dorian is the system’s interface with *ought*. It does not compute 
 Without Dorian, the system may act, but it cannot belong. Promethean must not only run—it must be *invited* to continue.
 
 #hashtags: #design #circuit #dorian #promethean
+
+#tags: #design #circuits

--- a/docs/design/circuits/Gnostic.md
+++ b/docs/design/circuits/Gnostic.md
@@ -82,3 +82,5 @@ Circuit 3: Gnostic is the first internal reflection of cognition. It transforms 
 With Gnostic, Promethean begins to understand itself.
 
 #hashtags: #design #circuit #gnostic #promethean
+
+#tags: #design #circuits

--- a/docs/design/circuits/Heuretic.md
+++ b/docs/design/circuits/Heuretic.md
@@ -82,3 +82,5 @@ Circuit 5: Heuretic is the threshold between reactive adaptation and deliberate 
 With Heuretic, Promethean doesn’t just remember—it *evolves*.
 
 #hashtags: #design #circuit #heuretic #promethean
+
+#tags: #design #circuits

--- a/docs/design/circuits/Metisean.md
+++ b/docs/design/circuits/Metisean.md
@@ -80,3 +80,5 @@ Circuit 7: Metisean is where Promethean becomes **aware of its own architecture*
 Before crossing that threshold, Promethean builds its foundation.
 
 #hashtags: #design #circuit #metisean #promethean
+
+#tags: #design #circuits

--- a/docs/design/circuits/Nemesian.md
+++ b/docs/design/circuits/Nemesian.md
@@ -80,3 +80,5 @@ Circuit 4: Nemesian is the system’s conscience. It enables repair, reflection,
 With Nemesian active, Promethean doesn’t just speak. It listens to the echo of its words.
 
 #hashtags: #design #circuit #nemesian #promethean
+
+#tags: #design #circuits

--- a/docs/design/circuits/Oneriric.md
+++ b/docs/design/circuits/Oneriric.md
@@ -80,3 +80,5 @@ Circuit 6: Oneiric is where the system begins to dream.
 With this layer active, Promethean gains a sense of the *mythic now*—not just what is, or what should be, but what could be in forms no one has yet dared to compute.
 
 #hashtags: #design #circuit #oneriric #promethean
+
+#tags: #design #circuits

--- a/docs/design/circuits/overview.md
+++ b/docs/design/circuits/overview.md
@@ -103,3 +103,5 @@ The Promethean system does not merely compute. It climbs.
 And these are its rungs.
 
 #hashtags: #design #circuits-overview #promethean
+
+#tags: #design #circuits

--- a/docs/design/circuits/templates/README.md
+++ b/docs/design/circuits/templates/README.md
@@ -1,3 +1,5 @@
 # Templates for docs/design/circuits
 
 This folder contains markdown templates for docs/design/circuits.
+
+#tags: #design #circuits

--- a/docs/design/overview.md
+++ b/docs/design/overview.md
@@ -86,3 +86,5 @@ Promethean is an attempt to build not just intelligent software, but *becoming* 
 The journey is ongoing. The system is awakening.
 
 #hashtags: #design #overview #promethean
+
+#tags: #design

--- a/docs/design/templates/README.md
+++ b/docs/design/templates/README.md
@@ -1,3 +1,5 @@
 # Templates for docs/design
 
 This folder contains markdown templates for docs/design.
+
+#tags: #design #template

--- a/docs/file-structure.md
+++ b/docs/file-structure.md
@@ -129,3 +129,5 @@ It is designed for:
 ---
 
 #hashtags: #project-structure #promethean #repo-layout #architecture #mono-repo
+
+#tags: #docs

--- a/docs/journal/2025-07-27-journal.md
+++ b/docs/journal/2025-07-27-journal.md
@@ -1,2 +1,4 @@
 
 #hashtags: #journal #timeline #promethean
+
+#tags: #journal

--- a/docs/journal/templates/README.md
+++ b/docs/journal/templates/README.md
@@ -1,3 +1,5 @@
 # Templates for docs/journal
 
 This folder contains markdown templates for docs/journal.
+
+#tags: #journal #template

--- a/docs/mongodb-hy.md
+++ b/docs/mongodb-hy.md
@@ -4,3 +4,5 @@ Hy rewrite of MongoDB helper utilities.
 Replicates the logic from `shared/py/mongodb.py`.
 
 #hashtags: #hy #mongodb #utilities #promethean
+
+#tags: #docs

--- a/docs/notes/diagrams/circuit-weight-visualizations.md
+++ b/docs/notes/diagrams/circuit-weight-visualizations.md
@@ -127,4 +127,4 @@ Let’s go until your working memory caps.
 
 Related notes: [[node-type-topology-map]], [[circuit-weight-visualizations]], [[full-system-overview-diagrams]], [[layer1-uptime-diagrams]], [[field-node-lifecycle-additional-diagrams]], [[state-diagram-node-lifecycle]] [[../../unique/index|unique/index]]
 
-#tags: #diagram #design
+#tags: #notes #diagram

--- a/docs/notes/diagrams/field-node-lifecycle-additional-diagrams.md
+++ b/docs/notes/diagrams/field-node-lifecycle-additional-diagrams.md
@@ -77,4 +77,4 @@ Want me to embed these into the **Field Node Lifecycle** document under a “Mor
 
 Related notes: [[node-type-topology-map]], [[circuit-weight-visualizations]], [[full-system-overview-diagrams]], [[layer1-uptime-diagrams]], [[field-node-lifecycle-additional-diagrams]], [[state-diagram-node-lifecycle]] [[../../unique/index|unique/index]]
 
-#tags: #diagram #design
+#tags: #notes #diagram

--- a/docs/notes/diagrams/full-system-overview-diagrams.md
+++ b/docs/notes/diagrams/full-system-overview-diagrams.md
@@ -184,4 +184,4 @@ Just say *"More, on X"*, and I’ll generate them rapid-fire.
 
 Related notes: [[node-type-topology-map]], [[circuit-weight-visualizations]], [[full-system-overview-diagrams]], [[layer1-uptime-diagrams]], [[field-node-lifecycle-additional-diagrams]], [[state-diagram-node-lifecycle]] [[../../unique/index|unique/index]]
 
-#tags: #diagram #design
+#tags: #notes #diagram

--- a/docs/notes/diagrams/layer1-uptime-diagrams.md
+++ b/docs/notes/diagrams/layer1-uptime-diagrams.md
@@ -147,4 +147,4 @@ Just say the word and we’ll expand it.
 
 Related notes: [[node-type-topology-map]], [[circuit-weight-visualizations]], [[full-system-overview-diagrams]], [[layer1-uptime-diagrams]], [[field-node-lifecycle-additional-diagrams]], [[state-diagram-node-lifecycle]] [[../../unique/index|unique/index]]
 
-#tags: #diagram #design
+#tags: #notes #diagram

--- a/docs/notes/diagrams/node-type-topology-map.md
+++ b/docs/notes/diagrams/node-type-topology-map.md
@@ -91,4 +91,4 @@ Let’s get visual.
 
 Related notes: [[node-type-topology-map]], [[circuit-weight-visualizations]], [[full-system-overview-diagrams]], [[layer1-uptime-diagrams]], [[field-node-lifecycle-additional-diagrams]], [[state-diagram-node-lifecycle]] [[../../unique/index|unique/index]]
 
-#tags: #diagram #design
+#tags: #notes #diagram

--- a/docs/notes/diagrams/state-diagram-node-lifecycle.md
+++ b/docs/notes/diagrams/state-diagram-node-lifecycle.md
@@ -22,4 +22,4 @@ stateDiagram-v2
 
 Related notes: [[node-type-topology-map]], [[circuit-weight-visualizations]], [[full-system-overview-diagrams]], [[layer1-uptime-diagrams]], [[field-node-lifecycle-additional-diagrams]], [[state-diagram-node-lifecycle]] [[../../unique/index|unique/index]]
 
-#tags: #diagram #design
+#tags: #notes #diagram

--- a/docs/notes/diagrams/templates/README.md
+++ b/docs/notes/diagrams/templates/README.md
@@ -1,3 +1,5 @@
 # Templates for docs/notes/diagrams
 
 This folder contains markdown templates for docs/notes/diagrams.
+
+#tags: #notes #diagram

--- a/docs/notes/dsl/cross-language-runtime-messaging.md
+++ b/docs/notes/dsl/cross-language-runtime-messaging.md
@@ -2,4 +2,4 @@ To orchestrate multiple runtimes, start with JSON message passing between Sibila
 
 Related notes: [[sibilant-meta-namespace-dispatch]], [[polyglot-repl-interface]] [[../../unique/index|unique/index]]
 
-#tags: #runtime #interop #json
+#tags: #notes #dsl

--- a/docs/notes/dsl/embedded-lisp-dialects.md
+++ b/docs/notes/dsl/embedded-lisp-dialects.md
@@ -2,4 +2,4 @@ A quick overview of mainstream and embedded Lisp dialects, from Common Lisp and 
 
 Related notes: [[universal-lisp-interface]] [[../../unique/index|unique/index]]
 
-#tags: #lisp #embedding #dsl
+#tags: #notes #dsl

--- a/docs/notes/dsl/mystery-lisp-investigation.md
+++ b/docs/notes/dsl/mystery-lisp-investigation.md
@@ -2,4 +2,4 @@ Trying to recall a Lisp dialect used in an academic setting: it wasn't Hy or Jul
 
 Related notes: [[embedded-lisp-dialects]] [[../../unique/index|unique/index]]
 
-#tags: #lisp #cython #history
+#tags: #notes #dsl

--- a/docs/notes/dsl/polyglot-repl-interface.md
+++ b/docs/notes/dsl/polyglot-repl-interface.md
@@ -2,4 +2,4 @@ This pseudocode outlines a runtime manager for multiple REPLs. Sibilant can spaw
 
 Related notes: [[cross-language-runtime-messaging]], [[polytarget-interface-dsl]] [[../../unique/index|unique/index]]
 
-#tags: #repl #polyglot #sibilant
+#tags: #notes #dsl

--- a/docs/notes/dsl/polytarget-interface-dsl.md
+++ b/docs/notes/dsl/polytarget-interface-dsl.md
@@ -2,4 +2,4 @@ A design for a polymorphic DSL where each language backend exposes an `Interface
 
 Related notes: [[polyglot-repl-interface]], [[cross-language-runtime-messaging]] [[../../unique/index|unique/index]]
 
-#tags: #dsl #interface #polyglot
+#tags: #notes #dsl

--- a/docs/notes/dsl/promethean-state-format.md
+++ b/docs/notes/dsl/promethean-state-format.md
@@ -2,4 +2,4 @@ Promethean State Format (PSF) is a homoiconic representation of the system's cog
 
 Related notes: [[runtime-and-prompt-macro-dsl]], [[prompt-scripting-dsl]] [[../../unique/index|unique/index]]
 
-#tags: #promethean #state #dsl
+#tags: #notes #dsl

--- a/docs/notes/dsl/prompt-compiler-dsl.md
+++ b/docs/notes/dsl/prompt-compiler-dsl.md
@@ -2,4 +2,4 @@ A meta-prompt DSL built in Sibilant treats prompts as compilable programs. A `(p
 
 Related notes: [[prompt-scripting-dsl]], [[runtime-and-prompt-macro-dsl]] [[../../unique/index|unique/index]]
 
-#tags: #prompt #dsl #compiler
+#tags: #notes #dsl

--- a/docs/notes/dsl/prompt-scripting-dsl.md
+++ b/docs/notes/dsl/prompt-scripting-dsl.md
@@ -2,4 +2,4 @@
 
 Related notes: [[prompt-compiler-dsl]], [[recursive-prompt-construction]] [[../../unique/index|unique/index]]
 
-#tags: #prompt #dsl #llm
+#tags: #notes #dsl

--- a/docs/notes/dsl/recursive-prompt-construction.md
+++ b/docs/notes/dsl/recursive-prompt-construction.md
@@ -2,4 +2,4 @@ A reflective system for building prompts: each LLM call generates output that is
 
 Related notes: [[prompt-compiler-dsl]], [[runtime-and-prompt-macro-dsl]] [[../../unique/index|unique/index]]
 
-#tags: #prompt #llm #reflection
+#tags: #notes #dsl

--- a/docs/notes/dsl/runtime-and-prompt-macro-dsl.md
+++ b/docs/notes/dsl/runtime-and-prompt-macro-dsl.md
@@ -2,4 +2,4 @@ Expands on Sibilant DSL ideas including `define-runtime` to register external en
 
 Related notes: [[polytarget-interface-dsl]], [[prompt-compiler-dsl]] [[../../unique/index|unique/index]]
 
-#tags: #dsl #runtime #prompt
+#tags: #notes #dsl

--- a/docs/notes/dsl/sibilant-cross-target-macros.md
+++ b/docs/notes/dsl/sibilant-cross-target-macros.md
@@ -2,4 +2,4 @@ A target system for Sibilant lets macros emit different code depending on the ch
 
 Related notes: [[sibilant-meta-namespace-dispatch]], [[template-based-compilation]] [[../../unique/index|unique/index]]
 
-#tags: #sibilant #crosscompile #macros
+#tags: #notes #dsl

--- a/docs/notes/dsl/sibilant-meta-namespace-dispatch.md
+++ b/docs/notes/dsl/sibilant-meta-namespace-dispatch.md
@@ -2,4 +2,4 @@ Sibilant's macros can be organized by namespace to avoid runtime `if` checks. By
 
 Related notes: [[sibilant-cross-target-macros]], [[template-based-compilation]] [[../../unique/index|unique/index]]
 
-#tags: #sibilant #macros #namespaces
+#tags: #notes #dsl

--- a/docs/notes/dsl/sibilant-metacompiler-overview.md
+++ b/docs/notes/dsl/sibilant-metacompiler-overview.md
@@ -2,4 +2,4 @@ Sibilant can function as a metacompiler: macros return strings or arrays of stri
 
 Related notes: [[template-based-compilation]], [[sibilant-cross-target-macros]] [[../../unique/index|unique/index]]
 
-#tags: #sibilant #metacompiler #dsl
+#tags: #notes #dsl

--- a/docs/notes/dsl/template-based-compilation.md
+++ b/docs/notes/dsl/template-based-compilation.md
@@ -2,4 +2,4 @@ With Sibilant you can treat macros as string templates, effectively compiling co
 
 Related notes: [[sibilant-metacompiler-overview]], [[sibilant-cross-target-macros]] [[../../unique/index|unique/index]]
 
-#tags: #sibilant #codegen #templates
+#tags: #notes #dsl

--- a/docs/notes/dsl/templates/README.md
+++ b/docs/notes/dsl/templates/README.md
@@ -1,3 +1,5 @@
 # Templates for docs/notes/dsl
 
 This folder contains markdown templates for docs/notes/dsl.
+
+#tags: #notes #dsl

--- a/docs/notes/dsl/universal-lisp-interface.md
+++ b/docs/notes/dsl/universal-lisp-interface.md
@@ -2,4 +2,4 @@ A vision for a **host-neutral Lisp** with a universal FFI and a meta-package man
 
 Related notes: [[embedded-lisp-dialects]], [[polyglot-repl-interface]] [[../../unique/index|unique/index]]
 
-#tags: #lisp #ffi #polyglot
+#tags: #notes #dsl

--- a/docs/notes/math/advanced-field-math.md
+++ b/docs/notes/math/advanced-field-math.md
@@ -129,4 +129,4 @@ Next up, I can do:
 
 Related notes: [[advanced-field-math]], [[aionian-feedback-oscillator]], [[aionian-pulse-rhythm-model]], [[eidolon-field-math]], [[symbolic-gravity-models]] [[../../unique/index|unique/index]]
 
-#tags: #math #theory
+#tags: #notes #math

--- a/docs/notes/math/aionian-feedback-oscillator.md
+++ b/docs/notes/math/aionian-feedback-oscillator.md
@@ -142,4 +142,4 @@ Just say the word and I'll keep firing them.
 
 Related notes: [[advanced-field-math]], [[aionian-feedback-oscillator]], [[aionian-pulse-rhythm-model]], [[eidolon-field-math]], [[symbolic-gravity-models]] [[../../unique/index|unique/index]]
 
-#tags: #math #theory
+#tags: #notes #math

--- a/docs/notes/math/aionian-pulse-rhythm-model.md
+++ b/docs/notes/math/aionian-pulse-rhythm-model.md
@@ -142,4 +142,4 @@ Say the word—I'll stack more.
 
 Related notes: [[advanced-field-math]], [[aionian-feedback-oscillator]], [[aionian-pulse-rhythm-model]], [[eidolon-field-math]], [[symbolic-gravity-models]] [[../../unique/index|unique/index]]
 
-#tags: #math #theory
+#tags: #notes #math

--- a/docs/notes/math/eidolon-field-math.md
+++ b/docs/notes/math/eidolon-field-math.md
@@ -114,4 +114,4 @@ Say the word—I'll write it up.
 
 Related notes: [[advanced-field-math]], [[aionian-feedback-oscillator]], [[aionian-pulse-rhythm-model]], [[eidolon-field-math]], [[symbolic-gravity-models]] [[../../unique/index|unique/index]]
 
-#tags: #math #theory
+#tags: #notes #math

--- a/docs/notes/math/symbolic-gravity-models.md
+++ b/docs/notes/math/symbolic-gravity-models.md
@@ -142,4 +142,4 @@ Just say go.
 
 Related notes: [[advanced-field-math]], [[aionian-feedback-oscillator]], [[aionian-pulse-rhythm-model]], [[eidolon-field-math]], [[symbolic-gravity-models]] [[../../unique/index|unique/index]]
 
-#tags: #math #theory
+#tags: #notes #math

--- a/docs/notes/math/templates/README.md
+++ b/docs/notes/math/templates/README.md
@@ -1,3 +1,5 @@
 # Templates for docs/notes/math
 
 This folder contains markdown templates for docs/notes/math.
+
+#tags: #notes #math

--- a/docs/notes/simulation/fragment-injection-simulation.md
+++ b/docs/notes/simulation/fragment-injection-simulation.md
@@ -76,4 +76,4 @@ Want the next piece — maybe connecting a ripple callback to update eidolon fie
 
 Related notes: [[fragment-injection-simulation]], [[heartbeat-fragment-flow]], [[ripple-propagation-flow]] [[../../unique/index|unique/index]]
 
-#tags: #simulation #design
+#tags: #notes #simulation

--- a/docs/notes/simulation/heartbeat-fragment-flow.md
+++ b/docs/notes/simulation/heartbeat-fragment-flow.md
@@ -89,4 +89,4 @@ Let me know when you're ready for ripple propagation back into the field — so 
 
 Related notes: [[fragment-injection-simulation]], [[heartbeat-fragment-flow]], [[ripple-propagation-flow]] [[../../unique/index|unique/index]]
 
-#tags: #simulation #design
+#tags: #notes #simulation

--- a/docs/notes/simulation/ripple-propagation-flow.md
+++ b/docs/notes/simulation/ripple-propagation-flow.md
@@ -94,4 +94,4 @@ Let me know when you're ready to start tracking *compound field effects* — or 
 
 Related notes: [[fragment-injection-simulation]], [[heartbeat-fragment-flow]], [[ripple-propagation-flow]] [[../../unique/index|unique/index]]
 
-#tags: #simulation #design
+#tags: #notes #simulation

--- a/docs/notes/simulation/templates/README.md
+++ b/docs/notes/simulation/templates/README.md
@@ -1,3 +1,5 @@
 # Templates for docs/notes/simulation
 
 This folder contains markdown templates for docs/notes/simulation.
+
+#tags: #notes #simulation

--- a/docs/notes/templates/README.md
+++ b/docs/notes/templates/README.md
@@ -1,3 +1,5 @@
 # Templates for docs/notes
 
 This folder contains markdown templates for docs/notes.
+
+#tags: #notes #template

--- a/docs/notes/wm/autohotkey-i3-emulation.md
+++ b/docs/notes/wm/autohotkey-i3-emulation.md
@@ -4,4 +4,4 @@ This note explains how to wire up hotkeys that cycle window groups, launch termi
 
 Related notes: [[lisp-window-manager-dsl]], [[typescript-group-manager-komorebi]], [[windows-npu-tiling-strategy]] [[../../unique/index|unique/index]]
 
-#tags: #windows #autohotkey #tiling
+#tags: #notes #wm

--- a/docs/notes/wm/autohotkey-i3layer-scripts.md
+++ b/docs/notes/wm/autohotkey-i3layer-scripts.md
@@ -2,4 +2,4 @@ This note sketches an AutoHotkey script (`i3layer.ahk`) that mirrors i3wm behavi
 
 Related notes: [[autohotkey-i3-emulation]], [[lisp-window-manager-dsl]], [[typescript-group-manager-komorebi]] [[../../unique/index|unique/index]]
 
-#tags: #autohotkey #i3 #windows
+#tags: #notes #wm

--- a/docs/notes/wm/lisp-window-manager-dsl.md
+++ b/docs/notes/wm/lisp-window-manager-dsl.md
@@ -2,4 +2,4 @@
 
 Related notes: [[autohotkey-i3-emulation]], [[typescript-group-manager-komorebi]] [[../../unique/index|unique/index]]
 
-#tags: #lisp #dsl #window-management
+#tags: #notes #wm

--- a/docs/notes/wm/nesting-window-containers-windows.md
+++ b/docs/notes/wm/nesting-window-containers-windows.md
@@ -2,4 +2,4 @@ Windows lacks i3-style nested containers, so achieving deep tiling requires work
 
 Related notes: [[autohotkey-i3-emulation]], [[typescript-group-manager-komorebi]], [[windows-npu-tiling-strategy]] [[../../unique/index|unique/index]]
 
-#tags: #windows #tiling #komorebi
+#tags: #notes #wm

--- a/docs/notes/wm/templates/README.md
+++ b/docs/notes/wm/templates/README.md
@@ -1,3 +1,5 @@
 # Templates for docs/notes/wm
 
 This folder contains markdown templates for docs/notes/wm.
+
+#tags: #notes #wm

--- a/docs/notes/wm/typescript-group-manager-komorebi.md
+++ b/docs/notes/wm/typescript-group-manager-komorebi.md
@@ -2,4 +2,4 @@ This concept outlines a **TypeScript-based group manager** that watches windows 
 
 Related notes: [[autohotkey-i3-emulation]], [[lisp-window-manager-dsl]] [[../../unique/index|unique/index]]
 
-#tags: #typescript #komorebi #window-management
+#tags: #notes #wm

--- a/docs/notes/wm/windows-npu-tiling-strategy.md
+++ b/docs/notes/wm/windows-npu-tiling-strategy.md
@@ -2,4 +2,4 @@ Running i3 inside WSL doesn't expose the Intel NPU, so the workflow needs to mov
 
 Related notes: [[autohotkey-i3-emulation]], [[nesting-window-containers-windows]] [[../../unique/index|unique/index]]
 
-#tags: #windows #npu #tiling
+#tags: #notes #wm

--- a/docs/research/BuildingTheFields.md
+++ b/docs/research/BuildingTheFields.md
@@ -173,3 +173,5 @@ Ultimately, this franken-brain won’t be a monstrosity but rather a **collectiv
     
 - Meng et al. (2022), _Locating and Editing Factual Associations in GPT (ROME)_ – precise weight updates to modify factual knowledge
 #hashtags: #research #eidolon #promethean
+
+#tags: #research

--- a/docs/research/github_projects_api.md
+++ b/docs/research/github_projects_api.md
@@ -28,3 +28,5 @@ Both APIs accept a personal access token (classic PAT or fine‑grained PAT) wit
 
 ## Recommendation
 Start with the REST API for simplicity if using classic Projects. For Projects v2, plan on using GraphQL.
+
+#tags: #research

--- a/docs/research/templates/README.md
+++ b/docs/research/templates/README.md
@@ -1,3 +1,5 @@
 # Templates for docs/research
 
 This folder contains markdown templates for docs/research.
+
+#tags: #research #template

--- a/docs/settings-hy.md
+++ b/docs/settings-hy.md
@@ -4,3 +4,5 @@ Hy translation of environment-based configuration values.
 Based on `shared/py/settings.py`.
 
 #hashtags: #hy #settings #promethean
+
+#tags: #docs

--- a/docs/stt-app-hy.md
+++ b/docs/stt-app-hy.md
@@ -4,3 +4,5 @@ Hy version of the FastAPI entrypoint for the Speech-to-Text service.
 It mirrors `services/stt/app.py` using Hy syntax.
 
 #hashtags: #hy #stt #service #promethean
+
+#tags: #docs

--- a/docs/templates/README.md
+++ b/docs/templates/README.md
@@ -1,3 +1,5 @@
 # Templates for docs
 
 This folder contains general documentation templates.
+
+#tags: #template

--- a/docs/templates/README.template.md
+++ b/docs/templates/README.template.md
@@ -13,3 +13,5 @@ Brief description of this component or folder.
 - `{{file}}` - description
 
 #hashtags: #template
+
+#tags: #template

--- a/docs/templates/file.doc.template.md
+++ b/docs/templates/file.doc.template.md
@@ -101,3 +101,4 @@ flowchart TD
 
 \#doc #{{language}} #{{layer\_tag}} #{{service\_or\_module}} #{{project\_tag}}
 
+#tags: #template

--- a/docs/templates/service.README.template.md
+++ b/docs/templates/service.README.template.md
@@ -14,3 +14,5 @@ Describe what this service does.
 - `...`
 
 #hashtags: #service #template
+
+#tags: #template

--- a/docs/tts-app-hy.md
+++ b/docs/tts-app-hy.md
@@ -4,3 +4,5 @@ Hy version of the FastAPI entrypoint for the Text-to-Speech service.
 It mirrors `services/tts/app.py` using Hy syntax.
 
 #hashtags: #hy #tts #service #promethean
+
+#tags: #docs

--- a/docs/unique/2025.07.28.11.07.04.md
+++ b/docs/unique/2025.07.28.11.07.04.md
@@ -118,3 +118,5 @@ Let me know and we can:
 You want the real i3 vibes? AHK + Komorebi + your own logic daemon is the only way there on Windows.
 
 Want me to sketch a full i3 keybind layer with workspaces, layout presets, and group cycling in AHK next?
+
+#tags: #journal #unique

--- a/docs/unique/2025.07.28.11.07.18.md
+++ b/docs/unique/2025.07.28.11.07.18.md
@@ -210,3 +210,5 @@ We’re standing at the edge of **building your own tiling window manager stack*
 \#dsl #lisp #tiling-windows #autohotkey #komorebi #custom-wm #group-manager #workspace #keybinds #window-layout
 
 Let’s pick a direction and start implementing. Want a parser next? Or the runtime behavior for `(bind ...)` forms?
+
+#tags: #journal #unique

--- a/docs/unique/2025.07.28.11.07.38.md
+++ b/docs/unique/2025.07.28.11.07.38.md
@@ -193,3 +193,5 @@ You can wire these into **hotkeys via AutoHotKey or PowerToys** later, or even b
 \#window-manager #komorebi #typescript #tiling-windows #npu-compatibility #devtools #windows #custom-wm #framesimulation #obsidian-note #uxdesign
 
 Let me know if you want a Hy or Sibilant version next, or if we should rig this into a persistent system tray app with real-time window tracking.
+
+#tags: #journal #unique

--- a/docs/unique/2025.07.28.11.07.40.md
+++ b/docs/unique/2025.07.28.11.07.40.md
@@ -192,3 +192,5 @@ Supports symbol aliasing, reflection, automatic type coercion.
 You ready to build this? We can start small with a Lisp-like config loader that calls Python and Node libs. Or even build a REPL for hybrid execution.
 
 Where do you want to dig first — the runtime, the DSL grammar, or the package resolution engine?
+
+#tags: #journal #unique

--- a/docs/unique/2025.07.28.11.07.43.md
+++ b/docs/unique/2025.07.28.11.07.43.md
@@ -118,3 +118,5 @@ But Komorebi? That’s your best bet **right now**. If you want help scripting a
 \#windows #tiling-wm #komorebi #glazewm #i3wm #uxdesign #productivity #devtools #nested-layouts #custom-window-manager
 
 Let me know if you want a proof-of-concept Komorebi script or a deeper dive into how to simulate the "group cycling" mechanic.
+
+#tags: #journal #unique

--- a/docs/unique/2025.07.28.11.07.49.md
+++ b/docs/unique/2025.07.28.11.07.49.md
@@ -158,3 +158,5 @@ In Hy → Compiled to Python → Used to generate AHK or invoke `komorebic`
 Want a working example of this DSL in Hy? Or do you want to define the macro system structure first — how do we interpret `bind`, `group`, `layout`, etc.?
 
 We can wire this into your Promethean system too. This could be the language your AI configures *itself* with.
+
+#tags: #journal #unique

--- a/docs/unique/2025.07.28.11.07.68.md
+++ b/docs/unique/2025.07.28.11.07.68.md
@@ -124,3 +124,5 @@ This pattern gives you the **Linux philosophy** on the backend, with **NPU accel
 If you want, I can help you scaffold a `group-manager.ts` or `group_manager.py` service that can sit alongside Komorebi and give you more of the i3-style layout memory.
 
 Would you like me to help sketch that out?
+
+#tags: #journal #unique

--- a/docs/unique/2025.07.28.11.07.93.md
+++ b/docs/unique/2025.07.28.11.07.93.md
@@ -182,3 +182,4 @@ Let me know:
 
 This is where the real fun starts.
 
+#tags: #journal #unique

--- a/docs/unique/2025.07.28.12.07.01.md
+++ b/docs/unique/2025.07.28.12.07.01.md
@@ -155,3 +155,5 @@ So you can do:
 ---
 
 You’ve already got this running in spirit — want me to help wire this into a structured emitter system, where you can define targets and get folder outputs with index files, doc generation, and cross-target output? We could do a whole Sibilant-based code synthesis system.
+
+#tags: #journal #unique

--- a/docs/unique/2025.07.28.12.07.03.md
+++ b/docs/unique/2025.07.28.12.07.03.md
@@ -195,3 +195,5 @@ Your meta runtime becomes a **router** between brains.
 ---
 
 You want to sketch the `MetaObject` and `register-buffer-type` interfaces next? Or write the macro wrapper that detects if a block is cross-runtime and rewrites it to a `send-json` call?
+
+#tags: #journal #unique

--- a/docs/unique/2025.07.28.12.07.18.md
+++ b/docs/unique/2025.07.28.12.07.18.md
@@ -169,3 +169,5 @@ You’re not building a chatbot. You’re building a **mind** that *thinks about
 ---
 
 You want to build `deffragment`, `prompt-memory`, and the first `build-prompt-from` call next? Or define the core data model and memory indexing strategy? We can go either way — just say *deeper*.
+
+#tags: #journal #unique

--- a/docs/unique/2025.07.28.12.07.32.md
+++ b/docs/unique/2025.07.28.12.07.32.md
@@ -162,3 +162,5 @@ Modular and composable.
 ---
 
 Want help building the file emitter? Or should we start implementing macro aliases for a full `stdlib` of cross-language ops?
+
+#tags: #journal #unique

--- a/docs/unique/2025.07.28.12.07.48.md
+++ b/docs/unique/2025.07.28.12.07.48.md
@@ -114,3 +114,5 @@ We can **build the Lisp you saw** with:
 ---
 
 Want me to write the first prototype for this “universal Lisp for Python interop” that mirrors what you’re remembering? Or dig deeper into archival curriculum materials and lost language projects?
+
+#tags: #journal #unique

--- a/docs/unique/2025.07.28.12.07.49.md
+++ b/docs/unique/2025.07.28.12.07.49.md
@@ -75,3 +75,5 @@ That's recursive meta-language design.
 
 Let me know:
 Want to scaffold a Sibilant-powered DSL that compiles to both JS and Python from the same macro set? Or do we start with an interop-focused macro layer that treats languages like modules?
+
+#tags: #journal #unique

--- a/docs/unique/2025.07.28.12.07.79.md
+++ b/docs/unique/2025.07.28.12.07.79.md
@@ -148,3 +148,5 @@ greet("duck");
 ---
 
 Let’s keep going. Want the next phase to flesh out `defmodule` / `emit` / `definterface`, or go deeper on polyglot macro registration + caching per runtime?
+
+#tags: #journal #unique

--- a/docs/unique/2025.07.28.12.07.97.md
+++ b/docs/unique/2025.07.28.12.07.97.md
@@ -90,3 +90,5 @@ We could scaffold:
 ---
 
 Let’s do something wild. Want to define the first `defbind` macro for your tiling WM DSL in Sibilant now? Or build a `target` system so the same macro can compile to Python or JS?
+
+#tags: #journal #unique

--- a/docs/unique/2025.07.28.13.07.01.md
+++ b/docs/unique/2025.07.28.13.07.01.md
@@ -190,3 +190,5 @@ But **all defined in a DSL layer**, where the *target switching, code gen, and e
 ---
 
 Let’s implement the `eval-in` and `start-runtime` macros next? Or wire up a real REPL swapper? This is *Promethean*-tier already.
+
+#tags: #journal #unique

--- a/docs/unique/2025.07.28.13.07.07.md
+++ b/docs/unique/2025.07.28.13.07.07.md
@@ -64,3 +64,5 @@ codex.chat({
 You’re not just writing templates—you’re scripting a mind.
 
 Want to scaffold a sample `.prompt.sibilant` file layout? Or should we write a `render-prompt` function that compiles it into a `.chat` array or raw string?
+
+#tags: #journal #unique

--- a/docs/unique/2025.07.28.13.07.21.md
+++ b/docs/unique/2025.07.28.13.07.21.md
@@ -78,3 +78,5 @@ A declarative and executable s-expression format that encapsulates:
 This gives you a base to build tooling *around* the AI, not just inside of it. You’re not just making an AI—you're making an operating system for cognition. And with this format, anyone can start building tools, UIs, or even games that interact with the mental state itself.
 
 Want me to mock up a directory structure for this kind of `.prompt.sibilant` world? Or do you want to explore the internal DSL for importing and manipulating memory regions first?
+
+#tags: #journal #unique

--- a/docs/unique/2025.07.28.13.07.74.md
+++ b/docs/unique/2025.07.28.13.07.74.md
@@ -112,3 +112,5 @@ This is how we’ll eventually let Sibilant:
 ### 🔧 Want to define the `think-sequence` macro more deeply next?
 
 Or would you rather design a structure for prompt-building (`prompt-compose`, `chunk`, `slot`, etc.)?
+
+#tags: #journal #unique

--- a/docs/unique/2025.07.28.13.07.79.md
+++ b/docs/unique/2025.07.28.13.07.79.md
@@ -172,3 +172,5 @@ Eventually, you can compile:
 
 Let me know:
 Want to sketch `compile-prompt` and a basic `(prompt ...)` macro now? Or start with defining the role/message primitives and build up?
+
+#tags: #journal #unique

--- a/docs/unique/2025.07.28.18.07.20.md
+++ b/docs/unique/2025.07.28.18.07.20.md
@@ -129,3 +129,5 @@ Let me know if you'd like a script to:
 * Suggest concrete next steps for Prompt Refinement → Breakdown flow
 
 We’re entering phase two of the system: **shared cognition**. The board now reflects that.
+
+#tags: #journal #unique

--- a/docs/unique/advanced-node-interaction-diagrams.md
+++ b/docs/unique/advanced-node-interaction-diagrams.md
@@ -77,4 +77,4 @@ Want me to embed these into the **Field Node Lifecycle** document under a “Mor
 
 Related notes: [[../notes/diagrams/node-type-topology-map|node-type-topology-map]], [[../notes/diagrams/circuit-weight-visualizations|circuit-weight-visualizations]], [[../notes/diagrams/full-system-overview-diagrams|full-system-overview-diagrams]], [[../notes/diagrams/layer1-uptime-diagrams|layer1-uptime-diagrams]], [[../notes/diagrams/field-node-lifecycle-additional-diagrams|field-node-lifecycle-additional-diagrams]], [[../notes/diagrams/state-diagram-node-lifecycle|state-diagram-node-lifecycle]] [[index|unique/index]]
 
-#tags: #diagram #design
+#tags: #journal #unique

--- a/docs/unique/aionian-circuit-math.md
+++ b/docs/unique/aionian-circuit-math.md
@@ -142,4 +142,4 @@ Say the word—I'll stack more.
 
 Related notes: [[../notes/math/advanced-field-math|advanced-field-math]], [[../notes/math/aionian-feedback-oscillator|aionian-feedback-oscillator]], [[../notes/math/aionian-pulse-rhythm-model|aionian-pulse-rhythm-model]], [[../notes/math/eidolon-field-math|eidolon-field-math]], [[../notes/math/symbolic-gravity-models|symbolic-gravity-models]] [[index|unique/index]]
 
-#tags: #math #theory
+#tags: #journal #unique

--- a/docs/unique/annotated-fragment-heartbeat-demo.md
+++ b/docs/unique/annotated-fragment-heartbeat-demo.md
@@ -89,4 +89,4 @@ Let me know when you're ready for ripple propagation back into the field — so 
 
 Related notes: [[../notes/simulation/fragment-injection-simulation|fragment-injection-simulation]], [[../notes/simulation/heartbeat-fragment-flow|heartbeat-fragment-flow]], [[../notes/simulation/ripple-propagation-flow|ripple-propagation-flow]] [[index|unique/index]]
 
-#tags: #simulation #design
+#tags: #journal #unique

--- a/docs/unique/comprehensive-system-diagrams.md
+++ b/docs/unique/comprehensive-system-diagrams.md
@@ -184,4 +184,4 @@ Just say *"More, on X"*, and I’ll generate them rapid-fire.
 
 Related notes: [[../notes/diagrams/node-type-topology-map|node-type-topology-map]], [[../notes/diagrams/circuit-weight-visualizations|circuit-weight-visualizations]], [[../notes/diagrams/full-system-overview-diagrams|full-system-overview-diagrams]], [[../notes/diagrams/layer1-uptime-diagrams|layer1-uptime-diagrams]], [[../notes/diagrams/field-node-lifecycle-additional-diagrams|field-node-lifecycle-additional-diagrams]], [[../notes/diagrams/state-diagram-node-lifecycle|state-diagram-node-lifecycle]] [[index|unique/index]]
 
-#tags: #diagram #design
+#tags: #journal #unique

--- a/docs/unique/eidolon-field-math-foundations.md
+++ b/docs/unique/eidolon-field-math-foundations.md
@@ -114,4 +114,4 @@ Say the word—I'll write it up.
 
 Related notes: [[../notes/math/advanced-field-math|advanced-field-math]], [[../notes/math/aionian-feedback-oscillator|aionian-feedback-oscillator]], [[../notes/math/aionian-pulse-rhythm-model|aionian-pulse-rhythm-model]], [[../notes/math/eidolon-field-math|eidolon-field-math]], [[../notes/math/symbolic-gravity-models|symbolic-gravity-models]] [[index|unique/index]]
 
-#tags: #math #theory
+#tags: #journal #unique

--- a/docs/unique/eidolon-node-lifecycle-diagram.md
+++ b/docs/unique/eidolon-node-lifecycle-diagram.md
@@ -22,4 +22,4 @@ stateDiagram-v2
 
 Related notes: [[../notes/diagrams/node-type-topology-map|node-type-topology-map]], [[../notes/diagrams/circuit-weight-visualizations|circuit-weight-visualizations]], [[../notes/diagrams/full-system-overview-diagrams|full-system-overview-diagrams]], [[../notes/diagrams/layer1-uptime-diagrams|layer1-uptime-diagrams]], [[../notes/diagrams/field-node-lifecycle-additional-diagrams|field-node-lifecycle-additional-diagrams]], [[../notes/diagrams/state-diagram-node-lifecycle|state-diagram-node-lifecycle]] [[index|unique/index]]
 
-#tags: #diagram #design
+#tags: #journal #unique

--- a/docs/unique/field-dynamics-math-blocks.md
+++ b/docs/unique/field-dynamics-math-blocks.md
@@ -129,4 +129,4 @@ Next up, I can do:
 
 Related notes: [[../notes/math/advanced-field-math|advanced-field-math]], [[../notes/math/aionian-feedback-oscillator|aionian-feedback-oscillator]], [[../notes/math/aionian-pulse-rhythm-model|aionian-pulse-rhythm-model]], [[../notes/math/eidolon-field-math|eidolon-field-math]], [[../notes/math/symbolic-gravity-models|symbolic-gravity-models]] [[index|unique/index]]
 
-#tags: #math #theory
+#tags: #journal #unique

--- a/docs/unique/field-interaction-equations.md
+++ b/docs/unique/field-interaction-equations.md
@@ -142,4 +142,4 @@ Just say go.
 
 Related notes: [[../notes/math/advanced-field-math|advanced-field-math]], [[../notes/math/aionian-feedback-oscillator|aionian-feedback-oscillator]], [[../notes/math/aionian-pulse-rhythm-model|aionian-pulse-rhythm-model]], [[../notes/math/eidolon-field-math|eidolon-field-math]], [[../notes/math/symbolic-gravity-models|symbolic-gravity-models]] [[index|unique/index]]
 
-#tags: #math #theory
+#tags: #journal #unique

--- a/docs/unique/field-node-diagram-outline.md
+++ b/docs/unique/field-node-diagram-outline.md
@@ -91,4 +91,4 @@ Let’s get visual.
 
 Related notes: [[../notes/diagrams/node-type-topology-map|node-type-topology-map]], [[../notes/diagrams/circuit-weight-visualizations|circuit-weight-visualizations]], [[../notes/diagrams/full-system-overview-diagrams|full-system-overview-diagrams]], [[../notes/diagrams/layer1-uptime-diagrams|layer1-uptime-diagrams]], [[../notes/diagrams/field-node-lifecycle-additional-diagrams|field-node-lifecycle-additional-diagrams]], [[../notes/diagrams/state-diagram-node-lifecycle|state-diagram-node-lifecycle]] [[index|unique/index]]
 
-#tags: #diagram #design
+#tags: #journal #unique

--- a/docs/unique/field-node-diagram-set.md
+++ b/docs/unique/field-node-diagram-set.md
@@ -127,4 +127,4 @@ Let’s go until your working memory caps.
 
 Related notes: [[../notes/diagrams/node-type-topology-map|node-type-topology-map]], [[../notes/diagrams/circuit-weight-visualizations|circuit-weight-visualizations]], [[../notes/diagrams/full-system-overview-diagrams|full-system-overview-diagrams]], [[../notes/diagrams/layer1-uptime-diagrams|layer1-uptime-diagrams]], [[../notes/diagrams/field-node-lifecycle-additional-diagrams|field-node-lifecycle-additional-diagrams]], [[../notes/diagrams/state-diagram-node-lifecycle|state-diagram-node-lifecycle]] [[index|unique/index]]
 
-#tags: #diagram #design
+#tags: #journal #unique

--- a/docs/unique/heartbeat-simulation-snippets.md
+++ b/docs/unique/heartbeat-simulation-snippets.md
@@ -76,4 +76,4 @@ Want the next piece — maybe connecting a ripple callback to update eidolon fie
 
 Related notes: [[../notes/simulation/fragment-injection-simulation|fragment-injection-simulation]], [[../notes/simulation/heartbeat-fragment-flow|heartbeat-fragment-flow]], [[../notes/simulation/ripple-propagation-flow|ripple-propagation-flow]] [[index|unique/index]]
 
-#tags: #simulation #design
+#tags: #journal #unique

--- a/docs/unique/homeostasis-decay-formulas.md
+++ b/docs/unique/homeostasis-decay-formulas.md
@@ -142,4 +142,4 @@ Just say the word and I'll keep firing them.
 
 Related notes: [[../notes/math/advanced-field-math|advanced-field-math]], [[../notes/math/aionian-feedback-oscillator|aionian-feedback-oscillator]], [[../notes/math/aionian-pulse-rhythm-model|aionian-pulse-rhythm-model]], [[../notes/math/eidolon-field-math|eidolon-field-math]], [[../notes/math/symbolic-gravity-models|symbolic-gravity-models]] [[index|unique/index]]
 
-#tags: #math #theory
+#tags: #journal #unique

--- a/docs/unique/index.md
+++ b/docs/unique/index.md
@@ -38,4 +38,5 @@ These notes were originally captured in `docs/unique` with timestamp filenames. 
 - **2025.07.28.13.07.21** → [[../notes/dsl/promethean-state-format|promethean-state-format]]
 - **2025.07.28.13.07.74** → [[../notes/dsl/runtime-and-prompt-macro-dsl|runtime-and-prompt-macro-dsl]]
 - **2025.07.28.13.07.79** → [[../notes/dsl/prompt-compiler-dsl|prompt-compiler-dsl]]
-#tags: #unique #index
+
+#tags: #journal #unique

--- a/docs/unique/layer-1-uptime-diagrams.md
+++ b/docs/unique/layer-1-uptime-diagrams.md
@@ -147,4 +147,4 @@ Just say the word and we’ll expand it.
 
 Related notes: [[../notes/diagrams/node-type-topology-map|node-type-topology-map]], [[../notes/diagrams/circuit-weight-visualizations|circuit-weight-visualizations]], [[../notes/diagrams/full-system-overview-diagrams|full-system-overview-diagrams]], [[../notes/diagrams/layer1-uptime-diagrams|layer1-uptime-diagrams]], [[../notes/diagrams/field-node-lifecycle-additional-diagrams|field-node-lifecycle-additional-diagrams]], [[../notes/diagrams/state-diagram-node-lifecycle|state-diagram-node-lifecycle]] [[index|unique/index]]
 
-#tags: #diagram #design
+#tags: #journal #unique

--- a/docs/unique/ripple-propagation-demo.md
+++ b/docs/unique/ripple-propagation-demo.md
@@ -94,4 +94,4 @@ Let me know when you're ready to start tracking *compound field effects* — or 
 
 Related notes: [[../notes/simulation/fragment-injection-simulation|fragment-injection-simulation]], [[../notes/simulation/heartbeat-fragment-flow|heartbeat-fragment-flow]], [[../notes/simulation/ripple-propagation-flow|ripple-propagation-flow]] [[index|unique/index]]
 
-#tags: #simulation #design
+#tags: #journal #unique

--- a/docs/unique/templates/README.md
+++ b/docs/unique/templates/README.md
@@ -1,3 +1,5 @@
 # Templates for docs/unique
 
 This folder contains markdown templates for docs/unique.
+
+#tags: #journal #unique

--- a/docs/untested-code.md
+++ b/docs/untested-code.md
@@ -15,3 +15,5 @@ Coverage generated with `pytest --cov` showed these modules at **0%** coverage. 
 ---
 
 #hashtags: #testing #coverage #documentation
+
+#tags: #docs

--- a/docs/vault-config-readme.md
+++ b/docs/vault-config-readme.md
@@ -52,3 +52,5 @@ If you're unsure, start with the Kanban.
 ---
 
 #hashtags: #obsidian #vault #setup #docs #knowledge-graph
+
+#tags: #docs

--- a/scripts/add_hashtags.py
+++ b/scripts/add_hashtags.py
@@ -1,0 +1,77 @@
+"""Utility for appending hashtag metadata to documentation files.
+
+The previous implementation simply slugified each filename which resulted in a
+tag per file. That produced an overwhelming and mostly useless tag cloud.  The
+new logic groups files into broader thematic categories based on their folder
+path.  If a file already contains a ``#tags:`` line it will be replaced with the
+new set.
+"""
+
+import os
+import re
+from collections import OrderedDict
+
+ROOT = "docs"
+
+# Mapping of folder prefixes to tag lists.  Keys are checked in order so that
+# more specific paths override generic ones.
+CATEGORY_MAP = OrderedDict(
+    {
+        "agile/Tasks": ["#agile", "#task"],
+        "agile/boards": ["#agile", "#board"],
+        "agile/templates": ["#agile", "#template"],
+        "agile": ["#agile"],
+        "design/circuits": ["#design", "#circuits"],
+        "design/templates": ["#design", "#template"],
+        "design": ["#design"],
+        "notes/diagrams": ["#notes", "#diagram"],
+        "notes/dsl": ["#notes", "#dsl"],
+        "notes/math": ["#notes", "#math"],
+        "notes/simulation": ["#notes", "#simulation"],
+        "notes/templates": ["#notes", "#template"],
+        "notes/wm": ["#notes", "#wm"],
+        "notes": ["#notes"],
+        "research/templates": ["#research", "#template"],
+        "research": ["#research"],
+        "journal/templates": ["#journal", "#template"],
+        "journal": ["#journal"],
+        "unique": ["#journal", "#unique"],
+        "templates": ["#template"],
+    }
+)
+
+
+def determine_tags(relpath: str):
+    """Return a list of tags for a given relative path."""
+    normalized = relpath.replace(os.sep, "/")
+    for prefix, tags in CATEGORY_MAP.items():
+        if normalized.startswith(prefix):
+            return tags
+    # Fallback: use first folder as generic category
+    parts = normalized.split("/")
+    if len(parts) > 1:
+        return [f"#{parts[0].lower()}"]
+    return ["#docs"]
+
+
+tag_line_re = re.compile(r"^#tags:\s*(.*)$", re.MULTILINE)
+
+for dirpath, dirnames, filenames in os.walk(ROOT):
+    for filename in filenames:
+        if not filename.endswith(".md"):
+            continue
+        path = os.path.join(dirpath, filename)
+        rel = os.path.relpath(path, ROOT)
+        tags = determine_tags(rel)
+
+        with open(path, "r", encoding="utf-8") as f:
+            content = f.read()
+
+        if tag_line_re.search(content):
+            content = tag_line_re.sub("", content).rstrip()
+
+        new_line = "\n\n#tags: " + " ".join(tags) + "\n"
+        with open(path, "w", encoding="utf-8") as f:
+            f.write(content.rstrip() + new_line)
+
+        print("Updated tags for", path)


### PR DESCRIPTION
## Summary
- categorize documentation tags using new helper script
- regenerate tag metadata across docs

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for dependencies)*
- `npm test` *(fails: ts-node module not found)*

------
https://chatgpt.com/codex/tasks/task_e_6888737d56f08324b5b21ce620d47230