### PR TITLE
Update duck ecosystem to launch new services

### DIFF
--- a/agents/duck/.env.example
+++ b/agents/duck/.env.example
@@ -15,3 +15,6 @@ PROFILE_CHANNEL=<profile_channel>
 DEFAULT_CHANNEL=<dump_channel_name>
 
 DEFAULT_CHANNEL_NAME=<channel_name_to_dump_unassigned_agent_messages>
+
+# URL for the vision service used by Cephalon
+VISION_HOST=http://localhost:5003

--- a/agents/duck/ecosystem.config.js
+++ b/agents/duck/ecosystem.config.js
@@ -57,6 +57,111 @@ module.exports = {
             "args": "-m pipenv run chroma run --path ./chroma_data",
             restart_delay: 10000,
             kill_timeout: 10000
+        },
+        {
+            name: "tts",
+            cwd: "../../services/tts",
+            script: "../../services/tts/run.sh",
+            interpreter: "bash",
+            exec_mode: "fork",
+            watch: ["../../services/tts"],
+            instances: 1,
+            autorestart: true,
+            env: {
+                PYTHONPATH: require("path").resolve(__dirname, "../.."),
+                PYTHONUNBUFFERED: "1",
+                FLASK_APP: "app.py",
+                FLASK_ENV: "production",
+            },
+            restart_delay: 10000,
+            kill_timeout: 10000
+        },
+        {
+            name: "stt",
+            cwd: "../../services/stt",
+            script: "../../services/stt/run.sh",
+            interpreter: "bash",
+            exec_mode: "fork",
+            watch: ["../../services/stt"],
+            instances: 1,
+            autorestart: true,
+            env: {
+                PYTHONUNBUFFERED: "1",
+                PYTHONPATH: require("path").resolve(__dirname, "../.."),
+            },
+            restart_delay: 10000,
+            kill_timeout: 10000
+        },
+        {
+            name: "file-watcher",
+            cwd: "../../services/file-watcher",
+            script: "npm",
+            args: "start",
+            exec_mode: "fork",
+            watch: ["../../services/file-watcher"],
+            instances: 1,
+            autorestart: true,
+            env: {
+                NODE_ENV: "production"
+            },
+            restart_delay: 10000,
+            kill_timeout: 10000
+        },
+        {
+            name: "stt-ws",
+            cwd: "../../services/stt_ws",
+            script: "../../services/stt_ws/run.sh",
+            interpreter: "bash",
+            exec_mode: "fork",
+            watch: ["../../services/stt_ws"],
+            instances: 1,
+            autorestart: true,
+            env: {
+                PYTHONUNBUFFERED: "1",
+                PYTHONPATH: require("path").resolve(__dirname, "../.."),
+            },
+            restart_delay: 10000,
+            kill_timeout: 10000
+        },
+        {
+            name: "whisper-stream-ws",
+            cwd: "../../services/whisper_stream_ws",
+            script: "../../services/whisper_stream_ws/run.sh",
+            interpreter: "bash",
+            exec_mode: "fork",
+            watch: ["../../services/whisper_stream_ws"],
+            instances: 1,
+            autorestart: true,
+            env: {
+                PYTHONUNBUFFERED: "1",
+                PYTHONPATH: require("path").resolve(__dirname, "../.."),
+            },
+            restart_delay: 10000,
+            kill_timeout: 10000
+        },
+        {
+            name: "llm",
+            cwd: "../../services/llm",
+            script: "npm",
+            args: "start",
+            exec_mode: "fork",
+            watch: ["../../services/llm"],
+            instances: 1,
+            autorestart: true,
+            restart_delay: 10000,
+            kill_timeout: 10000
+        },
+        {
+            name: "vision",
+            cwd: "../../services/vision",
+            script: "npm",
+            args: "start",
+            exec_mode: "fork",
+            watch: ["../../services/vision"],
+            instances: 1,
+            autorestart: true,
+            restart_delay: 10000,
+            kill_timeout: 10000
         }
 
     ]


### PR DESCRIPTION
## Summary
- run new speech, vision, LLM and watcher services in Duck's PM2 config
- document vision host in Duck `.env.example`

## Testing
- `pytest -q`
- `npm test` *(fails: ts-node not found for cephalon and discord-embedder)*

------
https://chatgpt.com/codex/tasks/task_e_6889ba7ddcd48324bedd0043f2d8797b