### PR TITLE
Add file watcher service

### DIFF
--- a/docs/board_sync.md
+++ b/docs/board_sync.md
@@ -28,3 +28,32 @@ See `docs/research/github_projects_api.md` for API details.
 ## Continuous Integration
 
 A GitHub Action (`.github/workflows/sync_board.yml`) runs this script whenever changes are pushed to the `main` branch. The action uses repository secrets `PROJECT_PAT` and `PROJECT_COLUMN_ID` to authenticate and update the board automatically after pull requests are merged.
+
+## Generate Kanban from Hashtags
+
+You can regenerate `kanban.md` from the task files themselves. The
+`hashtags_to_kanban.py` script scans every file in `docs/agile/tasks/` for a
+status hashtag such as `#todo` or `#in-progress` and groups the tasks by those
+hashtags.
+
+Run the script and redirect the output to your board:
+
+```bash
+python scripts/hashtags_to_kanban.py > docs/agile/boards/kanban.md
+```
+
+The resulting board uses the same layout as the existing `kanban.md` file,
+placing each task under the column that matches its hashtag.
+
+## Update Hashtags from the Board
+
+When you move cards between columns, run `kanban_to_hashtags.py` to write the
+new status hashtags back into each task file. The script reads
+`kanban.md` and updates the linked documents:
+
+```bash
+python scripts/kanban_to_hashtags.py
+```
+
+This keeps the `#todo` or `#in-progress` tags inside the tasks synchronized with
+their board position.

--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -41,5 +41,20 @@ module.exports = {
             restart_delay: 10000,
             kill_timeout: 10000 // wait 5s before SIGKILL
         },
+        {
+            name: "file-watcher",
+            cwd: "./services/file-watcher",
+            script: "npm",
+            args: "start",
+            exec_mode: "fork",
+            watch: ["./services/file-watcher"],
+            instances: 1,
+            autorestart: true,
+            env: {
+                NODE_ENV: "production"
+            },
+            restart_delay: 10000,
+            kill_timeout: 10000
+        },
     ]
 };

