### PR TITLE
feat: store recordings in discord channel

### DIFF
--- a/services/ts/cephalon/src/bot.ts
+++ b/services/ts/cephalon/src/bot.ts
@@ -1,274 +1,288 @@
 import * as discord from 'discord.js';
 import {
-    Client,
-    Events,
-    GatewayIntentBits,
-    ApplicationCommandOptionType,
-    REST,
-    Routes,
-    type RESTPutAPIApplicationCommandsJSONBody,
+	Client,
+	Events,
+	GatewayIntentBits,
+	ApplicationCommandOptionType,
+	REST,
+	Routes,
+	type RESTPutAPIApplicationCommandsJSONBody,
 } from 'discord.js';
-import { VoiceSession } from "./voice-session";
-import { FinalTranscript } from "./transcriber";
+import { VoiceSession } from './voice-session';
+import { FinalTranscript } from './transcriber';
 import EventEmitter from 'events';
 import { AIAgent, AGENT_NAME } from './agent';
 import { ContextManager } from './contextManager';
 import { LLMService } from './llm-service';
-import { CollectionManager } from "./collectionManager";
+import { CollectionManager } from './collectionManager';
 
 // const VOICE_SERVICE_URL = process.env.VOICE_SERVICE_URL || 'http://localhost:4000';
 
 type Interaction = discord.ChatInputCommandInteraction<'cached'>;
 
 function interaction(commandConfig: Omit<discord.RESTPostAPIChatInputApplicationCommandsJSONBody, 'name'>) {
-    return function (target: any, key: string, describer: PropertyDescriptor) {
-        const ctor = target.constructor as typeof Bot;
-        const originalMethod = describer.value;
-        const name = key.replace(/[A-Z]/g, (l) => `_${l.toLowerCase()}`).toLowerCase();
-        ctor.interactions.set(name, { name, ...commandConfig });
-        ctor.handlers.set(name, (bot: Bot, interaction: Interaction) => originalMethod.call(bot, interaction));
-        return describer;
-    };
+	return function (target: any, key: string, describer: PropertyDescriptor) {
+		const ctor = target.constructor as typeof Bot;
+		const originalMethod = describer.value;
+		const name = key.replace(/[A-Z]/g, (l) => `_${l.toLowerCase()}`).toLowerCase();
+		ctor.interactions.set(name, { name, ...commandConfig });
+		ctor.handlers.set(name, (bot: Bot, interaction: Interaction) => originalMethod.call(bot, interaction));
+		return describer;
+	};
 }
 
 export interface BotOptions {
-    token: string;
-    applicationId: string;
+	token: string;
+	applicationId: string;
 }
 
 export class Bot extends EventEmitter {
-    static interactions = new Map<string, discord.RESTPostAPIChatInputApplicationCommandsJSONBody>();
-    static handlers = new Map<string, (bot: Bot, interaction: Interaction) => Promise<any>>();
+	static interactions = new Map<string, discord.RESTPostAPIChatInputApplicationCommandsJSONBody>();
+	static handlers = new Map<string, (bot: Bot, interaction: Interaction) => Promise<any>>();
 
-    agent: AIAgent;
-    client: Client;
-    token: string;
-    applicationId: string;
-    context: ContextManager = new ContextManager();
-    currentVoiceSession?: any;
+	agent: AIAgent;
+	client: Client;
+	token: string;
+	applicationId: string;
+	context: ContextManager = new ContextManager();
+	currentVoiceSession?: any;
+	waveformChannel?: discord.TextChannel;
 
-    constructor(options: BotOptions) {
-        super();
-        this.token = options.token;
-        this.applicationId = options.applicationId;
-        this.client = new Client({
-            intents: [GatewayIntentBits.Guilds, GatewayIntentBits.GuildMessages, GatewayIntentBits.GuildVoiceStates],
-        });
-        this.agent = new AIAgent({ historyLimit: 5, bot: this, context: this.context, llm: new LLMService() });
-    }
+	constructor(options: BotOptions) {
+		super();
+		this.token = options.token;
+		this.applicationId = options.applicationId;
+		this.client = new Client({
+			intents: [GatewayIntentBits.Guilds, GatewayIntentBits.GuildMessages, GatewayIntentBits.GuildVoiceStates],
+		});
+		this.agent = new AIAgent({ historyLimit: 5, bot: this, context: this.context, llm: new LLMService() });
+	}
 
-    get guilds(): Promise<discord.Guild[]> {
-        return this.client.guilds
-            .fetch()
-            .then((guildCollection) => Promise.all(guildCollection.map((g) => this.client.guilds.fetch(g.id))));
-    }
+	get guilds(): Promise<discord.Guild[]> {
+		return this.client.guilds
+			.fetch()
+			.then((guildCollection) => Promise.all(guildCollection.map((g) => this.client.guilds.fetch(g.id))));
+	}
 
-    async start() {
-        await this.context.createCollection('transcripts', 'text', 'createdAt');
-        await this.context.createCollection(`${AGENT_NAME}_discord_messages`, 'content', 'created_at');
-        await this.context.createCollection('agent_messages', 'text', 'createdAt');
-        await this.client.login(this.token);
-        await this.registerInteractions();
+	async start() {
+		await this.context.createCollection('transcripts', 'text', 'createdAt');
+		await this.context.createCollection(`${AGENT_NAME}_discord_messages`, 'content', 'created_at');
+		await this.context.createCollection('agent_messages', 'text', 'createdAt');
+		await this.client.login(this.token);
+		await this.registerInteractions();
 
-        this.client
-            .on(Events.InteractionCreate, async (interaction) => {
-                if (!interaction.inCachedGuild() || !interaction.isChatInputCommand()) return;
-                if (!Bot.interactions.has(interaction.commandName)) {
-                    await interaction.reply('Unknown command');
-                    return;
-                }
-                try {
-                    const handler = Bot.handlers.get(interaction.commandName);
-                    if (handler) await handler(this, interaction);
-                } catch (e) {
-                    console.warn(e);
-                }
-            })
-            .on(Events.Error, console.error);
-    }
+		this.client
+			.on(Events.InteractionCreate, async (interaction) => {
+				if (!interaction.inCachedGuild() || !interaction.isChatInputCommand()) return;
+				if (!Bot.interactions.has(interaction.commandName)) {
+					await interaction.reply('Unknown command');
+					return;
+				}
+				try {
+					const handler = Bot.handlers.get(interaction.commandName);
+					if (handler) await handler(this, interaction);
+				} catch (e) {
+					console.warn(e);
+				}
+			})
+			.on(Events.Error, console.error);
+	}
 
-    async registerInteractions() {
-        const commands: RESTPutAPIApplicationCommandsJSONBody = [];
-        for (const [, command] of Bot.interactions) commands.push(command);
-        return Promise.all(
-            (await this.guilds).map((guild) =>
-                new REST()
-                    .setToken(this.token)
-                    .put(Routes.applicationGuildCommands(this.applicationId, guild.id), { body: commands }),
-            ),
-        );
-    }
+	async registerInteractions() {
+		const commands: RESTPutAPIApplicationCommandsJSONBody = [];
+		for (const [, command] of Bot.interactions) commands.push(command);
+		return Promise.all(
+			(await this.guilds).map((guild) =>
+				new REST()
+					.setToken(this.token)
+					.put(Routes.applicationGuildCommands(this.applicationId, guild.id), { body: commands }),
+			),
+		);
+	}
 
-    @interaction({
-        description: "Joins the voice channel the requesting user is currently in",
-    })
-    async joinVoiceChannel(interaction: Interaction): Promise<any> {
-        // Join the specified voice channel
-        await interaction.deferReply()
-        let textChannel: discord.TextChannel | null
-        if (interaction?.channel?.id) {
-            const channel = await this.client.channels.fetch(interaction?.channel?.id)
-            if (channel?.isTextBased()) {
-                textChannel = channel as discord.TextChannel;
-            }
-        }
-        if (this.currentVoiceSession) {
-            return interaction.followUp("Cannot join a new voice session with out leaving the current one.")
-        }
-        if (!interaction.member.voice?.channel?.id) {
-            return interaction.followUp("Join a voice channel then try that again.")
-        }
-        this.currentVoiceSession = new VoiceSession({
-            bot: this,
-            guild: interaction.guild,
-            voiceChannelId: interaction.member.voice.channel.id
-        })
-        this.currentVoiceSession.transcriber.on("transcriptEnd", async (transcript: FinalTranscript) => {
-            const transcripts = this.context.getCollection("transcripts") as CollectionManager<"text", "createdAt">;
-            await transcripts.addEntry({
-                text: transcript.transcript,
-                createdAt: transcript.startTime || Date.now(),
-                metadata: {
-                    createdAt: Date.now(),
-                    endTime: transcript.endTime,
-                    userId: transcript.user?.id,
-                    userName: transcript.user?.username,
-                    is_transcript: true,
-                    channel: this.currentVoiceSession?.voiceChannelId,
-                    recipient: this.applicationId
-                }
-            })
-            if (textChannel && transcript.transcript.trim().length > 0 && transcript.speaker?.logTranscript)
-                await textChannel.send(`${transcript.user?.username}:${transcript.transcript}`)
-        })
-        this.currentVoiceSession.start();
-        return interaction.followUp("DONE!")
+	@interaction({
+		description: 'Joins the voice channel the requesting user is currently in',
+	})
+	async joinVoiceChannel(interaction: Interaction): Promise<any> {
+		// Join the specified voice channel
+		await interaction.deferReply();
+		let textChannel: discord.TextChannel | null;
+		if (interaction?.channel?.id) {
+			const channel = await this.client.channels.fetch(interaction?.channel?.id);
+			if (channel?.isTextBased()) {
+				textChannel = channel as discord.TextChannel;
+			}
+		}
+		if (this.currentVoiceSession) {
+			return interaction.followUp('Cannot join a new voice session with out leaving the current one.');
+		}
+		if (!interaction.member.voice?.channel?.id) {
+			return interaction.followUp('Join a voice channel then try that again.');
+		}
+		this.currentVoiceSession = new VoiceSession({
+			bot: this,
+			guild: interaction.guild,
+			voiceChannelId: interaction.member.voice.channel.id,
+		});
+		this.currentVoiceSession.transcriber.on('transcriptEnd', async (transcript: FinalTranscript) => {
+			const transcripts = this.context.getCollection('transcripts') as CollectionManager<'text', 'createdAt'>;
+			await transcripts.addEntry({
+				text: transcript.transcript,
+				createdAt: transcript.startTime || Date.now(),
+				metadata: {
+					createdAt: Date.now(),
+					endTime: transcript.endTime,
+					userId: transcript.user?.id,
+					userName: transcript.user?.username,
+					is_transcript: true,
+					channel: this.currentVoiceSession?.voiceChannelId,
+					recipient: this.applicationId,
+				},
+			});
+			if (textChannel && transcript.transcript.trim().length > 0 && transcript.speaker?.logTranscript)
+				await textChannel.send(`${transcript.user?.username}:${transcript.transcript}`);
+		});
+		this.currentVoiceSession.start();
+		return interaction.followUp('DONE!');
+	}
 
-    }
+	@interaction({
+		description: 'Leaves whatever channel the bot is currently in.',
+	})
+	async leaveVoiceChannel(interaction: Interaction) {
+		if (this.currentVoiceSession) {
+			this.currentVoiceSession.stop();
+			return interaction.followUp('Successfully left voice channel');
+		}
+		return interaction.followUp('No voice channel to leave.');
 
-    @interaction({
-        description: "Leaves whatever channel the bot is currently in."
-    })
-    async leaveVoiceChannel(interaction: Interaction) {
-        if (this.currentVoiceSession) {
-            this.currentVoiceSession.stop();
-            return interaction.followUp("Successfully left voice channel")
-        }
-        return interaction.followUp("No voice channel to leave.")
+		// Leave the specified voice channel
+	}
+	@interaction({
+		description: 'Sets the channel where recorded waveforms will be stored',
+		options: [
+			{
+				name: 'channel',
+				description: 'Text channel for waveform storage',
+				type: ApplicationCommandOptionType.Channel,
+				required: true,
+			},
+		],
+	})
+	async setWaveformChannel(interaction: Interaction) {
+		const channel = interaction.options.getChannel('channel', true);
+		if (!channel.isTextBased()) {
+			return interaction.reply('Channel must be text-based.');
+		}
+		this.waveformChannel = channel as discord.TextChannel;
+		return interaction.reply(`Waveform channel set to ${channel.id}`);
+	}
+	@interaction({
+		description: 'begin recording the given user.',
+		options: [
+			{
+				name: 'speaker',
+				description: 'The user to begin recording',
+				type: ApplicationCommandOptionType.User,
+				required: true,
+			},
+		],
+	})
+	async beginRecordingUser(interaction: Interaction) {
+		if (this.currentVoiceSession) {
+			const user = interaction.options.getUser('speaker', true);
+			this.currentVoiceSession.addSpeaker(user);
+			this.currentVoiceSession.startSpeakerRecord(user);
+		}
+		return interaction.reply('Recording!');
+	}
 
-        // Leave the specified voice channel
-    }
-    @interaction({
-        description: "begin recording the given user.",
-        options: [
-            {
-                name: "speaker",
-                description: "The user to begin recording", type: ApplicationCommandOptionType.User,
-                required: true
-            }
-        ]
-    })
-    async beginRecordingUser(interaction: Interaction) {
-        if (this.currentVoiceSession) {
-            const user = interaction.options.getUser("speaker", true)
-            this.currentVoiceSession.addSpeaker(user)
-            this.currentVoiceSession.startSpeakerRecord(user)
-        }
-        return interaction.reply("Recording!")
+	@interaction({
+		description: 'stop recording the given user.',
+		options: [
+			{
+				name: 'speaker',
+				description: 'The user to begin recording',
+				type: ApplicationCommandOptionType.User,
+				required: true,
+			},
+		],
+	})
+	async stopRecordingUser(interaction: Interaction) {
+		if (this.currentVoiceSession) {
+			const user = interaction.options.getUser('speaker', true);
+			this.currentVoiceSession.stopSpeakerRecord(user);
+		}
+		return interaction.reply("I'm not recording you any more... I promise...");
+	}
 
-    }
+	@interaction({
+		description: 'Begin transcribing the speech of users in the current channel to the target text channel',
+		options: [
+			{
+				name: 'speaker',
+				description: 'The user to begin transcribing',
+				type: ApplicationCommandOptionType.User,
+				required: true,
+			},
+			{
+				name: 'log',
+				description: 'Should the bot send the transcript to the current text channel?',
+				type: ApplicationCommandOptionType.Boolean,
+			},
+		],
+	})
+	async beginTranscribingUser(interaction: Interaction) {
+		// Begin transcribing audio in the voice channel to the specified text channel
+		if (this.currentVoiceSession) {
+			const user = interaction.options.getUser('speaker', true);
+			this.currentVoiceSession.addSpeaker(user);
+			this.currentVoiceSession.startSpeakerTranscribe(user, interaction.options.getBoolean('log') || false);
 
-    @interaction({
-        description: "stop recording the given user.",
-        options: [
-            {
-                name: "speaker",
-                description: "The user to begin recording", type: ApplicationCommandOptionType.User,
-                required: true
-            },
-
-        ]
-    })
-    async stopRecordingUser(interaction: Interaction) {
-        if (this.currentVoiceSession) {
-
-            const user = interaction.options.getUser("speaker", true)
-            this.currentVoiceSession.stopSpeakerRecord(user)
-        }
-        return interaction.reply("I'm not recording you any more... I promise...")
-    }
-
-    @interaction({
-        "description": "Begin transcribing the speech of users in the current channel to the target text channel",
-        options: [
-            {
-                name: "speaker",
-                description: "The user to begin transcribing",
-                type: ApplicationCommandOptionType.User,
-                required: true
-            },
-            {
-                name: "log",
-                description: "Should the bot send the transcript to the current text channel?",
-                type: ApplicationCommandOptionType.Boolean,
-            }
-        ]
-    })
-    async beginTranscribingUser(interaction: Interaction) {
-        // Begin transcribing audio in the voice channel to the specified text channel
-        if (this.currentVoiceSession) {
-            const user = interaction.options.getUser("speaker", true)
-            this.currentVoiceSession.addSpeaker(user)
-            this.currentVoiceSession.startSpeakerTranscribe(user, interaction.options.getBoolean("log") || false)
-
-            return interaction.reply(`I will faithfully transcribe every word ${user.displayName} says... I promise.`)
-        }
-        return interaction.reply("I can't transcribe what I can't hear. Join a voice channel.")
-    }
-    @interaction({
-        description: "speak the message with text to speech",
-        options: [
-            {
-                "name": "message",
-                description: "The message you wish spoken in the voice channel",
-                type: ApplicationCommandOptionType.String,
-                required: true
-            }
-        ]
-    })
-    async tts(interaction: Interaction) {
-        if (this.currentVoiceSession) {
-            await interaction.deferReply({ ephemeral: true });
-            await this.currentVoiceSession.playVoice(interaction.options.getString("message", true))
-        } else {
-            await interaction.reply("That didn't work... try again?")
-        }
-        await interaction.deleteReply().catch(() => {}) // Ignore if already deleted or errored
-
-
-    }
-    @interaction({
-        description: "Start a dialog with the bot"
-    })
-    async startDialog(interaction: Interaction) {
-        if (this.currentVoiceSession) {
-            await interaction.deferReply({ ephemeral: true });
-            this.currentVoiceSession.transcriber
-                .on("transcriptEnd", async () => {
-                    if (this.agent) {
-                        this.agent.newTranscript = true
-                        this.agent.userSpeaking = false
-                    }
-                })
-                .on("transcriptStart", async () => {
-
-                    if (this.agent) {
-                        this.agent.newTranscript = false
-                        this.agent.userSpeaking = true
-                    }
-                })
-            return this.agent?.start()
-        }
-
-    }
+			return interaction.reply(`I will faithfully transcribe every word ${user.displayName} says... I promise.`);
+		}
+		return interaction.reply("I can't transcribe what I can't hear. Join a voice channel.");
+	}
+	@interaction({
+		description: 'speak the message with text to speech',
+		options: [
+			{
+				name: 'message',
+				description: 'The message you wish spoken in the voice channel',
+				type: ApplicationCommandOptionType.String,
+				required: true,
+			},
+		],
+	})
+	async tts(interaction: Interaction) {
+		if (this.currentVoiceSession) {
+			await interaction.deferReply({ ephemeral: true });
+			await this.currentVoiceSession.playVoice(interaction.options.getString('message', true));
+		} else {
+			await interaction.reply("That didn't work... try again?");
+		}
+		await interaction.deleteReply().catch(() => {}); // Ignore if already deleted or errored
+	}
+	@interaction({
+		description: 'Start a dialog with the bot',
+	})
+	async startDialog(interaction: Interaction) {
+		if (this.currentVoiceSession) {
+			await interaction.deferReply({ ephemeral: true });
+			this.currentVoiceSession.transcriber
+				.on('transcriptEnd', async () => {
+					if (this.agent) {
+						this.agent.newTranscript = true;
+						this.agent.userSpeaking = false;
+					}
+				})
+				.on('transcriptStart', async () => {
+					if (this.agent) {
+						this.agent.newTranscript = false;
+						this.agent.userSpeaking = true;
+					}
+				});
+			return this.agent?.start();
+		}
+	}
 }

