### PR TITLE
Add tasks from design docs

### DIFF
--- a/docs/agile/Tasks/Add semantic overlays for layer1 through layer8.md
+++ b/docs/agile/Tasks/Add semantic overlays for layer1 through layer8.md
@@ -1,0 +1,50 @@
+## 🛠️ Task: Add semantic overlays for layer1 through layer8
+
+Implement documentation overlays that explain how each cognitive layer maps to the system. These overlays should provide conceptual context for the eight circuits described in the design docs.
+
+---
+
+## 🎯 Goals
+
+- Mirror the eight circuits with dedicated documentation sections
+- Provide consistent naming conventions and tags for each layer
+- Clarify the relationship between circuits and system modules
+
+---
+
+## 📦 Requirements
+
+- [ ] Create markdown stubs for each layer under `docs/design/circuits/`
+- [ ] Include links back to relevant services or agents
+- [ ] Tag each doc with `#layerX` where `X` is 1-8
+
+---
+
+## 📋 Subtasks
+
+- [ ] Draft outline for each circuit overlay
+- [ ] Link overlays from the main design overview
+- [ ] Update Kanban board when overlays are complete
+
+---
+
+## 🔗 Related Epics
+
+#framework-core
+
+---
+
+## ⛓️ Blocked By
+
+Nothing
+
+## ⛓️ Blocks
+
+Nothing
+
+---
+
+## 🔍 Relevant Links
+
+- [design overview](../../design/overview.md)
+- [kanban](../boards/kanban.md)

--- a/docs/agile/Tasks/Auto-generate AGENTS.md stubs from services structure.md
+++ b/docs/agile/Tasks/Auto-generate AGENTS.md stubs from services structure.md
@@ -1,0 +1,50 @@
+## 🛠️ Task: Auto-generate AGENTS.md stubs from services structure
+
+Build a small script that scans `services/` and produces initial `AGENTS.md` files for each service. These stubs should include minimal metadata and links back to implementation files.
+
+---
+
+## 🎯 Goals
+
+- Ensure every service has a corresponding documentation stub
+- Keep docs up to date as services are added or removed
+- Provide a foundation for more detailed service docs
+
+---
+
+## 📦 Requirements
+
+- [ ] Script can be run via `npm run build:docs` or similar
+- [ ] Output files go to `docs/services/<service>/AGENTS.md`
+- [ ] Include service description, path, and tags
+
+---
+
+## 📋 Subtasks
+
+- [ ] Enumerate existing services
+- [ ] Generate stub for each service
+- [ ] Add instructions to `docs/vault-config-readme.md`
+
+---
+
+## 🔗 Related Epics
+
+#framework-core
+
+---
+
+## ⛓️ Blocked By
+
+Nothing
+
+## ⛓️ Blocks
+
+Nothing
+
+---
+
+## 🔍 Relevant Links
+
+- [vault config readme](../../vault-config-readme.md)
+- [kanban](../boards/kanban.md)

--- a/docs/agile/Tasks/Integrate synthesis-agent pass on unique to produce draft docs.md
+++ b/docs/agile/Tasks/Integrate synthesis-agent pass on unique to produce draft docs.md
@@ -1,0 +1,50 @@
+## 🛠️ Task: Integrate synthesis-agent pass on `unique/` to produce draft docs
+
+Run the synthesis agent over the files in `docs/unique/` to generate more polished documentation. The agent should create drafts in the appropriate design subfolders.
+
+---
+
+## 🎯 Goals
+
+- Transform raw notes in `unique/` into coherent design docs
+- Keep generated drafts separate from hand-written notes
+- Provide a repeatable command for future runs
+
+---
+
+## 📦 Requirements
+
+- [ ] Identify which notes should be processed
+- [ ] Output drafts to `docs/design/drafts/` or similar
+- [ ] Document the workflow in `docs/Process.md`
+
+---
+
+## 📋 Subtasks
+
+- [ ] Configure synthesis-agent to read from `docs/unique/`
+- [ ] Export cleaned markdown to new folder
+- [ ] Link resulting docs on the kanban board
+
+---
+
+## 🔗 Related Epics
+
+#framework-core
+
+---
+
+## ⛓️ Blocked By
+
+Nothing
+
+## ⛓️ Blocks
+
+Nothing
+
+---
+
+## 🔍 Relevant Links
+
+- [Process](../Process.md)
+- [kanban](../boards/kanban.md)

--- a/docs/agile/Tasks/Mirror shared utils with language-specific doc folders.md
+++ b/docs/agile/Tasks/Mirror shared utils with language-specific doc folders.md
@@ -1,0 +1,50 @@
+## 🛠️ Task: Mirror shared utils with language-specific doc folders
+
+Create documentation folders that mirror the utilities in `shared/`, grouped by their implementation language. This will make it easier to reference cross-language helpers in the design docs.
+
+---
+
+## 🎯 Goals
+
+- Align documentation structure with the `shared/` directory
+- Provide examples for Python, Hy, and Sibilant/JS utilities
+- Improve discoverability of common helper functions
+
+---
+
+## 📦 Requirements
+
+- [ ] Audit `shared/` to list existing utility modules
+- [ ] Create matching folders under `docs/shared/` for each language
+- [ ] Generate README stubs summarizing available utilities
+
+---
+
+## 📋 Subtasks
+
+- [ ] Draft initial README for Python utilities
+- [ ] Draft initial README for Sibilant/JS utilities
+- [ ] Link these docs from `docs/file-structure.md`
+
+---
+
+## 🔗 Related Epics
+
+#framework-core
+
+---
+
+## ⛓️ Blocked By
+
+Nothing
+
+## ⛓️ Blocks
+
+Nothing
+
+---
+
+## 🔍 Relevant Links
+
+- [file structure](../file-structure.md)
+- [kanban](../boards/kanban.md)

--- a/docs/agile/boards/kanban.md
+++ b/docs/agile/boards/kanban.md
@@ -28,6 +28,10 @@ kanban-plugin: board
 - [ ] update github actions to use makefile
 - [ ] Update makefile to have commands specific for agents
 - [ ] Update cephalon to use custom embedding function
+- [ ] [Add semantic overlays for layer1 through layer8](../tasks/Add%20semantic%20overlays%20for%20layer1%20through%20layer8.md)
+- [ ] [Mirror shared utils with language-specific doc folders](../tasks/Mirror%20shared%20utils%20with%20language-specific%20doc%20folders.md)
+- [ ] [Auto-generate AGENTS.md stubs from services structure](../tasks/Auto-generate%20AGENTS.md%20stubs%20from%20services%20structure.md)
+- [ ] [Integrate synthesis-agent pass on unique to produce draft docs](../tasks/Integrate%20synthesis-agent%20pass%20on%20unique%20to%20produce%20draft%20docs.md)
 
 
 ## Rejected


### PR DESCRIPTION
## Summary
- create new tasks from docs/AGENTS future work
- link new tasks in `kanban.md`
- clarify incoming tasks around overlays and doc generation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688874baf0c08324ba930480de4d8cfb