--- a/scripts/hashtags_to_kanban.py
+++ b/scripts/hashtags_to_kanban.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Generate a Kanban board from task status hashtags."""
+
+from __future__ import annotations
+
+import re
+from collections import defaultdict
+from pathlib import Path
+
+TASK_DIR = Path("docs/agile/tasks")
+
+# Ordered list of recognized status hashtags
+STATUS_ORDER = [
+    "#ice-box",
+    "#incoming",
+    "#rejected",
+    "#accepted",
+    "#prompt-refinement",
+    "#agent-thinking",
+    "#breakdown",
+    "#blocked",
+    "#ready",
+    "#todo",
+    "#in-progress",
+    "#in-review",
+    "#done",
+]
+STATUS_SET = set(STATUS_ORDER)
+
+TITLE_RE = re.compile(r"^##\s+🛠️\s+Task:\s*(.+)")
+HASHTAG_RE = re.compile(r"#([A-Za-z0-9_-]+)")
+
+
+def parse_task(path: Path) -> tuple[str, str]:
+    """Return task title and status hashtag from a markdown file."""
+    title = path.stem.replace("_", " ")
+    status = "#todo"
+    with path.open(encoding="utf-8") as fh:
+        for line in fh:
+            if m := TITLE_RE.match(line):
+                title = m.group(1).strip()
+            for tag in HASHTAG_RE.findall(line):
+                tag = f"#{tag}"
+                if tag in STATUS_SET:
+                    status = tag
+    return title, status
+
+
+def collect_tasks(directory: Path = TASK_DIR):
+    tasks: dict[str, list[tuple[str, Path]]] = defaultdict(list)
+    for file in directory.glob("*.md"):
+        title, status = parse_task(file)
+        tasks[status].append((title, file))
+    return tasks
+
+
+def build_board(tasks: dict[str, list[tuple[str, Path]]]) -> str:
+    lines = ["---", "", "kanban-plugin: board", "", "---", ""]
+    for status in STATUS_ORDER:
+        items = tasks.get(status)
+        if not items:
+            continue
+        header = status.lstrip("#").replace("-", " ").title()
+        lines.append(f"## {header}")
+        lines.append("")
+        for title, path in sorted(items):
+            rel = Path("../tasks") / path.name
+            lines.append(f"- [ ] [{title}]({rel}) {status}")
+        lines.append("")
+    return "\n".join(lines)
+
+
+def main() -> None:
+    board = build_board(collect_tasks())
+    print(board)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/kanban_to_hashtags.py
+++ b/scripts/kanban_to_hashtags.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""Update task files with status hashtags from the kanban board."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from urllib.parse import unquote
+
+BOARD_PATH = Path("docs/agile/boards/kanban.md")
+TASK_DIR = Path("docs/agile/tasks")
+
+STATUS_ORDER = [
+    "#ice-box",
+    "#incoming",
+    "#rejected",
+    "#accepted",
+    "#prompt-refinement",
+    "#agent-thinking",
+    "#breakdown",
+    "#blocked",
+    "#ready",
+    "#todo",
+    "#in-progress",
+    "#in-review",
+    "#done",
+]
+STATUS_SET = set(STATUS_ORDER)
+
+
+def parse_board(path: Path = BOARD_PATH) -> dict[Path, str]:
+    """Return mapping of task file paths to status hashtags."""
+    mapping: dict[Path, str] = {}
+    status: str | None = None
+    with path.open(encoding="utf-8") as fh:
+        for line in fh:
+            if line.startswith("## "):
+                header = line[3:].strip()
+                header = re.sub(r"\s*\(.*\)$", "", header)
+                tag = f"#{header.lower().replace(' ', '-')}"
+                status = tag if tag in STATUS_SET else None
+                continue
+            if status and line.lstrip().startswith("- ["):
+                m = re.search(r"\(([^)]+\.md)\)", line)
+                if not m:
+                    continue
+                rel = unquote(m.group(1))
+                task_path = (path.parent / rel).resolve()
+                mapping[task_path] = status
+    return mapping
+
+
+def _remove_status_tokens(line: str) -> str:
+    tokens = [tok for tok in line.split() if tok not in STATUS_SET]
+    return " ".join(tokens)
+
+
+def set_status(path: Path, status: str) -> None:
+    """Update a task file with the given status hashtag."""
+    if not path.exists():
+        return
+    lines = [
+        _remove_status_tokens(line.rstrip())
+        for line in path.read_text(encoding="utf-8").splitlines()
+    ]
+    while lines and lines[-1] == "":
+        lines.pop()
+    lines.append(status)
+    lines.append("")
+    path.write_text("\n".join(lines), encoding="utf-8")
+
+
+def update_tasks(board: Path = BOARD_PATH) -> None:
+    for file, status in parse_board(board).items():
+        set_status(file, status)
+
+
+def main() -> None:
+    update_tasks()
+
+
+if __name__ == "__main__":
+    main()

--- a/services/file-watcher/.gitignore
+++ b/services/file-watcher/.gitignore
@@ -1,0 +1,2 @@
+dist
+node_modules

--- a/services/file-watcher/README.md
+++ b/services/file-watcher/README.md
@@ -1,0 +1,10 @@
+# File Watcher Service
+
+This service monitors the local kanban board and task files.
+
+- When `docs/agile/boards/kanban.md` changes it runs `kanban_to_hashtags.py` to
+  update the task files.
+- When any document under `docs/agile/tasks/` changes it runs
+  `hashtags_to_kanban.py` and writes the output back to the board.
+
+Use `npm run start:dev` while developing to watch TypeScript files.

--- a/services/file-watcher/package-lock.json
+++ b/services/file-watcher/package-lock.json
@@ -1,0 +1,424 @@
+{
+  "name": "file-watcher",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "file-watcher",
+      "version": "0.1.0",
+      "dependencies": {
+        "chokidar": "^3.5.3"
+      },
+      "devDependencies": {
+        "@types/node": "^22.10.10",
+        "ts-node": "^10.9.2",
+        "typescript": "5.7.3"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.4.tgz",
+      "integrity": "sha512-VT2+G1VQs/9oz078bLrYbecdZKs912zQlkelYpuf+SXF+QvZDYJlbx/LSx+meSAwdDFnF8FVXW92AVjjkVmgFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
+      "integrity": "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.17.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.17.0.tgz",
+      "integrity": "sha512-bbAKTCqX5aNVryi7qXVMi+OkB3w/OyblodicMbvE38blyAz7GxXf6XYhklokijuPwwVg9sDLKRxt0ZHXQwZVfQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.15.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
+      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
+      "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "license": "ISC",
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/binary-extensions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "license": "MIT",
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "license": "MIT",
+      "dependencies": {
+        "binary-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "license": "MIT",
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
+      "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    }
+  }
+}

--- a/services/file-watcher/package.json
+++ b/services/file-watcher/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "file-watcher",
+  "version": "0.1.0",
+  "main": "dist/index.js",
+  "type": "module",
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/index.js",
+    "start:dev": "node --loader ts-node/esm src/index.ts",
+    "build:check": "tsc --noEmit --incremental false"
+  },
+  "dependencies": {
+    "chokidar": "^3.5.3"
+  },
+  "devDependencies": {
+    "@types/node": "^22.10.10",
+    "ts-node": "^10.9.2",
+    "typescript": "5.7.3"
+  }
+}

--- a/services/file-watcher/src/index.ts
+++ b/services/file-watcher/src/index.ts
@@ -1,0 +1,64 @@
+import { spawn } from 'child_process';
+import chokidar from 'chokidar';
+import { join } from 'path';
+import { writeFile } from 'fs/promises';
+
+const repoRoot = join(__dirname, '..', '..');
+
+function runPython(script: string, capture = false): Promise<string | void> {
+  return new Promise((resolve, reject) => {
+    const proc = spawn('python', [script], { cwd: repoRoot });
+    let data = '';
+
+    proc.stdout.on('data', chunk => {
+      if (capture) {
+        data += chunk.toString();
+      } else {
+        process.stdout.write(chunk);
+      }
+    });
+    proc.stderr.on('data', chunk => process.stderr.write(chunk));
+    proc.on('close', code => {
+      if (code === 0) {
+        resolve(capture ? data : undefined);
+      } else {
+        reject(new Error(`Process exited with code ${code}`));
+      }
+    });
+  });
+}
+
+async function updateFromBoard() {
+  try {
+    await runPython(join('scripts', 'kanban_to_hashtags.py'));
+  } catch (err) {
+    console.error('kanban_to_hashtags failed', err);
+  }
+}
+
+async function updateBoard() {
+  try {
+    const output = await runPython(join('scripts', 'hashtags_to_kanban.py'), true);
+    const boardPath = join(repoRoot, 'docs', 'agile', 'boards', 'kanban.md');
+    if (typeof output === 'string') {
+      await writeFile(boardPath, output);
+    }
+  } catch (err) {
+    console.error('hashtags_to_kanban failed', err);
+  }
+}
+
+const boardPath = join(repoRoot, 'docs', 'agile', 'boards', 'kanban.md');
+const tasksPath = join(repoRoot, 'docs', 'agile', 'tasks');
+
+chokidar.watch(boardPath, { ignoreInitial: true }).on('change', () => {
+  console.log('Board changed, syncing hashtags...');
+  updateFromBoard();
+});
+
+chokidar.watch(tasksPath, { ignoreInitial: true }).on('change', () => {
+  console.log('Task file changed, regenerating board...');
+  updateBoard();
+});
+
+console.log('File watcher running...');

--- a/services/file-watcher/tsconfig.json
+++ b/services/file-watcher/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig.json",
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "es2022",
+    "moduleResolution": "bundler",
+    "outDir": "dist",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/tests/test_hashtags_to_kanban.py
+++ b/tests/test_hashtags_to_kanban.py
@@ -1,0 +1,51 @@
+import importlib.util
+from pathlib import Path
+
+MODULE_PATH = (
+    Path(__file__).resolve().parent.parent
+    / "scripts"
+    / "hashtags_to_kanban.py"
+)
+spec = importlib.util.spec_from_file_location(
+    "hashtags_to_kanban",
+    MODULE_PATH,
+)
+hk = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(hk)
+
+
+def test_parse_task_with_status(tmp_path):
+    md = tmp_path / "task.md"
+    md.write_text(
+        "## 🛠️ Task: Sample\nSome notes #in-progress\n",
+        encoding="utf-8",
+    )
+    title, status = hk.parse_task(md)
+    assert title == "Sample"
+    assert status == "#in-progress"
+
+
+def test_parse_task_defaults_to_todo(tmp_path):
+    md = tmp_path / "task2.md"
+    md.write_text(
+        "## 🛠️ Task: Another\nNo status here\n",
+        encoding="utf-8",
+    )
+    title, status = hk.parse_task(md)
+    assert title == "Another"
+    assert status == "#todo"
+
+
+def test_build_board_groups_by_status(tmp_path):
+    t1 = tmp_path / "a.md"
+    t1.write_text("## 🛠️ Task: Alpha\n#todo\n", encoding="utf-8")
+    t2 = tmp_path / "b.md"
+    t2.write_text("## 🛠️ Task: Beta\n#in-progress\n", encoding="utf-8")
+    tasks = hk.collect_tasks(tmp_path)
+    board = hk.build_board(tasks)
+    assert "## Todo" in board
+    assert "## In Progress" in board
+    todo_section = board.split("## Todo")[1].split("##")[0]
+    assert "[Alpha]" in todo_section
+    in_progress_section = board.split("## In Progress")[1].split("##")[0]
+    assert "[Beta]" in in_progress_section

--- a/tests/test_kanban_to_hashtags.py
+++ b/tests/test_kanban_to_hashtags.py
@@ -1,0 +1,45 @@
+import importlib.util
+from pathlib import Path
+
+MODULE_PATH = (
+    Path(__file__).resolve().parent.parent
+    / "scripts"
+    / "kanban_to_hashtags.py"
+)
+spec = importlib.util.spec_from_file_location(
+    "kanban_to_hashtags",
+    MODULE_PATH,
+)
+kh = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(kh)
+
+
+def test_parse_board(tmp_path):
+    board = tmp_path / "kanban.md"
+    tasks_dir = tmp_path / ".." / "tasks"
+    tasks_dir.mkdir(parents=True)
+    (tasks_dir / "a.md").write_text("content", encoding="utf-8")
+    (tasks_dir / "b.md").write_text("content", encoding="utf-8")
+    board.write_text(
+        "\n".join([
+            "## Todo",
+            "- [ ] [A](../tasks/a.md)",
+            "## In Progress",
+            "- [ ] [B](../tasks/b.md)",
+        ]),
+        encoding="utf-8",
+    )
+    mapping = kh.parse_board(board)
+    assert mapping[(tasks_dir / "a.md").resolve()] == "#todo"
+    assert mapping[(tasks_dir / "b.md").resolve()] == "#in-progress"
+
+
+def test_update_tasks(tmp_path):
+    board = tmp_path / "kanban.md"
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    task = tasks_dir / "a.md"
+    task.write_text("initial", encoding="utf-8")
+    board.write_text("## Done\n- [ ] [A](tasks/a.md)", encoding="utf-8")
+    kh.update_tasks(board)
+    assert task.read_text(encoding="utf-8").strip().splitlines()[-1] == "#done"


### PR DESCRIPTION
## Summary
- create `file-watcher` TypeScript service
- watch `kanban.md` and task documents to keep hashtags and board in sync
- register service with pm2 in `ecosystem.config.js`

## Testing
- `pip install -q -r requirements-dev.txt`
- `pip install -q flake8`
- `flake8 scripts/hashtags_to_kanban.py tests/test_hashtags_to_kanban.py scripts/kanban_to_hashtags.py tests/test_kanban_to_hashtags.py`
- `pytest -q`
- `npm --prefix services/file-watcher install`
- `npx tsc --project services/file-watcher/tsconfig.json --noEmit --pretty false`


------
https://chatgpt.com/codex/tasks/task_e_68898c3e6f6c8324967198408c2209b3