### PR TITLE
Fix service doc paths

### DIFF
--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -41,8 +41,8 @@ Most services rely on these variables for configuration. Defaults are taken from
 These variables appear in multiple locations:
 
 - Python settings module: `shared/py/settings.py`【F:shared/py/settings.py†L3-L29】
-- Vision service: `services/vision/index.js`【F:services/vision/index.js†L5-L32】
-- Cephalon agent: `services/cephalon/src/agent.ts`【F:services/cephalon/src/agent.ts†L19-L30】
+- Vision service: `services/js/vision/index.js`【F:services/js/vision/index.js†L5-L32】
+- Cephalon agent: `services/ts/cephalon/src/agent.ts`【F:services/ts/cephalon/src/agent.ts†L19-L30】
 - GitHub utilities: `scripts/github_board_sync.py` and `scripts/kanban_to_issues.py`【F:scripts/github_board_sync.py†L7-L10】【F:scripts/kanban_to_issues.py†L5-L7】
 - PM2 ecosystem configuration sets common Python and Node environment values【F:ecosystem.config.js†L15-L18】【F:ecosystem.config.js†L53-L70】
 - Development scripts under `agents/duck/scripts/` export additional variables for local runs【F:agents/duck/scripts/discord_indexer_run.sh†L5-L8】

--- a/docs/services/cephalon/src/agent.md
+++ b/docs/services/cephalon/src/agent.md
@@ -1,6 +1,6 @@
 # agent.ts
 
-**Path**: `services/cephalon/src/agent.ts`
+**Path**: `services/ts/cephalon/src/agent.ts`
 
 **Description**: @file agent.ts
 

--- a/docs/services/vision/index.md
+++ b/docs/services/vision/index.md
@@ -1,6 +1,6 @@
 # index.js
 
-**Path**: `services/vision/index.js`
+**Path**: `services/js/vision/index.js`
 
 **Description**: Express endpoint `/capture` returns a PNG screenshot via `screenshot-desktop`. The module exports `app`, `start()`, and `setCaptureFn()` for testing.
 
@@ -9,4 +9,4 @@
 - screenshot-desktop
 
 ## Dependents
-- `services/cephalon/src/agent.ts`
+- `services/ts/cephalon/src/agent.ts`


### PR DESCRIPTION
## Summary
- correct path references in environment-variables docs
- fix links in service docs

## Testing
- `make lint` *(fails: ESLint reports all files ignored)*
- `make format`

------
https://chatgpt.com/codex/tasks/task_e_688bebdfaa18832488698aab4df9af00