### PR TITLE
feat: compile file watcher ts on start

### DIFF
--- a/services/ts/file-watcher/README.md
+++ b/services/ts/file-watcher/README.md
@@ -7,4 +7,5 @@ This service monitors the local kanban board and task files.
 - When any document under `docs/agile/tasks/` changes it runs
   `hashtags_to_kanban.py` and writes the output back to the board.
 
+`npm start` will compile the TypeScript source before launching.
 Use `npm run start:dev` while developing to watch TypeScript files.

--- a/services/ts/file-watcher/package.json
+++ b/services/ts/file-watcher/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "build": "tsc && node scripts/patch-imports.js",
+    "prestart": "npm run build",
     "start": "node dist/index.js",
     "start:dev": "node --loader ts-node/esm src/index.ts",
     "build:check": "tsc --noEmit --incremental false",


### PR DESCRIPTION
## Summary
- compile TypeScript before launching file watcher service
- document automatic TypeScript compilation in service README

## Testing
- `npm run build`
- `npx ava tests/dummy.test.ts --node-arguments="--loader ts-node/esm"`
- `npx eslint src/index.ts` (ignored: file matched ignore pattern)
- `npx prettier --write package.json README.md`

------
https://chatgpt.com/codex/tasks/task_e_688ef37680b0832491c0189a1f23298a