### PR TITLE
refactor: extract kanban helpers to shared module

### DIFF
--- a/scripts/hashtags_to_kanban.py
+++ b/scripts/hashtags_to_kanban.py
@@ -1,73 +1,7 @@
 #!/usr/bin/env python3
 """Generate a Kanban board from task status hashtags."""
 
-from __future__ import annotations
-
-import re
-from collections import defaultdict
-from pathlib import Path
-
-TASK_DIR = Path("docs/agile/tasks")
-
-# Ordered list of recognized status hashtags
-STATUS_ORDER = [
-    "#ice-box",
-    "#incoming",
-    "#rejected",
-    "#accepted",
-    "#prompt-refinement",
-    "#agent-thinking",
-    "#breakdown",
-    "#blocked",
-    "#ready",
-    "#todo",
-    "#in-progress",
-    "#in-review",
-    "#done",
-]
-STATUS_SET = set(STATUS_ORDER)
-
-TITLE_RE = re.compile(r"^##\s+🛠️\s+Task:\s*(.+)")
-HASHTAG_RE = re.compile(r"#([A-Za-z0-9_-]+)")
-
-
-def parse_task(path: Path) -> tuple[str, str]:
-    """Return task title and status hashtag from a markdown file."""
-    title = path.stem.replace("_", " ")
-    status = "#todo"
-    with path.open(encoding="utf-8") as fh:
-        for line in fh:
-            if m := TITLE_RE.match(line):
-                title = m.group(1).strip()
-            for tag in HASHTAG_RE.findall(line):
-                tag = f"#{tag}"
-                if tag in STATUS_SET:
-                    status = tag
-    return title, status
-
-
-def collect_tasks(directory: Path = TASK_DIR):
-    tasks: dict[str, list[tuple[str, Path]]] = defaultdict(list)
-    for file in directory.glob("*.md"):
-        title, status = parse_task(file)
-        tasks[status].append((title, file))
-    return tasks
-
-
-def build_board(tasks: dict[str, list[tuple[str, Path]]]) -> str:
-    lines = ["---", "", "kanban-plugin: board", "", "---", ""]
-    for status in STATUS_ORDER:
-        items = tasks.get(status)
-        if not items:
-            continue
-        header = status.lstrip("#").replace("-", " ").title()
-        lines.append(f"## {header}")
-        lines.append("")
-        for title, path in sorted(items):
-            rel = Path("../tasks") / path.name
-            lines.append(f"- [ ] [{title}]({rel}) {status}")
-        lines.append("")
-    return "\n".join(lines)
+from shared.py.agile.kanban import build_board, collect_tasks
 
 
 def main() -> None:

--- a/scripts/kanban_to_hashtags.py
+++ b/scripts/kanban_to_hashtags.py
@@ -1,78 +1,7 @@
 #!/usr/bin/env python3
 """Update task files with status hashtags from the kanban board."""
 
-from __future__ import annotations
-
-import re
-from pathlib import Path
-from urllib.parse import unquote
-
-BOARD_PATH = Path("docs/agile/boards/kanban.md")
-TASK_DIR = Path("docs/agile/tasks")
-
-STATUS_ORDER = [
-    "#ice-box",
-    "#incoming",
-    "#rejected",
-    "#accepted",
-    "#prompt-refinement",
-    "#agent-thinking",
-    "#breakdown",
-    "#blocked",
-    "#ready",
-    "#todo",
-    "#in-progress",
-    "#in-review",
-    "#done",
-]
-STATUS_SET = set(STATUS_ORDER)
-
-
-def parse_board(path: Path = BOARD_PATH) -> dict[Path, str]:
-    """Return mapping of task file paths to status hashtags."""
-    mapping: dict[Path, str] = {}
-    status: str | None = None
-    with path.open(encoding="utf-8") as fh:
-        for line in fh:
-            if line.startswith("## "):
-                header = line[3:].strip()
-                header = re.sub(r"\s*\(.*\)$", "", header)
-                tag = f"#{header.lower().replace(' ', '-')}"
-                status = tag if tag in STATUS_SET else None
-                continue
-            if status and line.lstrip().startswith("- ["):
-                m = re.search(r"\(([^)]+\.md)\)", line)
-                if not m:
-                    continue
-                rel = unquote(m.group(1))
-                task_path = (path.parent / rel).resolve()
-                mapping[task_path] = status
-    return mapping
-
-
-def _remove_status_tokens(line: str) -> str:
-    tokens = [tok for tok in line.split() if tok not in STATUS_SET]
-    return " ".join(tokens)
-
-
-def set_status(path: Path, status: str) -> None:
-    """Update a task file with the given status hashtag."""
-    if not path.exists():
-        return
-    lines = [
-        _remove_status_tokens(line.rstrip())
-        for line in path.read_text(encoding="utf-8").splitlines()
-    ]
-    while lines and lines[-1] == "":
-        lines.pop()
-    lines.append(status)
-    lines.append("")
-    path.write_text("\n".join(lines), encoding="utf-8")
-
-
-def update_tasks(board: Path = BOARD_PATH) -> None:
-    for file, status in parse_board(board).items():
-        set_status(file, status)
+from shared.py.agile.kanban import update_tasks
 
 
 def main() -> None:

--- a/shared/py/agile/__init__.py
+++ b/shared/py/agile/__init__.py
@@ -1,0 +1,25 @@
+"""Utilities for working with agile task boards."""
+
+from .kanban import (
+    BOARD_PATH,
+    TASK_DIR,
+    STATUS_ORDER,
+    STATUS_SET,
+    build_board,
+    collect_tasks,
+    parse_board,
+    set_status,
+    update_tasks,
+)
+
+__all__ = [
+    "BOARD_PATH",
+    "TASK_DIR",
+    "STATUS_ORDER",
+    "STATUS_SET",
+    "build_board",
+    "collect_tasks",
+    "parse_board",
+    "set_status",
+    "update_tasks",
+]

--- a/shared/py/agile/kanban.py
+++ b/shared/py/agile/kanban.py
@@ -1,0 +1,136 @@
+"""Reusable helpers for converting between task files and kanban boards."""
+
+from __future__ import annotations
+
+import re
+from collections import defaultdict
+from pathlib import Path
+from urllib.parse import unquote
+from typing import Dict, List, Tuple
+
+# Default locations for tasks and the kanban board
+TASK_DIR = Path("docs/agile/tasks")
+BOARD_PATH = Path("docs/agile/boards/kanban.md")
+
+# Ordered list of recognized status hashtags
+STATUS_ORDER = [
+    "#ice-box",
+    "#incoming",
+    "#rejected",
+    "#accepted",
+    "#prompt-refinement",
+    "#agent-thinking",
+    "#breakdown",
+    "#blocked",
+    "#ready",
+    "#todo",
+    "#in-progress",
+    "#in-review",
+    "#done",
+]
+STATUS_SET = set(STATUS_ORDER)
+
+# Regular expressions used by both conversions
+TITLE_RE = re.compile(r"^##\s+🛠️\s+Task:\s*(.+)")
+HASHTAG_RE = re.compile(r"#([A-Za-z0-9_-]+)")
+TASK_PATTERN = re.compile(r"^- \[ \] (.+)")
+
+
+# ---------------------------------------------------------------------------
+# Task -> Kanban
+# ---------------------------------------------------------------------------
+
+
+def parse_task(path: Path) -> Tuple[str, str]:
+    """Return task title and status hashtag from a markdown file."""
+    title = path.stem.replace("_", " ")
+    status = "#todo"
+    with path.open(encoding="utf-8") as fh:
+        for line in fh:
+            if m := TITLE_RE.match(line):
+                title = m.group(1).strip()
+            for tag in HASHTAG_RE.findall(line):
+                tag = f"#{tag}"
+                if tag in STATUS_SET:
+                    status = tag
+    return title, status
+
+
+def collect_tasks(directory: Path = TASK_DIR) -> Dict[str, List[Tuple[str, Path]]]:
+    """Collect all markdown task files grouped by status."""
+    tasks: Dict[str, List[Tuple[str, Path]]] = defaultdict(list)
+    for file in directory.glob("*.md"):
+        title, status = parse_task(file)
+        tasks[status].append((title, file))
+    return tasks
+
+
+def build_board(tasks: Dict[str, List[Tuple[str, Path]]]) -> str:
+    """Build kanban board markdown from collected tasks."""
+    lines = ["---", "", "kanban-plugin: board", "", "---", ""]
+    for status in STATUS_ORDER:
+        items = tasks.get(status)
+        if not items:
+            continue
+        header = status.lstrip("#").replace("-", " ").title()
+        lines.append(f"## {header}")
+        lines.append("")
+        for title, path in sorted(items):
+            rel = Path("../tasks") / path.name
+            lines.append(f"- [ ] [{title}]({rel}) {status}")
+        lines.append("")
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Kanban -> Task
+# ---------------------------------------------------------------------------
+
+
+def parse_board(path: Path = BOARD_PATH) -> Dict[Path, str]:
+    """Return mapping of task file paths to status hashtags."""
+    mapping: Dict[Path, str] = {}
+    status: str | None = None
+    with path.open(encoding="utf-8") as fh:
+        for line in fh:
+            if line.startswith("## "):
+                header = line[3:].strip()
+                header = re.sub(r"\s*\(.*\)$", "", header)
+                tag = f"#{header.lower().replace(' ', '-')}"
+                status = tag if tag in STATUS_SET else None
+                continue
+            if status and line.lstrip().startswith("- ["):
+                m = re.search(r"\(([^)]+\.md)\)", line)
+                if not m:
+                    continue
+                rel = unquote(m.group(1))
+                task_path = (path.parent / rel).resolve()
+                mapping[task_path] = status
+    return mapping
+
+
+def _remove_status_tokens(line: str) -> str:
+    """Remove any known status hashtags from a line."""
+    tokens = [tok for tok in line.split() if tok not in STATUS_SET]
+    return " ".join(tokens)
+
+
+def set_status(path: Path, status: str) -> None:
+    """Update a task file with the given status hashtag."""
+    if not path.exists():
+        return
+    lines = [
+        _remove_status_tokens(line.rstrip())
+        for line in path.read_text(encoding="utf-8").splitlines()
+    ]
+    while lines and lines[-1] == "":
+        lines.pop()
+    lines.append(status)
+    lines.append("")
+    path.write_text("\n".join(lines), encoding="utf-8")
+
+
+def update_tasks(board: Path = BOARD_PATH) -> None:
+    """Update all task files to match statuses from the kanban board."""
+    for file, status in parse_board(board).items():
+        set_status(file, status)

