### PR TITLE
Add documentation stubs for services

### DIFF
--- a/docs/services/cephalon/scripts/patch-imports.md
+++ b/docs/services/cephalon/scripts/patch-imports.md
@@ -1,0 +1,13 @@
+# patch-imports.js
+
+**Path**: `services/cephalon/scripts/patch-imports.js`
+
+**Description**: Documentation stub.
+
+## Dependencies
+- fs/promises
+- path
+
+## Dependents
+- `services/cephalon/package.json`
+

--- a/docs/services/cephalon/src/agent.md
+++ b/docs/services/cephalon/src/agent.md
@@ -1,0 +1,23 @@
+# agent.ts
+
+**Path**: `services/cephalon/src/agent.ts`
+
+**Description**: @file agent.ts
+
+## Dependencies
+- ./bot
+- ./collectionManager
+- ./contextManager
+- ./util
+- @discordjs/voice
+- dotenv
+- events
+- fs
+- fs/promises
+- ollama
+- sbd
+- screenshot-desktop
+
+## Dependents
+- None
+

--- a/docs/services/cephalon/src/bot.md
+++ b/docs/services/cephalon/src/bot.md
@@ -1,0 +1,19 @@
+# bot.ts
+
+**Path**: `services/cephalon/src/bot.ts`
+
+**Description**: Handles top level discord interactions. EG slash commands send by the user.
+
+## Dependencies
+- ./agent
+- ./collectionManager
+- ./contextManager
+- ./transcriber
+- ./voice-session
+- ./voice-synth
+- discord.js
+- events
+
+## Dependents
+- `services/cephalon/tests/bot.test.ts`
+

--- a/docs/services/cephalon/src/collectionManager.md
+++ b/docs/services/cephalon/src/collectionManager.md
@@ -1,0 +1,15 @@
+# collectionManager.ts
+
+**Path**: `services/cephalon/src/collectionManager.ts`
+
+**Description**: AddEntry method:
+
+## Dependencies
+- chromadb
+- crypto
+- dotenv
+- mongodb
+
+## Dependents
+- None
+

--- a/docs/services/cephalon/src/collections.md
+++ b/docs/services/cephalon/src/collections.md
@@ -1,0 +1,13 @@
+# collections.ts
+
+**Path**: `services/cephalon/src/collections.ts`
+
+**Description**: Documentation stub.
+
+## Dependencies
+- ./agent
+- ./collectionManager
+
+## Dependents
+- None
+

--- a/docs/services/cephalon/src/contextManager.md
+++ b/docs/services/cephalon/src/contextManager.md
@@ -1,0 +1,15 @@
+# contextManager.ts
+
+**Path**: `services/cephalon/src/contextManager.ts`
+
+**Description**: Documentation stub.
+
+## Dependencies
+- ./collectionManager
+- javascript-time-ago
+- javascript-time-ago/locale/en
+- ollama
+
+## Dependents
+- None
+

--- a/docs/services/cephalon/src/converter.md
+++ b/docs/services/cephalon/src/converter.md
@@ -1,0 +1,14 @@
+# converter.ts
+
+**Path**: `services/cephalon/src/converter.ts`
+
+**Description**: Documentation stub.
+
+## Dependencies
+- node:stream
+- prism-media
+- wav
+
+## Dependents
+- `services/discord-embedder/tests/converter.ts`
+

--- a/docs/services/cephalon/src/index.md
+++ b/docs/services/cephalon/src/index.md
@@ -1,0 +1,14 @@
+# index.ts
+
+**Path**: `services/cephalon/src/index.ts`
+
+**Description**: dotenv.config({ path: '../../.env' });  // 👈 resolve from wherever you want
+
+## Dependencies
+- ./bot
+- source-map-support/register.js
+
+## Dependents
+- `services/discord-embedder/package.json`
+- `services/cephalon/package.json`
+

--- a/docs/services/cephalon/src/speaker.md
+++ b/docs/services/cephalon/src/speaker.md
@@ -1,0 +1,18 @@
+# speaker.ts
+
+**Path**: `services/cephalon/src/speaker.ts`
+
+**Description**: Handles decoding ogg streams to pcm packets.
+
+## Dependencies
+- ./transcriber
+- ./voice-recorder
+- @discordjs/voice
+- discord.js
+- node:events
+- node:stream
+- prism-media
+
+## Dependents
+- None
+

