### PR TITLE
Align pipenv settings with CI

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -54,4 +54,4 @@ pytest = "*"
 pytest-cov = "*"
 
 [requires]
-python_version = "3.12"
+python_version = "3.11"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -5,7 +5,7 @@
         },
         "pipfile-spec": 6,
         "requires": {
-            "python_version": "3.12"
+            "python_version": "3.11"
         },
         "sources": [
             {

--- a/services/discord-indexer/Pipfile
+++ b/services/discord-indexer/Pipfile
@@ -13,4 +13,4 @@ pymongo = "*"
 pytest = "*"
 
 [requires]
-python_version = "3.10"
+python_version = "3.11"

--- a/services/discord-indexer/Pipfile.lock
+++ b/services/discord-indexer/Pipfile.lock
@@ -5,7 +5,7 @@
         },
         "pipfile-spec": 6,
         "requires": {
-            "python_version": "3.10"
+            "python_version": "3.11"
         },
         "sources": [
             {

--- a/services/stt/whisper-npu-py/Pipfile
+++ b/services/stt/whisper-npu-py/Pipfile
@@ -20,4 +20,4 @@ transformers = "*"
 pytest = "*"
 
 [requires]
-python_version = "3.12"
+python_version = "3.11"

--- a/services/stt/whisper-npu-py/Pipfile.lock
+++ b/services/stt/whisper-npu-py/Pipfile.lock
@@ -5,7 +5,7 @@
         },
         "pipfile-spec": 6,
         "requires": {
-            "python_version": "3.12"
+            "python_version": "3.11"
         },
         "sources": [
             {


### PR DESCRIPTION
## Summary
- adjust Python version in all Pipfiles to 3.11 to match CI image

## Testing
- `make test` *(fails: ModuleNotFoundError: 'pymongo', plus integration failures)*
- `make simulate-ci` *(fails: `act` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6889cbfa36688324a3e77107e72a2f82