### PR TITLE
Fix pre-commit run step handling spaces

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -35,7 +35,8 @@ jobs:
         run: make build
 
       - name: Pre-commit
-        run: pre-commit run --files $(git ls-files | tr '\n' ' ')
+        run: |
+          git ls-files -z | xargs -0 pre-commit run --files
 
       - name: Lint
         run: make lint

--- a/docs/pre-commit.md
+++ b/docs/pre-commit.md
@@ -24,5 +24,11 @@ pre-commit run --files <file1> <file2>
 To check the entire repository, use `--all-files` instead of listing
 specific paths.
 
+If some tracked files contain spaces, you can run hooks on every file safely with:
+
+```bash
+git ls-files -z | xargs -0 pre-commit run --files
+```
+
 The CI workflow runs the same command to verify that committed files pass
 the configured hooks.


### PR DESCRIPTION
## Summary
- run pre-commit in CI using null-delimited file list to handle filenames with spaces
- document safe pre-commit command for repos with spaces

## Testing
- `python -m pre_commit run --files .github/workflows/lint.yml docs/pre-commit.md`
- `make lint` *(fails: services/py/tts/app.py:49:1: E303 too many blank lines (5))*
- `make test` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `make build` *(fails: Cannot find module 'child_process' and other TypeScript declarations)*
- `make format` *(reformatted files; changes reverted to keep commit scoped)*

------
https://chatgpt.com/codex/tasks/task_e_688ee050867483249dfc34c8e3cd4bf9