### PR TITLE
Add design-derived tasks

### DIFF
--- a/docs/agile/Tasks/Clearly seperate service dependency files.md
+++ b/docs/agile/Tasks/Clearly seperate service dependency files.md
@@ -1,0 +1,42 @@
+## 🛠️ Task: Clearly seperate service dependency files
+
+Each service should maintain its own dependency declarations so deployments remain isolated. Refer to the design notes in `file-structure.md` and the migration plan for guidance.
+
+---
+
+## 🎯 Goals
+- Distinct `requirements.txt` or `package.json` for every service
+- Document dependency layout in `/docs/file-structure.md`
+
+---
+
+## 📦 Requirements
+- [ ] Audit current shared dependency usage
+- [ ] Create per-service files and update CI accordingly
+
+---
+
+## 📋 Subtasks
+- [ ] Split Python requirements by service
+- [ ] Split Node dependencies by service
+- [ ] Update documentation with examples
+
+---
+
+## 🔗 Related Epics
+#devops #cicd
+
+---
+
+## ⛓️ Blocked By
+Nothing
+
+## ⛓️ Blocks
+- Update GitHub Actions to use makefile
+
+---
+
+## 🔍 Relevant Links
+- [kanban](../boards/kanban.md)
+- [file-structure](../file-structure.md)
+- [MIGRATION_PLAN](../MIGRATION_PLAN.md)

--- a/docs/agile/Tasks/Move all testing to individual services.md
+++ b/docs/agile/Tasks/Move all testing to individual services.md
@@ -1,0 +1,40 @@
+## 🛠️ Task: Move all testing to individual services
+
+Testing should run within each service directory to better reflect microservice boundaries and speed CI. The design plan favors modular pipelines.
+
+---
+
+## 🎯 Goals
+- Place test suites next to service code
+- Remove root-level test runners
+
+---
+
+## 📦 Requirements
+- [ ] Relocate existing tests into their corresponding service folders
+- [ ] Update import paths and fixtures
+
+---
+
+## 📋 Subtasks
+- [ ] Migrate Python tests
+- [ ] Migrate Node tests
+- [ ] Verify `pytest` and `ava` configs per service
+
+---
+
+## 🔗 Related Epics
+#cicd #framework-core
+
+---
+
+## ⛓️ Blocked By
+- seperate all testing pipelines in GitHub Actions
+
+## ⛓️ Blocks
+Nothing
+
+---
+
+## 🔍 Relevant Links
+- [kanban](../boards/kanban.md)

--- a/docs/agile/Tasks/Update cephalon to use custom embedding function.md
+++ b/docs/agile/Tasks/Update cephalon to use custom embedding function.md
@@ -1,0 +1,41 @@
+## 🛠️ Task: Update cephalon to use custom embedding function
+
+Design notes point toward replacing the default Chroma embeddings with a lightweight Python service. Cephalon should call this service when generating context vectors.
+
+---
+
+## 🎯 Goals
+- Decouple embedding logic from Node code
+- Allow experimentation with alternative models
+
+---
+
+## 📦 Requirements
+- [ ] Implement API calls to the embedding service
+- [ ] Remove old Chroma dependency
+
+---
+
+## 📋 Subtasks
+- [ ] Define request/response schema in `bridge/protocols`
+- [ ] Update `cephalon/src` to fetch embeddings asynchronously
+- [ ] Write unit tests for the new helper
+
+---
+
+## 🔗 Related Epics
+#framework-core
+
+---
+
+## ⛓️ Blocked By
+Nothing
+
+## ⛓️ Blocks
+Nothing
+
+---
+
+## 🔍 Relevant Links
+- [kanban](../boards/kanban.md)
+- [pseudo/eidolon-field-scratchpad.lisp](../../pseudo/eidolon-field-scratchpad.lisp)

--- a/docs/agile/Tasks/Update makefile to have commands specific for agents.md
+++ b/docs/agile/Tasks/Update makefile to have commands specific for agents.md
@@ -1,0 +1,41 @@
+## 🛠️ Task: Update Makefile to have commands specific for agents
+
+The monorepo hosts multiple agents. The Makefile should expose targets to launch or test each agent individually as referenced in the migration plan.
+
+---
+
+## 🎯 Goals
+- `make start:duck` or similar commands
+- Reusable patterns for any future agent
+
+---
+
+## 📦 Requirements
+- [ ] Define agent-specific PM2 targets
+- [ ] Document usage in the root README
+
+---
+
+## 📋 Subtasks
+- [ ] Extend current Makefile with per-agent start/stop
+- [ ] Provide example for Duck
+- [ ] Add placeholder for new agents
+
+---
+
+## 🔗 Related Epics
+#devops
+
+---
+
+## ⛓️ Blocked By
+- update GitHub Actions to use makefile
+
+## ⛓️ Blocks
+Nothing
+
+---
+
+## 🔍 Relevant Links
+- [kanban](../boards/kanban.md)
+- [MIGRATION_PLAN](../MIGRATION_PLAN.md)

