### PR TITLE
Add doc stubs mirroring services

### DIFF
--- a/docs/services/cephalon/scripts/patch-imports.js.md
+++ b/docs/services/cephalon/scripts/patch-imports.js.md
@@ -1,0 +1,11 @@
+# services/cephalon/scripts/patch-imports.js
+
+## What it does
+Module patch-imports.js
+
+## Depends on
+- fs
+- path
+
+## Depended on by
+None

--- a/docs/services/cephalon/src/agent.ts.md
+++ b/docs/services/cephalon/src/agent.ts.md
@@ -1,0 +1,13 @@
+# services/cephalon/src/agent.ts
+
+## What it does
+Module agent.ts
+
+## Depends on
+- EventEmitter
+- ollama
+- screenshot
+- tokenizer
+
+## Depended on by
+None

--- a/docs/services/cephalon/src/bot.ts.md
+++ b/docs/services/cephalon/src/bot.ts.md
@@ -1,0 +1,10 @@
+# services/cephalon/src/bot.ts
+
+## What it does
+Module bot.ts
+
+## Depends on
+- EventEmitter
+
+## Depended on by
+- services/cephalon/tests/bot.test.ts

--- a/docs/services/cephalon/src/collectionManager.ts.md
+++ b/docs/services/cephalon/src/collectionManager.ts.md
@@ -1,0 +1,10 @@
+# services/cephalon/src/collectionManager.ts
+
+## What it does
+Module collectionManager.ts
+
+## Depends on
+- crypto
+
+## Depended on by
+None

--- a/docs/services/cephalon/src/collections.ts.md
+++ b/docs/services/cephalon/src/collections.ts.md
@@ -1,0 +1,10 @@
+# services/cephalon/src/collections.ts
+
+## What it does
+Module collections.ts
+
+## Depends on
+None
+
+## Depended on by
+None

--- a/docs/services/cephalon/src/contextManager.ts.md
+++ b/docs/services/cephalon/src/contextManager.ts.md
@@ -1,0 +1,12 @@
+# services/cephalon/src/contextManager.ts
+
+## What it does
+Module contextManager.ts
+
+## Depends on
+- TimeAgo
+- collections
+- en
+
+## Depended on by
+None

--- a/docs/services/cephalon/src/converter.ts.md
+++ b/docs/services/cephalon/src/converter.ts.md
@@ -1,0 +1,10 @@
+# services/cephalon/src/converter.ts
+
+## What it does
+Module converter.ts
+
+## Depends on
+None
+
+## Depended on by
+None

--- a/docs/services/cephalon/src/index.ts.md
+++ b/docs/services/cephalon/src/index.ts.md
@@ -1,0 +1,10 @@
+# services/cephalon/src/index.ts
+
+## What it does
+Module index.ts
+
+## Depends on
+None
+
+## Depended on by
+None

--- a/docs/services/cephalon/src/speaker.ts.md
+++ b/docs/services/cephalon/src/speaker.ts.md
@@ -1,0 +1,10 @@
+# services/cephalon/src/speaker.ts
+
+## What it does
+Module speaker.ts
+
+## Depends on
+- EventEmitter
+
+## Depended on by
+None

--- a/docs/services/cephalon/src/transcriber.ts.md
+++ b/docs/services/cephalon/src/transcriber.ts.md
@@ -1,0 +1,11 @@
+# services/cephalon/src/transcriber.ts
+
+## What it does
+Module transcriber.ts
+
+## Depends on
+- EventEmitter
+- http
+
+## Depended on by
+- services/cephalon/src/bot.ts

--- a/docs/services/cephalon/src/util.ts.md
+++ b/docs/services/cephalon/src/util.ts.md
@@ -1,0 +1,10 @@
+# services/cephalon/src/util.ts
+
+## What it does
+Module util.ts
+
+## Depends on
+None
+
+## Depended on by
+None

--- a/docs/services/cephalon/src/voice-recorder.ts.md
+++ b/docs/services/cephalon/src/voice-recorder.ts.md
@@ -1,0 +1,10 @@
+# services/cephalon/src/voice-recorder.ts
+
+## What it does
+Module voice-recorder.ts
+
+## Depends on
+- EventEmitter
+
+## Depended on by
+- services/cephalon/src/bot.ts

--- a/docs/services/cephalon/src/voice-session.ts.md
+++ b/docs/services/cephalon/src/voice-session.ts.md
@@ -1,0 +1,10 @@
+# services/cephalon/src/voice-session.ts
+
+## What it does
+Module voice-session.ts
+
+## Depends on
+- EventEmitter
+
+## Depended on by
+- services/cephalon/tests/voice_session.test.ts

