### PR TITLE
refactor: extract speech service clients

### DIFF
--- a/docs/shared-py-speech-service-clients.md
+++ b/docs/shared-py-speech-service-clients.md
@@ -1,0 +1,11 @@
+# shared/py/speech/service_clients.py
+
+Helper functions extracted from various scripts to interact with the
+speech services over HTTP.
+
+- `send_wav_as_pcm(file_path, url="http://localhost:5001/transcribe_pcm", query_params=None)` –
+  send a 16‑bit PCM WAV file to the STT service and return the
+  transcription text.
+- `synthesize_text_to_file(text, output_path, url="http://localhost:5000/synth_voice")` –
+  request speech synthesis from the TTS service and write the resulting
+  audio to ``output_path``.

--- a/scripts/stt_request.py
+++ b/scripts/stt_request.py
@@ -1,84 +1,57 @@
-import requests
-from urllib.parse import urlencode
-from scipy.io import wavfile
+"""Convenience script for invoking the STT service."""
+
+from shared.py.speech.service_clients import send_wav_as_pcm
 
 
-def send_wav_as_pcm(file_path, url='http://localhost:5001/transcribe_pcm', query_params=None):
-    sample_rate, data = wavfile.read(file_path)
+if __name__ == "__main__":
+    send_wav_as_pcm("longer_recording.wav", url="http://localhost:5001/transcribe_pcm")
 
-    if data.dtype != 'int16':
-        raise ValueError("Only 16-bit PCM WAV files are supported.")
+    send_wav_as_pcm(
+        "longer_recording.wav",
+        url="http://localhost:5001/transcribe_pcm/equalized",
+    )
 
-    pcm_data = data.tobytes()
+    # Config 1 – Standard voice cleanup
+    send_wav_as_pcm(
+        "longer_recording.wav",
+        url="http://localhost:5001/transcribe_pcm/equalized",
+        query_params={
+            "highpass": 100,
+            "lowpass": 7500,
+            "notch1": "200-300",
+            "notch2": "400-700",
+        },
+    )
 
-    # Add query params to URL if provided
-    if query_params:
-        url += '?' + urlencode(query_params)
+    # Config 2 – Brighter voice, no lowpass
+    send_wav_as_pcm(
+        "longer_recording.wav",
+        url="http://localhost:5001/transcribe_pcm/equalized",
+        query_params={
+            "highpass": 120,
+            "notch1": "180-280",
+            "notch2": "500-800",
+            "boost": "3000-4000",
+        },
+    )
 
-    headers = {
-        'Content-Type': 'application/octet-stream',
-        'X-Sample-Rate': str(sample_rate),
-        'X-Dtype': 'int16'
-    }
+    # Config 3 – Softer high end
+    send_wav_as_pcm(
+        "longer_recording.wav",
+        url="http://localhost:5001/transcribe_pcm/equalized",
+        query_params={
+            "highpass": 80,
+            "lowpass": 5000,
+            "notch1": "250-350",
+        },
+    )
 
-    print(f"\n=== Transcribing '{file_path}' ===")
-    print("POST", url)
-
-    response = requests.post(url, data=pcm_data, headers=headers)
-
-    if response.ok:
-        print("Transcription:", response.json().get('transcription'))
-    else:
-        print("Error:", response.status_code, response.text)
-
-
-# === Example Usages ===
-
-send_wav_as_pcm("longer_recording.wav", url='http://localhost:5001/transcribe_pcm')
-
-send_wav_as_pcm("longer_recording.wav", url='http://localhost:5001/transcribe_pcm/equalized')
-
-# Config 1 – Standard voice cleanup
-send_wav_as_pcm(
-    "longer_recording.wav",
-    url='http://localhost:5001/transcribe_pcm/equalized',
-    query_params={
-        'highpass': 100,
-        'lowpass': 7500,
-        'notch1': '200-300',
-        'notch2': '400-700'
-    }
-)
-
-# Config 2 – Brighter voice, no lowpass
-send_wav_as_pcm(
-    "longer_recording.wav",
-    url='http://localhost:5001/transcribe_pcm/equalized',
-    query_params={
-        'highpass': 120,
-        'notch1': '180-280',
-        'notch2': '500-800',
-        'boost': '3000-4000'
-    }
-)
-
-# Config 3 – Softer high end
-send_wav_as_pcm(
-    "longer_recording.wav",
-    url='http://localhost:5001/transcribe_pcm/equalized',
-    query_params={
-        'highpass': 80,
-        'lowpass': 5000,
-        'notch1': '250-350'
-    }
-)
-
-# Config 4 – No notch filters, just broad shaping
-send_wav_as_pcm(
-    "longer_recording.wav",
-    url='http://localhost:5001/transcribe_pcm/equalized',
-    query_params={
-        'highpass': 90,
-        'lowpass': 6800
-    }
-)
+    # Config 4 – No notch filters, just broad shaping
+    send_wav_as_pcm(
+        "longer_recording.wav",
+        url="http://localhost:5001/transcribe_pcm/equalized",
+        query_params={
+            "highpass": 90,
+            "lowpass": 6800,
+        },
+    )

