### PR TITLE
Run pre-commit hooks in lint workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,27 +16,29 @@ jobs:
 
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.11'
+          python-version: "3.11"
 
       - name: Install system dependencies
         run: make system-deps
 
       - uses: actions/setup-node@v3
         with:
-          node-version: '20'
+          node-version: "20"
 
       - name: Install dependencies
         run: make install
 
-      - name: Install flake8
-        run: python -m pip install flake8
+      - name: Install lint dependencies
+        run: python -m pip install flake8 pre-commit
 
       - name: Build project
         run: make build
+
+      - name: Pre-commit
+        run: pre-commit run --files $(git ls-files | tr '\n' ' ')
 
       - name: Lint
         run: make lint
 
       # - name: Format
       #   run: make format
-

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,3 +6,22 @@ repos:
         entry: python scripts/convert_wikilinks.py
         language: system
         files: '\.md$'
+  - repo: https://github.com/psf/black
+    rev: 24.4.2
+    hooks:
+      - id: black
+        language_version: python3
+  - repo: https://github.com/pycqa/flake8
+    rev: 7.3.0
+    hooks:
+      - id: flake8
+  - repo: https://github.com/pre-commit/mirrors-eslint
+    rev: v9.32.0
+    hooks:
+      - id: eslint
+        types: [javascript, ts, tsx]
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: v3.1.0
+    hooks:
+      - id: prettier
+        types_or: [javascript, ts, tsx, json, yaml]

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,6 +12,7 @@ This `docs` directory houses internal documentation for the **Promethean Framewo
         
     - [MIGRATION_PLAN](MIGRATION_PLAN.md) – a living checklist of steps to migrate code from legacy repositories into this structure.
     - [site README](../site/README.md) – instructions for building and serving the portfolio site.
+    - [pre-commit](pre-commit.md) – how to install and run repository hooks before committing changes.
         
 - **Agile process and tasks**
     

--- a/docs/pre-commit.md
+++ b/docs/pre-commit.md
@@ -1,0 +1,28 @@
+# Pre-commit Workflow
+
+This repository uses [pre-commit](https://pre-commit.com/) to enforce
+formatting and lint rules for multiple languages.
+
+## Installation
+
+Install the tool inside your development environment and register the
+Git hook:
+
+```bash
+pip install pre-commit
+pre-commit install
+```
+
+## Running hooks
+
+Run the hooks against modified files before committing:
+
+```bash
+pre-commit run --files <file1> <file2>
+```
+
+To check the entire repository, use `--all-files` instead of listing
+specific paths.
+
+The CI workflow runs the same command to verify that committed files pass
+the configured hooks.


### PR DESCRIPTION
## Summary
- add flake8, black, eslint and prettier hooks to pre-commit
- run pre-commit hooks in lint workflow
- document pre-commit workflow for contributors

## Testing
- `pre-commit run --files .pre-commit-config.yaml .github/workflows/lint.yml docs/pre-commit.md docs/README.md`
- `make lint` *(fails: E303 too many blank lines)*
- `make test` *(fails: No module named pipenv)*
- `make build` *(fails: missing TypeScript modules)*
- `make format`

------
https://chatgpt.com/codex/tasks/task_e_688d775682188324b2a83dba9f5e4c80