### PR TITLE
Add CI pipeline simulation issues doc

### DIFF
--- a/docs/ci/pipeline_simulation_issues.md
+++ b/docs/ci/pipeline_simulation_issues.md
@@ -1,0 +1,37 @@
+# CI Pipeline Simulation Issues
+
+The `simulate-ci` script and the high-level Make targets were executed to emulate the continuous integration workflow. Several failures occurred due to missing tools and packages. Below is a summary of each command and the resulting problem.
+
+## make format
+- **Result:** completed successfully.
+- **Output:** `All done!` with no changes required.
+
+## make lint
+- **Result:** failed because `flake8` was not installed.
+- **Error:** `make: flake8: No such file or directory`.
+
+## make test
+- **Result:** failed when running Python tests.
+- **Error:** `No module named pipenv` while trying to execute tests via Pipenv.
+
+## make build
+- **Result:** failed during TypeScript compilation.
+- **Error:** `rimraf: not found`.
+
+## make coverage
+- **Result:** failed because pytest did not recognize coverage options.
+- **Error:** `pytest: error: unrecognized arguments: --cov=./ --cov-report=xml --cov-report=term`.
+
+## make simulate-ci
+- **Result:** failed when the simulation script attempted to import PyYAML.
+- **Error:** `ModuleNotFoundError: No module named 'yaml'`.
+
+## make install
+- **Result:** repeatedly created and removed virtual environments, then aborted.
+- **Error:** virtual environment creation failed due to missing directories.
+
+### Recommended Fixes
+1. Install required Python tools such as `pipenv`, `flake8`, `pytest-cov`, `numpy`, `inflect`, and `PyYAML` either via `make setup` or dedicated requirements files.
+2. Ensure Node.js dependencies are installed so utilities like `rimraf` are available.
+3. Update the coverage configuration after `pytest-cov` is installed to remove argument errors.
+4. Review the install target to avoid endless virtual environment creation.


### PR DESCRIPTION
## Summary
- document failed CI/CD pipeline commands and suggest fixes

## Testing
- `make format`
- `make lint` *(fails: flake8 missing)*
- `make test` *(fails: pipenv missing)*
- `make build` *(fails: rimraf not found)*
- `make coverage` *(fails: pytest cov args)*
- `make simulate-ci` *(fails: missing PyYAML)*
- `make install` *(fails: env creation loop)*

------
https://chatgpt.com/codex/tasks/task_e_688bedaec6b88324893ee7d3c31c092a