### PR TITLE
docs: add auto-generated tasks list

### DIFF
--- a/tasks/automatically-generated-tasks.md
+++ b/tasks/automatically-generated-tasks.md
@@ -1,0 +1,23 @@
+# Automatically Generated Tasks
+
+The following tasks were derived from notes in `docs/unique` and are intended for future work:
+
+## Board workflow & migration
+- Migrate server-side Sibilant libraries to the Promethean architecture and annotate legacy code with migration tags
+- Develop tools such as a smart task templater and integrate Ollama; consider starting the Eidolon subsystem
+- Build utilities for fragment ingestion, memory-contradiction detection, and metaprogramming updates
+- Create foundational documentation and tooling, including README templates, Makefile integration for Python/JS, GitHub-compatible markdown settings, and an Obsidian↔GitHub board mirror system
+- Finalize `MIGRATION_PLAN.md`, mirror the vault structure to match code directories, and add vault onboarding docs and `.obsidian/` gitignore entries
+- Explore concepts such as Eidolon field structures, transcendence cascades, and board-sync or GitHub Projects workflows
+
+## Eidolon field & error handling
+- Prototype an exception-event schema, classifier, and diagnostic logging UI to visualize exception flows
+- Classify error messages, project them into the Eidolon field, and create a library of error patterns; wire a test agent into this system
+- Develop a 2D field sandbox with potential extensions like Sibilant ports, real-time visualization, or particle-type experiments
+- Generalize the field engine to N dimensions with optional CLI visualization and snapshot serialization
+- Enhance the Node.js visual simulation with velocity-based coloring, multiple field nodes, trails or heatmaps, and higher-dimensional projections
+- Build resource monitoring agents and a stress-field system, including a resource snapshot collector, 2D vector stress map, agent responses, stress injector, and self-healing demo
+
+## Interface and runtime improvements
+- Extract and classify parenthetical phrases to drive context-aware pauses in speech output
+- Design a Windows-native tiling environment using Komorebi, a custom group manager, and WSL as a headless service layer for tasks like file indexing and AI data preparation


### PR DESCRIPTION
## Summary
- add `automatically-generated-tasks.md` to track future work found in `docs/unique`

## Testing
- `make install` *(failed: interrupted during setup)*
- `make test` *(missing numpy dependency)*
- `make build` *(no rule to make target `build-python`)*
- `make lint` *(flake8: command not found)*
- `make format` *(Black failed to reformat some files)*

------
https://chatgpt.com/codex/tasks/task_e_688eefdc91f48324925198e8b1343f8f