--- a/shared/py/tests/test_agile_kanban.py
+++ b/shared/py/tests/test_agile_kanban.py
@@ -1,0 +1,36 @@
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(
+    0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../"))
+)
+
+from shared.py.agile.kanban import build_board, collect_tasks, parse_board, set_status
+
+
+def test_roundtrip(tmp_path: Path) -> None:
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    board_dir = tmp_path / "boards"
+    board_dir.mkdir()
+
+    (tasks_dir / "task1.md").write_text("## 🛠️ Task: Example\n#todo\n", encoding="utf-8")
+    (tasks_dir / "task2.md").write_text("#in-progress\n", encoding="utf-8")
+
+    tasks = collect_tasks(tasks_dir)
+    board_text = build_board(tasks)
+    board_path = board_dir / "kanban.md"
+    board_path.write_text(board_text, encoding="utf-8")
+
+    mapping = parse_board(board_path)
+    assert mapping[tasks_dir / "task1.md"] == "#todo"
+    assert mapping[tasks_dir / "task2.md"] == "#in-progress"
+
+
+def test_set_status(tmp_path: Path) -> None:
+    task = tmp_path / "task.md"
+    task.write_text("Initial\n#todo\n", encoding="utf-8")
+    set_status(task, "#done")
+    text = task.read_text(encoding="utf-8")
+    assert text.endswith("#done\n")


### PR DESCRIPTION
## Summary
- factor common kanban parsing logic into `shared/py/agile/kanban.py`
- trim kanban scripts to use new shared helpers
- cover kanban helpers with unit tests

## Testing
- `make install` *(fails: venv warning)*
- `make format` *(fails: setup interrupted)*
- `make lint` *(fails: flake8 missing)*
- `make build` *(fails: npm http-proxy config)*
- `make test` *(fails: pipenv virtualenv error)*
- `python -m pytest shared/py/tests/test_agile_kanban.py`

------
https://chatgpt.com/codex/tasks/task_e_688ef55d629483248b21bddd57f59d30