### PR TITLE
Fix service paths in PM2 configs

### DIFF
--- a/agents/duck/ecosystem.config.js
+++ b/agents/duck/ecosystem.config.js
@@ -60,11 +60,11 @@ module.exports = {
         },
         {
             name: "tts",
-            cwd: "../../services/tts",
-            script: "../../services/tts/run.sh",
+            cwd: "../../services/py/tts",
+            script: "../../services/py/tts/run.sh",
             interpreter: "bash",
             exec_mode: "fork",
-            watch: ["../../services/tts"],
+            watch: ["../../services/py/tts"],
             instances: 1,
             autorestart: true,
             env: {
@@ -78,11 +78,11 @@ module.exports = {
         },
         {
             name: "stt",
-            cwd: "../../services/stt",
-            script: "../../services/stt/run.sh",
+            cwd: "../../services/py/stt",
+            script: "../../services/py/stt/run.sh",
             interpreter: "bash",
             exec_mode: "fork",
-            watch: ["../../services/stt"],
+            watch: ["../../services/py/stt"],
             instances: 1,
             autorestart: true,
             env: {
@@ -109,11 +109,11 @@ module.exports = {
         },
         {
             name: "stt-ws",
-            cwd: "../../services/stt_ws",
-            script: "../../services/stt_ws/run.sh",
+            cwd: "../../services/py/stt_ws",
+            script: "../../services/py/stt_ws/run.sh",
             interpreter: "bash",
             exec_mode: "fork",
-            watch: ["../../services/stt_ws"],
+            watch: ["../../services/py/stt_ws"],
             instances: 1,
             autorestart: true,
             env: {
@@ -125,11 +125,11 @@ module.exports = {
         },
         {
             name: "whisper-stream-ws",
-            cwd: "../../services/whisper_stream_ws",
-            script: "../../services/whisper_stream_ws/run.sh",
+            cwd: "../../services/py/whisper_stream_ws",
+            script: "../../services/py/whisper_stream_ws/run.sh",
             interpreter: "bash",
             exec_mode: "fork",
-            watch: ["../../services/whisper_stream_ws"],
+            watch: ["../../services/py/whisper_stream_ws"],
             instances: 1,
             autorestart: true,
             env: {

--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -3,11 +3,11 @@ module.exports = {
     apps: [
         {
             name: "tts",
-            cwd: "./services/tts",
-            script: "./services/tts/run.sh",
+            cwd: "./services/py/tts",
+            script: "./services/py/tts/run.sh",
             interpreter:"bash",
             "exec_mode": "fork",
-            watch: ["./services/tts"],
+            watch: ["./services/py/tts"],
             instances: 1,
             autorestart: true,
             env: {
@@ -23,11 +23,11 @@ module.exports = {
         },
         {
             name: "stt",
-            cwd: "./services/stt",
-            script: "./services/stt/run.sh",
+            cwd: "./services/py/stt",
+            script: "./services/py/stt/run.sh",
             interpreter: "bash",
             exec_mode: "fork",
-            watch: ["./services/stt"],
+            watch: ["./services/py/stt"],
             instances: 1,
             autorestart: true,
             out_file: "./logs/stt-out.log",
@@ -58,11 +58,11 @@ module.exports = {
         },
         {
             name: "stt-ws",
-            cwd: "./services/stt_ws",
-            script: "./services/stt_ws/run.sh",
+            cwd: "./services/py/stt_ws",
+            script: "./services/py/stt_ws/run.sh",
             interpreter: "bash",
             exec_mode: "fork",
-            watch: ["./services/stt_ws"],
+            watch: ["./services/py/stt_ws"],
             instances: 1,
             autorestart: true,
             env: {
@@ -74,11 +74,11 @@ module.exports = {
         },
         {
             name: "whisper-stream-ws",
-            cwd: "./services/whisper_stream_ws",
-            script: "./services/whisper_stream_ws/run.sh",
+            cwd: "./services/py/whisper_stream_ws",
+            script: "./services/py/whisper_stream_ws/run.sh",
             interpreter: "bash",
             exec_mode: "fork",
-            watch: ["./services/whisper_stream_ws"],
+            watch: ["./services/py/whisper_stream_ws"],
             instances: 1,
             autorestart: true,
             env: {


### PR DESCRIPTION
## Summary
- point PM2 to the Python service directories under `services/py`
- update Duck agent PM2 config with the same paths

## Testing
- `make install`
- `make test`
- `make build` *(fails: No rule to make target 'build-python')*
- `make lint` *(fails: flake8 errors)*
- `make format` *(fails: cannot format some files)*

------
https://chatgpt.com/codex/tasks/task_e_688ba1d5a3008324b050ca13bf8f6d15