### PR TITLE
Add fastapi to stt_ws Pipfile

### DIFF
--- a/services/py/stt_ws/Pipfile
+++ b/services/py/stt_ws/Pipfile
@@ -4,7 +4,7 @@ verify_ssl = true
 name = "pypi"
 
 [packages]
-fastapi = "*"
+fastapi = "==0.116.1"
 transformers = "*"
 torch = "*"
 numpy = "*"


### PR DESCRIPTION
## Summary
- pin `fastapi` for `stt_ws` Python service

## Testing
- `pipenv install --dev` in `services/py/stt_ws`
- `make test-python-service-stt_ws`


------
https://chatgpt.com/codex/tasks/task_e_688bd59bdb6c83249311900dea245ad3