### PR TITLE
Update Python test path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ format-python:
 	black services/ shared/py/
 
 test-python:
-	pytest tests/python/
+	pytest tests/
 
 # === JS/TS/Sibilant ===
 
@@ -71,7 +71,7 @@ format-js:
 	prettier --write shared/js/ services/**/
 
 test-js:
-        npm test
+	npm test
 
 # === Service Management ===
 

--- a/docs/agile/tasks/Fix_makefile_test_target.md
+++ b/docs/agile/tasks/Fix_makefile_test_target.md
@@ -1,6 +1,7 @@
 ## 🛠️ Task: Fix Makefile test target
 
-The `test-python` target points to `tests/python/` but tests live in `tests/`.
+The `test-python` target originally pointed to `tests/python/` but tests live in `tests/`.
+Update the path so that `pytest` runs against `tests/`.
 
 ---
 


### PR DESCRIPTION
## Summary
- fix `test-python` target to run against `tests/`
- document the updated path in the task entry

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68898bbde02483249da4e4f605c78de3