### PR TITLE
feat: index links from discord images

### DIFF
--- a/Makefile.python
+++ b/Makefile.python
@@ -1,4 +1,4 @@
-SERVICES_PY=services/py/stt services/py/tts services/py/discord_indexer services/py/stt_ws services/py/whisper_stream_ws
+SERVICES_PY=services/py/stt services/py/tts services/py/discord_indexer services/py/stt_ws services/py/whisper_stream_ws services/py/discord_link_collector
 # Install dependencies =========================================================
 
 

--- a/docs/services/discord-link-collector/main.md
+++ b/docs/services/discord-link-collector/main.md
@@ -1,0 +1,12 @@
+# main.py
+
+**Path**: `services/discord-link-collector/main.py`
+
+**Description**: Scans indexed Discord messages for image attachments and stores URLs from those messages in a dedicated MongoDB collection.
+
+## Dependencies
+- shared.py.mongodb
+- re
+
+## Dependents
+- `services/py/discord_link_collector/README.md`

--- a/services/py/discord_link_collector/Pipfile
+++ b/services/py/discord_link_collector/Pipfile
@@ -1,0 +1,16 @@
+[[source]]
+url = "https://pypi.org/simple"
+verify_ssl = true
+name = "pypi"
+
+[packages]
+pymongo = "*"
+
+[dev-packages]
+pytest = "*"
+pytest-cov = "*"
+flake8 = "*"
+black = "*"
+
+[requires]
+python_version = "3.12"