--- a/docs/agile/Tasks/seperate all testing pipelines in github Actions.md
+++ b/docs/agile/Tasks/seperate all testing pipelines in github Actions.md
@@ -1,0 +1,41 @@
+## 🛠️ Task: seperate all testing pipelines in GitHub Actions
+
+Design docs suggest isolating service tests. Each service should have its own workflow file so failures don't block unrelated code.
+
+---
+
+## 🎯 Goals
+- Independent CI jobs per service
+- Faster feedback on failing components
+
+---
+
+## 📦 Requirements
+- [ ] Create a workflow file under `.github/workflows` for each service
+- [ ] Ensure shared setup steps use the Makefile
+
+---
+
+## 📋 Subtasks
+- [ ] Draft workflow template
+- [ ] Apply to Python services
+- [ ] Apply to Node services
+
+---
+
+## 🔗 Related Epics
+#cicd
+
+---
+
+## ⛓️ Blocked By
+Nothing
+
+## ⛓️ Blocks
+- Move all testing to individual services
+
+---
+
+## 🔍 Relevant Links
+- [kanban](../boards/kanban.md)
+- [ci](../ci.md)

--- a/docs/agile/Tasks/update github actions to use makefile.md
+++ b/docs/agile/Tasks/update github actions to use makefile.md
@@ -1,0 +1,41 @@
+## 🛠️ Task: update GitHub Actions to use Makefile
+
+CI workflows should call standardized Makefile targets rather than duplicating commands. This keeps automation consistent with the design docs.
+
+---
+
+## 🎯 Goals
+- Invoke `make test` and `make build` from workflows
+- Reduce script duplication across jobs
+
+---
+
+## 📦 Requirements
+- [ ] Modify existing workflow files to call Makefile targets
+- [ ] Ensure the Makefile covers setup for all services
+
+---
+
+## 📋 Subtasks
+- [ ] Audit current workflow steps
+- [ ] Add `make lint` and `make test` usage
+- [ ] Verify environment variables for PM2
+
+---
+
+## 🔗 Related Epics
+#cicd #devops
+
+---
+
+## ⛓️ Blocked By
+- Clearly seperate service dependency files
+
+## ⛓️ Blocks
+- Update Makefile to have commands specific for agents
+
+---
+
+## 🔍 Relevant Links
+- [kanban](../boards/kanban.md)
+- [Process](../Process.md)

--- a/docs/agile/boards/kanban.md
+++ b/docs/agile/boards/kanban.md
@@ -22,12 +22,12 @@ kanban-plugin: board
 
 ## Incoming
 
-- [ ] Clearly seperate service dependency  files
-- [ ] seperate all  testing pipelines  in github Actions
-- [ ] Move all testing to individual  services
-- [ ] update github actions to use makefile
-- [ ] Update makefile to have commands specific for agents
-- [ ] Update cephalon to use custom embedding function
+- [ ] [Clearly seperate service dependency  files](../tasks/Clearly%20seperate%20service%20dependency%20files.md)
+- [ ] [seperate all  testing pipelines  in github Actions](../tasks/seperate%20all%20testing%20pipelines%20in%20github%20Actions.md)
+- [ ] [Move all testing to individual  services](../tasks/Move%20all%20testing%20to%20individual%20services.md)
+- [ ] [update github actions to use makefile](../tasks/update%20github%20actions%20to%20use%20makefile.md)
+- [ ] [Update makefile to have commands specific for agents](../tasks/Update%20makefile%20to%20have%20commands%20specific%20for%20agents.md)
+- [ ] [Update cephalon to use custom embedding function](../tasks/Update%20cephalon%20to%20use%20custom%20embedding%20function.md)
 
 
 ## Rejected


### PR DESCRIPTION
## Summary
- add tasks referenced by design docs and link them on the kanban
- record work to separate dependencies, tests, Makefile and Cephalon embedding

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688874baf0c08324ba930480de4d8cfb