--- a/docs/services/cephalon/src/transcriber.md
+++ b/docs/services/cephalon/src/transcriber.md
@@ -1,0 +1,16 @@
+# transcriber.ts
+
+**Path**: `services/cephalon/src/transcriber.ts`
+
+**Description**: ✅ Pipe PCM directly into the HTTP request
+
+## Dependencies
+- ./speaker
+- discord.js
+- node:events
+- node:http
+- node:stream
+
+## Dependents
+- `services/cephalon/src/bot.ts`
+

--- a/docs/services/cephalon/src/util.md
+++ b/docs/services/cephalon/src/util.md
@@ -1,0 +1,12 @@
+# util.ts
+
+**Path**: `services/cephalon/src/util.ts`
+
+**Description**: Documentation stub.
+
+## Dependencies
+- ./contextManager
+
+## Dependents
+- None
+

--- a/docs/services/cephalon/src/voice-recorder.md
+++ b/docs/services/cephalon/src/voice-recorder.md
@@ -1,0 +1,16 @@
+# voice-recorder.ts
+
+**Path**: `services/cephalon/src/voice-recorder.ts`
+
+**Description**: Handles saving pcm data to wav files on disk.
+
+## Dependencies
+- discord.js
+- node:events
+- node:fs
+- node:stream
+- wav
+
+## Dependents
+- `services/cephalon/src/bot.ts`
+

--- a/docs/services/cephalon/src/voice-session.md
+++ b/docs/services/cephalon/src/voice-session.md
@@ -1,0 +1,20 @@
+# voice-session.ts
+
+**Path**: `services/cephalon/src/voice-session.ts`
+
+**Description**: Handles all things voice. Emits an event when a user begins speaking, and when they stop speaking
+
+## Dependencies
+- ./bot
+- ./speaker
+- ./transcriber
+- ./voice-recorder
+- ./voice-synth
+- @discordjs/voice
+- crypto
+- discord.js
+- events
+
+## Dependents
+- `services/cephalon/tests/voice_session.test.ts`
+

--- a/docs/services/cephalon/src/voice-synth.md
+++ b/docs/services/cephalon/src/voice-synth.md
@@ -1,0 +1,15 @@
+# voice-synth.ts
+
+**Path**: `services/cephalon/src/voice-synth.ts`
+
+**Description**: Pipe the PCM stream directly
+
+## Dependencies
+- child_process
+- events
+- http
+- stream
+
+## Dependents
+- None
+

--- a/docs/services/cephalon/tests/bot.test.md
+++ b/docs/services/cephalon/tests/bot.test.md
@@ -1,0 +1,14 @@
+# bot.test.ts
+
+**Path**: `services/cephalon/tests/bot.test.ts`
+
+**Description**: Documentation stub.
+
+## Dependencies
+- ../src/bot.ts
+- ava
+- discord.js
+
+## Dependents
+- None
+

--- a/docs/services/cephalon/tests/converter.md
+++ b/docs/services/cephalon/tests/converter.md
@@ -1,0 +1,13 @@
+# converter.ts
+
+**Path**: `services/cephalon/tests/converter.ts`
+
+**Description**: simple test to ensure convert returns a Buffer with same contents
+
+## Dependencies
+- ../src/converter
+- ava
+
+## Dependents
+- `services/discord-embedder/tests/converter.ts`
+

--- a/docs/services/cephalon/tests/test.md
+++ b/docs/services/cephalon/tests/test.md
@@ -1,0 +1,12 @@
+# test.ts
+
+**Path**: `services/cephalon/tests/test.ts`
+
+**Description**: Documentation stub.
+
+## Dependencies
+- ava
+
+## Dependents
+- `services/cephalon/package.json`
+

