### PR TITLE
Add websocket benchmarks

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -47,6 +47,7 @@ g2p-en = "*"
 nltk = "*"
 whisper = "*"
 openai-whisper = "*"
+websockets = "*"
 
 [dev-packages]
 pytest = "*"

--- a/docs/benchmarks/tts_ws_benchmark.md
+++ b/docs/benchmarks/tts_ws_benchmark.md
@@ -1,0 +1,13 @@
+# TTS WebSocket Benchmark
+
+**Path**: `scripts/bench_tts_ws.py`
+
+**Description**: Measures round-trip latency of the WebSocket-based text to speech service.
+
+## Dependencies
+- websockets
+
+## Usage
+```bash
+python scripts/bench_tts_ws.py --host localhost --port 5003 --text "Hello" -n 5
+```

--- a/docs/services/tts/ws.md
+++ b/docs/services/tts/ws.md
@@ -1,0 +1,13 @@
+# ws.py
+
+**Path**: `services/tts/ws.py`
+
+**Description**: WebSocket interface that streams synthesized speech from text messages.
+
+## Dependencies
+- fastapi
+- soundfile
+- shared.py.speech.tts
+
+## Dependents
+- `run_ws.sh`

--- a/scripts/bench_tts_ws.py
+++ b/scripts/bench_tts_ws.py
@@ -1,0 +1,30 @@
+import asyncio
+import argparse
+import time
+import websockets
+
+async def run_benchmark(host, port, text, iterations):
+    uri = f"ws://{host}:{port}/ws/tts"
+    latencies = []
+    async with websockets.connect(uri) as ws:
+        for _ in range(iterations):
+            start = time.perf_counter()
+            await ws.send(text)
+            await ws.recv()
+            latencies.append(time.perf_counter() - start)
+    avg = sum(latencies) / len(latencies)
+    print(f"Average latency over {iterations} runs: {avg:.3f}s")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Benchmark TTS WebSocket service")
+    parser.add_argument("--host", default="localhost")
+    parser.add_argument("--port", type=int, default=5003)
+    parser.add_argument("--text", default="hello world")
+    parser.add_argument("-n", "--iterations", type=int, default=10)
+    args = parser.parse_args()
+    asyncio.run(run_benchmark(args.host, args.port, args.text, args.iterations))
+
+
+if __name__ == "__main__":
+    main()

--- a/services/tts/run_ws.sh
+++ b/services/tts/run_ws.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/bash
+pipenv run uvicorn ws:app --host 0.0.0.0 --port 5003

--- a/services/tts/ws.py
+++ b/services/tts/ws.py
@@ -1,0 +1,21 @@
+from fastapi import FastAPI, WebSocket, WebSocketDisconnect
+import io
+import soundfile as sf
+
+app = FastAPI()
+
+@app.websocket("/ws/tts")
+async def tts_websocket(ws: WebSocket):
+    await ws.accept()
+    try:
+        from shared.py.speech import tts
+        while True:
+            text = await ws.receive_text()
+            audio = tts.generate_voice(text)
+            buf = io.BytesIO()
+            sf.write(buf, audio, samplerate=22050, format="WAV")
+            await ws.send_bytes(buf.getvalue())
+    except WebSocketDisconnect:
+        pass
+    finally:
+        await ws.close()

