### PR TITLE
ci: cache pip and npm dependencies

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,6 +25,22 @@ jobs:
         with:
           node-version: '20'
 
+      - name: Cache pip dependencies
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('Pipfile.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
+      - name: Cache npm dependencies
+        uses: actions/cache@v3
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-npm-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-npm-
+
       - name: Install dependencies
         run: make install
 

--- a/.github/workflows/test-js.yml
+++ b/.github/workflows/test-js.yml
@@ -18,6 +18,22 @@ jobs:
         with:
           node-version: '20'
 
+      - name: Cache pip dependencies
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('Pipfile.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
+      - name: Cache npm dependencies
+        uses: actions/cache@v3
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-npm-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-npm-
+
       - name: Install dependencies
         run: make system-deps  setup-js
 

--- a/.github/workflows/test-py.yml
+++ b/.github/workflows/test-py.yml
@@ -14,6 +14,21 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: Cache pip dependencies
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('Pipfile.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
+      - name: Cache npm dependencies
+        uses: actions/cache@v3
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-npm-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-npm-
 
       - name: Install dependencies
         run: make system-deps  setup-python

--- a/.github/workflows/test-ts.yml
+++ b/.github/workflows/test-ts.yml
@@ -19,6 +19,22 @@ jobs:
         with:
           node-version: '20'
 
+      - name: Cache pip dependencies
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('Pipfile.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
+      - name: Cache npm dependencies
+        uses: actions/cache@v3
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-npm-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-npm-
+
       - name: Install dependencies
         run: make system-deps  setup-ts
 

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -21,3 +21,22 @@ step.
 Both `make test` and `make simulate-ci` should succeed before sending a pull
 request.
 
+## Dependency caching
+
+The CI workflows cache package downloads to speed up installs:
+
+- `~/.cache/pip` for Python packages, keyed by the hash of `Pipfile.lock`
+- `~/.npm` for npm packages, keyed by the hash of `package-lock.json`
+
+If a job reports a cache miss:
+
+1. Ensure the lockfiles are checked into the repository and match the
+   environment you expect.
+2. Modifying either lockfile invalidates the cache. Rerun the job to populate a
+   new cache with the updated dependencies.
+3. Delete the cache manually from the GitHub Actions interface if a cache
+   becomes corrupt.
+
+These caches are scoped by operating system so they won't cross-contaminate
+between Windows, macOS, and Linux runners.
+


### PR DESCRIPTION
## Summary
- cache pip and npm directories in JS/TS/Python test workflows and lint workflow
- document GitHub Actions caching strategy

## Testing
- `make install` *(fails: connect ENETUNREACH 140.82.114.3:443)*
- `make build` *(fails: make: *** [Makefile.ts:37: build-ts] Error 1)*
- `make test`
- `make lint` *(fails: make: flake8: No such file or directory)*
- `make format`


------
https://chatgpt.com/codex/tasks/task_e_688d77668a788324855e79eaf978aea1