### PR TITLE
Align GitHub tests with Makefile

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,32 +16,30 @@ jobs:
         with:
           python-version: '3.12'
 
-      - name: Install Python dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install numpy inflect pytest discord pytest-asyncio pymongo pytest-cov uvicorn websockets fastapi httpx scipy soundfile
+      - name: Install pipenv
+        run: python -m pip install pipenv
 
-      - name: Run Python tests with coverage
-        run: pytest --cov=./ --cov-report=xml --cov-report=term
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '20'
+
+      - name: Project setup
+        run: make setup
+
+      - name: Build project
+        run: make build
+
+      - name: Lint
+        run: make lint
+
+      - name: Run tests with coverage
+        run: make coverage
 
       - name: Upload Python coverage
         uses: actions/upload-artifact@v4
         with:
           name: python-coverage
           path: coverage.xml
-
-      - uses: actions/setup-node@v3
-        with:
-          node-version: '20'
-
-      - name: Install JS/TS dependencies
-        run: |
-          npm install
-          npm --prefix services/cephalon install --no-package-lock
-          npm --prefix services/discord-embedder install --no-package-lock
-
-      - name: Run JS/TS tests with coverage
-        run: npx c8 --reporter=text --reporter=lcov npm test
 
       - name: Upload JS coverage
         uses: actions/upload-artifact@v4

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ TS_OUT=shared/js
 
 # === High-Level Targets ===
 
-.PHONY: all build clean lint format test setup start stop start-tts start-stt stop-tts stop-stt
+.PHONY: all build clean lint format test setup start stop start-tts start-stt stop-tts stop-stt coverage coverage-python coverage-js
 
 SERVICES_PY=services/stt services/tts services/discord-indexer
 SERVICES_JS=services/cephalon services/discord-embedder
@@ -72,6 +72,16 @@ format-js:
 
 test-js:
 	npm test
+
+# === Coverage ===
+
+coverage-python:
+	pytest --cov=./ --cov-report=xml --cov-report=term
+
+coverage-js:
+	npx c8 --reporter=text --reporter=lcov npm test
+
+coverage: coverage-python coverage-js
 
 # === Service Management ===
 

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -1,8 +1,8 @@
 # Continuous Integration
 
 GitHub Actions run tests and collect coverage on every pull request.
-The workflow file `.github/workflows/tests.yml` installs dependencies and
-executes `pytest` with the `pytest-cov` plugin. JavaScript tests are executed
-through `c8` to gather coverage reports. Coverage artifacts are uploaded for
-review after the job completes.
+The job now relies on the repository `Makefile` so CI mirrors local
+development. `make setup` installs all dependencies, `make build` compiles
+sources, and `make coverage` runs Python and JavaScript tests with coverage
+enabled. The workflow uploads the resulting coverage artifacts for review.
 

--- a/readme.md
+++ b/readme.md
@@ -61,6 +61,7 @@ Common tasks are wrapped in the root `Makefile`:
 - `make start:<service>` – run a service from `ecosystem.config.js` by name
 - `make stop` – stop running services
 - `make test` – run Python and JS test suites
+- `make coverage` – run tests with coverage reports
 
 Agent-specific services may define their own `ecosystem.config.js` files.
 


### PR DESCRIPTION
## Summary
- update CI workflow to use Makefile
- document Makefile-based CI workflow
- add coverage targets to Makefile
- note `make coverage` command in README

## Testing
- `make lint` *(fails: flake8 not found)*
- `make coverage` *(fails: ModuleNotFoundError: No module named 'discord')*

------
https://chatgpt.com/codex/tasks/task_e_6889b83e72408324a51672ffa17da88a