### PR TITLE
chore(ci): enable js and ts coverage

### DIFF
--- a/.github/workflows/test-js.yml
+++ b/.github/workflows/test-js.yml
@@ -22,18 +22,16 @@ jobs:
         run: make system-deps  setup-js
 
 
-      - name: Run tests
-        run: make test-js
+        - name: Run tests
+          run: make test-js
 
-      # - name: Upload Python coverage
-      #   uses: actions/upload-artifact@v4
-      #   with:
-      #     name: python-coverage
-      #     path: coverage.xml
+        - name: Generate coverage report
+          run: make coverage-js
 
-      # - name: Upload JS coverage
-      #   uses: actions/upload-artifact@v4
-      #   with:
-      #     name: js-coverage
-      #     path: coverage
+        - name: Upload coverage to Codecov
+          uses: codecov/codecov-action@v3
+          with:
+            token: ${{ secrets.CODECOV_TOKEN }}
+            files: services/js/**/coverage/lcov.info
+            flags: js
 

--- a/.github/workflows/test-ts.yml
+++ b/.github/workflows/test-ts.yml
@@ -23,17 +23,15 @@ jobs:
         run: make system-deps  setup-ts
 
 
-      - name: Run tests
-        run: make test-ts
+        - name: Run tests
+          run: make test-ts
 
-      # - name: Upload Python coverage
-      #   uses: actions/upload-artifact@v4
-      #   with:
-      #     name: python-coverage
-      #     path: coverage.xml
+        - name: Generate coverage report
+          run: make coverage-ts
 
-      # - name: Upload TS coverage
-      #   uses: actions/upload-artifact@v4
-      #   with:
-      #     name: ts-coverage
-      #     path: coverage
+        - name: Upload coverage to Codecov
+          uses: codecov/codecov-action@v3
+          with:
+            token: ${{ secrets.CODECOV_TOKEN }}
+            files: services/ts/**/coverage/lcov.info
+            flags: ts

--- a/Makefile.js
+++ b/Makefile.js
@@ -28,7 +28,7 @@ test-js-services:
 test-js: test-js-services
 
 coverage-js-services:
-	       @$(call run_dirs,$(SERVICES_JS),echo "Generating coverage in $$d..." \&\& npm run coverage)
+	@$(call run_dirs,$(SERVICES_JS),npm run coverage && npx c8 report -r lcov)
 coverage-js: coverage-js-services
 
 clean-js:

--- a/Makefile.ts
+++ b/Makefile.ts
@@ -25,7 +25,7 @@ test-ts-services:
 test-ts: test-ts-services
 
 coverage-ts-services:
-	       @$(call run_dirs,$(SERVICES_TS),echo "Generating coverage in $$d..." \&\& npm run coverage)
+	@$(call run_dirs,$(SERVICES_TS),npm run coverage && npx c8 report -r lcov)
 coverage-ts: coverage-ts-services
 clean-ts:
 		       @$(call run_dirs,$(SERVICES_TS),npm run clean >/dev/null)


### PR DESCRIPTION
## Summary
- upload JS and TS coverage to Codecov
- generate lcov reports from JS and TS make targets

## Testing
- `make coverage-js`
- `make coverage-ts` *(fails: c8: not found)*
- `make format` *(interrupted)*
- `make lint` *(fails: flake8: No such file or directory)*
- `make test` *(fails: No module named pipenv)*
- `make build` *(fails: [Makefile.ts:37: build-ts] Error 1)*

------
https://chatgpt.com/codex/tasks/task_e_688d77830cfc832489a65cf5f9546c13