### PR TITLE
Document makefile as single source

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,6 +61,9 @@ site/            # Website or UI content (optional)
 * Contributors may submit raw JS or TS modules—Sibilant is preferred but not mandatory
 * If a module evolves entirely into JS or TS, it will be respected as-is if quality is maintained
 
+### Makefile Driven Workflow
+All development and board automation tasks should use the root `Makefile` targets for consistency.
+
 ---
 
 ## ⚙️ Codex Permissions

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,8 @@ TS_OUT=shared/js
 
 # === High-Level Targets ===
 
-.PHONY: all build clean lint format test setup start stop start-tts start-stt stop-tts stop-stt
+.PHONY: all build clean lint format test setup start stop start-tts start-stt stop-tts stop-stt \
+    board-sync kanban-from-tasks kanban-to-hashtags kanban-to-issues
 
 SERVICES_PY=services/stt services/tts services/discord-indexer
 SERVICES_JS=services/cephalon services/discord-embedder
@@ -95,3 +96,17 @@ start-%:
 
 stop-%:
 	pm2 stop $* || true
+
+# === Kanban Board ===
+
+board-sync:
+	python scripts/github_board_sync.py
+
+kanban-from-tasks:
+	python scripts/hashtags_to_kanban.py > docs/agile/boards/kanban.md
+
+kanban-to-hashtags:
+	python scripts/kanban_to_hashtags.py
+
+kanban-to-issues:
+	python scripts/kanban_to_issues.py

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -54,6 +54,8 @@ To sync with system structure:
 npm run build:docs  # optional sync or generate script
 ````
 
+Board automation tasks are run via Makefile targets such as `make kanban-from-tasks`.
+
 To browse:
 
 * Open `docs/` in Obsidian with plugins enabled

--- a/docs/agile/AGENTS.md
+++ b/docs/agile/AGENTS.md
@@ -4,7 +4,7 @@ This agent is responsible for maintaining and navigating the Kanban board in `ag
 It acts as the glue between human contributors and Codex by interpreting board
 states, enforcing WIP limits, and prompting Codex when a card carries the
 `#codex-task` tag. The board itself is generated from the task files in
-`agile/tasks/` using `scripts/update_kanban_from_tasks.py`.
+`agile/tasks/` via the `make kanban-from-tasks` target.
 
 ---
 
@@ -17,6 +17,7 @@ states, enforcing WIP limits, and prompting Codex when a card carries the
 - Agents may generate, edit, or move tasks on the board based on defined tags and the process graph.
 - The numbers in kanban column headings (e.g. "In Progress (4)") store WIP limits for the plugin. Avoid editing these counts directly.
 - Works alongside the user and Codex to convert discussions into actionable tasks.
+- All board scripts should be invoked through Makefile targets rather than directly running Python files.
 
 ---
 
@@ -79,7 +80,7 @@ The board columns are derived from these hashtags in each task file:
 - Tasks: `agile/tasks/*.md`
 - Process flow: `process.md`
 
-The board file is regenerated whenever `scripts/update_kanban_from_tasks.py` is run. **Do not edit `kanban.md` manually.** To move a task between columns, edit the status hashtag in its corresponding task file and rerun the script.
+The board file is regenerated whenever `make kanban-from-tasks` is run. **Do not edit `kanban.md` manually.** To move a task between columns, edit the status hashtag in its corresponding task file and rerun `make kanban-to-hashtags`.
 
 ---
 

--- a/docs/board_sync.md
+++ b/docs/board_sync.md
@@ -1,6 +1,6 @@
 # Board Sync Workflow
 
-This document explains how to keep the local `kanban.md` board in sync with a GitHub Projects board using `scripts/github_board_sync.py`.
+This document explains how to keep the local `kanban.md` board in sync with a GitHub Projects board using the `make board-sync` target.
 
 ## Setup
 1. Obtain a GitHub personal access token with `project` and `repo` scopes.
@@ -8,10 +8,10 @@ This document explains how to keep the local `kanban.md` board in sync with a Gi
 3. Set `GITHUB_TOKEN` in your environment.
 
 ## Usage
