### PR TITLE
Add coverage reporting to CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,10 +19,16 @@ jobs:
       - name: Install Python dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install numpy inflect pytest discord pytest-asyncio pymongo
+          pip install numpy inflect pytest discord pytest-asyncio pymongo pytest-cov
 
-      - name: Run Python tests
-        run: pytest -q
+      - name: Run Python tests with coverage
+        run: pytest --cov=./ --cov-report=xml --cov-report=term
+
+      - name: Upload Python coverage
+        uses: actions/upload-artifact@v3
+        with:
+          name: python-coverage
+          path: coverage.xml
 
       - uses: actions/setup-node@v3
         with:
@@ -34,6 +40,12 @@ jobs:
           npm --prefix services/cephalon install --no-package-lock
           npm --prefix services/discord-embedder install --no-package-lock
 
-      - name: Run JS/TS Tests
-        run: npm test
+      - name: Run JS/TS tests with coverage
+        run: npx c8 --reporter=text --reporter=lcov npm test
+
+      - name: Upload JS coverage
+        uses: actions/upload-artifact@v3
+        with:
+          name: js-coverage
+          path: coverage
 

--- a/Pipfile
+++ b/Pipfile
@@ -50,6 +50,7 @@ openai-whisper = "*"
 
 [dev-packages]
 pytest = "*"
+pytest-cov = "*"
 
 [requires]
 python_version = "3.12"

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -1,5 +1,8 @@
 # Continuous Integration
 
-GitHub Actions run `pytest` on every pull request to ensure the test suite passes.
-The workflow file lives at `.github/workflows/tests.yml` and installs minimal
-dependencies before executing the tests.
+GitHub Actions run tests and collect coverage on every pull request.
+The workflow file `.github/workflows/tests.yml` installs dependencies and
+executes `pytest` with the `pytest-cov` plugin. JavaScript tests are executed
+through `c8` to gather coverage reports. Coverage artifacts are uploaded for
+review after the job completes.
+

--- a/package.json
+++ b/package.json
@@ -1,17 +1,18 @@
 {
-    "scripts": {
-        "test": "npm --prefix services/cephalon test && npm --prefix services/discord-embedder test"
-    },
-    "dependencies": {
-        "@discordjs/voice": "^0.18.0",
-        "pm2": "^6.0.8",
-        "screenshot-desktop": "^1.15.1",
-        "tokenizers": "^0.13.3",
-        "typescript": "^5.8.3"
-    },
-    "devDependencies": {
-        "@types/sbd": "^1.0.5",
-        "@types/screenshot-desktop": "^1.12.3",
-        "ava": "^6.4.1"
-    }
+  "scripts": {
+    "test": "npm --prefix services/cephalon test && npm --prefix services/discord-embedder test"
+  },
+  "dependencies": {
+    "@discordjs/voice": "^0.18.0",
+    "pm2": "^6.0.8",
+    "screenshot-desktop": "^1.15.1",
+    "tokenizers": "^0.13.3",
+    "typescript": "^5.8.3"
+  },
+  "devDependencies": {
+    "@types/sbd": "^1.0.5",
+    "@types/screenshot-desktop": "^1.12.3",
+    "ava": "^6.4.1",
+    "c8": "^10.1.3"
+  }
 }

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,3 +4,4 @@ inflect
 pytest
 pytest-asyncio
 pymongo
+pytest-cov


### PR DESCRIPTION
## Summary
- generate test coverage in the main workflow
- upload coverage artifacts for Python and JS
- document how coverage works
- add coverage dependencies

## Testing
- `pytest -q`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6889a1ae8c608324ad8a667158f67f85