### PR TITLE
Fix lint workflow to install flake8

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -28,6 +28,9 @@ jobs:
       - name: Install dependencies
         run: make install
 
+      - name: Install flake8
+        run: python -m pip install flake8
+
       - name: Build project
         run: make build
 


### PR DESCRIPTION
## Summary
- ensure `flake8` is available in the CI linter job

## Testing
- `make install` *(fails: pipenv sync interrupted)*
- `make test` *(fails: KeyboardInterrupt during pytest)*
- `make build`
- `make lint` *(fails: flake8 missing)*
- `make format`


------
https://chatgpt.com/codex/tasks/task_e_688be0834d0c8324ac10116a5c2a5bb2