### PR TITLE
Add script to index project files into ChromaDB

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ shared/py/.coverage
 !agents/duck/scripts/download_chroma_data.sh
 
 .infio_json_db/
+.chromadb/

--- a/docs/scripts/index_project_files.md
+++ b/docs/scripts/index_project_files.md
@@ -1,0 +1,14 @@
+# index_project_files.py
+
+Indexes every file in the repository into a [ChromaDB](https://www.trychroma.com/) collection.
+
+This utility script is useful for creating an embedding-powered search index of the project files for later retrieval or semantic search.
+
+Run it with:
+
+```bash
+python scripts/index_project_files.py
+```
+
+The collection will be persisted in a `.chromadb/` directory at the repository root.
+

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -15,3 +15,4 @@ uvicorn
 httpx
 websockets
 PyYAML
+chromadb

--- a/scripts/index_project_files.py
+++ b/scripts/index_project_files.py
@@ -1,0 +1,79 @@
+"""Index all project files into a ChromaDB collection.
+
+This script walks the repository tree, reading each file and storing its
+contents in a ChromaDB collection. The file path is used as the document
+ID and stored in the metadata for easy retrieval.
+
+Usage:
+
+```bash
+python scripts/index_project_files.py
+```
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Iterable, List
+
+import chromadb
+from chromadb.config import Settings
+
+
+SKIP_DIRS = {".git", "node_modules", "__pycache__", ".chromadb"}
+
+
+def iter_project_files(root_dir: str) -> Iterable[str]:
+    """Yield file paths under ``root_dir`` excluding ``SKIP_DIRS``."""
+
+    for base, dirs, files in os.walk(root_dir):
+        dirs[:] = [d for d in dirs if d not in SKIP_DIRS]
+        for name in files:
+            yield os.path.join(base, name)
+
+
+def index_project_files(
+    root_dir: str = ".",
+    collection_name: str = "project_files",
+    persist_directory: str = ".chromadb",
+) -> int:
+    """Index files beneath ``root_dir`` into a ChromaDB collection.
+
+    Returns the number of files indexed.
+    """
+
+    client = chromadb.Client(
+        Settings(chroma_db_impl="duckdb+parquet", persist_directory=persist_directory)
+    )
+    collection = client.get_or_create_collection(collection_name)
+
+    documents: List[str] = []
+    ids: List[str] = []
+    metadatas: List[dict] = []
+
+    for path in iter_project_files(root_dir):
+        try:
+            with open(path, "r", encoding="utf-8", errors="ignore") as fh:
+                text = fh.read()
+        except Exception as exc:  # pragma: no cover - log and skip
+            print(f"Skipping {path}: {exc}")
+            continue
+
+        documents.append(text)
+        ids.append(path)
+        metadatas.append({"path": path})
+
+    if documents:
+        collection.upsert(ids=ids, documents=documents, metadatas=metadatas)
+
+    return len(documents)
+
+
+def main() -> None:
+    count = index_project_files()
+    print(f"Indexed {count} files into ChromaDB collection 'project_files'.")
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry
+    main()
+

--- a/tests/scripts/test_index_project_files.py
+++ b/tests/scripts/test_index_project_files.py
@@ -1,0 +1,22 @@
+"""Tests for :mod:`scripts.index_project_files`."""
+
+from pathlib import Path
+
+from scripts.index_project_files import index_project_files
+
+
+def test_index_project_files(tmp_path: Path) -> None:
+    sample_dir = tmp_path / "sample"
+    sample_dir.mkdir()
+
+    (sample_dir / "a.txt").write_text("alpha")
+    (sample_dir / "b.txt").write_text("beta")
+
+    count = index_project_files(
+        root_dir=str(sample_dir),
+        collection_name="test_collection",
+        persist_directory=str(tmp_path / "db"),
+    )
+
+    assert count == 2
+


### PR DESCRIPTION
## Summary
- add script to index all repo files into a ChromaDB collection
- document how to run the indexer
- test indexing on sample files

## Testing
- `make install` *(fails: ENOTEMPTY and network errors)*
- `make test`
- `make build` *(fails: env config http-proxy / make build-ts error)*
- `make lint` *(fails: flake8 missing)*
- `make format`


------
https://chatgpt.com/codex/tasks/task_e_688efc8a98ac8324a595a13d906d2a62