### PR TITLE
Move tasks to prompt refinement

### DIFF
--- a/docs/agile/boards/kanban.md
+++ b/docs/agile/boards/kanban.md
@@ -22,14 +22,6 @@ kanban-plugin: board
 
 ## Incoming
 
-- [ ] Clearly seperate service dependency  files
-- [ ] seperate all  testing pipelines  in github Actions
-- [ ] Move all testing to individual  services
-- [ ] update github actions to use makefile
-- [ ] Update makefile to have commands specific for agents
-- [ ] Update cephalon to use custom embedding function
-
-
 ## Rejected
 
 - [ ] [Write vault-config README.md for Obsidian vault onboarding](../tasks/Write%20vault-config%20README.md%20for%20Obsidian%20vault%20onboarding.md) #Duplicate
@@ -51,6 +43,12 @@ kanban-plugin: board
 - [ ] [Smart Task templater](../tasks/Smart%20Task%20templater.md)
 - [ ] [Start Eidolon](../tasks/Start%20Eidolon.md)
 - [ ] [Create vault-config .obsidian with Kanban and minimal vault setup](../tasks/Create%20vault-config%20.obsidian%20with%20Kanban%20and%20minimal%20vault%20setup.md)
+- [ ] [Clearly separate service dependency files](../tasks/Clearly%20separate%20service%20dependency%20files.md)
+- [ ] [Separate all testing pipelines in GitHub Actions](../tasks/separate%20all%20testing%20pipelines%20in%20github%20Actions.md)
+- [ ] [Move all testing to individual services](../tasks/Move%20all%20testing%20to%20individual%20services.md)
+- [ ] [Update GitHub Actions to use makefile](../tasks/update%20github%20actions%20to%20use%20makefile.md)
+- [ ] [Update makefile to have commands specific for agents](../tasks/Update%20makefile%20to%20have%20commands%20specific%20for%20agents.md)
+- [ ] [Update cephalon to use custom embedding function](../tasks/Update%20cephalon%20to%20use%20custom%20embedding%20function.md)
 
 
 ## Agent thinking

--- a/docs/agile/tasks/Clearly separate service dependency files.md
+++ b/docs/agile/tasks/Clearly separate service dependency files.md
@@ -1,0 +1,54 @@
+## 🛠️ Task: Clearly separate service dependency files
+
+Create isolated dependency manifests for each service so they can be installed
+independently. Currently some packages are shared in the root `package.json`
+and `Pipfile`, which complicates per-service deployment.
+
+---
+
+## 🎯 Goals
+
+- Each service should declare its own Python and Node dependencies
+  (`requirements.txt` or `package.json`).
+- Reduce cross‑service coupling in the root manifests.
+- Document how to install dependencies for an individual service.
+
+---
+
+## 📦 Requirements
+
+- [ ] Audit existing packages in the root manifests.
+- [ ] Move service‑specific libraries into the corresponding service folder.
+- [ ] Keep shared dev tooling (lint, test runners) at the repository root.
+- [ ] Update documentation to describe per‑service setup.
+
+---
+
+## 📋 Subtasks
+
+- [ ] List all current dependencies by service.
+- [ ] Create `requirements.txt` or `package.json` as needed.
+- [ ] Update the Makefile to install dependencies per service.
+- [ ] Clean up obsolete references in the root manifests.
+
+---
+
+## 🔗 Related Epics
+
+#framework-core
+
+---
+
+## ⛓️ Blocked By
+
+Nothing
+
+## ⛓️ Blocks
+
+Nothing
+
+---
+
+## 🔍 Relevant Links
+
+- [kanban](../boards/kanban.md)

--- a/docs/agile/tasks/Move all testing to individual services.md
+++ b/docs/agile/tasks/Move all testing to individual services.md
@@ -1,53 +1,40 @@
 ## 🛠️ Task: Move all testing to individual services
 
