### PR TITLE
Add testing improvement tasks

### DIFF
--- a/docs/agile/boards/kanban.md
+++ b/docs/agile/boards/kanban.md
@@ -50,7 +50,6 @@ kanban-plugin: board
 - [ ] [Add starter notes - eidolon\_fields, cephalon\_inner\_monologue](../tasks/Add%20starter%20notes%20-%20eidolon_fields,%20cephalon_inner_monologue.md)
 - [ ] [Smart Task templater](../tasks/Smart%20Task%20templater.md)
 - [ ] [Start Eidolon](../tasks/Start%20Eidolon.md)
-- [ ] Write meaningful tests for Cephalon
 - [ ] [Create vault-config .obsidian with Kanban and minimal vault setup](../tasks/Create%20vault-config%20.obsidian%20with%20Kanban%20and%20minimal%20vault%20setup.md)
 
 
@@ -63,6 +62,15 @@ kanban-plugin: board
 ## Breakdown (10)
 
 - [ ] [Migrate server side sibilant libs to promethean architecture](../tasks/Migrate%20server%20side%20sibilant%20libs%20to%20promethean%20architecture.md)
+- [ ] [Add unit tests for date_tools.py](../tasks/Add_unit_tests_for_date_tools.py.md) #codex-task #testing
+- [ ] [Add unit tests for GUI helpers](../tasks/Add_unit_tests_for_gui_helpers.md) #codex-task #testing
+- [ ] [Add unit tests for wav_processing](../tasks/Add_unit_tests_for_wav_processing.md) #codex-task #testing
+- [ ] [Add STT service tests](../tasks/Add_STT_service_tests.md) #codex-task #testing
+- [ ] [Add TTS service tests](../tasks/Add_TTS_service_tests.md) #codex-task #testing
+- [ ] [Write meaningful tests for Cephalon](../tasks/Write_meaningful_tests_for_Cephalon.md) #codex-task #testing
+- [ ] [Fix Makefile test target](../tasks/Fix_makefile_test_target.md) #codex-task #testing
+- [ ] [Document local testing setup](../tasks/Document_local_testing_setup.md) #codex-task #testing
+- [ ] [Finalize STT workflow](../tasks/Finalize_STT_workflow.md) #codex-task #testing
 
 
 ## Blocked

--- a/docs/agile/tasks/Add_STT_service_tests.md
+++ b/docs/agile/tasks/Add_STT_service_tests.md
@@ -1,0 +1,39 @@
+## 🛠️ Task: Add STT service tests
+
+Create unit tests for the speech-to-text service in `services/stt/`.
+
+---
+
+## 🎯 Goals
+- Verify `transcribe_file` produces expected text
+- Lay groundwork for integration tests
+
+---
+
+## 📦 Requirements
+- [ ] Use small audio samples
+- [ ] Mock external model calls where possible
+
+---
+
+## 📋 Subtasks
+- [ ] Test CLI transcription
+- [ ] Test API endpoint behaviour if available
+
+---
+
+## 🔗 Related Epics
+#codex-task #testing
+
+---
+
+## ⛓️ Blocked By
+Nothing
+
+## ⛓️ Blocks
+Nothing
+
+---
+
+## 🔍 Relevant Links
+- [kanban](../boards/kanban.md)

--- a/docs/agile/tasks/Add_TTS_service_tests.md
+++ b/docs/agile/tasks/Add_TTS_service_tests.md
@@ -1,0 +1,39 @@
+## 🛠️ Task: Add TTS service tests
+
+Create unit tests for the text-to-speech service in `services/tts/`.
+
+---
+
+## 🎯 Goals
+- Validate audio output for given text
+- Ensure API endpoints respond correctly
+
+---
+
+## 📦 Requirements
+- [ ] Use sample text phrases
+- [ ] Mock model inference calls
+
+---
+
+## 📋 Subtasks
+- [ ] Test synthesis function
+- [ ] Test HTTP handler if present
+
+---
+
+## 🔗 Related Epics
+#codex-task #testing
+
+---
+
+## ⛓️ Blocked By
+Nothing
+
+## ⛓️ Blocks
+Nothing
+
+---
+
+## 🔍 Relevant Links
+- [kanban](../boards/kanban.md)

