### PR TITLE
Add board usage documentation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -14,7 +14,7 @@ This `docs` directory houses internal documentation for the **Promethean Framewo
         
 - **Agile process and tasks**
     
-    - [Kanban board](agile/boards/kanban.md) – the Kanban board used to track work. When opened in Obsidian with the Kanban plugin, it renders as an interactive board.
+    - [Kanban board](agile/boards/kanban.md) – the Kanban board used to track work. When opened in Obsidian with the Kanban plugin, it renders as an interactive board. See [board usage](board_usage.md) for how to interact with it.
         
     - [Process](agile/Process.md) – explains the stages of the development flow (Ice Box, Accepted, Breakdown, etc.) and when cards move between them[raw.githubusercontent.com](https://raw.githubusercontent.com/riatzukiza/promethean/ef2459fe07e70d361b9d915670ce2fa8218fbe51/docs/agile/Process.md#:~:text=).
         

--- a/docs/agile/boards/kanban.md
+++ b/docs/agile/boards/kanban.md
@@ -4,6 +4,9 @@ kanban-plugin: board
 
 ---
 
+For guidelines on using this board effectively, see
+[Board Usage](../board_usage.md).
+
 ## Ice Box
 
 - [ ] [Migrating relevant modules from riatzukiza.github.io to -site- and -docs-](../tasks/Migrating%20relevant%20modules%20from%20riatzukiza.github.io%20to%20-site-%20and%20-docs-.md) #framework-core

--- a/docs/board_usage.md
+++ b/docs/board_usage.md
@@ -1,0 +1,43 @@
+# Kanban Board Usage Guide
+
+This page explains how to work with the Promethean Kanban board located at
+[`docs/agile/boards/kanban.md`](agile/boards/kanban.md). The board is designed
+for the Obsidian Kanban plugin but renders fine on GitHub.
+
+## Adding and linking tasks
+
+1. Create a new markdown file in `docs/agile/Tasks/` using the task template.
+2. Include a status hashtag such as `#todo` or `#in-progress` at the top.
+3. Link the file from the appropriate column on the board using a relative
+   markdown link.
+4. Run the sync scripts (`hashtags_to_kanban.py` or `kanban_to_hashtags.py`) if
+   you reorganise tasks outside Obsidian.
+
+Tasks should always be linked on the board before moving to **Ready** or beyond.
+The board manager agent checks this linkage and can create stubs when needed.
+
+## Typical workflow
+
+The board columns map to the stages in
+[`docs/agile/Process.md`](agile/Process.md). A common flow is:
+
+`Ice Box → Accepted → Breakdown → Ready → To Do → In Progress → In Review → Done`
+
+Refer to [`docs/agile/AGENTS.md`](agile/AGENTS.md) for details on how the board
+manager enforces this process.
+
+## WIP limits
+
+Some column headings include numbers like `In Progress (4)`. These numbers store
+WIP (work in progress) limits used by the Kanban plugin. Avoid editing them
+manually. Moving cards beyond the limit will highlight the column in Obsidian.
+
+## Tips
+
+- Keep filenames short and use kebab case.
+- Use relative links so the board works on GitHub as well as in Obsidian.
+- When a task is complete, ensure its file links to resulting code or docs before
+  moving it to **Done**.
+
+See [`docs/board_sync.md`](board_sync.md) for information about syncing with a
+GitHub Projects board.


### PR DESCRIPTION
## Summary
- document Kanban usage
- add cross-links from board and docs README

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6889af03909483248a1f12dc1b790f92