### PR TITLE
refactor: centralize agile statuses and script loader

### DIFF
--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,1 @@
+"""Helper package for standalone project scripts."""

--- a/scripts/agile_statuses.py
+++ b/scripts/agile_statuses.py
@@ -1,0 +1,21 @@
+"""Common agile status definitions shared by kanban utilities."""
+
+STATUS_ORDER = [
+    "#ice-box",
+    "#incoming",
+    "#rejected",
+    "#accepted",
+    "#prompt-refinement",
+    "#agent-thinking",
+    "#breakdown",
+    "#blocked",
+    "#ready",
+    "#todo",
+    "#in-progress",
+    "#in-review",
+    "#done",
+]
+
+STATUS_SET = set(STATUS_ORDER)
+
+__all__ = ["STATUS_ORDER", "STATUS_SET"]

--- a/scripts/hashtags_to_kanban.py
+++ b/scripts/hashtags_to_kanban.py
@@ -7,25 +7,12 @@ import re
 from collections import defaultdict
 from pathlib import Path
 
-TASK_DIR = Path("docs/agile/tasks")
+try:  # pragma: no cover - fallback for direct execution
+    from .agile_statuses import STATUS_ORDER, STATUS_SET
+except ImportError:  # pragma: no cover
+    from agile_statuses import STATUS_ORDER, STATUS_SET
 
-# Ordered list of recognized status hashtags
-STATUS_ORDER = [
-    "#ice-box",
-    "#incoming",
-    "#rejected",
-    "#accepted",
-    "#prompt-refinement",
-    "#agent-thinking",
-    "#breakdown",
-    "#blocked",
-    "#ready",
-    "#todo",
-    "#in-progress",
-    "#in-review",
-    "#done",
-]
-STATUS_SET = set(STATUS_ORDER)
+TASK_DIR = Path("docs/agile/tasks")
 
 TITLE_RE = re.compile(r"^##\s+🛠️\s+Task:\s*(.+)")
 HASHTAG_RE = re.compile(r"#([A-Za-z0-9_-]+)")

--- a/scripts/kanban_to_hashtags.py
+++ b/scripts/kanban_to_hashtags.py
@@ -7,25 +7,13 @@ import re
 from pathlib import Path
 from urllib.parse import unquote
 
+try:  # pragma: no cover - fallback for direct execution
+    from .agile_statuses import STATUS_ORDER, STATUS_SET
+except ImportError:  # pragma: no cover
+    from agile_statuses import STATUS_ORDER, STATUS_SET
+
 BOARD_PATH = Path("docs/agile/boards/kanban.md")
 TASK_DIR = Path("docs/agile/tasks")
-
-STATUS_ORDER = [
-    "#ice-box",
-    "#incoming",
-    "#rejected",
-    "#accepted",
-    "#prompt-refinement",
-    "#agent-thinking",
-    "#breakdown",
-    "#blocked",
-    "#ready",
-    "#todo",
-    "#in-progress",
-    "#in-review",
-    "#done",
-]
-STATUS_SET = set(STATUS_ORDER)
 
 
 def parse_board(path: Path = BOARD_PATH) -> dict[Path, str]:

--- a/tests/scripts/test_hashtags_to_kanban.py
+++ b/tests/scripts/test_hashtags_to_kanban.py
@@ -1,17 +1,10 @@
-import importlib.util
 from pathlib import Path
+import sys
 
-MODULE_PATH = (
-    Path(__file__).resolve().parent.parent.parent
-    / "scripts"
-    / "hashtags_to_kanban.py"
-)
-spec = importlib.util.spec_from_file_location(
-    "hashtags_to_kanban",
-    MODULE_PATH,
-)
-hk = importlib.util.module_from_spec(spec)
-spec.loader.exec_module(hk)
+sys.path.append(str(Path(__file__).resolve().parent))
+from utils import load_script_module
+
+hk = load_script_module("hashtags_to_kanban")
 
 
 def test_parse_task_with_status(tmp_path):

--- a/tests/scripts/test_kanban_to_hashtags.py
+++ b/tests/scripts/test_kanban_to_hashtags.py
@@ -1,17 +1,10 @@
-import importlib.util
 from pathlib import Path
+import sys
 
-MODULE_PATH = (
-    Path(__file__).resolve().parent.parent.parent
-    / "scripts"
-    / "kanban_to_hashtags.py"
-)
-spec = importlib.util.spec_from_file_location(
-    "kanban_to_hashtags",
-    MODULE_PATH,
-)
-kh = importlib.util.module_from_spec(spec)
-spec.loader.exec_module(kh)
+sys.path.append(str(Path(__file__).resolve().parent))
+from utils import load_script_module
+
+kh = load_script_module("kanban_to_hashtags")
 
 
 def test_parse_board(tmp_path):

--- a/tests/scripts/test_simulate_ci.py
+++ b/tests/scripts/test_simulate_ci.py
@@ -1,10 +1,10 @@
-import importlib.util
 from pathlib import Path
+import sys
 
-MODULE_PATH = Path(__file__).resolve().parents[2] / "scripts" / "simulate_ci.py"
-spec = importlib.util.spec_from_file_location("simulate_ci", MODULE_PATH)
-sc = importlib.util.module_from_spec(spec)
-spec.loader.exec_module(sc)
+sys.path.append(str(Path(__file__).resolve().parent))
+from utils import load_script_module
+
+sc = load_script_module("simulate_ci")
 
 
 def test_collect_jobs(tmp_path):

--- a/tests/scripts/utils.py
+++ b/tests/scripts/utils.py
@@ -1,0 +1,26 @@
+"""Utilities for loading script modules for testing."""
+
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS_DIR = ROOT / "scripts"
+
+
+def load_script_module(name: str):
+    """Load a module from the ``scripts`` package by name."""
+    if "scripts" not in sys.modules:
+        pkg_spec = spec_from_file_location("scripts", SCRIPTS_DIR / "__init__.py")
+        pkg = module_from_spec(pkg_spec)
+        assert pkg_spec.loader is not None
+        pkg_spec.loader.exec_module(pkg)  # type: ignore[attr-defined]
+        sys.modules["scripts"] = pkg
+        sys.path.insert(0, str(SCRIPTS_DIR))
+    path = SCRIPTS_DIR / f"{name}.py"
+    spec = spec_from_file_location(f"scripts.{name}", path)
+    module = module_from_spec(spec)
+    sys.modules[spec.name] = module
+    assert spec.loader is not None
+    spec.loader.exec_module(module)  # type: ignore[attr-defined]
+    return module


### PR DESCRIPTION
## Summary
- share agile status constants between kanban scripts
- unify script module loading in tests

## Testing
- `make install` (fails: setup-python-services Error 1)
- `pytest tests/scripts/test_hashtags_to_kanban.py tests/scripts/test_kanban_to_hashtags.py tests/scripts/test_simulate_ci.py`
- `make build` (fails: build-ts Error 1)
- `make lint` (fails: lint-python Error 1)
- `make format`


------
https://chatgpt.com/codex/tasks/task_e_688ef56e0ecc8324a7f42c9c158bee27