--- a/docs/agile/tasks/Add_unit_tests_for_date_tools.py.md
+++ b/docs/agile/tasks/Add_unit_tests_for_date_tools.py.md
@@ -1,0 +1,40 @@
+## 🛠️ Task: Add unit tests for date_tools.py
+
+Write pytest tests covering functions in `shared/py/date_tools.py`.
+
+---
+
+## 🎯 Goals
+- Achieve at least 90% coverage for this module
+- Ensure edge cases for `time_ago` and related utilities are tested
+
+---
+
+## 📦 Requirements
+- [ ] Use pytest with clear assertions
+- [ ] Include small datetime fixtures
+
+---
+
+## 📋 Subtasks
+- [ ] Test `time_ago` relative formatting
+- [ ] Test `days_until` calculation
+
+---
+
+## 🔗 Related Epics
+#codex-task #testing
+
+---
+
+## ⛓️ Blocked By
+Nothing
+
+## ⛓️ Blocks
+Nothing
+
+---
+
+## 🔍 Relevant Links
+- [kanban](../boards/kanban.md)
+- [Untested modules](../../untested-code.md)

--- a/docs/agile/tasks/Add_unit_tests_for_gui_helpers.md
+++ b/docs/agile/tasks/Add_unit_tests_for_gui_helpers.md
@@ -1,0 +1,40 @@
+## 🛠️ Task: Add unit tests for GUI helpers
+
+Cover `shared/py/utils/gui.py` with pytest.
+
+---
+
+## 🎯 Goals
+- Verify widget creation and layout helpers
+- Improve maintainability of GUI utilities
+
+---
+
+## 📦 Requirements
+- [ ] Mock Tkinter root objects
+- [ ] Avoid real window rendering
+
+---
+
+## 📋 Subtasks
+- [ ] Test `build_root_window`
+- [ ] Test default widget options
+
+---
+
+## 🔗 Related Epics
+#codex-task #testing
+
+---
+
+## ⛓️ Blocked By
+Nothing
+
+## ⛓️ Blocks
+Nothing
+
+---
+
+## 🔍 Relevant Links
+- [kanban](../boards/kanban.md)
+- [Untested modules](../../untested-code.md)

--- a/docs/agile/tasks/Add_unit_tests_for_wav_processing.md
+++ b/docs/agile/tasks/Add_unit_tests_for_wav_processing.md
@@ -1,0 +1,40 @@
+## 🛠️ Task: Add unit tests for wav_processing
+
+Improve coverage of `shared/py/utils/wav_processing.py`.
+
+---
+
+## 🎯 Goals
+- Exercise batch conversion and resampling functions
+- Ensure correct handling of edge cases
+
+---
+
+## 📦 Requirements
+- [ ] Provide small sample wav fixtures
+- [ ] Use pytest
+
+---
+
+## 📋 Subtasks
+- [ ] Test `batch_convert`
+- [ ] Test `resample`
+
+---
+
+## 🔗 Related Epics
+#codex-task #testing
+
+---
+
+## ⛓️ Blocked By
+Nothing
+
+## ⛓️ Blocks
+Nothing
+
+---
+
+## 🔍 Relevant Links
+- [kanban](../boards/kanban.md)
+- [Untested modules](../../untested-code.md)

