### PR TITLE
Decouple test and coverage

### DIFF
--- a/.github/workflows/test-py.yml
+++ b/.github/workflows/test-py.yml
@@ -21,8 +21,9 @@ jobs:
 
       - name: Run tests
         run: make test-python
-      # - name: Run tests with coverage
-      #   run: make coverage
+
+      - name: Generate coverage
+        run: make coverage-python
 
       - name: Upload Python coverage
         uses: actions/upload-artifact@v4

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ include Makefile.sibilant
 # === High-Level Targets ===
 
 .PHONY: all build clean lint format test setup install system-deps start stop start-tts start-stt stop-tts stop-stt \
-        board-sync kanban-from-tasks kanban-to-hashtags kanban-to-issues coverage coverage-python coverage-js coverage-ts simulate-ci
+        board-sync kanban-from-tasks kanban-to-hashtags kanban-to-issues coverage coverage-python coverage-js coverage-ts simulate-ci test-python test-js test-ts
 
 
 all: build
@@ -21,7 +21,7 @@ build: build-python build-js build-ts
 clean: clean-python clean-js clean-ts
 lint: lint-python lint-js lint-ts
 format: format-python format-js lint-ts
-test: test-python-services test-js-services test-js-services
+test: test-python test-js test-ts
 coverage: coverage-python coverage-js coverage-ts
 setup:
 	@echo "Setting up all services..."

--- a/Makefile.python
+++ b/Makefile.python
@@ -21,13 +21,27 @@ test-python-service-%:
 	cd services/py/$* && PIPENV_NOSPIN=1 python -m pipenv run pytest tests/
 test-python-services:
 	@for d in $(SERVICES_PY); do \
-		echo "Running tests in $$d...";\
-		cd $$d && PIPENV_NOSPIN=1 python -m pipenv run pytest tests/ --cov=./ --cov-report=xml --cov-report=term && cd - >/dev/null; \
+	echo "Running tests in $$d...";\
+	cd $$d && PIPENV_NOSPIN=1 python -m pipenv run pytest tests/ && cd - >/dev/null; \
 	done
 
 test-shared-python:
-	cd shared/py && PIPENV_NOSPIN=1 python -m pipenv run pytest tests/ --cov=./ --cov-report=xml --cov-report=term
+	cd shared/py && PIPENV_NOSPIN=1 python -m pipenv run pytest tests/
 test-python: test-python-services test-shared-python
+
+# Coverage=====================================================================
+coverage-python-service-%:
+	@echo "Running coverage for Python service: $*"
+	cd services/py/$* && PIPENV_NOSPIN=1 python -m pipenv run pytest tests/ --cov=./ --cov-report=xml --cov-report=term
+coverage-python-services:
+	@for d in $(SERVICES_PY); do \
+	echo "Generating coverage in $$d...";\
+	cd $$d && PIPENV_NOSPIN=1 python -m pipenv run pytest tests/ --cov=./ --cov-report=xml --cov-report=term && cd - >/dev/null; \
+	done
+
+coverage-shared-python:
+	cd shared/py && PIPENV_NOSPIN=1 python -m pipenv run pytest tests/ --cov=./ --cov-report=xml --cov-report=term
+coverage-python: coverage-python-services coverage-shared-python
 
 # Lint/formatting================================================================
 lint-python-service-%:

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -3,8 +3,9 @@
 GitHub Actions run tests and collect coverage on every pull request.
 The job now relies on the repository `Makefile` so CI mirrors local
 development. `make setup` installs all dependencies, `make build` compiles
-sources, and `make coverage` runs Python, JavaScript, and TypeScript tests with coverage
-enabled. The workflow uploads the resulting coverage artifacts for review.
+sources. `make test` executes the suites without coverage, while `make coverage` runs
+Python, JavaScript, and TypeScript tests with coverage enabled. The workflow uploads
+the resulting coverage artifacts for review.
 
 You can emulate this workflow locally using the
 [`act`](https://github.com/nektos/act) CLI. A Makefile target wraps the

--- a/readme.md
+++ b/readme.md
@@ -66,7 +66,7 @@ Common tasks are wrapped in the root `Makefile`:
 - `make start` – launch shared services defined in `ecosystem.config.js` via PM2
 - `make start:<service>` – run a service from `ecosystem.config.js` by name
 - `make stop` – stop running services
-- `make test` – run Python and JS test suites
+- `make test` – run Python and JS test suites without coverage
 - `make board-sync` – sync `kanban.md` with GitHub Projects
 - `make kanban-from-tasks` – regenerate `kanban.md` from task files
 - `make kanban-to-hashtags` – update task statuses from `kanban.md`


### PR DESCRIPTION
## Summary
- run Python tests without coverage data
- add dedicated coverage targets
- clarify Makefile workflow in docs
- collect coverage in CI

## Testing
- `make format` *(fails: cannot parse some python files)*
- `make lint` *(fails: flake8 reported many issues)*
- `make build` *(fails: missing build-python target)*
- `make test`
- `make coverage` *(fails: coverage errors and missing ts service paths)*

------
https://chatgpt.com/codex/tasks/task_e_688b9e648f288324b0f7d6c4d2ca283b