### PR TITLE
Update placeholder site README

### DIFF
--- a/site/README.md
+++ b/site/README.md
@@ -1,33 +1,8 @@
-# Portfolio Site
+# Portfolio Site (Placeholder)
 
-This folder hosts the files for the personal portfolio originally maintained at [riatzukiza.github.io](https://github.com/riatzukiza/riatzukiza.github.io).
-It has been migrated into Promethean as described in [docs/MIGRATION_PLAN.md](../docs/MIGRATION_PLAN.md).
+This directory is reserved for the personal portfolio previously hosted at [riatzukiza.github.io](https://github.com/riatzukiza/riatzukiza.github.io).
+The source files have not yet been migrated into the Promethean monorepo.
 
-## Prerequisites
+For now the folder only contains this README. References to `npm` scripts from the original project have been removed until the site assets and build configuration are restored.
 
-The site uses Node.js and PM2. Install dependencies once after cloning:
-
-```bash
-npm install
-```
-
-## Developing Locally
-
-Start the local server and automatic recompilation using the provided npm scripts:
-
-```bash
-npm run dev:start   # start the portfolio server via pm2
-npm run dev:watch   # watch sources and rebuild on changes
-```
-
-When running, visit `http://localhost:5000` to view the portfolio.
-
-## Building for Deployment
-
-Compiled assets are written to the `static/` directory. If you only need a fresh build without starting the server, run:
-
-```bash
-npm run dev:compile
-```
-
-See the original repository for additional scripts and context.
+Progress on migrating the site can be tracked in [docs/MIGRATION_PLAN.md](../docs/MIGRATION_PLAN.md).


### PR DESCRIPTION
## Summary
- replace outdated `site/README.md` with a placeholder notice

## Testing
- `make format` (fails: npm warnings)
- `make lint` (fails: flake8 missing)
- `make build` (fails: rimraf missing)
- `make test` (fails: ModuleNotFoundError: numpy)


------
https://chatgpt.com/codex/tasks/task_e_688bebf655ec8324ac696b57877c08da