### PR TITLE
Add local CI workflow simulation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -174,6 +174,15 @@ train_stt_quantize.py
 train_cephalon_align_lora.py
 ```
 
+## 🚥 CI Verification
+
+All contributions must be validated locally before opening a pull request:
+
+1. Run `make test` for the relevant services.
+2. Run `make simulate-ci` to emulate GitHub Actions using [`act`](https://github.com/nektos/act).
+
+Work is only considered complete when both commands succeed.
+
 ---
 
 ## 🔐 Versioning and Storage Rules

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ TS_OUT=shared/js
 
 # === High-Level Targets ===
 
-.PHONY: all build clean lint format test setup start stop start-tts start-stt stop-tts stop-stt
+.PHONY: all build clean lint format test simulate-ci setup start stop start-tts start-stt stop-tts stop-stt
 
 SERVICES_PY=services/stt services/tts services/discord-indexer
 SERVICES_JS=services/cephalon services/discord-embedder
@@ -24,6 +24,10 @@ lint: lint-python lint-js
 format: format-python format-js
 
 test: test-python test-js
+
+# === Workflow Simulation ===
+simulate-ci:
+	act -W .github/workflows/tests.yml pull_request
 
 # === Python/HY ===
 

--- a/docs/agile/AGENTS.md
+++ b/docs/agile/AGENTS.md
@@ -66,6 +66,7 @@ The board columns are derived from these hashtags in each task file:
 - Before moving to `Done`, confirm:
   - The outcome is documented
   - Any generated files are linked
+  - `make test` and `make simulate-ci` run successfully
 - When a task is added to the board with no backing file:
   - Create a markdown stub in `agile/tasks/` with metadata and checklist
   - Flag it for review in `Breakdown`

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -6,3 +6,15 @@ executes `pytest` with the `pytest-cov` plugin. JavaScript tests are executed
 through `c8` to gather coverage reports. Coverage artifacts are uploaded for
 review after the job completes.
 
+You can emulate this workflow locally using the
+[`act`](https://github.com/nektos/act) CLI. A Makefile target wraps the
+command:
+
+```bash
+make simulate-ci
+```
+
+This runs `act pull_request` to replicate the GitHub Actions job definitions.
+Both `make test` and `make simulate-ci` should succeed before sending a pull
+request.
+


### PR DESCRIPTION
## Summary
- add `simulate-ci` target in Makefile that runs `act`
- document local workflow simulation in `docs/ci.md`
- require `make simulate-ci` and `make test` in contributor guide
- update board manager rules to check the new requirement

## Testing
- `make test` *(fails: ModuleNotFoundError, connection refused)*
- `make simulate-ci` *(fails: Docker not available)*

------
https://chatgpt.com/codex/tasks/task_e_6889bcf12fc88324bfd56f8093858704