### PR TITLE
Replace act-based CI simulation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,3 +70,6 @@ kanban-to-hashtags:
 
 kanban-to-issues:
 	python scripts/kanban_to_issues.py
+
+simulate-ci:
+	python scripts/simulate_ci.py

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -7,15 +7,17 @@ sources. `make test` executes the suites without coverage, while `make coverage`
 Python, JavaScript, and TypeScript tests with coverage enabled. The workflow uploads
 the resulting coverage artifacts for review.
 
-You can emulate this workflow locally using the
-[`act`](https://github.com/nektos/act) CLI. A Makefile target wraps the
-command:
+You can emulate this workflow locally using the `make simulate-ci` target,
+which parses the workflow files and executes the `pull_request` job steps
+directly:
 
 ```bash
 make simulate-ci
 ```
 
-This runs `act pull_request` to replicate the GitHub Actions job definitions.
+The underlying script runs each `run:` command from the workflows in order,
+honoring any environment variables and working directories defined for the
+step.
 Both `make test` and `make simulate-ci` should succeed before sending a pull
 request.
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -14,3 +14,4 @@ fastapi
 uvicorn
 httpx
 websockets
+PyYAML

--- a/scripts/simulate_ci.py
+++ b/scripts/simulate_ci.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""Simulate GitHub Actions pull_request workflows locally."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Iterable
+
+import yaml
+
+WORKFLOWS_DIR = Path('.github/workflows')
+
+
+def _is_pull_request(event: Any) -> bool:
+    if event is None:
+        return False
+    if isinstance(event, str):
+        return event == 'pull_request'
+    if isinstance(event, dict):
+        return 'pull_request' in event
+    if isinstance(event, Iterable):
+        return 'pull_request' in event
+    return False
+
+
+@dataclass
+class Step:
+    job: str
+    name: str
+    run: str
+    env: Dict[str, str]
+    cwd: Path
+
+
+def load_workflows(directory: Path = WORKFLOWS_DIR) -> Iterable[tuple[str, Any]]:
+    for path in directory.glob('*.yml'):
+        with path.open() as fh:
+            data = yaml.safe_load(fh) or {}
+        yield path.name, data
+
+
+def _get_on(data: dict) -> Any:
+    if 'on' in data:
+        return data['on']
+    if True in data:
+        return data[True]
+    return None
+
+
+def collect_jobs(data: dict) -> Dict[str, list[Step]]:
+    jobs: Dict[str, list[Step]] = {}
+    if not _is_pull_request(_get_on(data)):
+        return jobs
+    for job_name, job in (data.get('jobs') or {}).items():
+        job_env = job.get('env', {}) or {}
+        steps = []
+        for idx, step in enumerate(job.get('steps') or []):
+            if 'run' not in step:
+                continue
+            env = {**job_env, **(step.get('env') or {})}
+            cwd = Path(step.get('working-directory', '.'))
+            name = step.get('name') or f'step-{idx+1}'
+            steps.append(Step(job=job_name, name=name, run=step['run'], env=env, cwd=cwd))
+        if steps:
+            jobs[job_name] = steps
+    return jobs
+
+
+def execute_jobs(jobs: Dict[str, list[Step]], only_job: str | None = None) -> None:
+    for job_name, steps in jobs.items():
+        if only_job and job_name != only_job:
+            continue
+        print(f'== Job: {job_name}')
+        for step in steps:
+            print(f'-- Running {step.name}')
+            env = os.environ.copy()
+            env.update(step.env)
+            try:
+                subprocess.run(step.run, shell=True, check=True, cwd=step.cwd, env=env)
+            except subprocess.CalledProcessError as exc:
+                print(f'Step failed with exit code {exc.returncode}')
+                sys.exit(exc.returncode)
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description='Simulate GitHub Actions pull_request workflows')
+    parser.add_argument('--job', help='Only run a specific job')
+    args = parser.parse_args(argv)
+    jobs: Dict[str, list[Step]] = {}
+    for _, data in load_workflows():
+        for name, steps in collect_jobs(data).items():
+            jobs.setdefault(name, []).extend(steps)
+    if not jobs:
+        print('No pull_request jobs found')
+        return
+    execute_jobs(jobs, only_job=args.job)
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/scripts/test_simulate_ci.py
+++ b/tests/scripts/test_simulate_ci.py
@@ -1,0 +1,37 @@
+import importlib.util
+from pathlib import Path
+
+MODULE_PATH = Path(__file__).resolve().parents[2] / "scripts" / "simulate_ci.py"
+spec = importlib.util.spec_from_file_location("simulate_ci", MODULE_PATH)
+sc = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(sc)
+
+
+def test_collect_jobs(tmp_path):
+    wf = tmp_path / "workflows"
+    wf.mkdir()
+    yml = wf / "demo.yml"
+    yml.write_text(
+        """
+on: pull_request
+jobs:
+  build:
+    env:
+      GREETING: hello
+    steps:
+      - run: echo $GREETING
+      - name: second
+        run: echo world
+        working-directory: tests
+        env:
+          NAME: test
+""",
+        encoding="utf-8",
+    )
+    name, data = next(sc.load_workflows(wf))
+    jobs = sc.collect_jobs(data)
+    assert "build" in jobs
+    steps = jobs["build"]
+    assert len(steps) == 2
+    assert steps[0].env["GREETING"] == "hello"
+    assert steps[1].cwd == Path("tests")


### PR DESCRIPTION
## Summary
- implement `simulate_ci.py` to run pull_request workflow steps locally
- invoke script from new `simulate-ci` make target
- document usage in `docs/ci.md`
- include PyYAML in development requirements
- add basic unit test for workflow parsing

## Testing
- `make format`
- `make lint` *(fails: Invalid option '--ext' and missing TS services)*
- `make test`
- `make build`
- `make simulate-ci` *(interrupted during dependency installation)*

------
https://chatgpt.com/codex/tasks/task_e_688bd581f9788324a83aafa978b56d1e