-Testing currently runs from the repo root which makes it hard to target a
-single service. Move test suites so they live alongside their respective
-service code and can be executed independently.
+Testing should run within each service directory to better reflect microservice boundaries and speed CI. The design plan favors modular pipelines.
 
 ---
 
 ## 🎯 Goals
-
-- Each service should provide its own `tests/` directory.
-- Running `npm test` or `pytest` within a service runs only that service's
-  suite.
-- CI jobs can trigger tests selectively based on touched code.
+- Place test suites next to service code
+- Remove root-level test runners
 
 ---
 
 ## 📦 Requirements
-
-- [ ] Split existing consolidated tests by service.
-- [ ] Ensure shared utilities still import correctly.
-- [ ] Provide a convenience command in the Makefile for running all tests.
+- [ ] Relocate existing tests into their corresponding service folders
+- [ ] Update import paths and fixtures
 
 ---
 
 ## 📋 Subtasks
-
-- [ ] Identify current test locations and map to target services.
-- [ ] Move or copy files to `services/<name>/tests`.
-- [ ] Update import paths and fixtures as needed.
-- [ ] Adjust CI configuration to run tests per service.
+- [ ] Migrate Python tests
+- [ ] Migrate Node tests
+- [ ] Verify `pytest` and `ava` configs per service
 
 ---
 
 ## 🔗 Related Epics
-
-#framework-core
+#cicd #framework-core
 
 ---
 
 ## ⛓️ Blocked By
-
-Nothing
+- seperate all testing pipelines in GitHub Actions
 
 ## ⛓️ Blocks
-
 Nothing
 
 ---
 
 ## 🔍 Relevant Links
-
 - [kanban](../boards/kanban.md)

--- a/docs/agile/tasks/Move all testing to individual services.md
+++ b/docs/agile/tasks/Move all testing to individual services.md
@@ -1,0 +1,53 @@
+## 🛠️ Task: Move all testing to individual services
+
+Testing currently runs from the repo root which makes it hard to target a
+single service. Move test suites so they live alongside their respective
+service code and can be executed independently.
+
+---
+
+## 🎯 Goals
+
+- Each service should provide its own `tests/` directory.
+- Running `npm test` or `pytest` within a service runs only that service's
+  suite.
+- CI jobs can trigger tests selectively based on touched code.
+
+---
+
+## 📦 Requirements
+
+- [ ] Split existing consolidated tests by service.
+- [ ] Ensure shared utilities still import correctly.
+- [ ] Provide a convenience command in the Makefile for running all tests.
+
+---
+
+## 📋 Subtasks
+
+- [ ] Identify current test locations and map to target services.
+- [ ] Move or copy files to `services/<name>/tests`.
+- [ ] Update import paths and fixtures as needed.
+- [ ] Adjust CI configuration to run tests per service.
+
+---
+
+## 🔗 Related Epics
+
+#framework-core
+
+---
+
+## ⛓️ Blocked By
+
+Nothing
+
+## ⛓️ Blocks
+
+Nothing
+
+---
+
+## 🔍 Relevant Links
+
+- [kanban](../boards/kanban.md)

--- a/docs/agile/tasks/Update cephalon to use custom embedding function.md
+++ b/docs/agile/tasks/Update cephalon to use custom embedding function.md
@@ -1,53 +1,41 @@
 ## 🛠️ Task: Update cephalon to use custom embedding function
 
-Cephalon currently relies on standard sentence-transformer embeddings. We want
-to experiment with a custom embedding function tailored to the agent's memory
-model. This requires wiring the new function into the existing embedding
-pipeline and providing a fallback to the default implementation.
+Design notes point toward replacing the default Chroma embeddings with a lightweight Python service. Cephalon should call this service when generating context vectors.
 
 ---
 
 ## 🎯 Goals
-
-- Improve retrieval quality for Cephalon's long-term memory store.
-- Allow plug‑and‑play embedding functions via configuration.
-- Provide benchmarks comparing the custom function to the baseline.
+- Decouple embedding logic from Node code
+- Allow experimentation with alternative models
 
 ---
 
 ## 📦 Requirements
