### PR TITLE
feat(file-watcher): format changed files

### DIFF
--- a/services/ts/file-watcher/README.md
+++ b/services/ts/file-watcher/README.md
@@ -6,5 +6,7 @@ This service monitors the local kanban board and task files.
   update the task files.
 - When any document under `docs/agile/tasks/` changes it runs
   `hashtags_to_kanban.py` and writes the output back to the board.
+- When source files change it automatically formats them using `black` (Python)
+  and `prettier` (JavaScript/TypeScript/Markdown).
 
 Use `npm run start:dev` while developing to watch TypeScript files.

--- a/services/ts/file-watcher/package-lock.json
+++ b/services/ts/file-watcher/package-lock.json
@@ -14,6 +14,7 @@
         "@types/node": "^22.10.10",
         "ava": "^6.4.1",
         "c8": "^9.1.0",
+        "prettier": "^3.4.2",
         "ts-node": "^10.9.2",
         "typescript": "5.7.3"
       }
@@ -2092,6 +2093,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
+      "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/pretty-ms": {

--- a/services/ts/file-watcher/package.json
+++ b/services/ts/file-watcher/package.json
@@ -18,15 +18,13 @@
     "@types/node": "^22.10.10",
     "ava": "^6.4.1",
     "c8": "^9.1.0",
+    "prettier": "^3.4.2",
     "ts-node": "^10.9.2",
     "typescript": "5.7.3"
   },
   "ava": {
-    "extensions": {
-      "ts": "module"
-    },
     "files": [
-      "dist/tests/**/*.ts"
+      "dist/tests/**/*.js"
     ]
   }
 }

--- a/services/ts/file-watcher/src/index.ts
+++ b/services/ts/file-watcher/src/index.ts
@@ -1,24 +1,29 @@
-import { spawn } from 'child_process';
-import chokidar from 'chokidar';
-import { join } from 'path';
-import { writeFile } from 'fs/promises';
+import { spawn } from "child_process";
+import chokidar from "chokidar";
+import { join } from "path";
+import { writeFile } from "fs/promises";
+import { pathToFileURL } from "url";
 
-const repoRoot = process.env.REPO_ROOT || ""
+const repoRoot = process.env.REPO_ROOT || "";
 