--- a/docs/agile/tasks/Document_local_testing_setup.md
+++ b/docs/agile/tasks/Document_local_testing_setup.md
@@ -1,0 +1,40 @@
+## 🛠️ Task: Document local testing setup
+
+Running `pytest` locally fails without extra dependencies.
+
+---
+
+## 🎯 Goals
+- Provide clear installation steps for developers
+- Align Makefile commands with CI
+
+---
+
+## 📦 Requirements
+- [ ] List Python packages required for tests
+- [ ] Mention npm setup for JS services
+
+---
+
+## 📋 Subtasks
+- [ ] Update `readme.md` test section
+- [ ] Add optional `make setup-tests` target
+
+---
+
+## 🔗 Related Epics
+#codex-task #testing
+
+---
+
+## ⛓️ Blocked By
+Nothing
+
+## ⛓️ Blocks
+Nothing
+
+---
+
+## 🔍 Relevant Links
+- [kanban](../boards/kanban.md)
+- [ci docs](../../ci.md)

--- a/docs/agile/tasks/Finalize_STT_workflow.md
+++ b/docs/agile/tasks/Finalize_STT_workflow.md
@@ -1,0 +1,40 @@
+## 🛠️ Task: Finalize STT workflow
+
+The STT service has a GitHub workflow but no requirements file.
+
+---
+
+## 🎯 Goals
+- Provide `requirements.txt` for STT tests
+- Ensure workflow installs dependencies correctly
+
+---
+
+## 📦 Requirements
+- [ ] Add a minimal `requirements.txt` to `services/stt`
+- [ ] Update `python-tests.yml` accordingly
+
+---
+
+## 📋 Subtasks
+- [ ] Define dependencies needed for STT
+- [ ] Verify workflow passes in CI
+
+---
+
+## 🔗 Related Epics
+#codex-task #testing
+
+---
+
+## ⛓️ Blocked By
+Nothing
+
+## ⛓️ Blocks
+Nothing
+
+---
+
+## 🔍 Relevant Links
+- [kanban](../boards/kanban.md)
+- [python-tests.yml](../../services/stt/.github/workflows/python-tests.yml)

--- a/docs/agile/tasks/Fix_makefile_test_target.md
+++ b/docs/agile/tasks/Fix_makefile_test_target.md
@@ -1,0 +1,39 @@
+## 🛠️ Task: Fix Makefile test target
+
+The `test-python` target points to `tests/python/` but tests live in `tests/`.
+
+---
+
+## 🎯 Goals
+- Ensure `make test` runs all Python tests
+- Prevent false confidence in CI results
+
+---
+
+## 📦 Requirements
+- [ ] Update the Makefile target
+- [ ] Document correct usage in `readme.md`
+
+---
+
+## 📋 Subtasks
+- [ ] Modify `test-python` path
+- [ ] Run `make test` locally to confirm
+
+---
+
+## 🔗 Related Epics
+#codex-task #testing
+
+---
+
+## ⛓️ Blocked By
+Nothing
+
+## ⛓️ Blocks
+Nothing
+
+---
+
+## 🔍 Relevant Links
+- [kanban](../boards/kanban.md)

--- a/docs/agile/tasks/Write_meaningful_tests_for_Cephalon.md
+++ b/docs/agile/tasks/Write_meaningful_tests_for_Cephalon.md
@@ -1,0 +1,39 @@
+## 🛠️ Task: Write meaningful tests for Cephalon
+
+Cover core functions of the Cephalon service with automated tests.
+
+---
+
+## 🎯 Goals
+- Validate message routing and embedding logic
+- Protect against regression in conversation flow
+
+---
+
+## 📦 Requirements
+- [ ] Use pytest
+- [ ] Mock dependencies like embeddings and STT/TTS calls
+
+---
+
+## 📋 Subtasks
+- [ ] Test command router behaviour
+- [ ] Test memory update logic
+
+---
+
+## 🔗 Related Epics
+#codex-task #testing
+
+---
+
+## ⛓️ Blocked By
+Nothing
+
+## ⛓️ Blocks
+Nothing
+
+---
+
+## 🔍 Relevant Links
+- [kanban](../boards/kanban.md)


### PR DESCRIPTION
## Summary
- generate tasks for untested modules and services
- track local test setup and workflow fixes
- add tasks to the Breakdown column

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688873afb44c8324bf3322ee48b85b5a