### PR TITLE
Fix board path references

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,7 +88,7 @@ Codex collaborates with the board manager agent described in
 `docs/agile/AGENTS.md` to keep tasks in sync with the kanban workflow.
 Codex mode can:
 
-* Read from Obsidian Kanban boards, if they are stored in `docs/kanban.md` or elsewhere in the vault
+* Read from Obsidian Kanban boards, if they are stored in `docs/agile/boards/kanban.md` or elsewhere in the vault
 * Use card titles as task names and tag them with `#in-progress`, `#todo`, etc
 * Generate PRs tied to board updates
 * Reflect status back to the board, though user review is always preferred

--- a/readme.md
+++ b/readme.md
@@ -88,7 +88,7 @@ pytest -q
 
 ## Converting Kanban Tasks to GitHub Issues
 
-A helper script `scripts/kanban_to_issues.py` can create GitHub issues from the tasks listed in `docs/kanban.md`. Set the following environment variables before running the script:
+A helper script `scripts/kanban_to_issues.py` can create GitHub issues from the tasks listed in `docs/agile/boards/kanban.md`. Set the following environment variables before running the script:
 
 - `GITHUB_TOKEN` – a personal access token with permission to create issues
 - `GITHUB_REPO` – the repository in `owner/repo` format

--- a/scripts/kanban_to_issues.py
+++ b/scripts/kanban_to_issues.py
@@ -2,7 +2,7 @@ import os
 import re
 import requests
 
-KANBAN_PATH = os.environ.get("KANBAN_PATH", "docs/kanban.md")
+KANBAN_PATH = os.environ.get("KANBAN_PATH", "docs/agile/boards/kanban.md")
 GITHUB_TOKEN = os.environ.get("GITHUB_TOKEN")
 GITHUB_REPO = os.environ.get("GITHUB_REPO")
 


### PR DESCRIPTION
## Summary
- reference kanban board at `docs/agile/boards/kanban.md` in docs and scripts
- update default path used in `kanban_to_issues.py`
- clarify board path in `AGENTS.md`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68897fe07f4883249a602da5b9dbdefc