--- a/services/py/discord_link_collector/Pipfile.lock
+++ b/services/py/discord_link_collector/Pipfile.lock
@@ -1,0 +1,335 @@
+{
+    "_meta": {
+        "hash": {
+            "sha256": "6ec7e23374ec89fe92cd3eb3670da74f32030a8ea50ceecb95ba5c1360ff00f7"
+        },
+        "pipfile-spec": 6,
+        "requires": {
+            "python_version": "3.12"
+        },
+        "sources": [
+            {
+                "name": "pypi",
+                "url": "https://pypi.org/simple",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {
+        "dnspython": {
+            "hashes": [
+                "sha256:b4c34b7d10b51bcc3a5071e7b8dee77939f1e878477eeecc965e9835f63c6c86",
+                "sha256:ce9c432eda0dc91cf618a5cedf1a4e142651196bbcd2c80e89ed5a907e5cfaf1"
+            ],
+            "markers": "python_version >= '3.9'",
+            "version": "==2.7.0"
+        },
+        "pymongo": {
+            "hashes": [
+                "sha256:01065eb1838e3621a30045ab14d1a60ee62e01f65b7cf154e69c5c722ef14d2f",
+                "sha256:01c184b612f67d5a4c8f864ae7c40b6cc33c0e9bb05e39d08666f8831d120504",
+                "sha256:02f131a6e61559613b1171b53fbe21fed64e71b0cb4858c47fc9bc7c8e0e501c",
+                "sha256:0603145c9be5e195ae61ba7a93eb283abafdbd87f6f30e6c2dfc242940fe280c",
+                "sha256:0cce9428d12ba396ea245fc4c51f20228cead01119fcc959e1c80791ea45f820",
+                "sha256:0f64c6469c2362962e6ce97258ae1391abba1566a953a492562d2924b44815c2",
+                "sha256:16440d0da30ba804c6c01ea730405fdbbb476eae760588ea09e6e7d28afc06de",
+                "sha256:239b5f83b83008471d54095e145d4c010f534af99e87cc8877fc6827736451a0",
+                "sha256:34cc7d4cd7586c1c4f7af2b97447404046c2d8e7ed4c7214ed0e21dbeb17d57d",
+                "sha256:389cb6415ec341c73f81fbf54970ccd0cd5d3fa7c238dcdb072db051d24e2cb4",
+                "sha256:3dcb0b8cdd499636017a53f63ef64cf9b6bd3fd9355796c5a1d228e4be4a4c94",
+                "sha256:3e20862b81e3863bcd72334e3577a3107604553b614a8d25ee1bb2caaea4eb90",
+                "sha256:3efc4c515b371a9fa1d198b6e03340985bfe1a55ae2d2b599a714934e7bc61ab",
+                "sha256:49f9968ea7e6a86d4c9bd31d2095f0419efc498ea5e6067e75ade1f9e64aea3d",
+                "sha256:4dc60b3f5e1448fd011c729ad5d8735f603b0a08a8773ec8e34a876ccc7de45f",
+                "sha256:51040e1ba78d6671f8c65b29e2864483451e789ce93b1536de9cc4456ede87fa",
+                "sha256:54a89739a86da31adcef41f6c3ae62b38a8bad156bba71fe5898871746c5af83",
+                "sha256:66f168f8c5b1e2e3d518507cf9f200f0c86ac79e2b2be9e7b6c8fd1e2f7d7824",
+                "sha256:6b4d5794ca408317c985d7acfb346a60f96f85a7c221d512ff0ecb3cce9d6110",
+                "sha256:6bceb524110c32319eb7119422e400dbcafc5b21bcc430d2049a894f69b604e5",
+                "sha256:75462d6ce34fb2dd98f8ac3732a7a1a1fbb2e293c4f6e615766731d044ad730e",
+                "sha256:7ab86b98a18c8689514a9f8d0ec7d9ad23a949369b31c9a06ce4a45dcbffcc5e",
+                "sha256:7af8c56d0a7fcaf966d5292e951f308fb1f8bac080257349e14742725fd7990d",
+                "sha256:812a473d584bcb02ab819d379cd5e752995026a2bb0d7713e78462b6650d3f3a",
+                "sha256:850168d115680ab66a0931a6aa9dd98ed6aa5e9c3b9a6c12128049b9a5721bc5",
+                "sha256:884cb88a9d4c4c9810056b9c71817bd9714bbe58c461f32b65be60c56759823b",
+                "sha256:8860445a8da1b1545406fab189dc20319aff5ce28e65442b2b4a8f4228a88478",
+                "sha256:8c942d1c6334e894271489080404b1a2e3b8bd5de399f2a0c14a77d966be5bc9",
+                "sha256:8ef6ae029a3390565a0510c872624514dde350007275ecd8126b09175aa02cca",
+                "sha256:9ab0325d436075f5f1901cde95afae811141d162bc42d9a5befb647fda585ae6",
+                "sha256:9c8e0420fb4901006ae7893e76108c2a36a343b4f8922466d51c45e9e2ceb717",
+                "sha256:a10069454195d1d2dda98d681b1dbac9a425f4b0fe744aed5230c734021c1cb9",
+                "sha256:a457d2ac34c05e9e8a6bb724115b093300bf270f0655fb897df8d8604b2e3700",
+                "sha256:ab87484c97ae837b0a7bbdaa978fa932fbb6acada3f42c3b2bee99121a594715",
+                "sha256:ac9241b727a69c39117c12ac1e52d817ea472260dadc66262c3fdca0bab0709b",
+                "sha256:ad24f5864706f052b05069a6bc59ff875026e28709548131448fe1e40fc5d80f",
+                "sha256:ad9a2d1357aed5d6750deb315f62cb6f5b3c4c03ffb650da559cb09cb29e6fe8",
+                "sha256:ae07315bb106719c678477e61077cd28505bb7d3fd0a2341e75a9510118cb785",
+                "sha256:ae2ea8c62d5f3c6529407c12471385d9a05f9fb890ce68d64976340c85cd661b",
+                "sha256:af7dfff90647ee77c53410f7fe8ca4fe343f8b768f40d2d0f71a5602f7b5a541",
+                "sha256:b00ab04630aa4af97294e9abdbe0506242396269619c26f5761fd7b2524ef501",
+                "sha256:b7e04c45f6a7d5a13fe064f42130d29b0730cb83dd387a623563ff3b9bd2f4d1",
+                "sha256:bf43ae07804d7762b509f68e5ec73450bb8824e960b03b861143ce588b41f467",
+                "sha256:c38168263ed94a250fc5cf9c6d33adea8ab11c9178994da1c3481c2a49d235f8",
+                "sha256:c793223aef21a8c415c840af1ca36c55a05d6fa3297378da35de3fb6661c0174",
+                "sha256:c9c7d345d57f17b1361008aea78a37e8c139631a46aeb185dd2749850883c7ba",
+                "sha256:cdd8041902963c84dc4e27034fa045ac55fabcb2a4ba5b68b880678557573e70",
+                "sha256:cfc69d7bc4d4d5872fd1e6de25e6a16e2372c7d5556b75c3b8e2204dce73e3fb",
+                "sha256:d13556e91c4a8cb07393b8c8be81e66a11ebc8335a40fa4af02f4d8d3b40c8a1",
+                "sha256:d6044ca0eb74d97f7d3415264de86a50a401b7b0b136d30705f022f9163c3124",
+                "sha256:dd326bcb92d28d28a3e7ef0121602bad78691b6d4d1f44b018a4616122f1ba8b",
+                "sha256:de529aebd1ddae2de778d926b3e8e2e42a9b37b5c668396aad8f28af75e606f9",
+                "sha256:dfb0c21bdd58e58625c9cd8de13e859630c29c9537944ec0a14574fdf88c2ac4",
+                "sha256:ec89516622dfc8b0fdff499612c0bd235aa45eeb176c9e311bcc0af44bf952b6",
+                "sha256:f30eab4d4326df54fee54f31f93e532dc2918962f733ee8e115b33e6fe151d92",
+                "sha256:f57a664aa74610eb7a52fa93f2cf794a1491f4f76098343485dd7da5b3bcff06",
+                "sha256:f8057f9bc9c94a8fd54ee4f5e5106e445a8f406aff2df74746f21c8791ee2403"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.9'",
+            "version": "==4.13.2"
+        }
+    },
+    "develop": {
+        "black": {
+            "hashes": [
+                "sha256:030b9759066a4ee5e5aca28c3c77f9c64789cdd4de8ac1df642c40b708be6171",
+                "sha256:055e59b198df7ac0b7efca5ad7ff2516bca343276c466be72eb04a3bcc1f82d7",
+                "sha256:0e519ecf93120f34243e6b0054db49c00a35f84f195d5bce7e9f5cfc578fc2da",
+                "sha256:172b1dbff09f86ce6f4eb8edf9dede08b1fce58ba194c87d7a4f1a5aa2f5b3c2",
+                "sha256:1e2978f6df243b155ef5fa7e558a43037c3079093ed5d10fd84c43900f2d8ecc",
+                "sha256:33496d5cd1222ad73391352b4ae8da15253c5de89b93a80b3e2c8d9a19ec2666",
+                "sha256:3b48735872ec535027d979e8dcb20bf4f70b5ac75a8ea99f127c106a7d7aba9f",
+                "sha256:4b60580e829091e6f9238c848ea6750efed72140b91b048770b64e74fe04908b",
+                "sha256:759e7ec1e050a15f89b770cefbf91ebee8917aac5c20483bc2d80a6c3a04df32",
+                "sha256:8f0b18a02996a836cc9c9c78e5babec10930862827b1b724ddfe98ccf2f2fe4f",
+                "sha256:95e8176dae143ba9097f351d174fdaf0ccd29efb414b362ae3fd72bf0f710717",
+                "sha256:96c1c7cd856bba8e20094e36e0f948718dc688dba4a9d78c3adde52b9e6c2299",
+                "sha256:a1ee0a0c330f7b5130ce0caed9936a904793576ef4d2b98c40835d6a65afa6a0",
+                "sha256:a22f402b410566e2d1c950708c77ebf5ebd5d0d88a6a2e87c86d9fb48afa0d18",
+                "sha256:a39337598244de4bae26475f77dda852ea00a93bd4c728e09eacd827ec929df0",
+                "sha256:afebb7098bfbc70037a053b91ae8437c3857482d3a690fefc03e9ff7aa9a5fd3",
+                "sha256:bacabb307dca5ebaf9c118d2d2f6903da0d62c9faa82bd21a33eecc319559355",
+                "sha256:bce2e264d59c91e52d8000d507eb20a9aca4a778731a08cfff7e5ac4a4bb7096",
+                "sha256:d9e6827d563a2c820772b32ce8a42828dc6790f095f441beef18f96aa6f8294e",
+                "sha256:db8ea9917d6f8fc62abd90d944920d95e73c83a5ee3383493e35d271aca872e9",
+                "sha256:ea0213189960bda9cf99be5b8c8ce66bb054af5e9e861249cd23471bd7b0b3ba",
+                "sha256:f3df5f1bf91d36002b0a75389ca8663510cf0531cca8aa5c1ef695b46d98655f"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.9'",
+            "version": "==25.1.0"
+        },
+        "click": {
+            "hashes": [
+                "sha256:27c491cc05d968d271d5a1db13e3b5a184636d9d930f148c50b038f0d0646202",
+                "sha256:61a3265b914e850b85317d0b3109c7f8cd35a670f963866005d6ef1d5175a12b"
+            ],
+            "markers": "python_version >= '3.10'",
+            "version": "==8.2.1"
+        },
+        "coverage": {
+            "extras": [
+                "toml"
+            ],
+            "hashes": [
+                "sha256:042125c89cf74a074984002e165d61fe0e31c7bd40ebb4bbebf07939b5924613",
+                "sha256:083442ecf97d434f0cb3b3e3676584443182653da08b42e965326ba12d6b5f2a",
+                "sha256:1217a54cfd79be20512a67ca81c7da3f2163f51bbfd188aab91054df012154f5",
+                "sha256:166d89c57e877e93d8827dac32cedae6b0277ca684c6511497311249f35a280c",
+                "sha256:1a108dd78ed185020f66f131c60078f3fae3f61646c28c8bb4edd3fa121fc7fc",
+                "sha256:1aadfb06a30c62c2eb82322171fe1f7c288c80ca4156d46af0ca039052814bab",
+                "sha256:1c4f679c6b573a5257af6012f167a45be4c749c9925fd44d5178fd641ad8bf72",
+                "sha256:1c86eb388bbd609d15560e7cc0eb936c102b6f43f31cf3e58b4fd9afe28e1372",
+                "sha256:1e0c768b0f9ac5839dac5cf88992a4bb459e488ee8a1f8489af4cb33b1af00f1",
+                "sha256:21eb7d8b45d3700e7c2936a736f732794c47615a20f739f4133d5230a6512a88",
+                "sha256:2348631f049e884839553b9974f0821d39241c6ffb01a418efce434f7eba0fe7",
+                "sha256:283005bb4d98ae33e45f2861cd2cde6a21878661c9ad49697f6951b358a0379b",
+                "sha256:2b225a06d227f23f386fdc0eab471506d9e644be699424814acc7d114595495f",
+                "sha256:320d86da829b012982b414c7cdda65f5d358d63f764e0e4e54b33097646f39a3",
+                "sha256:37b69226001d8b7de7126cad7366b0778d36777e4d788c66991455ba817c5b41",
+                "sha256:3a7a4d74cb0f5e3334f9aa26af7016ddb94fb4bfa11b4a573d8e98ecba8c34f1",
+                "sha256:3beb76e20b28046989300c4ea81bf690df84ee98ade4dc0bbbf774a28eb98440",
+                "sha256:3e31dfb8271937cab9425f19259b1b1d1f556790e98eb266009e7a61d337b6d4",
+                "sha256:3e59d00830da411a1feef6ac828b90bbf74c9b6a8e87b8ca37964925bba76dbe",
+                "sha256:4072b31361b0d6d23f750c524f694e1a417c1220a30d3ef02741eed28520c48e",
+                "sha256:40f9a38676f9c073bf4b9194707aa1eb97dca0e22cc3766d83879d72500132c7",
+                "sha256:47ab6dbbc31a14c5486420c2c1077fcae692097f673cf5be9ddbec8cdaa4cdbc",
+                "sha256:47c91f32ba4ac46f1e224a7ebf3f98b4b24335bad16137737fe71a5961a0665c",
+                "sha256:4fcfe294f95b44e4754da5b58be750396f2b1caca8f9a0e78588e3ef85f8b8be",
+                "sha256:5121d8cf0eacb16133501455d216bb5f99899ae2f52d394fe45d59229e6611d0",
+                "sha256:51f30da7a52c009667e02f125737229d7d8044ad84b79db454308033a7808ab2",
+                "sha256:51fe93f3fe4f5d8483d51072fddc65e717a175490804e1942c975a68e04bf97a",
+                "sha256:57b6e8789cbefdef0667e4a94f8ffa40f9402cee5fc3b8e4274c894737890145",
+                "sha256:590bdba9445df4763bdbebc928d8182f094c1f3947a8dc0fc82ef014dbdd8324",
+                "sha256:5ba9a8770effec5baaaab1567be916c87d8eea0c9ad11253722d86874d885eca",
+                "sha256:607f82389f0ecafc565813aa201a5cade04f897603750028dd660fb01797265e",
+                "sha256:6b4ba0f488c1bdb6bd9ba81da50715a372119785458831c73428a8566253b86b",
+                "sha256:6b7dc7f0a75a7eaa4584e5843c873c561b12602439d2351ee28c7478186c4da4",
+                "sha256:7092cc82382e634075cc0255b0b69cb7cada7c1f249070ace6a95cb0f13548ef",
+                "sha256:7718060dd4434cc719803a5e526838a5d66e4efa5dc46d2b25c21965a9c6fcc4",
+                "sha256:780f750a25e7749d0af6b3631759c2c14f45de209f3faaa2398312d1c7a22759",
+                "sha256:7f39edd52c23e5c7ed94e0e4bf088928029edf86ef10b95413e5ea670c5e92d7",
+                "sha256:80b9ccd82e30038b61fc9a692a8dc4801504689651b281ed9109f10cc9fe8b4d",
+                "sha256:85b22a9cce00cb03156334da67eb86e29f22b5e93876d0dd6a98646bb8a74e53",
+                "sha256:871ebe8143da284bd77b84a9136200bd638be253618765d21a1fce71006d94af",
+                "sha256:89ec0ffc215c590c732918c95cd02b55c7d0f569d76b90bb1a5e78aa340618e4",
+                "sha256:924563481c27941229cb4e16eefacc35da28563e80791b3ddc5597b062a5c386",
+                "sha256:97b6983a2f9c76d345ca395e843a049390b39652984e4a3b45b2442fa733992d",
+                "sha256:991196702d5e0b120a8fef2664e1b9c333a81d36d5f6bcf6b225c0cf8b0451a2",
+                "sha256:998c4751dabf7d29b30594af416e4bf5091f11f92a8d88eb1512c7ba136d1ed7",
+                "sha256:9b2df80cb6a2af86d300e70acb82e9b79dab2c1e6971e44b78dbfc1a1e736b53",
+                "sha256:9d6f494c307e5cb9b1e052ec1a471060f1dea092c8116e642e7a23e79d9388ea",
+                "sha256:9eb245a8d8dd0ad73b4062135a251ec55086fbc2c42e0eb9725a9b553fba18a3",
+                "sha256:a22c3bfe09f7a530e2c94c87ff7af867259c91bef87ed2089cd69b783af7b84e",
+                "sha256:aa309df995d020f3438407081b51ff527171cca6772b33cf8f85344b8b4b8770",
+                "sha256:ab6e19b684981d0cd968906e293d5628e89faacb27977c92f3600b201926b994",
+                "sha256:ac0c5bba938879c2fc0bc6c1b47311b5ad1212a9dcb8b40fe2c8110239b7faed",
+                "sha256:ae2b4856f29ddfe827106794f3589949a57da6f0d38ab01e24ec35107979ba57",
+                "sha256:ae8e59e5f4fd85d6ad34c2bb9d74037b5b11be072b8b7e9986beb11f957573d4",
+                "sha256:b2f22102197bcb1722691296f9e589f02b616f874e54a209284dd7b9294b0b7f",
+                "sha256:b45e2f9d5b0b5c1977cb4feb5f594be60eb121106f8900348e29331f553a726f",
+                "sha256:bc265a7945e8d08da28999ad02b544963f813a00f3ed0a7a0ce4165fd77629f8",
+                "sha256:bed4a2341b33cd1a7d9ffc47df4a78ee61d3416d43b4adc9e18b7d266650b83e",
+                "sha256:c1a40c486041006b135759f59189385da7c66d239bad897c994e18fd1d0c128f",
+                "sha256:c36baa0ecde742784aa76c2b816466d3ea888d5297fda0edbac1bf48fa94688a",
+                "sha256:c4c746d11c8aba4b9f58ca8bfc6fbfd0da4efe7960ae5540d1a1b13655ee8892",
+                "sha256:ca79146ee421b259f8131f153102220b84d1a5e6fb9c8aed13b3badfd1796de6",
+                "sha256:cc452481e124a819ced0c25412ea2e144269ef2f2534b862d9f6a9dae4bda17b",
+                "sha256:cfb8b9d8855c8608f9747602a48ab525b1d320ecf0113994f6df23160af68262",
+                "sha256:d12b15a8c3759e2bb580ffa423ae54be4f184cf23beffcbd641f4fe6e1584293",
+                "sha256:d24fb3c0c8ff0d517c5ca5de7cf3994a4cd559cde0315201511dbfa7ab528894",
+                "sha256:d4b0aab55ad60ead26159ff12b538c85fbab731a5e3411c642b46c3525863437",
+                "sha256:d6a558c2725bfb6337bf57c1cd366c13798bfd3bfc9e3dd1f4a6f6fc95a4605f",
+                "sha256:d946a0c067aa88be4a593aad1236493313bafaa27e2a2080bfe88db827972f3c",
+                "sha256:dc60ddd483c556590da1d9482a4518292eec36dd0e1e8496966759a1f282bcd0",
+                "sha256:dcc93488c9ebd229be6ee1f0d9aad90da97b33ad7e2912f5495804d78a3cd6b7",
+                "sha256:ddca1e4f5f4c67980533df01430184c19b5359900e080248bbf4ed6789584d8b",
+                "sha256:ddf2a63b91399a1c2f88f40bc1705d5a7777e31c7e9eb27c602280f477b582ba",
+                "sha256:df1c742ca6f46a6f6cbcaef9ac694dc2cb1260d30a6a2f5c68c5f5bcfee1cfd7",
+                "sha256:e37c72eaccdd5ed1130c67a92ad38f5b2af66eeff7b0abe29534225db2ef7b18",
+                "sha256:e58991a2b213417285ec866d3cd32db17a6a88061a985dbb7e8e8f13af429c47",
+                "sha256:e6150d167f32f2a54690e572e0a4c90296fb000a18e9b26ab81a6489e24e78dd",
+                "sha256:e88dd71e4ecbc49d9d57d064117462c43f40a21a1383507811cf834a4a620651",
+                "sha256:e8ab8e4c7ec7f8a55ac05b5b715a051d74eac62511c6d96d5bb79aaafa3b04cf",
+                "sha256:ebb08d0867c5a25dffa4823377292a0ffd7aaafb218b5d4e2e106378b1061e39",
+                "sha256:ed3718c757c82d920f1c94089066225ca2ad7f00bb904cb72b1c39ebdd906ccb",
+                "sha256:ee6be07af68d9c4fca4027c70cea0c31a0f1bc9cb464ff3c84a1f916bf82e652",
+                "sha256:efa23166da3fe2915f8ab452dde40319ac84dc357f635737174a08dbd912980c",
+                "sha256:f32a95a83c2e17422f67af922a89422cd24c6fa94041f083dd0bb4f6057d0bc7",
+                "sha256:f7da31a1ba31f1c1d4d5044b7c5813878adae1f3af8f4052d679cc493c7328f4",
+                "sha256:fa2a258aa6bf188eb9a8948f7102a83da7c430a0dce918dbd8b60ef8fcb772d7",
+                "sha256:fc0e46d86905ddd16b85991f1f4919028092b4e511689bbdaff0876bd8aab3dd",
+                "sha256:fefe31d61d02a8b2c419700b1fade9784a43d726de26495f243b663cd9fe1513"
+            ],
+            "markers": "python_version >= '3.9'",
+            "version": "==7.10.1"
+        },
+        "flake8": {
+            "hashes": [
+                "sha256:b9696257b9ce8beb888cdbe31cf885c90d31928fe202be0889a7cdafad32f01e",
+                "sha256:fe044858146b9fc69b551a4b490d69cf960fcb78ad1edcb84e7fbb1b4a8e3872"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.9'",
+            "version": "==7.3.0"
+        },
+        "iniconfig": {
+            "hashes": [
+                "sha256:3abbd2e30b36733fee78f9c7f7308f2d0050e88f0087fd25c2645f63c773e1c7",
+                "sha256:9deba5723312380e77435581c6bf4935c94cbfab9b1ed33ef8d238ea168eb760"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==2.1.0"
+        },
+        "mccabe": {
+            "hashes": [
+                "sha256:348e0240c33b60bbdf4e523192ef919f28cb2c3d7d5c7794f74009290f236325",
+                "sha256:6c2d30ab6be0e4a46919781807b4f0d834ebdd6c6e3dca0bda5a15f863427b6e"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==0.7.0"
+        },
+        "mypy-extensions": {
+            "hashes": [
+                "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505",
+                "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==1.1.0"
+        },
+        "packaging": {
+            "hashes": [
+                "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484",
+                "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==25.0"
+        },
+        "pathspec": {
+            "hashes": [
+                "sha256:a0d503e138a4c123b27490a4f7beda6a01c6f288df0e4a8b79c7eb0dc7b4cc08",
+                "sha256:a482d51503a1ab33b1c67a6c3813a26953dbdc71c31dacaef9a838c4e29f5712"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==0.12.1"
+        },
+        "platformdirs": {
+            "hashes": [
+                "sha256:3d512d96e16bcb959a814c9f348431070822a6496326a4be0911c40b5a74c2bc",
+                "sha256:ff7059bb7eb1179e2685604f4aaf157cfd9535242bd23742eadc3c13542139b4"
+            ],
+            "markers": "python_version >= '3.9'",
+            "version": "==4.3.8"
+        },
+        "pluggy": {
+            "hashes": [
+                "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3",
+                "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746"
+            ],
+            "markers": "python_version >= '3.9'",
+            "version": "==1.6.0"
+        },
+        "pycodestyle": {
+            "hashes": [
+                "sha256:c4b5b517d278089ff9d0abdec919cd97262a3367449ea1c8b49b91529167b783",
+                "sha256:dd6bf7cb4ee77f8e016f9c8e74a35ddd9f67e1d5fd4184d86c3b98e07099f42d"
+            ],
+            "markers": "python_version >= '3.9'",
+            "version": "==2.14.0"
+        },
+        "pyflakes": {
+            "hashes": [
+                "sha256:b24f96fafb7d2ab0ec5075b7350b3d2d2218eab42003821c06344973d3ea2f58",
+                "sha256:f742a7dbd0d9cb9ea41e9a24a918996e8170c799fa528688d40dd582c8265f4f"
+            ],
+            "markers": "python_version >= '3.9'",
+            "version": "==3.4.0"
+        },
+        "pygments": {
+            "hashes": [
+                "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887",
+                "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==2.19.2"
+        },
+        "pytest": {
+            "hashes": [
+                "sha256:539c70ba6fcead8e78eebbf1115e8b589e7565830d7d006a8723f19ac8a0afb7",
+                "sha256:7c67fd69174877359ed9371ec3af8a3d2b04741818c51e5e99cc1742251fa93c"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.9'",
+            "version": "==8.4.1"
+        },
+        "pytest-cov": {
+            "hashes": [
+                "sha256:25cc6cc0a5358204b8108ecedc51a9b57b34cc6b8c967cc2c01a4e00d8a67da2",
+                "sha256:f5bc4c23f42f1cdd23c70b1dab1bbaef4fc505ba950d53e0081d0730dd7e86d5"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.9'",
+            "version": "==6.2.1"
+        }
+    }
+}

--- a/services/py/discord_link_collector/README.md
+++ b/services/py/discord_link_collector/README.md
@@ -1,0 +1,13 @@
+# Discord Link Collector
+
+A service that scans Discord messages indexed by `discord_indexer` for image attachments and stores any links contained in the messages into a separate MongoDB collection.
+
+## Usage
+
+Run the service to process existing indexed messages:
+
+```bash
+python main.py
+```
+
+The script will iterate through indexed messages, look for image attachments, extract URLs from the message content, and save them in the `discord_links` collection.

--- a/services/py/discord_link_collector/main.py
+++ b/services/py/discord_link_collector/main.py
@@ -1,0 +1,54 @@
+import re
+
+from shared.py.mongodb import (
+    discord_message_collection,
+    discord_link_collection,
+)
+
+URL_REGEX = r"https?://\S+"
+IMAGE_EXTENSIONS = (".png", ".jpg", ".jpeg", ".gif", ".webp", ".bmp")
+
+
+def has_image_attachments(message: dict) -> bool:
+    """Return True if the message has at least one image attachment."""
+    for att in message.get("attachments", []):
+        url = att.get("url", "").lower()
+        if url.endswith(IMAGE_EXTENSIONS):
+            return True
+    return False
+
+
+def extract_links(text: str) -> list[str]:
+    """Extract all URLs from the provided text."""
+    return re.findall(URL_REGEX, text or "")
+
+
+def collect_links(
+    message_collection=discord_message_collection,
+    link_collection=discord_link_collection,
+) -> None:
+    """Scan messages for image attachments and store links in a new collection."""
+    for message in message_collection.find(
+        {"attachments": {"$exists": True, "$ne": []}}
+    ):
+        if not has_image_attachments(message):
+            continue
+        links = extract_links(message.get("content", ""))
+        if not links:
+            continue
+        link_collection.update_one(
+            {"message_id": message["id"]},
+            {
+                "$set": {
+                    "message_id": message["id"],
+                    "links": links,
+                    "channel": message.get("channel"),
+                    "author": message.get("author"),
+                }
+            },
+            upsert=True,
+        )
+
+
+if __name__ == "__main__":
+    collect_links()

--- a/services/py/discord_link_collector/tests/test_discord_link_collector.py
+++ b/services/py/discord_link_collector/tests/test_discord_link_collector.py
@@ -1,0 +1,79 @@
+import os
+import sys
+import importlib
+
+import pytest
+
+
+class MemoryCollection:
+    def __init__(self, data=None):
+        self.data = data or []
+
+    def find(self, query=None):
+        return list(self.data)
+
+    def update_one(self, query, update, upsert=False):
+        doc = next(
+            (d for d in self.data if all(d.get(k) == v for k, v in query.items())), None
+        )
+        if doc:
+            doc.update(update.get("$set", {}))
+        elif upsert:
+            new_doc = {**query, **update.get("$set", {})}
+            self.data.append(new_doc)
+
+    def find_one(self, query):
+        for item in self.data:
+            if all(item.get(k) == v for k, v in query.items()):
+                return item
+        return None
+
+
+@pytest.fixture(autouse=True)
+def setup_env(monkeypatch):
+    monkeypatch.setenv("DISCORD_TOKEN", "token")
+    monkeypatch.setenv("DEFAULT_CHANNEL", "0")
+    monkeypatch.setenv("DEFAULT_CHANNEL_NAME", "general")
+    monkeypatch.setenv("DISCORD_CLIENT_USER_ID", "1")
+    monkeypatch.setenv("DISCORD_CLIENT_USER_NAME", "client")
+
+
+@pytest.fixture
+def service():
+    sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+    sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../../"))
+    mod = importlib.import_module("main")
+    return mod
+
+
+def test_collect_links(service):
+    message_collection = MemoryCollection(
+        [
+            {
+                "id": 1,
+                "content": "look http://example.com",
+                "attachments": [{"url": "http://img.png"}],
+                "channel": 5,
+                "author": 7,
+            },
+            {
+                "id": 2,
+                "content": "no links here",
+                "attachments": [{"url": "http://img2.png"}],
+            },
+            {
+                "id": 3,
+                "content": "link but no image http://example.org",
+                "attachments": [{"url": "http://file.txt"}],
+            },
+        ]
+    )
+    link_collection = MemoryCollection()
+
+    service.collect_links(message_collection, link_collection)
+
+    assert link_collection.find_one({"message_id": 1})["links"] == [
+        "http://example.com"
+    ]
+    assert link_collection.find_one({"message_id": 2}) is None
+    assert link_collection.find_one({"message_id": 3}) is None

--- a/shared/py/mongodb.py
+++ b/shared/py/mongodb.py
@@ -35,5 +35,6 @@ generated_message_collection = db[f"{AGENT_NAME}_generated_messages"]
 discord_channel_collection = db[f"{AGENT_NAME}_discord_channels"]
 discord_user_collection = db[f"{AGENT_NAME}_discord_users"]
 discord_server_collection = db[f"{AGENT_NAME}_discord_servers"]
+discord_link_collection = db[f"{AGENT_NAME}_discord_links"]
 
 duck_gpt = db[f"{AGENT_NAME}_gpt"]


### PR DESCRIPTION
## Summary
- add discord link collector service and associated MongoDB collection
- document link collector service and register in build config
- test link collector's URL extraction from messages with images

## Testing
- `pipenv sync --dev`
- `make test-python-service-discord_link_collector`
- `flake8 services/py/discord_link_collector shared/py/mongodb.py`
- `make lint` *(fails: services/py/tts/app.py:49:1: E303 too many blank lines (5))*
- `make build` *(fails: make: *** [Makefile.ts:39: build-ts] Error 1)*

------
https://chatgpt.com/codex/tasks/task_e_688efc3a5a948324b7fd23c04439ac07