### PR TITLE
feat: allow cephalon runtime config

### DIFF
--- a/services/ts/cephalon/readme.md
+++ b/services/ts/cephalon/readme.md
@@ -10,4 +10,11 @@ Handles everything to do with the top level discord.js library
 
 Handles everything todo with discord/voice
 
+# Runtime configuration
+
+Some Cephalon settings can be adjusted via Discord slash commands without restarting the service:
+
+- `/set_config` – update runtime values such as `historyLimit`, `forcedStopThreshold` or `prompt`.
+- `/set_state` – update inner state fields like `currentMood`, `currentGoal`, `likes`, and similar values. Array fields (`chatMembers`, `selfAffirmations`) accept comma-separated lists.
+
 #hashtags: #cephalon #service #promethean

--- a/services/ts/cephalon/src/bot.ts
+++ b/services/ts/cephalon/src/bot.ts
@@ -1,274 +1,345 @@
 import * as discord from 'discord.js';
 import {
-    Client,
-    Events,
-    GatewayIntentBits,
-    ApplicationCommandOptionType,
-    REST,
-    Routes,
-    type RESTPutAPIApplicationCommandsJSONBody,
+	Client,
+	Events,
+	GatewayIntentBits,
+	ApplicationCommandOptionType,
+	REST,
+	Routes,
+	type RESTPutAPIApplicationCommandsJSONBody,
 } from 'discord.js';
-import { VoiceSession } from "./voice-session";
-import { FinalTranscript } from "./transcriber";
+import { VoiceSession } from './voice-session';
+import { FinalTranscript } from './transcriber';
 import EventEmitter from 'events';
-import { AIAgent, AGENT_NAME } from './agent';
+import { AIAgent, AGENT_NAME, AgentInnerState } from './agent';
 import { ContextManager } from './contextManager';
 import { LLMService } from './llm-service';