--- a/docs/services/cephalon/tests/voice_session.test.md
+++ b/docs/services/cephalon/tests/voice_session.test.md
@@ -1,0 +1,15 @@
+# voice_session.test.ts
+
+**Path**: `services/cephalon/tests/voice_session.test.ts`
+
+**Description**: Documentation stub.
+
+## Dependencies
+- ../src/voice-session.ts
+- @discordjs/voice
+- ava
+- discord.js
+
+## Dependents
+- None
+

--- a/docs/services/discord-embedder/src/converter.md
+++ b/docs/services/discord-embedder/src/converter.md
@@ -1,0 +1,12 @@
+# converter.ts
+
+**Path**: `services/discord-embedder/src/converter.ts`
+
+**Description**: Documentation stub.
+
+## Dependencies
+- None
+
+## Dependents
+- `services/discord-embedder/tests/converter.ts`
+

--- a/docs/services/discord-embedder/src/embedding.md
+++ b/docs/services/discord-embedder/src/embedding.md
@@ -1,0 +1,12 @@
+# embedding.ts
+
+**Path**: `services/discord-embedder/src/embedding.ts`
+
+**Description**: Documentation stub.
+
+## Dependencies
+- chromadb
+
+## Dependents
+- None
+

--- a/docs/services/discord-embedder/src/index.md
+++ b/docs/services/discord-embedder/src/index.md
@@ -1,0 +1,16 @@
+# index.ts
+
+**Path**: `services/discord-embedder/src/index.ts`
+
+**Description**: Documentation stub.
+
+## Dependencies
+- ./embedding
+- chromadb
+- dotenv
+- mongodb
+
+## Dependents
+- `services/discord-embedder/package.json`
+- `services/cephalon/package.json`
+

--- a/docs/services/discord-embedder/tests/converter.md
+++ b/docs/services/discord-embedder/tests/converter.md
@@ -1,0 +1,13 @@
+# converter.ts
+
+**Path**: `services/discord-embedder/tests/converter.ts`
+
+**Description**: Documentation stub.
+
+## Dependencies
+- ../src/converter.ts
+- ava
+
+## Dependents
+- None
+

--- a/docs/services/discord-embedder/tests/test.md
+++ b/docs/services/discord-embedder/tests/test.md
@@ -1,0 +1,12 @@
+# test.ts
+
+**Path**: `services/discord-embedder/tests/test.ts`
+
+**Description**: Documentation stub.
+
+## Dependencies
+- ava
+
+## Dependents
+- `services/cephalon/package.json`
+

--- a/docs/services/discord-indexer/main.md
+++ b/docs/services/discord-indexer/main.md
@@ -1,0 +1,15 @@
+# main.py
+
+**Path**: `services/discord-indexer/main.py`
+
+**Description**: load_dotenv()
+
+## Dependencies
+- shared.py
+- shared.py.mongodb
+- typing
+
+## Dependents
+- `services/discord-indexer/README.md`
+- `services/discord-indexer/__pycache__/main.cpython-312.pyc`
+

--- a/docs/services/stt/app.md
+++ b/docs/services/stt/app.md
@@ -1,0 +1,14 @@
+# app.py
+
+**Path**: `services/stt/app.py`
+
+**Description**: Now call your transcription logic
+
+## Dependencies
+- fastapi
+- fastapi.responses
+- shared.py.speech.wisper_stt
+
+## Dependents
+- None
+

--- a/docs/services/stt/whisper-npu-py/audio.md
+++ b/docs/services/stt/whisper-npu-py/audio.md
@@ -1,0 +1,12 @@
+# audio.py
+
+**Path**: `services/stt/whisper-npu-py/audio.py`
+
+**Description**: load the mel filterbank matrix for projecting STFT into a Mel spectrogram.
+
+## Dependencies
+- typing
+
+## Dependents
+- `services/stt/whisper-npu-py/__pycache__/audio.cpython-312.pyc`
+

--- a/docs/services/stt/whisper-npu-py/beam_decoder.md
+++ b/docs/services/stt/whisper-npu-py/beam_decoder.md
@@ -1,0 +1,16 @@
+# beam_decoder.py
+
+**Path**: `services/stt/whisper-npu-py/beam_decoder.py`
+
+**Description**: Input:
+
+## Dependencies
+- audio
+- cache
+- decoder
+- models
+- post_processing
+
+## Dependents
+- None
+

