### PR TITLE
Remove stray screenshot

### DIFF
--- a/services/ts/cephalon/.gitignore
+++ b/services/ts/cephalon/.gitignore
@@ -1,3 +1,4 @@
 .env
 tsconfig.tsbuildinfo
 dist
+*.png


### PR DESCRIPTION
## Summary
- drop unused test screenshot from cephalon service
- keep future screenshots out of version control via gitignore

## Testing
- `make install`
- `make test`
- `make build` *(fails: No rule to make target 'build-python')*
- `make lint` *(fails: flake8 reported many style violations)*
- `make format` *(fails: black could not parse some files)*

------
https://chatgpt.com/codex/tasks/task_e_688ba3e5f8488324a729700c5c098baf