### PR TITLE
Fix agent ecosystem config path

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -6,11 +6,13 @@ This repository contains a modular multi‑agent architecture. To start shared i
 pm2 start ecosystem.config.js
 ```
 
-Then start individual agents, for example Duck, using the agent config:
+Then start individual agents using their own ecosystem file. For Duck you would
+run:
 
 ```bash
-pm2 start agents/ecosystem.config.js
+pm2 start agents/duck/ecosystem.config.js
 ```
+Choose the config inside `agents/<agent>/` for other agents.
 
 Set `AGENT_NAME` in your environment before launching agent services to isolate collections and data.
 Promethean is a modular cognitive architecture for building embodied AI agents. It breaks the system into small services that handle speech-to-text, text-to-speech, memory, and higher level reasoning. Agents such as **Duck** combine these services to create an interactive assistant with emotional state and memory.


### PR DESCRIPTION
## Summary
- fix README instructions for starting agents with pm2

## Testing
- `make install`
- `make format`
- `make lint` *(fails: Invalid option '--ext' - using eslint.config.js)*
- `make build` *(fails: build-ts error)*
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_688bebe5bd648324bda43a40be869012