--- a/tests/test_speech_utils.py
+++ b/tests/test_speech_utils.py
@@ -1,0 +1,116 @@
+import os, sys, importlib, types
+from unittest import mock
+
+ROOT_DIR = os.path.join(os.path.dirname(__file__), "..")
+sys.path.insert(0, os.path.join(ROOT_DIR, "shared", "py"))
+
+import numpy as np
+import pytest
+
+
+def load_stt_module():
+    """Import speech.stt with heavy deps stubbed."""
+    dummy_torch = types.ModuleType("torch")
+    dummy_torch.Tensor = np.ndarray
+    dummy_torch.stack = lambda seq: np.stack(seq)
+    functional = types.ModuleType("torch.nn.functional")
+    functional.pad = lambda x, pad, mode='constant', value=0: x
+    dummy_torch.nn = types.ModuleType("torch.nn")
+    dummy_torch.nn.functional = functional
+
+    dummy_torchaudio = types.ModuleType("torchaudio")
+    dummy_torchaudio.load = lambda *a, **k: (np.zeros((1, 16000)), 16000)
+    class DummyResample:
+        def __init__(self, orig_freq, new_freq):
+            pass
+        def __call__(self, waveform):
+            return waveform
+    dummy_torchaudio.transforms = types.SimpleNamespace(Resample=DummyResample)
+
+    dummy_transformers = types.ModuleType("transformers")
+    dummy_transformers.Wav2Vec2ForCTC = types.SimpleNamespace(from_pretrained=lambda *a, **k: None)
+    dummy_transformers.Wav2Vec2Processor = types.SimpleNamespace(from_pretrained=lambda *a, **k: None)
+    dummy_transformers.AutoTokenizer = types.SimpleNamespace(from_pretrained=lambda *a, **k: types.SimpleNamespace(__call__=lambda text, return_tensors=None: types.SimpleNamespace(input_ids=None, attention_mask=None)))
+    dummy_transformers.AutoModelForSeq2SeqLM = types.SimpleNamespace(from_pretrained=lambda *a, **k: types.SimpleNamespace(generate=lambda *a, **k: [0]))
+
+    dummy_ov = types.ModuleType("openvino")
+    class DummyInput:
+        def get_partial_shape(self):
+            return None
+        def __hash__(self):
+            return 1
+
+    class DummyModel:
+        def __init__(self):
+            self.inputs = [DummyInput()]
+        def reshape(self, mapping):
+            pass
+
+    dummy_ov.convert_model = lambda *a, **k: DummyModel()
+    dummy_ov.compile_model = lambda *a, **k: lambda inputs: {"logits": [0]}
+    dummy_ov.PartialShape = lambda x: None
+
+    dummy_symspellpy = types.ModuleType("symspellpy.symspellpy")
+    class DummySymSpell:
+        def __init__(self, *args, **kwargs):
+            pass
+        def load_dictionary(self, *a, **k):
+            pass
+    dummy_symspellpy.SymSpell = DummySymSpell
+    dummy_symspellpy.Verbosity = object
+
+    sys.modules.setdefault("torch", dummy_torch)
+    sys.modules.setdefault("torch.nn", dummy_torch.nn)
+    sys.modules.setdefault("torch.nn.functional", dummy_torch.nn.functional)
+    sys.modules.setdefault("torchaudio", dummy_torchaudio)
+    sys.modules.setdefault("openvino", dummy_ov)
+    sys.modules.setdefault("transformers", dummy_transformers)
+    sys.modules.setdefault("symspellpy.symspellpy", dummy_symspellpy)
+    return importlib.import_module("speech.stt")
+
+
+stt = load_stt_module()
+from speech.wav import normalize_audio
+
+clamp_freq = stt.clamp_freq
+convert_to_mono_np = stt.convert_to_mono_np
+convert_to_mono = stt.convert_to_mono
+
+
+def test_clamp_freq_bounds():
+    assert clamp_freq(-10, 16000) == 1.0
+    nyquist = 16000 / 2
+    assert clamp_freq(nyquist + 1000, 16000) == nyquist - 1.0
+    assert clamp_freq(1000, 16000) == 1000
+
+
+def test_convert_to_mono_np_channels_samples():
+    stereo = np.array([[1.0, -1.0, 0.5], [0.0, 0.5, -0.5]])  # shape [2,3]
+    mono = convert_to_mono_np(stereo)
+    expected = np.array([0.5, -0.25, 0.0])
+    assert np.allclose(mono, expected)
+
+
+def test_convert_to_mono_np_samples_channels():
+    stereo = np.array([[1.0, 0.0], [-1.0, 0.5], [0.5, -0.5]])  # shape [3,2]
+    mono = convert_to_mono_np(stereo)
+    expected = np.array([0.5, -0.25, 0.0])
+    assert np.allclose(mono, expected)
+
+
+def test_convert_to_mono_dispatch_numpy():
+    stereo = np.array([[1.0, -1.0], [0.5, 0.0]])
+    mono = convert_to_mono(stereo)
+    assert mono.shape == (2,)
+
+
+def test_convert_to_mono_invalid_type():
+    with pytest.raises(TypeError):
+        convert_to_mono("invalid")
+
+
+def test_normalize_audio_no_clip():
+    data = np.array([0.0, 0.5, -1.0])
+    assert np.allclose(normalize_audio(data), data)
+
+

--- a/tests/test_tts_websocket.py
+++ b/tests/test_tts_websocket.py
@@ -1,0 +1,29 @@
+import os, sys
+ROOT_DIR = os.path.join(os.path.dirname(__file__), "..")
+sys.path.insert(0, os.path.join(ROOT_DIR, "shared", "py"))
+sys.path.insert(0, ROOT_DIR)
+
+import numpy as np
+from fastapi.testclient import TestClient
+from services.tts.ws import app
+from unittest.mock import patch
+import types
+
+
+def test_websocket_tts_returns_wav_bytes():
+    dummy_audio = np.zeros(22050, dtype=np.float32)
+    dummy_module = types.SimpleNamespace(generate_voice=lambda text: dummy_audio)
+    dummy_package = types.ModuleType('speech')
+    dummy_package.tts = dummy_module
+    with patch.dict(sys.modules, {
+        'speech': dummy_package,
+        'speech.tts': dummy_module,
+        'shared.py.speech': dummy_package,
+        'shared.py.speech.tts': dummy_module,
+    }):
+        client = TestClient(app)
+        with client.websocket_connect('/ws/tts') as websocket:
+            websocket.send_text('hello')
+            data = websocket.receive_bytes()
+            assert data.startswith(b'RIFF')
+            assert len(data) > 44  # standard WAV header size


### PR DESCRIPTION
## Summary
- add benchmark utility for the websocket TTS service
- document running the benchmark script
- include websockets dependency
- add tests for the speech utility functions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68899db306bc8324bd464367d40f9319