--- a/docs/services/cephalon/src/voice-synth.ts.md
+++ b/docs/services/cephalon/src/voice-synth.ts.md
@@ -1,0 +1,10 @@
+# services/cephalon/src/voice-synth.ts
+
+## What it does
+Module voice-synth.ts
+
+## Depends on
+- EventEmitter
+
+## Depended on by
+None

--- a/docs/services/cephalon/tests/bot.test.ts.md
+++ b/docs/services/cephalon/tests/bot.test.ts.md
@@ -1,0 +1,10 @@
+# services/cephalon/tests/bot.test.ts
+
+## What it does
+Module bot.test.ts
+
+## Depends on
+- test
+
+## Depended on by
+None

--- a/docs/services/cephalon/tests/converter.ts.md
+++ b/docs/services/cephalon/tests/converter.ts.md
@@ -1,0 +1,10 @@
+# services/cephalon/tests/converter.ts
+
+## What it does
+Module converter.ts
+
+## Depends on
+- test
+
+## Depended on by
+None

--- a/docs/services/cephalon/tests/node_modules/@discordjs/voice/index.js.md
+++ b/docs/services/cephalon/tests/node_modules/@discordjs/voice/index.js.md
@@ -1,0 +1,10 @@
+# services/cephalon/tests/node_modules/@discordjs/voice/index.js
+
+## What it does
+Module index.js
+
+## Depends on
+None
+
+## Depended on by
+None

--- a/docs/services/cephalon/tests/node_modules/discord.js/index.js.md
+++ b/docs/services/cephalon/tests/node_modules/discord.js/index.js.md
@@ -1,0 +1,10 @@
+# services/cephalon/tests/node_modules/discord.js/index.js
+
+## What it does
+Module index.js
+
+## Depends on
+None
+
+## Depended on by
+None

--- a/docs/services/cephalon/tests/test.ts.md
+++ b/docs/services/cephalon/tests/test.ts.md
@@ -1,0 +1,10 @@
+# services/cephalon/tests/test.ts
+
+## What it does
+Module test.ts
+
+## Depends on
+- test
+
+## Depended on by
+None

--- a/docs/services/cephalon/tests/voice_session.test.ts.md
+++ b/docs/services/cephalon/tests/voice_session.test.ts.md
@@ -1,0 +1,10 @@
+# services/cephalon/tests/voice_session.test.ts
+
+## What it does
+Module voice_session.test.ts
+
+## Depends on
+- test
+
+## Depended on by
+None

--- a/docs/services/discord-embedder/src/converter.ts.md
+++ b/docs/services/discord-embedder/src/converter.ts.md
@@ -1,0 +1,10 @@
+# services/discord-embedder/src/converter.ts
+
+## What it does
+Module converter.ts
+
+## Depends on
+None
+
+## Depended on by
+- services/discord-embedder/tests/converter.ts

--- a/docs/services/discord-embedder/src/embedding.ts.md
+++ b/docs/services/discord-embedder/src/embedding.ts.md
@@ -1,0 +1,10 @@
+# services/discord-embedder/src/embedding.ts
+
+## What it does
+Module embedding.ts
+
+## Depends on
+- type
+
+## Depended on by
+None

--- a/docs/services/discord-embedder/src/index.ts.md
+++ b/docs/services/discord-embedder/src/index.ts.md
@@ -1,0 +1,10 @@
+# services/discord-embedder/src/index.ts
+
+## What it does
+Module index.ts
+
+## Depends on
+None
+
+## Depended on by
+None

--- a/docs/services/discord-embedder/tests/converter.ts.md
+++ b/docs/services/discord-embedder/tests/converter.ts.md
@@ -1,0 +1,10 @@
+# services/discord-embedder/tests/converter.ts
+
+## What it does
+Module converter.ts
+
+## Depends on
+- test
+
+## Depended on by
+None

--- a/docs/services/discord-embedder/tests/test.ts.md
+++ b/docs/services/discord-embedder/tests/test.ts.md
@@ -1,0 +1,10 @@
+# services/discord-embedder/tests/test.ts
+
+## What it does
+Module test.ts
+
+## Depends on
+- test
+
+## Depended on by
+None

--- a/docs/services/discord-indexer/main.py.md
+++ b/docs/services/discord-indexer/main.py.md
@@ -1,0 +1,20 @@
+# services/discord-indexer/main.py
+
+## What it does
+Module main.py
+
+## Depends on
+- List
+- asyncio
+- discord
+- discord_message_collection
+- os
+- random
+- settings
+- shared.py
+- shared.py.mongodb
+- traceback
+- typing
+
+## Depended on by
+None

