### PR TITLE
docs: link raw wav dataset and batch transcription

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -32,6 +32,8 @@ This `docs` directory houses internal documentation for the **Promethean Framewo
     - Various notes under `docs/research/` summarize APIs or algorithms (e.g. `github_projects_api.md`).
         
     - Utility scripts in `scripts/` (outside `docs`) may be referenced here; for example, `scripts/github_board_sync.py` syncs the Kanban board with a GitHub Projects column[api.github.com](https://api.github.com/repos/riatzukiza/promethean/pulls/41/files).
+
+    - The raw WAV dataset for STT lives in [../data/raw-wav/](../data/raw-wav/). Run [scripts/batch_transcribe.py](../scripts/batch_transcribe.py) to generate transcripts stored in [../data/transcripts/](../data/transcripts/).
         
 
 ## Writing and navigating docs

--- a/docs/services/stt/app.md
+++ b/docs/services/stt/app.md
@@ -2,7 +2,7 @@
 
 **Path**: `services/stt/app.py`
 
-**Description**: Now call your transcription logic
+**Description**: Now call your transcription logic. For offline processing, run [batch_transcribe.py](../../scripts/batch_transcribe.py) on the raw WAV dataset in [data/raw-wav/](../../data/raw-wav/); transcripts are written to [data/transcripts/](../../data/transcripts/).
 
 ## Dependencies
 - fastapi


### PR DESCRIPTION
## Summary
- document the raw WAV dataset and batch transcription script in STT app docs
- reference dataset and transcript output paths in repo documentation

## Testing
- `pre-commit run --files docs/services/stt/app.md docs/README.md`
- `make lint-python` (fails: services/py/tts/app.py:49:1: E303)
- `make test-python` (fails: No module named pipenv)
- `make build` (fails: npm warn Unknown env config "http-proxy"; Error 1)
- `make install` (interrupted after virtualenv creation)
- `make format-python`

------
https://chatgpt.com/codex/tasks/task_e_688d661e8b248324becab40b1b7b7592