### PR TITLE
Refine AI collaboration in agile docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,6 +84,8 @@ Codex is **not** allowed to:
 
 ## 🧠 Codex Mode Integration
 
+Codex collaborates with the board manager agent described in
+`docs/agile/AGENTS.md` to keep tasks in sync with the kanban workflow.
 Codex mode can:
 
 * Read from Obsidian Kanban boards, if they are stored in `docs/kanban.md` or elsewhere in the vault

--- a/docs/agile/AGENTS.md
+++ b/docs/agile/AGENTS.md
@@ -1,6 +1,9 @@
 # 🤖 Agent: Board Manager
 
 This agent is responsible for maintaining and navigating the Kanban board in `agile/boards/kanban`.
+It acts as the glue between human contributors and Codex by interpreting board
+states, enforcing WIP limits, and prompting Codex when a card carries the
+`#codex-task` tag.
 
 ---
 

--- a/docs/agile/Process.md
+++ b/docs/agile/Process.md
@@ -131,6 +131,15 @@ Needs written `AGENT.md`, docstrings, or Markdown notes.
 
 Confirmed complete and aligned with system.
 
+## 🤖 Agent Collaboration
+
+Codex and the board manager agent participate throughout this flow. The board
+manager keeps tasks synced between the Kanban board and `agile/tasks/`, while
+Codex provides code or documentation when a card carries the `#codex-task` tag.
+During **Prompt Refinement** and **Agent Thinking**, the user and the agent talk
+through rough ideas until they can be broken down into actionable work. The agent
+suggests board movements based on metadata and helps enforce WIP limits.
+
 ---
 
 ## 🏷 Tags


### PR DESCRIPTION
## Summary
- clarify the board manager's role as a glue between contributors and Codex
- document how Codex collaborates with the board manager
- add an **Agent Collaboration** section describing how agents fit into the workflow

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888759f23048324822cdfe57d743024