--- a/docs/services/stt/app.py.md
+++ b/docs/services/stt/app.py.md
@@ -1,0 +1,16 @@
+# services/stt/app.py
+
+## What it does
+Module app.py
+
+## Depends on
+- FastAPI
+- JSONResponse
+- asyncio
+- fastapi
+- fastapi.responses
+- shared.py.speech.wisper_stt
+- transcribe_pcm
+
+## Depended on by
+None

--- a/docs/services/stt/whisper-npu-py/audio.py.md
+++ b/docs/services/stt/whisper-npu-py/audio.py.md
@@ -1,0 +1,18 @@
+# services/stt/whisper-npu-py/audio.py
+
+## What it does
+Module audio.py
+
+## Depends on
+- Optional
+- librosa
+- librosa.display
+- matplotlib.pyplot
+- numpy
+- time
+- torch
+- torch.nn.functional
+- typing
+
+## Depended on by
+None

--- a/docs/services/stt/whisper-npu-py/beam_decoder.py.md
+++ b/docs/services/stt/whisper-npu-py/beam_decoder.py.md
@@ -1,0 +1,21 @@
+# services/stt/whisper-npu-py/beam_decoder.py
+
+## What it does
+Module beam_decoder.py
+
+## Depends on
+- Google
+- audio
+- cache
+- decoder
+- generate_token
+- init_empty_cache
+- models
+- numpy
+- post_processing
+- preprocess_audio
+- time
+- torch
+
+## Depended on by
+None

--- a/docs/services/stt/whisper-npu-py/cache.py.md
+++ b/docs/services/stt/whisper-npu-py/cache.py.md
@@ -1,0 +1,11 @@
+# services/stt/whisper-npu-py/cache.py
+
+## What it does
+Module cache.py
+
+## Depends on
+- config
+- numpy
+
+## Depended on by
+None

--- a/docs/services/stt/whisper-npu-py/config.py.md
+++ b/docs/services/stt/whisper-npu-py/config.py.md
@@ -1,0 +1,10 @@
+# services/stt/whisper-npu-py/config.py
+
+## What it does
+Module config.py
+
+## Depends on
+None
+
+## Depended on by
+None

--- a/docs/services/stt/whisper-npu-py/decoder.py.md
+++ b/docs/services/stt/whisper-npu-py/decoder.py.md
@@ -1,0 +1,17 @@
+# services/stt/whisper-npu-py/decoder.py
+
+## What it does
+Module decoder.py
+
+## Depends on
+- 0
+- cache
+- cross_kv
+- models
+- numpy
+- post_processing
+- torch
+- update_cache
+
+## Depended on by
+None

--- a/docs/services/stt/whisper-npu-py/inspect_whisper_io.py.md
+++ b/docs/services/stt/whisper-npu-py/inspect_whisper_io.py.md
@@ -1,0 +1,13 @@
+# services/stt/whisper-npu-py/inspect_whisper_io.py
+
+## What it does
+Module inspect_whisper_io.py
+
+## Depends on
+- Core
+- json
+- openvino.runtime
+- os
+
+## Depended on by
+None

--- a/docs/services/stt/whisper-npu-py/models.py.md
+++ b/docs/services/stt/whisper-npu-py/models.py.md
@@ -1,0 +1,14 @@
+# services/stt/whisper-npu-py/models.py
+
+## What it does
+Module models.py
+
+## Depends on
+- Core
+- WhisperTokenizer
+- numpy
+- openvino.runtime
+- transformers
+
+## Depended on by
+None

--- a/docs/services/stt/whisper-npu-py/post_processing.py.md
+++ b/docs/services/stt/whisper-npu-py/post_processing.py.md
@@ -1,0 +1,16 @@
+# services/stt/whisper-npu-py/post_processing.py
+
+## What it does
+Module post_processing.py
+
+## Depends on
+- SequenceMatcher
+- collections
+- defaultdict
+- difflib
+- models
+- the
+- tokenizer
+
+## Depended on by
+None

--- a/docs/services/stt/whisper-npu-py/whisper.py.md
+++ b/docs/services/stt/whisper-npu-py/whisper.py.md
@@ -1,0 +1,15 @@
+# services/stt/whisper-npu-py/whisper.py
+
+## What it does
+Module whisper.py
+
+## Depends on
+- audio
+- decoder
+- generate_tokens_for_chunk
+- models
+- preprocess_audio
+- time
+
+## Depended on by
+None

