### PR TITLE
Add link lowercase script

### DIFF
--- a/scripts/lowercase_links.py
+++ b/scripts/lowercase_links.py
@@ -1,0 +1,52 @@
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+LINK_RE = re.compile(r"\[[^\]]+\]\(([^)]+)\)")
+
+
+def rename_dirs(base: Path, link: str) -> None:
+    """Rename directories in the link path to lowercase if they exist."""
+    if '/' not in link:
+        return
+    target = (base.parent / link).resolve()
+    if not target.exists():
+        return
+    try:
+        rel = target.relative_to(ROOT)
+    except ValueError:
+        return
+    cur = ROOT
+    for part in rel.parts[:-1]:
+        cur = cur / part
+        lower = cur.with_name(cur.name.lower())
+        if cur.exists() and cur.name != cur.name.lower():
+            if lower.exists():
+                print(f"Skipping rename of {cur} -> {lower}: target exists")
+            else:
+                cur.rename(lower)
+                cur = lower
+        else:
+            cur = lower if cur.name != lower.name else cur
+
+
+def process_file(path: Path) -> None:
+    text = path.read_text(encoding="utf-8")
+
+    def repl(match: re.Match) -> str:
+        link = match.group(1)
+        lower = link.lower()
+        if link != lower:
+            rename_dirs(path, link)
+        return match.group(0).replace(link, lower)
+
+    new_text = LINK_RE.sub(repl, text)
+    if new_text != text:
+        path.write_text(new_text, encoding="utf-8")
+
+
+if __name__ == "__main__":
+    files = [Path(p) for p in sys.argv[1:]] or list(ROOT.rglob("*.md"))
+    for f in files:
+        process_file(f)


### PR DESCRIPTION
## Summary
- add `scripts/lowercase_links.py` to lowercase links in markdown
- recursively rename directories referenced by links

## Testing
- `make format-python` *(fails: cannot parse some files)*
- `make test-python` *(fails: 1 failed, 33 passed)*
- `make lint-python` *(fails: flake8 missing)*

------
https://chatgpt.com/codex/tasks/task_e_6889ba027d388324bd3ef79a1ac709ab