### PR TITLE
Add site README

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -11,6 +11,7 @@ This `docs` directory houses internal documentation for the **Promethean Framewo
     - [file‑structure](file-structure.md) – a description of the monorepo layout and design principles[raw.githubusercontent.com](https://raw.githubusercontent.com/riatzukiza/promethean/ef2459fe07e70d361b9d915670ce2fa8218fbe51/docs/file-structure.md#:~:text=).
         
     - [MIGRATION_PLAN](MIGRATION_PLAN.md) – a living checklist of steps to migrate code from legacy repositories into this structure.
+    - [site README](../site/README.md) – instructions for building and serving the portfolio site.
         
 - **Agile process and tasks**
     

--- a/site/README.md
+++ b/site/README.md
@@ -1,0 +1,33 @@
+# Portfolio Site
+
+This folder hosts the files for the personal portfolio originally maintained at [riatzukiza.github.io](https://github.com/riatzukiza/riatzukiza.github.io).
+It has been migrated into Promethean as described in [docs/MIGRATION_PLAN.md](../docs/MIGRATION_PLAN.md).
+
+## Prerequisites
+
+The site uses Node.js and PM2. Install dependencies once after cloning:
+
+```bash
+npm install
+```
+
+## Developing Locally
+
+Start the local server and automatic recompilation using the provided npm scripts:
+
+```bash
+npm run dev:start   # start the portfolio server via pm2
+npm run dev:watch   # watch sources and rebuild on changes
+```
+
+When running, visit `http://localhost:5000` to view the portfolio.
+
+## Building for Deployment
+
+Compiled assets are written to the `static/` directory. If you only need a fresh build without starting the server, run:
+
+```bash
+npm run dev:compile
+```
+
+See the original repository for additional scripts and context.


### PR DESCRIPTION
## Summary
- add instructions on building and serving the portfolio site
- reference MIGRATION_PLAN
- link to site README from docs

## Testing
- `make test` *(fails: vision service e2e)*

------
https://chatgpt.com/codex/tasks/task_e_6889c697cb2c8324ba6b84aea82e48b4