-import { CollectionManager } from "./collectionManager";
+import { CollectionManager } from './collectionManager';
 
 // const VOICE_SERVICE_URL = process.env.VOICE_SERVICE_URL || 'http://localhost:4000';
 
 type Interaction = discord.ChatInputCommandInteraction<'cached'>;
 
 function interaction(commandConfig: Omit<discord.RESTPostAPIChatInputApplicationCommandsJSONBody, 'name'>) {
-    return function (target: any, key: string, describer: PropertyDescriptor) {
-        const ctor = target.constructor as typeof Bot;
-        const originalMethod = describer.value;
-        const name = key.replace(/[A-Z]/g, (l) => `_${l.toLowerCase()}`).toLowerCase();
-        ctor.interactions.set(name, { name, ...commandConfig });
-        ctor.handlers.set(name, (bot: Bot, interaction: Interaction) => originalMethod.call(bot, interaction));
-        return describer;
-    };
+	return function (target: any, key: string, describer: PropertyDescriptor) {
+		const ctor = target.constructor as typeof Bot;
+		const originalMethod = describer.value;
+		const name = key.replace(/[A-Z]/g, (l) => `_${l.toLowerCase()}`).toLowerCase();
+		ctor.interactions.set(name, { name, ...commandConfig });
+		ctor.handlers.set(name, (bot: Bot, interaction: Interaction) => originalMethod.call(bot, interaction));
+		return describer;
+	};
 }
 
 export interface BotOptions {
-    token: string;
-    applicationId: string;
+	token: string;
+	applicationId: string;
 }
 
 export class Bot extends EventEmitter {
-    static interactions = new Map<string, discord.RESTPostAPIChatInputApplicationCommandsJSONBody>();
-    static handlers = new Map<string, (bot: Bot, interaction: Interaction) => Promise<any>>();
+	static interactions = new Map<string, discord.RESTPostAPIChatInputApplicationCommandsJSONBody>();
+	static handlers = new Map<string, (bot: Bot, interaction: Interaction) => Promise<any>>();
 
-    agent: AIAgent;
-    client: Client;
-    token: string;
-    applicationId: string;
-    context: ContextManager = new ContextManager();
-    currentVoiceSession?: any;
+	agent: AIAgent;
+	client: Client;
+	token: string;
+	applicationId: string;
+	context: ContextManager = new ContextManager();
+	currentVoiceSession?: any;
 
-    constructor(options: BotOptions) {
-        super();
-        this.token = options.token;
-        this.applicationId = options.applicationId;
-        this.client = new Client({
-            intents: [GatewayIntentBits.Guilds, GatewayIntentBits.GuildMessages, GatewayIntentBits.GuildVoiceStates],
-        });
-        this.agent = new AIAgent({ historyLimit: 5, bot: this, context: this.context, llm: new LLMService() });
-    }
+	constructor(options: BotOptions) {
+		super();
+		this.token = options.token;
+		this.applicationId = options.applicationId;
+		this.client = new Client({
+			intents: [GatewayIntentBits.Guilds, GatewayIntentBits.GuildMessages, GatewayIntentBits.GuildVoiceStates],
+		});
+		this.agent = new AIAgent({ historyLimit: 5, bot: this, context: this.context, llm: new LLMService() });
+	}
 
-    get guilds(): Promise<discord.Guild[]> {
-        return this.client.guilds
-            .fetch()
-            .then((guildCollection) => Promise.all(guildCollection.map((g) => this.client.guilds.fetch(g.id))));
-    }
+	get guilds(): Promise<discord.Guild[]> {
+		return this.client.guilds
+			.fetch()
+			.then((guildCollection) => Promise.all(guildCollection.map((g) => this.client.guilds.fetch(g.id))));
+	}
 
-    async start() {
-        await this.context.createCollection('transcripts', 'text', 'createdAt');
-        await this.context.createCollection(`${AGENT_NAME}_discord_messages`, 'content', 'created_at');
-        await this.context.createCollection('agent_messages', 'text', 'createdAt');
-        await this.client.login(this.token);
-        await this.registerInteractions();
+	async start() {
+		await this.context.createCollection('transcripts', 'text', 'createdAt');
+		await this.context.createCollection(`${AGENT_NAME}_discord_messages`, 'content', 'created_at');
+		await this.context.createCollection('agent_messages', 'text', 'createdAt');
+		await this.client.login(this.token);
+		await this.registerInteractions();
 
-        this.client
-            .on(Events.InteractionCreate, async (interaction) => {
-                if (!interaction.inCachedGuild() || !interaction.isChatInputCommand()) return;
-                if (!Bot.interactions.has(interaction.commandName)) {
-                    await interaction.reply('Unknown command');
-                    return;
-                }
-                try {
-                    const handler = Bot.handlers.get(interaction.commandName);
-                    if (handler) await handler(this, interaction);
-                } catch (e) {
-                    console.warn(e);
-                }
-            })
-            .on(Events.Error, console.error);
-    }
+		this.client
+			.on(Events.InteractionCreate, async (interaction) => {
+				if (!interaction.inCachedGuild() || !interaction.isChatInputCommand()) return;
+				if (!Bot.interactions.has(interaction.commandName)) {
+					await interaction.reply('Unknown command');
+					return;
+				}
+				try {
+					const handler = Bot.handlers.get(interaction.commandName);
+					if (handler) await handler(this, interaction);
+				} catch (e) {
+					console.warn(e);
+				}
+			})
+			.on(Events.Error, console.error);
+	}
 
-    async registerInteractions() {
-        const commands: RESTPutAPIApplicationCommandsJSONBody = [];
-        for (const [, command] of Bot.interactions) commands.push(command);
-        return Promise.all(
-            (await this.guilds).map((guild) =>
-                new REST()
-                    .setToken(this.token)
-                    .put(Routes.applicationGuildCommands(this.applicationId, guild.id), { body: commands }),
-            ),
-        );
-    }
+	async registerInteractions() {
+		const commands: RESTPutAPIApplicationCommandsJSONBody = [];
+		for (const [, command] of Bot.interactions) commands.push(command);
+		return Promise.all(
+			(await this.guilds).map((guild) =>
+				new REST()
+					.setToken(this.token)
+					.put(Routes.applicationGuildCommands(this.applicationId, guild.id), { body: commands }),
+			),
+		);
+	}
 
-    @interaction({
-        description: "Joins the voice channel the requesting user is currently in",
-    })
-    async joinVoiceChannel(interaction: Interaction): Promise<any> {
-        // Join the specified voice channel
-        await interaction.deferReply()
-        let textChannel: discord.TextChannel | null
-        if (interaction?.channel?.id) {
-            const channel = await this.client.channels.fetch(interaction?.channel?.id)
-            if (channel?.isTextBased()) {
-                textChannel = channel as discord.TextChannel;
-            }
-        }
-        if (this.currentVoiceSession) {
-            return interaction.followUp("Cannot join a new voice session with out leaving the current one.")
-        }
-        if (!interaction.member.voice?.channel?.id) {
-            return interaction.followUp("Join a voice channel then try that again.")
-        }
-        this.currentVoiceSession = new VoiceSession({
-            bot: this,
-            guild: interaction.guild,
-            voiceChannelId: interaction.member.voice.channel.id
-        })
-        this.currentVoiceSession.transcriber.on("transcriptEnd", async (transcript: FinalTranscript) => {
-            const transcripts = this.context.getCollection("transcripts") as CollectionManager<"text", "createdAt">;
-            await transcripts.addEntry({
-                text: transcript.transcript,
-                createdAt: transcript.startTime || Date.now(),
-                metadata: {
-                    createdAt: Date.now(),
-                    endTime: transcript.endTime,
-                    userId: transcript.user?.id,
-                    userName: transcript.user?.username,
-                    is_transcript: true,
-                    channel: this.currentVoiceSession?.voiceChannelId,
-                    recipient: this.applicationId
-                }
-            })
-            if (textChannel && transcript.transcript.trim().length > 0 && transcript.speaker?.logTranscript)
-                await textChannel.send(`${transcript.user?.username}:${transcript.transcript}`)
-        })
-        this.currentVoiceSession.start();
-        return interaction.followUp("DONE!")
+	@interaction({
+		description: 'Update a runtime configuration option',
+		options: [
+			{
+				name: 'setting',
+				description: 'Configuration field to update',
+				type: ApplicationCommandOptionType.String,
+				required: true,
+				choices: [
+					{ name: 'historyLimit', value: 'historyLimit' },
+					{ name: 'forcedStopThreshold', value: 'forcedStopThreshold' },
+					{ name: 'prompt', value: 'prompt' },
+				],
+			},
+			{
+				name: 'value',
+				description: 'New value',
+				type: ApplicationCommandOptionType.String,
+				required: true,
+			},
+		],
+	})
+	async setConfig(interaction: Interaction) {
+		const key = interaction.options.getString('setting', true);
+		const value = interaction.options.getString('value', true);
+		switch (key) {
+			case 'historyLimit':
+				this.agent.historyLimit = Number(value);
+				break;
+			case 'forcedStopThreshold':
+				this.agent.forcedStopThreshold = Number(value);
+				break;
+			case 'prompt':
+				this.agent.prompt = value;
+				break;
+		}
+		await interaction.reply(`Updated ${key}`);
+	}
 
-    }
+	@interaction({
+		description: 'Update an inner state field',
+		options: [
+			{
+				name: 'field',
+				description: 'Inner state property to change',
+				type: ApplicationCommandOptionType.String,
+				required: true,
+				choices: [
+					{ name: 'currentFriend', value: 'currentFriend' },
+					{ name: 'chatMembers', value: 'chatMembers' },
+					{ name: 'currentMood', value: 'currentMood' },
+					{ name: 'currentDesire', value: 'currentDesire' },
+					{ name: 'currentGoal', value: 'currentGoal' },
+					{ name: 'likes', value: 'likes' },
+					{ name: 'dislikes', value: 'dislikes' },
+					{ name: 'favoriteColor', value: 'favoriteColor' },
+					{ name: 'favoriteTimeOfDay', value: 'favoriteTimeOfDay' },
+					{ name: 'selfAffirmations', value: 'selfAffirmations' },
+				],
+			},
+			{
+				name: 'value',
+				description: 'New value',
+				type: ApplicationCommandOptionType.String,
+				required: true,
+			},
+		],
+	})
+	async setState(interaction: Interaction) {
+		const field = interaction.options.getString('field', true) as keyof AgentInnerState;
+		const value = interaction.options.getString('value', true);
+		const parsed =
+			field === 'chatMembers' || field === 'selfAffirmations' ? value.split(',').map((v) => v.trim()) : value;
+		await this.agent.updateInnerState({ [field]: parsed } as Partial<AgentInnerState>);
+		await interaction.reply(`Updated ${field}`);
+	}
 
-    @interaction({
-        description: "Leaves whatever channel the bot is currently in."
-    })
-    async leaveVoiceChannel(interaction: Interaction) {
-        if (this.currentVoiceSession) {
-            this.currentVoiceSession.stop();
-            return interaction.followUp("Successfully left voice channel")
-        }
-        return interaction.followUp("No voice channel to leave.")
+	@interaction({
+		description: 'Joins the voice channel the requesting user is currently in',
+	})
+	async joinVoiceChannel(interaction: Interaction): Promise<any> {
+		// Join the specified voice channel
+		await interaction.deferReply();
+		let textChannel: discord.TextChannel | null;
+		if (interaction?.channel?.id) {
+			const channel = await this.client.channels.fetch(interaction?.channel?.id);
+			if (channel?.isTextBased()) {
+				textChannel = channel as discord.TextChannel;
+			}
+		}
+		if (this.currentVoiceSession) {
+			return interaction.followUp('Cannot join a new voice session with out leaving the current one.');
+		}
+		if (!interaction.member.voice?.channel?.id) {
+			return interaction.followUp('Join a voice channel then try that again.');
+		}
+		this.currentVoiceSession = new VoiceSession({
+			bot: this,
+			guild: interaction.guild,
+			voiceChannelId: interaction.member.voice.channel.id,
+		});
+		this.currentVoiceSession.transcriber.on('transcriptEnd', async (transcript: FinalTranscript) => {
+			const transcripts = this.context.getCollection('transcripts') as CollectionManager<'text', 'createdAt'>;
+			await transcripts.addEntry({
+				text: transcript.transcript,
+				createdAt: transcript.startTime || Date.now(),
+				metadata: {
+					createdAt: Date.now(),
+					endTime: transcript.endTime,
+					userId: transcript.user?.id,
+					userName: transcript.user?.username,
+					is_transcript: true,
+					channel: this.currentVoiceSession?.voiceChannelId,
+					recipient: this.applicationId,
+				},
+			});
+			if (textChannel && transcript.transcript.trim().length > 0 && transcript.speaker?.logTranscript)
+				await textChannel.send(`${transcript.user?.username}:${transcript.transcript}`);
+		});
+		this.currentVoiceSession.start();
+		return interaction.followUp('DONE!');
+	}
 
-        // Leave the specified voice channel
-    }
-    @interaction({
-        description: "begin recording the given user.",
-        options: [
-            {
-                name: "speaker",
-                description: "The user to begin recording", type: ApplicationCommandOptionType.User,
-                required: true
-            }
-        ]
-    })
-    async beginRecordingUser(interaction: Interaction) {
-        if (this.currentVoiceSession) {
-            const user = interaction.options.getUser("speaker", true)
-            this.currentVoiceSession.addSpeaker(user)
-            this.currentVoiceSession.startSpeakerRecord(user)
-        }
-        return interaction.reply("Recording!")
+	@interaction({
+		description: 'Leaves whatever channel the bot is currently in.',
+	})
+	async leaveVoiceChannel(interaction: Interaction) {
+		if (this.currentVoiceSession) {
+			this.currentVoiceSession.stop();
+			return interaction.followUp('Successfully left voice channel');
+		}
+		return interaction.followUp('No voice channel to leave.');
 
-    }
+		// Leave the specified voice channel
+	}
+	@interaction({
+		description: 'begin recording the given user.',
+		options: [
+			{
+				name: 'speaker',
+				description: 'The user to begin recording',
+				type: ApplicationCommandOptionType.User,
+				required: true,
+			},
+		],
+	})
+	async beginRecordingUser(interaction: Interaction) {
+		if (this.currentVoiceSession) {
+			const user = interaction.options.getUser('speaker', true);
+			this.currentVoiceSession.addSpeaker(user);
+			this.currentVoiceSession.startSpeakerRecord(user);
+		}
+		return interaction.reply('Recording!');
+	}
 
-    @interaction({
-        description: "stop recording the given user.",
-        options: [
-            {
-                name: "speaker",
-                description: "The user to begin recording", type: ApplicationCommandOptionType.User,
-                required: true
-            },
+	@interaction({
+		description: 'stop recording the given user.',
+		options: [
+			{
+				name: 'speaker',
+				description: 'The user to begin recording',
+				type: ApplicationCommandOptionType.User,
+				required: true,
+			},
+		],
+	})
+	async stopRecordingUser(interaction: Interaction) {
+		if (this.currentVoiceSession) {
+			const user = interaction.options.getUser('speaker', true);
+			this.currentVoiceSession.stopSpeakerRecord(user);
+		}
+		return interaction.reply("I'm not recording you any more... I promise...");
+	}
 
-        ]
-    })
-    async stopRecordingUser(interaction: Interaction) {
-        if (this.currentVoiceSession) {
+	@interaction({
+		description: 'Begin transcribing the speech of users in the current channel to the target text channel',
+		options: [
+			{
+				name: 'speaker',
+				description: 'The user to begin transcribing',
+				type: ApplicationCommandOptionType.User,
+				required: true,
+			},
+			{
+				name: 'log',
+				description: 'Should the bot send the transcript to the current text channel?',
+				type: ApplicationCommandOptionType.Boolean,
+			},
+		],
+	})
+	async beginTranscribingUser(interaction: Interaction) {
+		// Begin transcribing audio in the voice channel to the specified text channel
+		if (this.currentVoiceSession) {
+			const user = interaction.options.getUser('speaker', true);
+			this.currentVoiceSession.addSpeaker(user);
+			this.currentVoiceSession.startSpeakerTranscribe(user, interaction.options.getBoolean('log') || false);
 
-            const user = interaction.options.getUser("speaker", true)
-            this.currentVoiceSession.stopSpeakerRecord(user)
-        }
-        return interaction.reply("I'm not recording you any more... I promise...")
-    }
-
-    @interaction({
-        "description": "Begin transcribing the speech of users in the current channel to the target text channel",
-        options: [
-            {
-                name: "speaker",
-                description: "The user to begin transcribing",
-                type: ApplicationCommandOptionType.User,
-                required: true
-            },
-            {
-                name: "log",
-                description: "Should the bot send the transcript to the current text channel?",
-                type: ApplicationCommandOptionType.Boolean,
-            }
-        ]
-    })
-    async beginTranscribingUser(interaction: Interaction) {
-        // Begin transcribing audio in the voice channel to the specified text channel
-        if (this.currentVoiceSession) {
-            const user = interaction.options.getUser("speaker", true)
-            this.currentVoiceSession.addSpeaker(user)
-            this.currentVoiceSession.startSpeakerTranscribe(user, interaction.options.getBoolean("log") || false)
-
-            return interaction.reply(`I will faithfully transcribe every word ${user.displayName} says... I promise.`)
-        }
-        return interaction.reply("I can't transcribe what I can't hear. Join a voice channel.")
-    }
-    @interaction({
-        description: "speak the message with text to speech",
-        options: [
-            {
-                "name": "message",
-                description: "The message you wish spoken in the voice channel",
-                type: ApplicationCommandOptionType.String,
-                required: true
-            }
-        ]
-    })
-    async tts(interaction: Interaction) {
-        if (this.currentVoiceSession) {
-            await interaction.deferReply({ ephemeral: true });
-            await this.currentVoiceSession.playVoice(interaction.options.getString("message", true))
-        } else {
-            await interaction.reply("That didn't work... try again?")
-        }
-        await interaction.deleteReply().catch(() => {}) // Ignore if already deleted or errored
-
-
-    }
-    @interaction({
-        description: "Start a dialog with the bot"
-    })
-    async startDialog(interaction: Interaction) {
-        if (this.currentVoiceSession) {
-            await interaction.deferReply({ ephemeral: true });
-            this.currentVoiceSession.transcriber
-                .on("transcriptEnd", async () => {
-                    if (this.agent) {
-                        this.agent.newTranscript = true
-                        this.agent.userSpeaking = false
-                    }
-                })
-                .on("transcriptStart", async () => {
-
-                    if (this.agent) {
-                        this.agent.newTranscript = false
-                        this.agent.userSpeaking = true
-                    }
-                })
-            return this.agent?.start()
-        }
-
-    }
+			return interaction.reply(`I will faithfully transcribe every word ${user.displayName} says... I promise.`);
+		}
+		return interaction.reply("I can't transcribe what I can't hear. Join a voice channel.");
+	}
+	@interaction({
+		description: 'speak the message with text to speech',
+		options: [
+			{
+				name: 'message',
+				description: 'The message you wish spoken in the voice channel',
+				type: ApplicationCommandOptionType.String,
+				required: true,
+			},
+		],
+	})
+	async tts(interaction: Interaction) {
+		if (this.currentVoiceSession) {
+			await interaction.deferReply({ ephemeral: true });
+			await this.currentVoiceSession.playVoice(interaction.options.getString('message', true));
+		} else {
+			await interaction.reply("That didn't work... try again?");
+		}
+		await interaction.deleteReply().catch(() => {}); // Ignore if already deleted or errored
+	}
+	@interaction({
+		description: 'Start a dialog with the bot',
+	})
+	async startDialog(interaction: Interaction) {
+		if (this.currentVoiceSession) {
+			await interaction.deferReply({ ephemeral: true });
+			this.currentVoiceSession.transcriber
+				.on('transcriptEnd', async () => {
+					if (this.agent) {
+						this.agent.newTranscript = true;
+						this.agent.userSpeaking = false;
+					}
+				})
+				.on('transcriptStart', async () => {
+					if (this.agent) {
+						this.agent.newTranscript = false;
+						this.agent.userSpeaking = true;
+					}
+				});
+			return this.agent?.start();
+		}
+	}
 }

