### PR TITLE
Fix duplicate permissions key in board sync workflow

### DIFF
--- a/.github/workflows/sync_board.yml
+++ b/.github/workflows/sync_board.yml
@@ -7,10 +7,6 @@ on:
   push:
     branches: [main]
 
-
-permissions:
-  contents: read
-
 jobs:
   sync:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- remove duplicate `permissions` mapping in `.github/workflows/sync_board.yml`

## Testing
- `make lint` *(fails: services/py/tts/app.py:49:1: E303 too many blank lines)*
- `make test` *(fails: ModuleNotFoundError: No module named 'scipy')*
- `make build` *(fails: Cannot find module 'child_process' or its corresponding type declarations)*
- `make format`
- `make install` *(fails: npm ERR! command sh -c node ./script/install)*

------
https://chatgpt.com/codex/tasks/task_e_688f012d6e008324b5ac46b21e313064