-Run the script from the repository root:
+Run the sync target from the repository root:
 
 ```bash
-python scripts/github_board_sync.py
+make board-sync
 ```
 
 By default the script reads `docs/agile/boards/kanban.md` and creates note cards in the specified project column. Without environment variables it performs a dry run.
@@ -36,10 +36,10 @@ You can regenerate `kanban.md` from the task files themselves. The
 status hashtag such as `#todo` or `#in-progress` and groups the tasks by those
 hashtags.
 
-Run the script and redirect the output to your board:
+Generate the board from task files:
 
 ```bash
-python scripts/hashtags_to_kanban.py > docs/agile/boards/kanban.md
+make kanban-from-tasks
 ```
 
 The resulting board uses the same layout as the existing `kanban.md` file,
@@ -47,13 +47,8 @@ placing each task under the column that matches its hashtag.
 
 ## Update Hashtags from the Board
 
-When you move cards between columns, run `kanban_to_hashtags.py` to write the
-new status hashtags back into each task file. The script reads
-`kanban.md` and updates the linked documents:
-
-```bash
-python scripts/kanban_to_hashtags.py
-```
+When you move cards between columns, run `make kanban-to-hashtags` to write the
+new status hashtags back into each task file. The target reads `kanban.md` and updates the linked documents.
 
 This keeps the `#todo` or `#in-progress` tags inside the tasks synchronized with
 their board position.

--- a/docs/board_usage.md
+++ b/docs/board_usage.md
@@ -10,7 +10,7 @@ for the Obsidian Kanban plugin but renders fine on GitHub.
 2. Include a status hashtag such as `#todo` or `#in-progress` at the top.
 3. Link the file from the appropriate column on the board using a relative
    markdown link.
-4. Run the sync scripts (`hashtags_to_kanban.py` or `kanban_to_hashtags.py`) if
+4. Run the Makefile commands (`make kanban-from-tasks` or `make kanban-to-hashtags`) if
    you reorganise tasks outside Obsidian.
 
 Tasks should always be linked on the board before moving to **Ready** or beyond.

--- a/readme.md
+++ b/readme.md
@@ -61,6 +61,10 @@ Common tasks are wrapped in the root `Makefile`:
 - `make start:<service>` – run a service from `ecosystem.config.js` by name
 - `make stop` – stop running services
 - `make test` – run Python and JS test suites
+- `make board-sync` – sync `kanban.md` with GitHub Projects
+- `make kanban-from-tasks` – regenerate `kanban.md` from task files
+- `make kanban-to-hashtags` – update task statuses from `kanban.md`
+- `make kanban-to-issues` – create GitHub issues from the board
 
 Agent-specific services may define their own `ecosystem.config.js` files.
 
@@ -94,7 +98,7 @@ pytest -q
 
 ## Converting Kanban Tasks to GitHub Issues
 
-A helper script `scripts/kanban_to_issues.py` can create GitHub issues from the tasks listed in `docs/agile/boards/kanban.md`. Set the following environment variables before running the script:
+A helper Makefile target `make kanban-to-issues` can create GitHub issues from the tasks listed in `docs/agile/boards/kanban.md`. Set the following environment variables before running it:
 
 - `GITHUB_TOKEN` – a personal access token with permission to create issues
 - `GITHUB_REPO` – the repository in `owner/repo` format
@@ -102,7 +106,7 @@ A helper script `scripts/kanban_to_issues.py` can create GitHub issues from the 
 Then run:
 
 ```bash
-python scripts/kanban_to_issues.py
+make kanban-to-issues
 ```
 
 Without a token the script performs a dry run and prints the issues that would be created.


### PR DESCRIPTION
## Summary
- declare Makefile driven workflow in AGENTS
- add board-related commands in Makefile
- reference make targets in docs and README

## Testing
- `make test` *(fails: ModuleNotFoundError: No module named 'uvicorn')*

------
https://chatgpt.com/codex/tasks/task_e_6889b9a9e3088324b2a48882f89d070c