### PR TITLE
refactor cephalon agent utilities into shared modules

### DIFF
--- a/services/ts/cephalon/src/lib/captureScreen.ts
+++ b/services/ts/cephalon/src/lib/captureScreen.ts
@@ -1,0 +1,16 @@
+import * as dotenv from 'dotenv';
+import { Buffer } from 'buffer';
+
+dotenv.config({ path: '../../../.env' });
+
+const VISION_HOST = process.env.VISION_HOST || 'http://localhost:9999';
+
+export async function captureScreen(): Promise<Buffer> {
+	if (process.env.NO_SCREENSHOT === '1') {
+		return Buffer.alloc(0);
+	}
+	const res = await fetch(`${VISION_HOST}/capture`);
+	if (!res.ok) throw new Error('Failed to capture screen');
+	const arrayBuf = await res.arrayBuffer();
+	return Buffer.from(arrayBuf);
+}

--- a/services/ts/cephalon/src/lib/text.ts
+++ b/services/ts/cephalon/src/lib/text.ts
@@ -1,0 +1,30 @@
+import tokenizer from 'sbd';
+
+export const splitterOptions = {
+	newline_boundaries: false, // If true, \n is treated like a sentence boundary
+	html_boundaries: false, // If true, <p>, <br> and similar tags become boundaries
+	sanitize: true, // Strips non-breaking spaces and normalizes whitespace
+	abbreviations: ['Mr', 'Mrs', 'Dr', 'Ms', 'e.g', 'i.e', 'etc', 'vs', 'Prof', 'Sr', 'Jr', 'U.S', 'U.K', 'Duck', 'AI'],
+};
+
+export function mergeShortFragments(sentences: string[], minLength = 20) {
+	const merged: string[] = [];
+	let buffer = '';
+
+	for (const s of sentences) {
+		if ((buffer + ' ' + s).length < minLength) {
+			buffer += ' ' + s;
+		} else {
+			if (buffer) merged.push(buffer.trim());
+			buffer = s;
+		}
+	}
+	if (buffer) merged.push(buffer.trim());
+	return merged;
+}
+
+export function splitSentences(text: string) {
+	const sentences: string[] = tokenizer.sentences(text, splitterOptions);
+	const cleaned = sentences.map((s) => s.trim()).filter((s) => s.length > 0);
+	return mergeShortFragments(cleaned);
+}

--- a/services/ts/cephalon/src/types.ts
+++ b/services/ts/cephalon/src/types.ts
@@ -1,0 +1,37 @@
+import { Message } from 'ollama';
+
+export type FormatProperty = {
+	type: string;
+	description: string;
+	name: string;
+};
+
+export type FormatObject = {
+	type: 'object';
+	properties: FormatProperty[];
+};
+
+export type ChatMessage = {
+	role: 'system' | 'user' | 'assistant';
+	content: string;
+};
+
+export type AgentInnerState = {
+	currentFriend: string;
+	chatMembers: string[];
+	currentMood: string;
+	currentDesire: string;
+	currentGoal: string;
+	likes: string;
+	dislikes: string;
+	favoriteColor: string;
+	favoriteTimeOfDay: string;
+	selfAffirmations: string[];
+};
+
+export type GenerateResponseOptions = {
+	specialQuery?: string | undefined;
+	format?: object | undefined;
+	context?: Message[] | undefined;
+	prompt?: string | undefined;
+};

--- a/services/ts/cephalon/tests/text_utils.test.ts
+++ b/services/ts/cephalon/tests/text_utils.test.ts
@@ -1,0 +1,12 @@
+import test from 'ava';
+import { splitSentences, mergeShortFragments } from '../src/lib/text.js';
+
+test('splitSentences splits text into sentences', (t) => {
+	const result = splitSentences('Hello world. This is a test.');
+	t.deepEqual(result, ['Hello world.', 'This is a test.']);
+});
+
+test('mergeShortFragments merges short segments', (t) => {
+	const result = mergeShortFragments(['Hi', 'there friend', 'This is a long sentence'], 10);
+	t.deepEqual(result, ['Hi there friend', 'This is a long sentence']);
+});

--- a/services/ts/cephalon/tsconfig.json
+++ b/services/ts/cephalon/tsconfig.json
@@ -49,6 +49,6 @@
 		// Completeness
 		"skipLibCheck": true
 	},
-	"include": ["src/*.ts"],
+	"include": ["src/**/*.ts"],
 	"exclude": ["node_modules"]
 }


### PR DESCRIPTION
## Summary
- refactor Cephalon agent by moving screen capture and text utilities into shared modules
- add shared type definitions and update tsconfig for nested sources
- add unit tests for new text utilities

## Testing
- `make install` *(fails: onnxruntime-node download ENETUNREACH)*
- `make format`
- `make lint` *(fails: flake8: No such file or directory)*
- `make build` *(fails: build-ts Error 1)*
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_688ef6761cdc8324a81fcc74702db250