### PR TITLE
Standardize dependency setup docs

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -26,7 +26,7 @@ jobs:
           node-version: '20'
 
       - name: Install dependencies
-        run: make install
+        run: make setup
 
       - name: Install flake8
         run: python -m pip install flake8

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -213,7 +213,7 @@ train_cephalon_align_lora.py
 
 All contributions must be validated locally before opening a pull request:
 
-1. Run `make install` for the relevant services.
+1. Run `make setup` for the relevant services.
 2. Run `make test` for the relevant services.
 3. Run `make build` to ensure all modules compile correctly.
 4. Run `make lint` to check code style and formatting.


### PR DESCRIPTION
## Summary
- docs: reference `make setup` as the single install command
- update lint workflow to use `make setup`

## Testing
- `make setup` *(fails: interrupted)*
- `make test` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `make build` *(fails: rimraf not found)*
- `make lint` *(fails: flake8 not installed)*
- `make format`

------
https://chatgpt.com/codex/tasks/task_e_688bec1d09ec83249d9448c95c5588f7