--- a/services/ts/cephalon/tests/bot.test.ts
+++ b/services/ts/cephalon/tests/bot.test.ts
@@ -8,9 +8,6 @@ class TestBot extends Bot {
 	}
 }
 
-Bot.interactions.clear();
-Bot.interactions.set('hello', { name: 'hello', description: 'd' });
-
 function makeBot() {
 	const bot = new TestBot();
 	bot.client.guilds.fetch = async () => [{ id: 'g1' }];
@@ -23,4 +20,33 @@ test.skip('registerInteractions issues REST call', async (t) => {
 	t.true(lastPutArgs.length > 0);
 	const [endpoint] = lastPutArgs[0];
 	t.is(endpoint, '/guilds/g1/commands');
+});
+
+test('set_config updates agent values', async (t) => {
+	const bot = makeBot();
+	const handler = Bot.handlers.get('set_config');
+	const interaction: any = {
+		options: {
+			getString: (name: string) => (name === 'setting' ? 'historyLimit' : '7'),
+		},
+		reply: async () => {},
+	};
+	await handler?.(bot, interaction);
+	t.is(bot.agent.historyLimit, 7);
+});
+
+test('set_state updates inner state', async (t) => {
+	const bot = makeBot();
+	bot.agent.updateInnerState = async function (newState: any) {
+		this.innerState = { ...this.innerState, ...newState };
+	};
+	const handler = Bot.handlers.get('set_state');
+	const interaction: any = {
+		options: {
+			getString: (name: string) => (name === 'field' ? 'currentMood' : 'excited'),
+		},
+		reply: async () => {},
+	};
+	await handler?.(bot, interaction);
+	t.is(bot.agent.innerState.currentMood, 'excited');
 });


### PR DESCRIPTION
## Summary
- add `/set_config` command to update Cephalon runtime settings such as history limit and stop threshold
- add `/set_state` command to change agent inner state fields without restarting
- document new commands in Cephalon README and test their handlers

## Testing
- `make setup-ts-service-cephalon` *(fails: connect ENETUNREACH 140.82.113.4:443)*
- `make format-ts`
- `make lint-ts-service-cephalon` *(fails: ESLint: You are linting '.', but all of the files matching the glob pattern '.' are ignored)*
- `make test-ts-service-cephalon` *(fails: Cannot find module 'crypto' or its corresponding type declarations.)*
- `make build-ts` *(fails: Cannot find module 'child_process' or its corresponding type declarations.)*

------
https://chatgpt.com/codex/tasks/task_e_688efde061b88324b439f71afad6ebee