### PR TITLE
Add ava/c8 to TS services

### DIFF
--- a/Makefile.ts
+++ b/Makefile.ts
@@ -1,6 +1,6 @@
 TS_SRC=shared/ts
 TS_OUT=shared/js
-SERVICES_TS=services/ts/cephalon services/ts/discord-embedder services/ts/llm  services/ts/voice
+SERVICES_TS=services/ts/cephalon services/ts/discord-embedder services/ts/llm services/ts/voice services/ts/file-watcher
 
 lint-ts:
 	       @$(call run_dirs,$(SERVICES_TS),npx eslint . --no-warn-ignored --ext .js,.ts)

--- a/services/ts/file-watcher/package.json
+++ b/services/ts/file-watcher/package.json
@@ -7,14 +7,30 @@
     "build": "tsc",
     "start": "node dist/index.js",
     "start:dev": "node --loader ts-node/esm src/index.ts",
-    "build:check": "tsc --noEmit --incremental false"
+    "build:check": "tsc --noEmit --incremental false",
+    "test": "ava",
+    "coverage": "c8 ava"
   },
   "dependencies": {
     "chokidar": "^3.5.3"
   },
   "devDependencies": {
     "@types/node": "^22.10.10",
+    "ava": "^6.4.1",
+    "c8": "^9.1.0",
     "ts-node": "^10.9.2",
     "typescript": "5.7.3"
+  },
+  "ava": {
+    "extensions": {
+      "ts": "module"
+    },
+    "files": [
+      "tests/**/*.ts"
+    ],
+    "nodeArguments": [
+      "--loader",
+      "ts-node/esm"
+    ]
   }
 }

--- a/services/ts/file-watcher/tests/dummy.test.ts
+++ b/services/ts/file-watcher/tests/dummy.test.ts
@@ -1,0 +1,5 @@
+import test from 'ava';
+
+test('placeholder', t => {
+  t.pass();
+});

--- a/services/ts/file-watcher/tsconfig.json
+++ b/services/ts/file-watcher/tsconfig.json
@@ -9,6 +9,6 @@
     "esModuleInterop": true,
     "skipLibCheck": true
   },
-  "include": ["src/**/*.ts"],
+  "include": ["src/**/*.ts", "tests/**/*.ts"],
   "exclude": ["node_modules"]
 }

--- a/services/ts/voice/package.json
+++ b/services/ts/voice/package.json
@@ -7,7 +7,7 @@
     "build": "tsc",
     "start": "node dist/index.js",
     "test": "cross-env TS_NODE_TRANSPILE_ONLY=1 ava tests/dummy.test.ts",
-    "coverage": "npm run build && c8 ava \"dist/tests/**/*.js\""
+    "coverage": "cross-env TS_NODE_TRANSPILE_ONLY=1 c8 ava tests/dummy.test.ts"
   },
   "dependencies": {
     "@discordjs/voice": "^0.18.0",


### PR DESCRIPTION
## Summary
- include `file-watcher` in Makefile.ts service list
- configure `file-watcher` package to use ava and c8
- allow its tests to compile by including the test folder in tsconfig
- limit `voice` coverage to the dummy test

## Testing
- `make test-js`
- `make test-ts`
- `make coverage-js`
- `make coverage-ts`
- `npm run coverage` in `services/ts/file-watcher`
- `npm run coverage` in `services/ts/voice`


------
https://chatgpt.com/codex/tasks/task_e_688be47917d08324b78cacd6997c0cfc