-
-- [ ] Implement pluggable embedding interface in `cephalon/src`.
-- [ ] Add a config option to select the custom function.
-- [ ] Document how to enable or disable the feature.
+- [ ] Implement API calls to the embedding service
+- [ ] Remove old Chroma dependency
 
 ---
 
 ## 📋 Subtasks
-
-- [ ] Draft TypeScript interface for embedding providers.
-- [ ] Implement wrapper around the custom embedding library.
-- [ ] Update tests to validate new embeddings are generated.
-- [ ] Provide migration notes in the README.
+- [ ] Define request/response schema in `bridge/protocols`
+- [ ] Update `cephalon/src` to fetch embeddings asynchronously
+- [ ] Write unit tests for the new helper
 
 ---
 
 ## 🔗 Related Epics
-
 #framework-core
 
 ---
 
 ## ⛓️ Blocked By
-
 Nothing
 
 ## ⛓️ Blocks
-
 Nothing
 
 ---
 
 ## 🔍 Relevant Links
-
 - [kanban](../boards/kanban.md)
+- [pseudo/eidolon-field-scratchpad.lisp](../../pseudo/eidolon-field-scratchpad.lisp)

--- a/docs/agile/tasks/Update cephalon to use custom embedding function.md
+++ b/docs/agile/tasks/Update cephalon to use custom embedding function.md
@@ -1,0 +1,53 @@
+## 🛠️ Task: Update cephalon to use custom embedding function
+
+Cephalon currently relies on standard sentence-transformer embeddings. We want
+to experiment with a custom embedding function tailored to the agent's memory
+model. This requires wiring the new function into the existing embedding
+pipeline and providing a fallback to the default implementation.
+
+---
+
+## 🎯 Goals
+
+- Improve retrieval quality for Cephalon's long-term memory store.
+- Allow plug‑and‑play embedding functions via configuration.
+- Provide benchmarks comparing the custom function to the baseline.
+
+---
+
+## 📦 Requirements
+
+- [ ] Implement pluggable embedding interface in `cephalon/src`.
+- [ ] Add a config option to select the custom function.
+- [ ] Document how to enable or disable the feature.
+
+---
+
+## 📋 Subtasks
+
+- [ ] Draft TypeScript interface for embedding providers.
+- [ ] Implement wrapper around the custom embedding library.
+- [ ] Update tests to validate new embeddings are generated.
+- [ ] Provide migration notes in the README.
+
+---
+
+## 🔗 Related Epics
+
+#framework-core
+
+---
+
+## ⛓️ Blocked By
+
+Nothing
+
+## ⛓️ Blocks
+
+Nothing
+
+---
+
+## 🔍 Relevant Links
+
+- [kanban](../boards/kanban.md)

--- a/docs/agile/tasks/Update makefile to have commands specific for agents.md
+++ b/docs/agile/tasks/Update makefile to have commands specific for agents.md
@@ -1,0 +1,52 @@
+## 🛠️ Task: Update makefile to have commands specific for agents
+
+Extend the project Makefile with helper commands for managing individual
+agents. Each agent should have shortcuts for install, run and clean steps so
+contributors can work on them without affecting the rest of the repo.
+
+---
+
+## 🎯 Goals
+
+- Provide `make agent-<name>` style commands to start a specific agent.
+- Simplify setup with `make install-<name>` for agent dependencies.
+- Keep the Makefile readable and documented.
+
+---
+
+## 📦 Requirements
+
+- [ ] Discover all agent entry points in `agents/`.
+- [ ] Add `install`, `start` and `clean` targets per agent.
+- [ ] Document the commands in `agents/README.md`.
+
+---
+
+## 📋 Subtasks
+
+- [ ] Audit current Makefile and identify common patterns.
+- [ ] Create templated rules for agent actions.
+- [ ] Test commands against at least one agent (Duck).
+- [ ] Update CI scripts if necessary.
+
+---
+
+## 🔗 Related Epics
+
+#framework-core
+
+---
+
+## ⛓️ Blocked By
+
+Nothing
+
+## ⛓️ Blocks
+
+Nothing
+
+---
+
+## 🔍 Relevant Links
+
+- [kanban](../boards/kanban.md)

