### PR TITLE
Install uvicorn for Python services

### DIFF
--- a/services/py/stt/Pipfile
+++ b/services/py/stt/Pipfile
@@ -8,6 +8,7 @@ fastapi = "*"
 transformers = "*"
 torch = "*"
 numpy = "*"
+uvicorn = "*"
 
 [dev-packages]
 pytest = "*"

--- a/services/py/stt/Pipfile.lock
+++ b/services/py/stt/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "3c49b236c64c6d099a4a8ab9d6bf2ed00f7c73ac5aa2a0ce7a6b82e9fa9431a2"
+            "sha256": "e9b9bf9958bc9c0a41937e2a1c97c6e2cf58e70d59698b8d91a4be3a8f23abaf"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -864,14 +864,6 @@
             "markers": "python_version >= '3.10'",
             "version": "==8.2.1"
         },
-        "colorama": {
-            "hashes": [
-                "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44",
-                "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"
-            ],
-            "markers": "platform_system == 'Windows'",
-            "version": "==0.4.6"
-        },
         "coverage": {
             "extras": [
                 "toml"
@@ -1124,6 +1116,15 @@
             ],
             "markers": "python_version >= '3.9'",
             "version": "==4.14.1"
+        },
+        "uvicorn": {
+            "hashes": [
+                "sha256:197535216b25ff9b785e29a0b79199f55222193d47f820816e7da751e9bc8d4a",
+                "sha256:bc662f087f7cf2ce11a1d7fd70b90c9f98ef2e2831556dd078d131b96cc94a01"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.9'",
+            "version": "==0.35.0"
         }
     }
 }

--- a/services/py/stt_ws/Pipfile
+++ b/services/py/stt_ws/Pipfile
@@ -8,6 +8,7 @@ fastapi = "*"
 transformers = "*"
 torch = "*"
 numpy = "*"
+uvicorn = "*"
 
 [dev-packages]
 pytest = "*"

--- a/services/py/stt_ws/Pipfile.lock
+++ b/services/py/stt_ws/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "3373fa2cd01320466933fb92f40f8746ee07e4abefc8bc95b98c2ec84c563851"
+            "sha256": "e9b9bf9958bc9c0a41937e2a1c97c6e2cf58e70d59698b8d91a4be3a8f23abaf"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -839,14 +839,6 @@
             "markers": "python_version >= '3.10'",
             "version": "==8.2.1"
         },
-        "colorama": {
-            "hashes": [
-                "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44",
-                "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"
-            ],
-            "markers": "platform_system == 'Windows'",
-            "version": "==0.4.6"
-        },
         "coverage": {
             "extras": [
                 "toml"
@@ -1099,6 +1091,15 @@
             ],
             "markers": "python_version >= '3.9'",
             "version": "==4.14.1"
+        },
+        "uvicorn": {
+            "hashes": [
+                "sha256:197535216b25ff9b785e29a0b79199f55222193d47f820816e7da751e9bc8d4a",
+                "sha256:bc662f087f7cf2ce11a1d7fd70b90c9f98ef2e2831556dd078d131b96cc94a01"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.9'",
+            "version": "==0.35.0"
         }
     }
 }

--- a/services/py/stt_ws/run.sh
+++ b/services/py/stt_ws/run.sh
@@ -1,2 +1,2 @@
 #!/usr/bin/bash
-uvicorn app:app --host 0.0.0.0 --port 5002
+pipenv run uvicorn app:app --host 0.0.0.0 --port 5002

--- a/services/py/tts/Pipfile
+++ b/services/py/tts/Pipfile
@@ -9,6 +9,7 @@ soundfile = "*"
 safetensors = "*"
 torch = "*"
 fastapi = "*"
+uvicorn = "*"
 
 [dev-packages]
 pytest-cov = "*"

--- a/services/py/tts/Pipfile.lock
+++ b/services/py/tts/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "84098d3751df8b0b76b807f8ea4f85b841bd1e76261278e307a7937c23fd5287"
+            "sha256": "cd7372e8f6b33c48298d86d9a09b261971f41348aa0b42a15ada42a29af61cc8"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -732,14 +732,6 @@
             "markers": "python_version >= '3.10'",
             "version": "==8.2.1"
         },
-        "colorama": {
-            "hashes": [
-                "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44",
-                "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"
-            ],
-            "markers": "platform_system == 'Windows'",
-            "version": "==0.4.6"
-        },
         "coverage": {
             "extras": [
                 "toml"
@@ -992,6 +984,15 @@
             ],
             "markers": "python_version >= '3.9'",
             "version": "==4.14.1"
+        },
+        "uvicorn": {
+            "hashes": [
+                "sha256:197535216b25ff9b785e29a0b79199f55222193d47f820816e7da751e9bc8d4a",
+                "sha256:bc662f087f7cf2ce11a1d7fd70b90c9f98ef2e2831556dd078d131b96cc94a01"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.9'",
+            "version": "==0.35.0"
         }
     }
 }

--- a/services/py/whisper_stream_ws/Pipfile
+++ b/services/py/whisper_stream_ws/Pipfile
@@ -6,6 +6,7 @@ name = "pypi"
 [packages]
 fastapi = "*"
 numpy = "*"
+uvicorn = "*"
 
 [dev-packages]
 pytest-cov = "*"

--- a/services/py/whisper_stream_ws/Pipfile.lock
+++ b/services/py/whisper_stream_ws/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "40d83b88f2feef0a9cd105b493567aaf2d1defc07f95fbaca2c536bd1106f861"
+            "sha256": "540a77172e37306884a38fbcfe83c1a050b2926d35b06af5eb994d9d042f54b4"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -330,14 +330,6 @@
             "markers": "python_version >= '3.10'",
             "version": "==8.2.1"
         },
-        "colorama": {
-            "hashes": [
-                "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44",
-                "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"
-            ],
-            "markers": "sys_platform == 'win32'",
-            "version": "==0.4.6"
-        },
         "coverage": {
             "extras": [
                 "toml"
@@ -590,6 +582,15 @@
             ],
             "markers": "python_version >= '3.9'",
             "version": "==4.14.1"
+        },
+        "uvicorn": {
+            "hashes": [
+                "sha256:197535216b25ff9b785e29a0b79199f55222193d47f820816e7da751e9bc8d4a",
+                "sha256:bc662f087f7cf2ce11a1d7fd70b90c9f98ef2e2831556dd078d131b96cc94a01"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.9'",
+            "version": "==0.35.0"
         }
     }
 }

--- a/services/py/whisper_stream_ws/run.sh
+++ b/services/py/whisper_stream_ws/run.sh
@@ -1,2 +1,2 @@
 #!/usr/bin/bash
-uvicorn app:app --host 0.0.0.0 --port 5003
+pipenv run uvicorn app:app --host 0.0.0.0 --port 5003


### PR DESCRIPTION
## Summary
- add `uvicorn` as runtime dependency for Python services
- run it via `pipenv` for the STT websocket servers

## Testing
- `make setup`
- `make install`
- `make test`
- `make build` *(fails: No rule to make target 'build-python')*
- `make lint` *(fails: flake8 errors)*
- `make format` *(fails: black errors)*

------
https://chatgpt.com/codex/tasks/task_e_688ba1e1cb888324b8416b6fdb274925