--- a/scripts/tts_request.py
+++ b/scripts/tts_request.py
@@ -1,16 +1,10 @@
-import requests
+"""Convenience script for invoking the TTS service."""
 
-url = "http://localhost:5000/synth_voice"
-data = {
-    "input_text": "This is a test of the text to speech system"
-}
+from shared.py.speech.service_clients import synthesize_text_to_file
 
-response = requests.post(url, data=data)
 
-if response.status_code == 200:
-    with open("output.wav", "wb") as f:
-        f.write(response.content)
-    print("Audio saved as output.wav")
-else:
-    print("Request failed with status code:", response.status_code)
-    print("Response:", response.text)
+if __name__ == "__main__":
+    synthesize_text_to_file(
+        "This is a test of the text to speech system",
+        output_path="output.wav",
+    )

--- a/shared/py/speech/service_clients.py
+++ b/shared/py/speech/service_clients.py
@@ -1,0 +1,86 @@
+"""HTTP clients for speech services.
+
+This module provides simple helper functions to communicate with the
+speech-to-text (STT) and text-to-speech (TTS) services. They are
+extracted from various scripts so other modules can reuse the logic.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, Optional
+from urllib.parse import urlencode
+
+import requests
+from scipy.io import wavfile
+
+
+def send_wav_as_pcm(
+    file_path: str | Path,
+    url: str = "http://localhost:5001/transcribe_pcm",
+    query_params: Optional[Dict[str, Any]] = None,
+) -> str:
+    """Send a 16-bit PCM WAV file to the STT service.
+
+    Parameters
+    ----------
+    file_path:
+        Path to the WAV file to send.
+    url:
+        Endpoint of the STT service.
+    query_params:
+        Optional mapping of query parameters to append to the URL.
+
+    Returns
+    -------
+    str
+        Transcription text returned by the service.
+    """
+
+    sample_rate, data = wavfile.read(str(file_path))
+    if data.dtype != "int16":
+        raise ValueError("Only 16-bit PCM WAV files are supported.")
+
+    pcm_data = data.tobytes()
+    if query_params:
+        url += "?" + urlencode(query_params)
+
+    headers = {
+        "Content-Type": "application/octet-stream",
+        "X-Sample-Rate": str(sample_rate),
+        "X-Dtype": "int16",
+    }
+
+    response = requests.post(url, data=pcm_data, headers=headers)
+    response.raise_for_status()
+    return response.json().get("transcription", "")
+
+
+def synthesize_text_to_file(
+    text: str,
+    output_path: str | Path,
+    url: str = "http://localhost:5000/synth_voice",
+) -> Path:
+    """Request speech synthesis and save the audio to ``output_path``.
+
+    Parameters
+    ----------
+    text:
+        Text to synthesize.
+    output_path:
+        Location where the resulting WAV file will be written.
+    url:
+        Endpoint of the TTS service.
+
+    Returns
+    -------
+    pathlib.Path
+        Path to the written audio file.
+    """
+
+    response = requests.post(url, data={"input_text": text})
+    response.raise_for_status()
+    output_file = Path(output_path)
+    with output_file.open("wb") as f:
+        f.write(response.content)
+    return output_file

--- a/shared/py/tests/test_service_clients.py
+++ b/shared/py/tests/test_service_clients.py
@@ -1,0 +1,40 @@
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+from scipy.io import wavfile
+
+# Ensure repository root on sys.path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../")))
+
+from shared.py.speech.service_clients import (
+    send_wav_as_pcm,
+    synthesize_text_to_file,
+)
+
+
+def test_send_wav_as_pcm(tmp_path):
+    wav_path = tmp_path / "test.wav"
+    wavfile.write(wav_path, 16000, np.array([0, 1, -1], dtype=np.int16))
+
+    mock_response = MagicMock()
+    mock_response.raise_for_status = MagicMock()
+    mock_response.json.return_value = {"transcription": "hello"}
+
+    with patch("requests.post", return_value=mock_response) as mock_post:
+        result = send_wav_as_pcm(wav_path, url="http://example.com")
+        assert result == "hello"
+        mock_post.assert_called_once()
+
+
+def test_synthesize_text_to_file(tmp_path):
+    output = tmp_path / "out.wav"
+    mock_response = MagicMock(status_code=200, content=b"data")
+    mock_response.raise_for_status = MagicMock()
+
+    with patch("requests.post", return_value=mock_response) as mock_post:
+        path = synthesize_text_to_file("hi", output_path=output, url="http://example.com")
+        assert path == output
+        assert output.read_bytes() == b"data"
+        mock_post.assert_called_once()


### PR DESCRIPTION
## Summary
- centralize STT/TTS HTTP helpers into `shared/py/speech/service_clients.py`
- update request scripts to use shared helpers
- document and test the new speech service client module

## Testing
- `make format`
- `make lint` *(fails: flake8 not found)*
- `make test` *(fails: No module named pipenv)*
- `make build` *(fails: build-ts error)*
- `make install` *(interrupted)*
- `pytest shared/py/tests/test_service_clients.py`


------
https://chatgpt.com/codex/tasks/task_e_688ef55d629483248b21bddd57f59d30