--- a/docs/agile/tasks/Update makefile to have commands specific for agents.md
+++ b/docs/agile/tasks/Update makefile to have commands specific for agents.md
@@ -1,52 +1,41 @@
-## 🛠️ Task: Update makefile to have commands specific for agents
+## 🛠️ Task: Update Makefile to have commands specific for agents
 
-Extend the project Makefile with helper commands for managing individual
-agents. Each agent should have shortcuts for install, run and clean steps so
-contributors can work on them without affecting the rest of the repo.
+The monorepo hosts multiple agents. The Makefile should expose targets to launch or test each agent individually as referenced in the migration plan.
 
 ---
 
 ## 🎯 Goals
-
-- Provide `make agent-<name>` style commands to start a specific agent.
-- Simplify setup with `make install-<name>` for agent dependencies.
-- Keep the Makefile readable and documented.
+- `make start:duck` or similar commands
+- Reusable patterns for any future agent
 
 ---
 
 ## 📦 Requirements
-
-- [ ] Discover all agent entry points in `agents/`.
-- [ ] Add `install`, `start` and `clean` targets per agent.
-- [ ] Document the commands in `agents/README.md`.
+- [ ] Define agent-specific PM2 targets
+- [ ] Document usage in the root README
 
 ---
 
 ## 📋 Subtasks
-
-- [ ] Audit current Makefile and identify common patterns.
-- [ ] Create templated rules for agent actions.
-- [ ] Test commands against at least one agent (Duck).
-- [ ] Update CI scripts if necessary.
+- [ ] Extend current Makefile with per-agent start/stop
+- [ ] Provide example for Duck
+- [ ] Add placeholder for new agents
 
 ---
 
 ## 🔗 Related Epics
-
-#framework-core
+#devops
 
 ---
 
 ## ⛓️ Blocked By
-
-Nothing
+- update GitHub Actions to use makefile
 
 ## ⛓️ Blocks
-
 Nothing
 
 ---
 
 ## 🔍 Relevant Links
-
 - [kanban](../boards/kanban.md)
+- [MIGRATION_PLAN](../MIGRATION_PLAN.md)

--- a/docs/agile/tasks/separate all testing pipelines in github Actions.md
+++ b/docs/agile/tasks/separate all testing pipelines in github Actions.md
@@ -1,0 +1,52 @@
+## 🛠️ Task: Separate all testing pipelines in GitHub Actions
+
+Currently a single workflow runs all tests together, which slows feedback and
+makes failures hard to trace. Split the CI configuration so each service has
+its own test job.
+
+---
+
+## 🎯 Goals
+
+- Allow independent failure reporting per service.
+- Speed up CI by running jobs in parallel.
+- Provide a clear pattern for adding new services in the future.
+
+---
+
+## 📦 Requirements
+
+- [ ] Create one workflow file per service under `.github/workflows`.
+- [ ] Share common setup steps via a reusable action or composite script.
+- [ ] Trigger the appropriate workflow only when files under that service change.
+
+---
+
+## 📋 Subtasks
+
+- [ ] Audit existing `test.yml` workflow.
+- [ ] Duplicate and modify jobs for `cephalon`, `stt`, `tts`, etc.
+- [ ] Configure path filters for each workflow.
+- [ ] Update documentation on CI usage.
+
+---
+
+## 🔗 Related Epics
+
+#framework-core
+
+---
+
+## ⛓️ Blocked By
+
+Nothing
+
+## ⛓️ Blocks
+
+Nothing
+
+---
+
+## 🔍 Relevant Links
+
+- [kanban](../boards/kanban.md)

