### PR TITLE
Fix Python service requirements target and update docs

### DIFF
--- a/Makefile.python
+++ b/Makefile.python
@@ -14,17 +14,13 @@ setup-python-services:
 
 
 generate-python-shared-requirements:
-		cd shared/py && python -m pipenv requirements > requirements.txt
+	cd shared/py && python -m pipenv requirements > requirements.txt
+
 generate-python-services-requirements:
 	@echo "Generating requirements.txt for Python services..."
 	@for d in $(SERVICES_PY); do \
-		cd $$d &&  && cd - >/dev/null; \
+	cd $$d && python -m pipenv requirements > requirements.txt && cd - >/dev/null; \
 	done
-
-	cd shared/py && python -m pipenv lock -r > requirements.txt
-generate-python-services-requirements:
-	@echo "Generating requirements.txt for Python services..."
-	@$(call run_dirs,$(SERVICES_PY),python -m pipenv requirements > requirements.txt)
 
 generate-requirements-service-%:
 		cd services/py/$* && python -m pipenv requirements > requirements.txt
@@ -34,7 +30,7 @@ setup-shared-python:
 setup-shared-python-quick: generate-python-shared-requirements
 	cd shared/py && python -m pip install --user -r requirements.txt
 setup-python-services-quick: generate-python-services-requirements
-	              @$(call run_dirs,$(SERVICES_PY),python -m pip install --user -r requirements.txt)
+	@$(call run_dirs,$(SERVICES_PY),python -m pip install --user -r requirements.txt)
 
 setup-python-quick: setup-pipenv setup-python-services-quick setup-python-shared-quick
 generate-python-requirements: generate-python-services-requirements generate-python-shared-requirements
@@ -52,7 +48,7 @@ test-python-service-%:
 	@echo "Running tests for Python service: $*"
 	cd services/py/$* && PIPENV_NOSPIN=1 python -m pipenv run pytest tests/
 test-python-services:
-	              @$(call run_dirs,$(SERVICES_PY),echo "Running tests in $$d..." \&\& PIPENV_NOSPIN=1 python -m pipenv run pytest tests/)
+	@$(call run_dirs,$(SERVICES_PY),echo "Running tests in $$d..." \&\& PIPENV_NOSPIN=1 python -m pipenv run pytest tests/)
 
 test-shared-python:
 	cd shared/py && PIPENV_NOSPIN=1 python -m pipenv run pytest tests/
@@ -64,7 +60,7 @@ coverage-python-service-%:
 	cd services/py/$* && PIPENV_NOSPIN=1 python -m pipenv run pytest tests/ --cov=./ --cov-report=xml --cov-report=term
 
 coverage-python-services:
-	              @$(call run_dirs,$(SERVICES_PY),echo "Generating coverage in $$d..." \&\& PIPENV_NOSPIN=1 python -m pipenv run pytest tests/ --cov=./ --cov-report=xml --cov-report=term)
+	@$(call run_dirs,$(SERVICES_PY),echo "Generating coverage in $$d..." \&\& PIPENV_NOSPIN=1 python -m pipenv run pytest tests/ --cov=./ --cov-report=xml --cov-report=term)
 
 coverage-shared-python:
 	cd shared/py && PIPENV_NOSPIN=1 python -m pipenv run pytest tests/ --cov=./ --cov-report=xml --cov-report=term

--- a/readme.md
+++ b/readme.md
@@ -47,7 +47,7 @@ make setup-quick
 ```
 
 This skips `pipenv` during installation and uses the generated requirement
-files.
+files. `make setup-quick` calls `setup-python-services-quick`, which installs each Python service from its `requirements.txt`.
 
 Makefile targets for Python, JavaScript and TypeScript iterate over their
 respective service directories using a shared helper.


### PR DESCRIPTION
## Summary
- remove duplicate Python requirements target and consolidate loop
- document `setup-python-services-quick` using generated requirements

## Testing
- `pre-commit run --files Makefile.python readme.md`
- `make lint` *(fails: services/py/tts/app.py:49:1: E303 too many blank lines (5))*

------
https://chatgpt.com/codex/tasks/task_e_688d7760170c8324b022c2870f9a401e