-function runPython(script: string, capture = false): Promise<string | void> {
+function runCommand(
+  cmd: string,
+  args: string[],
+  capture = false,
+): Promise<string | void> {
   return new Promise((resolve, reject) => {
-    const proc = spawn('python', [script], { cwd: repoRoot });
-    let data = '';
+    const proc = spawn(cmd, args, { cwd: repoRoot });
+    let data = "";
 
-    proc.stdout.on('data', chunk => {
+    proc.stdout.on("data", (chunk) => {
       if (capture) {
         data += chunk.toString();
       } else {
         process.stdout.write(chunk);
       }
     });
-    proc.stderr.on('data', chunk => process.stderr.write(chunk));
-    proc.on('close', code => {
+    proc.stderr.on("data", (chunk) => process.stderr.write(chunk));
+    proc.on("close", (code) => {
       if (code === 0) {
         resolve(capture ? data : undefined);
       } else {
@@ -28,37 +33,85 @@ function runPython(script: string, capture = false): Promise<string | void> {
   });
 }
 
+function runPython(script: string, capture = false) {
+  return runCommand("python", [script], capture);
+}
+
+export function getFormatCommand(file: string): [string, string[]] | null {
+  if (file.endsWith(".py")) {
+    return ["black", [file]];
+  }
+  if (/(\.)(js|ts|jsx|tsx|json|md)$/.test(file)) {
+    return ["npx", ["prettier", "--write", file]];
+  }
+  return null;
+}
+
 async function updateFromBoard() {
   try {
-    await runPython(join('scripts', 'kanban_to_hashtags.py'));
+    await runPython(join("scripts", "kanban_to_hashtags.py"));
   } catch (err) {
-    console.error('kanban_to_hashtags failed', err);
+    console.error("kanban_to_hashtags failed", err);
   }
 }
 
 async function updateBoard() {
   try {
-    const output = await runPython(join('scripts', 'hashtags_to_kanban.py'), true);
-    const boardPath = join(repoRoot, 'docs', 'agile', 'boards', 'kanban.md');
-    if (typeof output === 'string') {
+    const output = await runPython(
+      join("scripts", "hashtags_to_kanban.py"),
+      true,
+    );
+    const boardPath = join(repoRoot, "docs", "agile", "boards", "kanban.md");
+    if (typeof output === "string") {
       await writeFile(boardPath, output);
     }
   } catch (err) {
-    console.error('hashtags_to_kanban failed', err);
+    console.error("hashtags_to_kanban failed", err);
   }
 }
 
-const boardPath = join(repoRoot, 'docs', 'agile', 'boards', 'kanban.md');
-const tasksPath = join(repoRoot, 'docs', 'agile', 'tasks');
+const boardPath = join(repoRoot, "docs", "agile", "boards", "kanban.md");
+const tasksPath = join(repoRoot, "docs", "agile", "tasks");
 
-chokidar.watch(boardPath, { ignoreInitial: true }).on('change', () => {
-  console.log('Board changed, syncing hashtags...');
-  updateFromBoard();
-});
+export function start() {
+  chokidar.watch(boardPath, { ignoreInitial: true }).on("change", () => {
+    console.log("Board changed, syncing hashtags...");
+    updateFromBoard();
+  });
 
-chokidar.watch(tasksPath, { ignoreInitial: true }).on('change', () => {
-  console.log('Task file changed, regenerating board...');
-  updateBoard();
-});
+  chokidar.watch(tasksPath, { ignoreInitial: true }).on("change", () => {
+    console.log("Task file changed, regenerating board...");
+    updateBoard();
+  });
 
-console.log('File watcher running...');
+  chokidar
+    .watch(["**/*.py", "**/*.{js,ts,jsx,tsx,json,md}"], {
+      cwd: repoRoot,
+      ignoreInitial: true,
+      ignored: [
+        "**/node_modules/**",
+        "**/dist/**",
+        "**/.git/**",
+        "docs/agile/boards/kanban.md",
+        "docs/agile/tasks/**",
+      ],
+    })
+    .on("change", (file) => {
+      const cmd = getFormatCommand(file);
+      if (cmd) {
+        console.log(`Formatting ${file}...`);
+        runCommand(cmd[0], cmd[1]).catch((err) =>
+          console.error("format failed", err),
+        );
+      }
+    });
+
+  console.log("File watcher running...");
+}
+
+if (process.argv[1]) {
+  const mainModule = pathToFileURL(process.argv[1]).href;
+  if (import.meta.url === mainModule) {
+    start();
+  }
+}

--- a/services/ts/file-watcher/tests/format.test.ts
+++ b/services/ts/file-watcher/tests/format.test.ts
@@ -1,0 +1,18 @@
+import test from "ava";
+// @ts-ignore
+import { getFormatCommand } from "../src/index.js";
+
+test("python files use black", (t) => {
+  const cmd = getFormatCommand("foo/bar.py");
+  t.deepEqual(cmd, ["black", ["foo/bar.py"]]);
+});
+
+test("typescript files use prettier", (t) => {
+  const cmd = getFormatCommand("foo/baz.ts");
+  t.deepEqual(cmd, ["npx", ["prettier", "--write", "foo/baz.ts"]]);
+});
+
+test("unsupported files return null", (t) => {
+  const cmd = getFormatCommand("foo/data.txt");
+  t.is(cmd, null);
+});

--- a/services/ts/file-watcher/tsconfig.json
+++ b/services/ts/file-watcher/tsconfig.json
@@ -1,54 +1,54 @@
 {
-	"$schema": "https://json.schemastore.org/tsconfig.json",
-	// Mapped from https://www.typescriptlang.org/tsconfig
-	"compilerOptions": {
-		// Type Checking
-		"allowUnreachableCode": false,
-		"allowUnusedLabels": false,
-		"exactOptionalPropertyTypes": true,
-		"noFallthroughCasesInSwitch": true,
-		"noImplicitOverride": true,
-		"noImplicitReturns": true,
-		"noPropertyAccessFromIndexSignature": false,
-		"noUncheckedIndexedAccess": true,
-		"noUnusedLocals": true,
-		"noUnusedParameters": true,
-		"strict": true,
+  "$schema": "https://json.schemastore.org/tsconfig.json",
+  // Mapped from https://www.typescriptlang.org/tsconfig
+  "compilerOptions": {
+    // Type Checking
+    "allowUnreachableCode": false,
+    "allowUnusedLabels": false,
+    "exactOptionalPropertyTypes": true,
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitOverride": true,
+    "noImplicitReturns": true,
+    "noPropertyAccessFromIndexSignature": false,
+    "noUncheckedIndexedAccess": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "strict": true,
 
-		// Modules
-		"allowArbitraryExtensions": false,
-		"allowImportingTsExtensions": false,
-		"module": "ESNext",
-		"moduleResolution": "Bundler",
-		"resolveJsonModule": true,
-		"resolvePackageJsonExports": true,
-		"resolvePackageJsonImports": true,
+    // Modules
+    "allowArbitraryExtensions": false,
+    "allowImportingTsExtensions": false,
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "resolveJsonModule": true,
+    "resolvePackageJsonExports": true,
+    "resolvePackageJsonImports": true,
 
-		// Emit
-		"declaration": true,
-		"declarationMap": true,
-		"importHelpers": false,
-		"newLine": "lf",
-		"noEmitHelpers": true,
-		"outDir": "dist",
-		"removeComments": false,
-		"sourceMap": true,
+    // Emit
+    "declaration": true,
+    "declarationMap": true,
+    "importHelpers": false,
+    "newLine": "lf",
+    "noEmitHelpers": true,
+    "outDir": "dist",
+    "removeComments": false,
+    "sourceMap": true,
 
-		// Interop Constraints
-		"allowSyntheticDefaultImports": true,
-		"esModuleInterop": false,
-		"forceConsistentCasingInFileNames": true,
-		"isolatedModules": true,
+    // Interop Constraints
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": false,
+    "forceConsistentCasingInFileNames": true,
+    "isolatedModules": true,
 
-		// Language and Environment
-		"experimentalDecorators": true,
-		"lib": ["ESNext", "esnext.disposable"],
-		"target": "ESNext",
-		"useDefineForClassFields": true,
+    // Language and Environment
+    "experimentalDecorators": true,
+    "lib": ["ESNext", "esnext.disposable"],
+    "target": "ESNext",
+    "useDefineForClassFields": true,
 
-		// Completeness
-		"skipLibCheck": true
-	},
-	"include": ["src/*.ts"],
-	"exclude": ["node_modules"]
+    // Completeness
+    "skipLibCheck": true
+  },
+  "include": ["src/*.ts", "tests/*.ts"],
+  "exclude": ["node_modules"]
 }


### PR DESCRIPTION
## Summary
- watch repository files and auto-format Python with Black and JS/TS/MD with Prettier
- document new formatting behaviour and add tests for formatter selection

## Testing
- `npm install` (file-watcher)
- `npm run build` (file-watcher)
- `npx eslint src tests --ext .ts` *(fails: files ignored)*
- `npx prettier --write .` (file-watcher)
- `npm test` (file-watcher)
- `make install` *(fails: onnxruntime network error)*
- `make build` *(fails: missing TypeScript modules in cephalon)*
- `make lint` *(fails: flake8 not installed)*
- `make format`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_688ef34c15448324b1f083187154114e