### PR TITLE
Add headless test for portfolio builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
-    "test": "npm --prefix services/cephalon test && npm --prefix services/discord-embedder test"
+    "test": "ava tests/**/*.js && npm --prefix services/cephalon test && npm --prefix services/discord-embedder test"
   },
   "dependencies": {
     "@discordjs/voice": "^0.18.0",
@@ -13,6 +13,12 @@
     "@types/sbd": "^1.0.5",
     "@types/screenshot-desktop": "^1.12.3",
     "ava": "^6.4.1",
-    "c8": "^10.1.3"
+    "c8": "^10.1.3",
+    "puppeteer": "^24.15.0"
+  },
+  "ava": {
+    "files": [
+      "tests/**/*.js"
+    ]
   }
 }

--- a/tests/portfolio.test.js
+++ b/tests/portfolio.test.js
@@ -1,0 +1,55 @@
+import test from 'ava';
+import {spawnSync} from 'child_process';
+import {promises as fs} from 'fs';
+import path from 'path';
+import puppeteer from 'puppeteer';
+
+const portfolioRoot = path.join(process.cwd(), 'site', 'portfolio');
+
+async function buildProject(projectPath) {
+  const pkgJson = path.join(projectPath, 'package.json');
+  const buildScript = path.join(projectPath, 'build.sh');
+
+  if (await fs.stat(pkgJson).then(() => true).catch(() => false)) {
+    const result = spawnSync('npm', ['run', 'build'], {cwd: projectPath, stdio: 'inherit'});
+    if (result.status !== 0) throw new Error(`build failed for ${projectPath}`);
+    return path.join(projectPath, 'dist', 'index.html');
+  }
+  if (await fs.stat(buildScript).then(() => true).catch(() => false)) {
+    const result = spawnSync('bash', [buildScript], {cwd: projectPath, stdio: 'inherit'});
+    if (result.status !== 0) throw new Error(`build failed for ${projectPath}`);
+    return path.join(projectPath, 'dist', 'index.html');
+  }
+  throw new Error(`No build script found for ${projectPath}`);
+}
+
+test('portfolio projects build without console errors', async t => {
+  let dirs;
+  try {
+    dirs = await fs.readdir(portfolioRoot, { withFileTypes: true });
+  } catch (err) {
+    t.log(`portfolio directory missing: ${err.message}`);
+    t.pass();
+    return;
+  }
+  for (const dir of dirs) {
+    if (!dir.isDirectory()) continue;
+    const projectPath = path.join(portfolioRoot, dir.name);
+    let index;
+    try {
+      index = await buildProject(projectPath);
+    } catch (err) {
+      t.fail(err.message);
+      continue;
+    }
+    const browser = await puppeteer.launch({headless: 'new'});
+    const page = await browser.newPage();
+    const errors = [];
+    page.on('console', msg => {
+      if (msg.type() === 'error') errors.push(msg.text());
+    });
+    await page.goto(`file://${index}`, {waitUntil: 'networkidle0'});
+    await browser.close();
+    t.deepEqual(errors, [], `${dir.name} had console errors`);
+  }
+});


### PR DESCRIPTION
## Summary
- add JS test that builds projects under `site/portfolio`
- hook AVA tests into npm's `test` script
- include Puppeteer for console error checking

## Testing
- `npm test` *(fails: tests/llm_forward.test.ts exited with a non-zero exit code)*
- `make test-js` *(fails: tests/llm_forward.test.ts exited with a non-zero exit code)*

------
https://chatgpt.com/codex/tasks/task_e_6889c698d7708324b11b95fde0505c5a