--- a/docs/services/stt/whisper-npu-py/cache.md
+++ b/docs/services/stt/whisper-npu-py/cache.md
@@ -1,0 +1,12 @@
+# cache.py
+
+**Path**: `services/stt/whisper-npu-py/cache.py`
+
+**Description**: Update cache with new present_key_values outputs from decoder
+
+## Dependencies
+- config
+
+## Dependents
+- `services/stt/whisper-npu-py/__pycache__/cache.cpython-312.pyc`
+

--- a/docs/services/stt/whisper-npu-py/config.md
+++ b/docs/services/stt/whisper-npu-py/config.md
@@ -1,0 +1,12 @@
+# config.py
+
+**Path**: `services/stt/whisper-npu-py/config.py`
+
+**Description**: Documentation stub.
+
+## Dependencies
+- None
+
+## Dependents
+- `services/stt/whisper-npu-py/__pycache__/config.cpython-312.pyc`
+

--- a/docs/services/stt/whisper-npu-py/decoder.md
+++ b/docs/services/stt/whisper-npu-py/decoder.md
@@ -1,0 +1,14 @@
+# decoder.py
+
+**Path**: `services/stt/whisper-npu-py/decoder.py`
+
+**Description**: def make_attention_mask(current_seq_len, max_seq_len=224):
+
+## Dependencies
+- cache
+- models
+- post_processing
+
+## Dependents
+- `services/stt/whisper-npu-py/__pycache__/decoder.cpython-312.pyc`
+

--- a/docs/services/stt/whisper-npu-py/inspect_whisper_io.md
+++ b/docs/services/stt/whisper-npu-py/inspect_whisper_io.md
@@ -1,0 +1,12 @@
+# inspect_whisper_io.py
+
+**Path**: `services/stt/whisper-npu-py/inspect_whisper_io.py`
+
+**Description**: Paths to the models
+
+## Dependencies
+- openvino.runtime
+
+## Dependents
+- None
+

--- a/docs/services/stt/whisper-npu-py/models.md
+++ b/docs/services/stt/whisper-npu-py/models.md
@@ -1,0 +1,13 @@
+# models.py
+
+**Path**: `services/stt/whisper-npu-py/models.py`
+
+**Description**: ie.set_property("NPU",{"LOG_LEVEL": "LOG_INFO"})
+
+## Dependencies
+- openvino.runtime
+- transformers
+
+## Dependents
+- `services/stt/whisper-npu-py/__pycache__/models.cpython-312.pyc`
+

--- a/docs/services/stt/whisper-npu-py/post_processing.md
+++ b/docs/services/stt/whisper-npu-py/post_processing.md
@@ -1,0 +1,14 @@
+# post_processing.py
+
+**Path**: `services/stt/whisper-npu-py/post_processing.py`
+
+**Description**: Remove special tokens like BOS, EOS, etc.
+
+## Dependencies
+- collections
+- difflib
+- models
+
+## Dependents
+- `services/stt/whisper-npu-py/__pycache__/post_processing.cpython-312.pyc`
+

--- a/docs/services/stt/whisper-npu-py/whisper.md
+++ b/docs/services/stt/whisper-npu-py/whisper.md
@@ -1,0 +1,14 @@
+# whisper.py
+
+**Path**: `services/stt/whisper-npu-py/whisper.py`
+
+**Description**: Documentation stub.
+
+## Dependencies
+- audio
+- decoder
+- models
+
+## Dependents
+- `services/stt/whisper-npu-py/readme.md`
+

--- a/docs/services/stt/whisper-npu-py/whisper_streamer.md
+++ b/docs/services/stt/whisper-npu-py/whisper_streamer.md
@@ -1,0 +1,13 @@
+# whisper_streamer.py
+
+**Path**: `services/stt/whisper-npu-py/whisper_streamer.py`
+
+**Description**: Load mono if stereo
+
+## Dependencies
+- openvino.runtime
+- transformers
+
+## Dependents
+- None
+