--- a/docs/services/stt/whisper-npu-py/whisper_streamer.py.md
+++ b/docs/services/stt/whisper-npu-py/whisper_streamer.py.md
@@ -1,0 +1,16 @@
+# services/stt/whisper-npu-py/whisper_streamer.py
+
+## What it does
+Module whisper_streamer.py
+
+## Depends on
+- Core
+- WhisperTokenizer
+- librosa
+- numpy
+- openvino.runtime
+- torch
+- transformers
+
+## Depended on by
+None

--- a/docs/services/stt/whisper_demo.py.md
+++ b/docs/services/stt/whisper_demo.py.md
@@ -1,0 +1,10 @@
+# services/stt/whisper_demo.py
+
+## What it does
+Module whisper_demo.py
+
+## Depends on
+- whisper
+
+## Depended on by
+None

--- a/docs/services/stt/whisper_npu/__init__.py.md
+++ b/docs/services/stt/whisper_npu/__init__.py.md
@@ -1,0 +1,20 @@
+# services/stt/whisper_npu/__init__.py
+
+## What it does
+Module __init__.py
+
+## Depends on
+- .audio
+- .config
+- .decoder
+- .models
+- .post_processing
+- AudioProcessor
+- Config
+- GreedyDecoder
+- ModelManager
+- PostProcessor
+- time
+
+## Depended on by
+None

--- a/docs/services/stt/whisper_npu/audio.py.md
+++ b/docs/services/stt/whisper_npu/audio.py.md
@@ -1,0 +1,25 @@
+# services/stt/whisper_npu/audio.py
+
+## What it does
+Module audio.py
+
+## Depends on
+- .config
+- Config
+- Iterator
+- Path
+- __future__
+- a
+- annotations
+- dataclass
+- dataclasses
+- librosa
+- logging
+- numpy
+- pathlib
+- torch
+- torch.nn.functional
+- typing
+
+## Depended on by
+None

--- a/docs/services/stt/whisper_npu/config.py.md
+++ b/docs/services/stt/whisper_npu/config.py.md
@@ -1,0 +1,16 @@
+# services/stt/whisper_npu/config.py
+
+## What it does
+Module config.py
+
+## Depends on
+- Optional
+- Path
+- dataclass
+- dataclasses
+- pathlib
+- the
+- typing
+
+## Depended on by
+None

--- a/docs/services/stt/whisper_npu/decoder.py.md
+++ b/docs/services/stt/whisper_npu/decoder.py.md
@@ -1,0 +1,24 @@
+# services/stt/whisper_npu/decoder.py
+
+## What it does
+Module decoder.py
+
+## Depends on
+- .config
+- .models
+- .post_processing
+- Config
+- Dict
+- ModelManager
+- PostProcessor
+- __future__
+- annotations
+- dataclass
+- dataclasses
+- logging
+- numpy
+- previous
+- typing
+
+## Depended on by
+None

--- a/docs/services/stt/whisper_npu/models.py.md
+++ b/docs/services/stt/whisper_npu/models.py.md
@@ -1,0 +1,21 @@
+# services/stt/whisper_npu/models.py
+
+## What it does
+Module models.py
+
+## Depends on
+- .config
+- Config
+- Dict
+- Path
+- WhisperTokenizer
+- __future__
+- annotations
+- logging
+- numpy
+- pathlib
+- transformers
+- typing
+
+## Depended on by
+None

--- a/docs/services/stt/whisper_npu/post_processing.py.md
+++ b/docs/services/stt/whisper_npu/post_processing.py.md
@@ -1,0 +1,23 @@
+# services/stt/whisper_npu/post_processing.py
+
+## What it does
+Module post_processing.py
+
+## Depends on
+- Dict
+- PreTrainedTokenizerBase
+- SequenceMatcher
+- __future__
+- annotations
+- collections
+- dataclass
+- dataclasses
+- defaultdict
+- difflib
+- logging
+- the
+- transformers
+- typing
+
+## Depended on by
+None

--- a/docs/services/tts/app.py.md
+++ b/docs/services/tts/app.py.md
@@ -1,0 +1,18 @@
+# services/tts/app.py
+
+## What it does
+Module app.py
+
+## Depends on
+- FastAPI
+- fastapi
+- io
+- load_file
+- nltk
+- safetensors.torch
+- soundfile
+- torch
+- transformers
+
+## Depended on by
+None


### PR DESCRIPTION
## Summary
- mirror all service files under `docs/services`
- add simple Markdown stubs describing each source file

## Testing
- `pytest -q`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68883aff258c83248bab51f662dad9f9