--- a/docs/agile/tasks/update github actions to use makefile.md
+++ b/docs/agile/tasks/update github actions to use makefile.md
@@ -1,52 +1,41 @@
-## 🛠️ Task: Update GitHub Actions to use makefile
+## 🛠️ Task: update GitHub Actions to use Makefile
 
-Our CI scripts currently duplicate install and build logic. By invoking the
-Makefile we can keep the workflow files minimal and ensure local and CI steps
-stay in sync.
+CI workflows should call standardized Makefile targets rather than duplicating commands. This keeps automation consistent with the design docs.
 
 ---
 
 ## 🎯 Goals
-
-- Delegate build and test steps to `make` commands.
-- Reduce maintenance overhead when build logic changes.
-- Demonstrate usage of the Makefile in automation.
+- Invoke `make test` and `make build` from workflows
+- Reduce script duplication across jobs
 
 ---
 
 ## 📦 Requirements
-
-- [ ] Add `make ci` target that installs deps and runs tests.
-- [ ] Modify existing workflow files to call `make ci`.
-- [ ] Ensure matrix jobs still set up language runtimes properly.
+- [ ] Modify existing workflow files to call Makefile targets
+- [ ] Ensure the Makefile covers setup for all services
 
 ---
 
 ## 📋 Subtasks
-
-- [ ] Implement `make ci` in the Makefile.
-- [ ] Update `.github/workflows/test.yml` (or equivalents) to use it.
-- [ ] Remove redundant install commands from workflows.
-- [ ] Verify workflows pass locally via `act` or remote run.
+- [ ] Audit current workflow steps
+- [ ] Add `make lint` and `make test` usage
+- [ ] Verify environment variables for PM2
 
 ---
 
 ## 🔗 Related Epics
-
-#framework-core
+#cicd #devops
 
 ---
 
 ## ⛓️ Blocked By
-
-Nothing
+- Clearly seperate service dependency files
 
 ## ⛓️ Blocks
-
-Nothing
+- Update Makefile to have commands specific for agents
 
 ---
 
 ## 🔍 Relevant Links
-
 - [kanban](../boards/kanban.md)
+- [Process](../Process.md)

--- a/docs/agile/tasks/update github actions to use makefile.md
+++ b/docs/agile/tasks/update github actions to use makefile.md
@@ -1,0 +1,52 @@
+## 🛠️ Task: Update GitHub Actions to use makefile
+
+Our CI scripts currently duplicate install and build logic. By invoking the
+Makefile we can keep the workflow files minimal and ensure local and CI steps
+stay in sync.
+
+---
+
+## 🎯 Goals
+
+- Delegate build and test steps to `make` commands.
+- Reduce maintenance overhead when build logic changes.
+- Demonstrate usage of the Makefile in automation.
+
+---
+
+## 📦 Requirements
+
+- [ ] Add `make ci` target that installs deps and runs tests.
+- [ ] Modify existing workflow files to call `make ci`.
+- [ ] Ensure matrix jobs still set up language runtimes properly.
+
+---
+
+## 📋 Subtasks
+
+- [ ] Implement `make ci` in the Makefile.
+- [ ] Update `.github/workflows/test.yml` (or equivalents) to use it.
+- [ ] Remove redundant install commands from workflows.
+- [ ] Verify workflows pass locally via `act` or remote run.
+
+---
+
+## 🔗 Related Epics
+
+#framework-core
+
+---
+
+## ⛓️ Blocked By
+
+Nothing
+
+## ⛓️ Blocks
+
+Nothing
+
+---
+
+## 🔍 Relevant Links
+
+- [kanban](../boards/kanban.md)


### PR DESCRIPTION
## Summary
- move recently added tasks from **Incoming** to **Prompt refinement** in `kanban.md`
- flesh out placeholder docs for new tasks

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688873968f5c83249befb62ecd571ba0