--- a/docs/services/stt/whisper_demo.md
+++ b/docs/services/stt/whisper_demo.md
@@ -1,0 +1,12 @@
+# whisper_demo.py
+
+**Path**: `services/stt/whisper_demo.py`
+
+**Description**: Documentation stub.
+
+## Dependencies
+- None
+
+## Dependents
+- None
+

--- a/docs/services/stt/whisper_npu/__init__.md
+++ b/docs/services/stt/whisper_npu/__init__.md
@@ -1,0 +1,16 @@
+# __init__.py
+
+**Path**: `services/stt/whisper_npu/__init__.py`
+
+**Description**: High‑level API for running Whisper on NPUs.
+
+## Dependencies
+- .audio
+- .config
+- .decoder
+- .models
+- .post_processing
+
+## Dependents
+- None
+

--- a/docs/services/stt/whisper_npu/audio.md
+++ b/docs/services/stt/whisper_npu/audio.md
@@ -1,0 +1,16 @@
+# audio.py
+
+**Path**: `services/stt/whisper_npu/audio.py`
+
+**Description**: resample if necessary
+
+## Dependencies
+- .config
+- __future__
+- dataclasses
+- pathlib
+- typing
+
+## Dependents
+- `services/stt/whisper-npu-py/__pycache__/audio.cpython-312.pyc`
+

--- a/docs/services/stt/whisper_npu/config.md
+++ b/docs/services/stt/whisper_npu/config.md
@@ -1,0 +1,14 @@
+# config.py
+
+**Path**: `services/stt/whisper_npu/config.py`
+
+**Description**: Configuration constants for the Whisper NPU pipeline.
+
+## Dependencies
+- dataclasses
+- pathlib
+- typing
+
+## Dependents
+- `services/stt/whisper-npu-py/__pycache__/config.cpython-312.pyc`
+

--- a/docs/services/stt/whisper_npu/decoder.md
+++ b/docs/services/stt/whisper_npu/decoder.md
@@ -1,0 +1,17 @@
+# decoder.py
+
+**Path**: `services/stt/whisper_npu/decoder.py`
+
+**Description**: Token decoding logic for Whisper models.
+
+## Dependencies
+- .config
+- .models
+- .post_processing
+- __future__
+- dataclasses
+- typing
+
+## Dependents
+- `services/stt/whisper-npu-py/__pycache__/decoder.cpython-312.pyc`
+

--- a/docs/services/stt/whisper_npu/models.md
+++ b/docs/services/stt/whisper_npu/models.md
@@ -1,0 +1,16 @@
+# models.py
+
+**Path**: `services/stt/whisper_npu/models.py`
+
+**Description**: Load and manage OpenVINO Whisper models.
+
+## Dependencies
+- .config
+- __future__
+- pathlib
+- transformers
+- typing
+
+## Dependents
+- `services/stt/whisper-npu-py/__pycache__/models.cpython-312.pyc`
+

--- a/docs/services/stt/whisper_npu/post_processing.md
+++ b/docs/services/stt/whisper_npu/post_processing.md
@@ -1,0 +1,17 @@
+# post_processing.py
+
+**Path**: `services/stt/whisper_npu/post_processing.py`
+
+**Description**: Token and text post‑processing for Whisper models.
+
+## Dependencies
+- __future__
+- collections
+- dataclasses
+- difflib
+- transformers
+- typing
+
+## Dependents
+- `services/stt/whisper-npu-py/__pycache__/post_processing.cpython-312.pyc`
+

--- a/docs/services/tts/app.md
+++ b/docs/services/tts/app.md
@@ -1,0 +1,14 @@
+# app.py
+
+**Path**: `services/tts/app.py`
+
+**Description**: print(hf_hub_download(repo_id="facebook/fastspeech2-en-ljspeech", filename="vocab.txt", cache_dir=None, local_files_only=True))
+
+## Dependencies
+- fastapi
+- safetensors.torch
+- transformers
+
+## Dependents
+- None
+


### PR DESCRIPTION
## Summary
- create docs/services folder mirroring service source tree
- generate documentation stubs for each Python/TypeScript/JavaScript file

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pymongo')*
- `npm test` *(fails: Cannot find package 'ts-node')*

------
https://chatgpt.com/codex/tasks/task_e_68883aff258c83248bab51f662dad9f9