--- a/services/ts/cephalon/src/voice-session.ts
+++ b/services/ts/cephalon/src/voice-session.ts
@@ -51,6 +51,16 @@ export class VoiceSession extends EventEmitter {
 		// this.transcript = new Transcript();
 		this.transcriber = new Transcriber();
 		this.recorder = new VoiceRecorder();
+		this.recorder.on('saved', async ({ filename }) => {
+			const channel = this.bot.waveformChannel;
+			if (channel) {
+				try {
+					await channel.send({ files: [filename] });
+				} catch (e) {
+					console.warn('Failed to upload waveform', e);
+				}
+			}
+		});
 		this.voiceSynth = new VoiceSynth();
 	}
 	get receiver() {

--- a/services/ts/cephalon/tests/waveform_channel.test.ts
+++ b/services/ts/cephalon/tests/waveform_channel.test.ts
@@ -1,0 +1,27 @@
+import test from 'ava';
+import { VoiceSession } from '../src/voice-session.js';
+
+// Verify that saved recordings are sent to the configured channel
+
+test('uploads saved waveform to configured channel', async (t) => {
+	let sent: any = null;
+	const channel = {
+		send: async (data: any) => {
+			sent = data;
+		},
+	} as any;
+	const bot = { waveformChannel: channel } as any;
+	const vs = new VoiceSession({ voiceChannelId: '1', guild: {} as any, bot });
+
+	const done = new Promise<void>((resolve) => {
+		channel.send = async (data: any) => {
+			sent = data;
+			resolve();
+		};
+	});
+
+	vs.recorder.emit('saved', { filename: 'test.wav', userId: 'u', saveTime: 0 });
+	await done;
+
+	t.deepEqual(sent.files, ['test.wav']);
+});

--- a/services/ts/cephalon/tsconfig.json
+++ b/services/ts/cephalon/tsconfig.json
@@ -49,6 +49,6 @@
 		// Completeness
 		"skipLibCheck": true
 	},
-	"include": ["src/*.ts"],
+	"include": ["src/*.ts", "tests/*.ts"],
 	"exclude": ["node_modules"]
 }


### PR DESCRIPTION
## Summary
- allow configuring a waveform storage channel
- upload saved recordings to that channel
- test waveform uploads

## Testing
- `npx prettier --write .`
- `npx eslint . --ext .js,.ts` *(fails: ESLint: 9.32.0 You are linting ".", but all of the files matching the glob pattern "." are ignored.)*
- `npm run build` *(fails: Cannot find type definition file for 'concat-stream' ... )*
- `npm test` *(fails: Cannot find type definition file for 'concat-stream' ... )*

------
https://chatgpt.com/codex/tasks/task_e_688efd6b4f148324a83fecc96b9f036e