### PR TITLE
Add model selection via LLM_MODEL

### DIFF
--- a/services/ts/llm/README.md
+++ b/services/ts/llm/README.md
@@ -3,10 +3,14 @@
 This service exposes a simple HTTP endpoint that proxies requests to the local LLM via the `ollama` library.
 
 Start the service:
+
 ```bash
 npm start
 ```
 
 POST `/generate` with JSON containing `prompt`, `context` and optional `format` to receive the generated reply.
+
+Set the `LLM_MODEL` environment variable to choose which model Ollama uses. If
+not provided, it defaults to `gemma3`.
 
 #hashtags: #llm #service #promethean

--- a/services/ts/llm/package.json
+++ b/services/ts/llm/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "start": "node src/index.js",
     "test": "ava",
-    "coverage": "c8 ava"
+    "coverage": "c8 ava",
+    "build": "echo 'no build step'"
   },
   "dependencies": {
     "express": "^4.18.2",

--- a/services/ts/llm/src/index.js
+++ b/services/ts/llm/src/index.js
@@ -1,36 +1,47 @@
-import express from 'express';
-import ollama from 'ollama';
+import express from "express";
+import ollama from "ollama";
 
-const app = express();
-app.use(express.json({limit:'5mb'}));
+export const MODEL = process.env.LLM_MODEL || "gemma3";
 
-async function callOllama({prompt, context, format}, retry=0) {
+export const app = express();
+app.use(express.json({ limit: "5mb" }));
+
+export async function callOllama({ prompt, context, format }, retry = 0) {
   try {
     const res = await ollama.chat({
-      model: 'gemma3',
-      messages: [{role:'system', content: prompt}, ...context],
-      format
+      model: MODEL,
+      messages: [{ role: "system", content: prompt }, ...context],
+      format,
     });
     const content = res.message.content;
     return format ? JSON.parse(content) : content;
   } catch (err) {
     if (retry < 5) {
-      await new Promise(r => setTimeout(r, retry * 1610));
-      return callOllama({prompt, context, format}, retry + 1);
+      await new Promise((r) => setTimeout(r, retry * 1610));
+      return callOllama({ prompt, context, format }, retry + 1);
     }
     throw err;
   }
 }
 
-app.post('/generate', async (req, res) => {
-  const {prompt, context, format} = req.body;
+app.post("/generate", async (req, res) => {
+  const { prompt, context, format } = req.body;
   try {
-    const reply = await callOllama({prompt, context, format});
-    res.json({reply});
+    const reply = await callOllama({ prompt, context, format });
+    res.json({ reply });
   } catch (e) {
-    res.status(500).json({error: e.message});
+    res.status(500).json({ error: e.message });
   }
 });
 
-const port = process.env.LLM_PORT || 5003;
-app.listen(port, () => console.log(`LLM service listening on ${port}`));
+export const port = process.env.LLM_PORT || 5003;
+
+export function start(listenPort = port) {
+  return app.listen(listenPort, () => {
+    console.log(`LLM service listening on ${listenPort}`);
+  });
+}
+
+if (process.env.NODE_ENV !== "test") {
+  start();
+}

--- a/services/ts/llm/tests/basic.test.js
+++ b/services/ts/llm/tests/basic.test.js
@@ -1,7 +1,14 @@
-import test from 'ava';
-import express from 'express';
+import test from "ava";
+import express from "express";
 
-test('express app initializes', t => {
+test("MODEL env variable overrides default", async (t) => {
+  process.env.NODE_ENV = "test";
+  process.env.LLM_MODEL = "test-model";
+  const { MODEL } = await import("../src/index.js");
+  t.is(MODEL, "test-model");
+});
+
+test("express app initializes", (t) => {
   const app = express();
   t.truthy(app);
 });


### PR DESCRIPTION
## Summary
- make llm-service choose model via `LLM_MODEL` env var
- export utilities from `llm` service for easier testing
- document `LLM_MODEL` in llm README
- add test covering environment variable logic
- provide stub build script

## Testing
- `make setup-ts-service-llm`
- `make lint-ts-service-llm` *(fails: ESLint couldn't find a config)*
- `npx prettier --write .`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688ba113726083248093fec69c9ccc4a