### PR TITLE
feat: add docker templates for services

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ include Makefile.sibilant
 
 .PHONY: all build clean lint format test setup setup-quick install system-deps start stop start-tts start-stt stop-tts stop-stt \
         board-sync kanban-from-tasks kanban-to-hashtags kanban-to-issues coverage coverage-python coverage-js coverage-ts simulate-ci \
-				generate-requirements generate-requirements-service-% setup-python-quick test-python test-js test-ts
+        generate-requirements generate-requirements-service-% setup-python-quick test-python test-js test-ts docker-build docker-up docker-down
 
 
 all: build
@@ -85,3 +85,12 @@ kanban-to-issues:
 
 simulate-ci:
 	python scripts/simulate_ci.py
+
+docker-build:
+	docker compose build
+
+docker-up:
+	docker compose up -d
+
+docker-down:
+	docker compose down

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+version: '3.8'
+services:
+  tts:
+    build: ./services/py/tts
+    ports:
+      - "5001:5001"
+  stt:
+    build: ./services/py/stt
+    ports:
+      - "5002:5002"
+  vision:
+    build: ./services/js/vision
+    environment:
+      - PORT=9999
+    ports:
+      - "9999:9999"

--- a/services/js/vision/Dockerfile
+++ b/services/js/vision/Dockerfile
@@ -1,0 +1,16 @@
+# syntax=docker/dockerfile:1
+FROM node:20-alpine
+
+WORKDIR /app
+
+# Install dependencies
+COPY package.json package-lock.json ./
+RUN npm ci --omit=dev
+
+# Copy source code
+COPY . .
+
+EXPOSE 9999
+ENV PORT=9999
+
+CMD ["node", "index.js"]

--- a/services/py/stt/Dockerfile
+++ b/services/py/stt/Dockerfile
@@ -1,0 +1,16 @@
+# syntax=docker/dockerfile:1
+FROM python:3.12-slim
+
+WORKDIR /app
+
+# Install dependencies
+COPY Pipfile Pipfile.lock ./
+RUN pip install --no-cache-dir pipenv && \
+    pipenv install --deploy --ignore-pipfile
+
+# Copy source code
+COPY . .
+
+EXPOSE 5002
+
+CMD ["pipenv", "run", "uvicorn", "--host", "0.0.0.0", "--port", "5002", "app:app"]

--- a/services/py/tts/Dockerfile
+++ b/services/py/tts/Dockerfile
@@ -1,0 +1,16 @@
+# syntax=docker/dockerfile:1
+FROM python:3.12-slim
+
+WORKDIR /app
+
+# Install dependencies
+COPY Pipfile Pipfile.lock ./
+RUN pip install --no-cache-dir pipenv && \
+    pipenv install --deploy --ignore-pipfile
+
+# Copy source code
+COPY . .
+
+EXPOSE 5001
+
+CMD ["pipenv", "run", "uvicorn", "--host", "0.0.0.0", "--port", "5001", "app:app"]


### PR DESCRIPTION
## Summary
- add Dockerfiles for `tts`, `stt`, and `vision` services
- compose services with `docker-compose.yml`
- expose `docker-build`, `docker-up`, and `docker-down` make targets

## Testing
- `make format` (interrupted: repeated npm http-proxy warnings)
- `make lint` (fails: flake8 missing)
- `make test` (fails: No module named pipenv)
- `make build` (fails: build-ts error after npm warnings)
- `make install` (interrupted)


------
https://chatgpt.com/codex/tasks/task_e_688d784c28ec8324b7a6d1b4a3d075bf