### PR TITLE
Add pm2 setup guidance

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,12 +24,13 @@ format: format-python format-js lint-ts
 test: test-python-services test-js-services test-js-services
 coverage: coverage-python coverage-js coverage-ts
 setup:
-	@echo "Setting up all services..."
-	@$(MAKE) setup-python
+		@echo "Setting up all services..."
+		@$(MAKE) setup-python
 	@$(MAKE) setup-js
 	@$(MAKE) setup-ts
 	@$(MAKE) setup-hy
 	@$(MAKE) setup-sibilant
+	@command -v pm2 >/dev/null 2>&1 || npm install -g pm2
 
 install: setup
 

--- a/readme.md
+++ b/readme.md
@@ -41,6 +41,12 @@ pipenv shell
 npm install
 ```
 
+Install PM2 globally if it isn't already available:
+
+```bash
+npm install -g pm2
+```
+
 ## Running Services
 
 Scripts in `agents/scripts/` launch commonly used services:


### PR DESCRIPTION
## Summary
- document pm2 installation in the README
- ensure `make setup` installs pm2 if missing

## Testing
- `make install`
- `make format` *(fails: 48 files reformatted, 2 files failed to reformat)*
- `make test`
- `make lint` *(fails: flake8 errors)*
- `make build` *(fails: No rule to make target `build-python`)*
- `make start` *(fails: script paths not found)*

------
https://chatgpt.com/codex/tasks/task_e_688ba1df1a988324aaa28f8b70d96f43