### PR TITLE
chore: add type checking

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -37,6 +37,12 @@ jobs:
       - name: Lint
         run: make lint
 
+      - name: Typecheck Python
+        run: make typecheck-python
+
+      - name: Typecheck TypeScript
+        run: make typecheck-ts
+
       # - name: Format
       #   run: make format
 

--- a/Makefile.python
+++ b/Makefile.python
@@ -79,3 +79,5 @@ lint-python:
 	flake8 services/ shared/py/
 format-python:
 	black services/ shared/py/
+typecheck-python:
+	mypy services/ shared/py/

--- a/Makefile.ts
+++ b/Makefile.ts
@@ -3,12 +3,14 @@ TS_OUT=shared/js
 SERVICES_TS=services/ts/cephalon services/ts/discord-embedder services/ts/llm services/ts/voice services/ts/file-watcher
 
 lint-ts:
-	       @$(call run_dirs,$(SERVICES_TS),npx eslint . --no-warn-ignored --ext .js,.ts)
+	@$(call run_dirs,$(SERVICES_TS),npx eslint . --no-warn-ignored --ext .js,.ts)
 format-ts:
-	       @$(call run_dirs,$(SERVICES_TS),npx prettier --write .)
+	@$(call run_dirs,$(SERVICES_TS),npx prettier --write .)
+typecheck-ts:
+	@$(call run_dirs,$(SERVICES_TS),npx tsc --noEmit)
 setup-ts:
-	       @echo "Setting up TypeScript services..."
-	       @$(call run_dirs,$(SERVICES_TS),npm install )
+	@echo "Setting up TypeScript services..."
+	@$(call run_dirs,$(SERVICES_TS),npm install )
 lint-ts-service-%:
 	@echo "Linting TS service: $*"
 	cd services/ts/$* && npx eslint . --ext .js,.ts


### PR DESCRIPTION
## Summary
- add mypy typechecking to python Makefile
- run tsc typecheck in TS Makefile
- invoke both typecheck targets in lint workflow

## Testing
- `python -m pre_commit run --files Makefile.python Makefile.ts .github/workflows/lint.yml`
- `make typecheck-python` *(fails: Cannot find implementation or library stub for module named 'discord')*
- `make typecheck-ts` *(fails: Cannot find module 'child_process' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_688d776e3140832495e4e8b7a3d61433