### PR TITLE
Add Git LFS rules and model download helpers

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,10 @@
+# Git LFS configuration for large model binaries
+
+# Whisper STT NPU binaries
+services/py/stt/whisper-npu/** filter=lfs diff=lfs merge=lfs -text
+
+# TTS model weights
+services/py/tts/models/** filter=lfs diff=lfs merge=lfs -text
+
+# Duck chroma embedding data
+agents/duck/chroma_data/** filter=lfs diff=lfs merge=lfs -text

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,10 @@ services/py/whisper_stream_ws/coverage.xml
 *.xml
 
 shared/py/.coverage
+
+# Allow model download helpers
+!services/py/tts/models/download.sh
+!services/py/tts/models/README.md
+!services/py/stt/whisper-npu/download.sh
+!services/py/stt/whisper-npu/README_LOCAL.md
+!agents/duck/scripts/download_chroma_data.sh

--- a/agents/duck/scripts/download_chroma_data.sh
+++ b/agents/duck/scripts/download_chroma_data.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# Fetch chroma embedding data for Duck agent
+
+set -e
+DATA_DIR="$(dirname "$0")/../chroma_data"
+mkdir -p "$DATA_DIR"
+
+# Placeholder URL - replace with actual storage location
+curl -L -o "$DATA_DIR/chroma_data.tar.gz" "https://huggingface.co/riatzukiza/duck-chroma/resolve/main/chroma_data.tar.gz"
+
+tar -xzf "$DATA_DIR/chroma_data.tar.gz" -C "$DATA_DIR"
+
+echo "Chroma data downloaded to $DATA_DIR"

--- a/docs/MIGRATION_PLAN.md
+++ b/docs/MIGRATION_PLAN.md
@@ -69,6 +69,11 @@ This document outlines the migration steps from the legacy `duck/` folder and `r
 * [x] Define `Promethean File Structure` canvas
 * [ ] Add `agent-mode` prompt guidance to `AGENTS.md`
 
+### 8. 📦 Model Asset Management
+
+* [x] Track large model binaries with Git LFS using `.gitattributes`
+* [x] Provide `download.sh` helpers in model folders so weights can be fetched on demand
+
 ---
 
 ## 🧠 Philosophy

--- a/services/py/stt/whisper-npu/README_LOCAL.md
+++ b/services/py/stt/whisper-npu/README_LOCAL.md
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b254632a1dc98188c46dd129b66e6d938d0291ec748a53e6e42d86c12eed91f4
+size 259

--- a/services/py/stt/whisper-npu/download.sh
+++ b/services/py/stt/whisper-npu/download.sh
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2ac0d3f78f51578f8d6746957eec1d45b1443dab7b35aa97b3eea10de88b4357
+size 488

--- a/services/py/tts/models/README.md
+++ b/services/py/tts/models/README.md
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:44d8a4739e1624cebdb53bcf74fa019bdb543dccbd5949f571d8dcc176cfbb95
+size 264

--- a/services/py/tts/models/download.sh
+++ b/services/py/tts/models/download.sh
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2a50eb292c8941cdac81841274b61f062e7a1bec380865aeac9025768fe2cabd
+size 563


### PR DESCRIPTION
## Summary
- track model binaries via Git LFS
- provide download scripts for STT, TTS and agent data
- update migration plan with model asset management section
- whitelist download scripts in `.gitignore`

## Testing
- `make format` *(fails: cannot parse some files)*
- `make lint` *(fails: flake8 missing)*
- `make build` *(fails: no rule to make target `build-python`)*
- `make test` *(fails: pipenv not installed)*

------
https://chatgpt.com/codex/tasks/task_e_688ba16234b48324803cd3c262c6dee4