### PR TITLE
feat: debounce file watcher self updates

### DIFF
--- a/services/ts/file-watcher/package.json
+++ b/services/ts/file-watcher/package.json
@@ -8,8 +8,8 @@
     "start": "node dist/index.js",
     "start:dev": "node --loader ts-node/esm src/index.ts",
     "build:check": "tsc --noEmit --incremental false",
-    "test": "ava",
-    "coverage": "c8 ava"
+    "test": "npm run build && ava",
+    "coverage": "npm run build && c8 ava"
   },
   "dependencies": {
     "chokidar": "^3.5.3"
@@ -22,11 +22,8 @@
     "typescript": "5.7.3"
   },
   "ava": {
-    "extensions": {
-      "ts": "module"
-    },
     "files": [
-      "dist/tests/**/*.ts"
+      "dist/tests/**/*.js"
     ]
   }
 }

--- a/services/ts/file-watcher/src/index.ts
+++ b/services/ts/file-watcher/src/index.ts
@@ -1,24 +1,39 @@
-import { spawn } from 'child_process';
-import chokidar from 'chokidar';
-import { join } from 'path';
-import { writeFile } from 'fs/promises';
+import { spawn } from "child_process";
+import chokidar from "chokidar";
+import { join } from "path";
+import { writeFile as fsWriteFile } from "fs/promises";
 
-const repoRoot = process.env.REPO_ROOT || ""
+/**
+ * Options for {@link startFileWatcher} allowing injection of dependencies for testing.
+ */
+export interface FileWatcherOptions {
+  /** Root of the repository. Defaults to the REPO_ROOT env var or "". */
+  repoRoot?: string;
+  /** Function used to execute python scripts. */
+  runPython?: (script: string, capture?: boolean) => Promise<string | void>;
+  /** Function used to write the kanban board file. */
+  writeFile?: (path: string, data: string) => Promise<void>;
+}
 
-function runPython(script: string, capture = false): Promise<string | void> {
+const defaultRepoRoot = process.env.REPO_ROOT || "";
+
+function defaultRunPython(
+  script: string,
+  capture = false,
+): Promise<string | void> {
   return new Promise((resolve, reject) => {
-    const proc = spawn('python', [script], { cwd: repoRoot });
-    let data = '';
+    const proc = spawn("python", [script], { cwd: defaultRepoRoot });
+    let data = "";
 
-    proc.stdout.on('data', chunk => {
+    proc.stdout.on("data", (chunk) => {
       if (capture) {
         data += chunk.toString();
       } else {
         process.stdout.write(chunk);
       }
     });
-    proc.stderr.on('data', chunk => process.stderr.write(chunk));
-    proc.on('close', code => {
+    proc.stderr.on("data", (chunk) => process.stderr.write(chunk));
+    proc.on("close", (code) => {
       if (code === 0) {
         resolve(capture ? data : undefined);
       } else {
@@ -28,37 +43,82 @@ function runPython(script: string, capture = false): Promise<string | void> {
   });
 }
 
-async function updateFromBoard() {
-  try {
-    await runPython(join('scripts', 'kanban_to_hashtags.py'));
-  } catch (err) {
-    console.error('kanban_to_hashtags failed', err);
-  }
-}
+/**
+ * Start the file watcher which keeps the kanban board and task files in sync.
+ *
+ * The watcher debounces changes it makes itself to avoid infinite loops. Only
+ * user initiated changes trigger updates.
+ */
+export function startFileWatcher(options: FileWatcherOptions = {}): {
+  boardWatcher: chokidar.FSWatcher;
+  tasksWatcher: chokidar.FSWatcher;
+} {
+  const repoRoot = options.repoRoot ?? defaultRepoRoot;
+  const runPython = options.runPython ?? defaultRunPython;
+  const writeFile = options.writeFile ?? fsWriteFile;
 
-async function updateBoard() {
-  try {
-    const output = await runPython(join('scripts', 'hashtags_to_kanban.py'), true);
-    const boardPath = join(repoRoot, 'docs', 'agile', 'boards', 'kanban.md');
-    if (typeof output === 'string') {
-      await writeFile(boardPath, output);
+  const boardPath = join(repoRoot, "docs", "agile", "boards", "kanban.md");
+  const tasksPath = join(repoRoot, "docs", "agile", "tasks");
+
+  let updatingBoard = false;
+  let updatingTasks = false;
+
+  async function updateFromBoard() {
+    try {
+      updatingTasks = true;
+      await runPython(join("scripts", "kanban_to_hashtags.py"));
+    } catch (err) {
+      console.error("kanban_to_hashtags failed", err);
+    } finally {
+      setTimeout(() => {
+        updatingTasks = false;
+      }, 100);
     }
-  } catch (err) {
-    console.error('hashtags_to_kanban failed', err);
   }
+
+  async function updateBoard() {
+    try {
+      updatingBoard = true;
+      const output = await runPython(
+        join("scripts", "hashtags_to_kanban.py"),
+        true,
+      );
+      if (typeof output === "string") {
+        await writeFile(boardPath, output);
+      }
+    } catch (err) {
+      console.error("hashtags_to_kanban failed", err);
+    } finally {
+      setTimeout(() => {
+        updatingBoard = false;
+      }, 100);
+    }
+  }
+
+  const boardWatcher = chokidar.watch(boardPath, { ignoreInitial: true });
+  boardWatcher.on("change", () => {
+    if (updatingBoard) {
+      console.log("Ignoring board change triggered by watcher");
+      return;
+    }
+    console.log("Board changed, syncing hashtags...");
+    updateFromBoard();
+  });
+
+  const tasksWatcher = chokidar.watch(tasksPath, { ignoreInitial: true });
+  tasksWatcher.on("change", () => {
+    if (updatingTasks) {
+      console.log("Ignoring task change triggered by watcher");
+      return;
+    }
+    console.log("Task file changed, regenerating board...");
+    updateBoard();
+  });
+
+  return { boardWatcher, tasksWatcher };
 }
 
-const boardPath = join(repoRoot, 'docs', 'agile', 'boards', 'kanban.md');
-const tasksPath = join(repoRoot, 'docs', 'agile', 'tasks');
-
-chokidar.watch(boardPath, { ignoreInitial: true }).on('change', () => {
-  console.log('Board changed, syncing hashtags...');
-  updateFromBoard();
-});
-
-chokidar.watch(tasksPath, { ignoreInitial: true }).on('change', () => {
-  console.log('Task file changed, regenerating board...');
-  updateBoard();
-});
-
-console.log('File watcher running...');
+if (process.env.NODE_ENV !== "test") {
+  startFileWatcher();
+  console.log("File watcher running...");
+}

--- a/services/ts/file-watcher/tests/debounce.test.ts
+++ b/services/ts/file-watcher/tests/debounce.test.ts
@@ -1,0 +1,78 @@
+import test from "ava";
+import { tmpdir } from "os";
+import { join } from "path";
+import { promises as fs } from "fs";
+import { startFileWatcher } from "../src/index.js";
+
+function delay(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function setupTempRepo() {
+  const root = await fs.mkdtemp(join(tmpdir(), "fw-"));
+  const boardDir = join(root, "docs", "agile", "boards");
+  const tasksDir = join(root, "docs", "agile", "tasks");
+  await fs.mkdir(boardDir, { recursive: true });
+  await fs.mkdir(tasksDir, { recursive: true });
+  await fs.writeFile(join(boardDir, "kanban.md"), "");
+  await fs.writeFile(join(tasksDir, "task.md"), "");
+  return {
+    root,
+    boardFile: join(boardDir, "kanban.md"),
+    taskFile: join(tasksDir, "task.md"),
+  };
+}
+
+test("ignores board changes caused by watcher", async (t) => {
+  process.env.NODE_ENV = "test";
+  const { root, taskFile } = await setupTempRepo();
+  const calls: string[] = [];
+
+  const watchers = startFileWatcher({
+    repoRoot: root,
+    runPython: async (script) => {
+      calls.push(script);
+      if (script.includes("hashtags_to_kanban.py")) {
+        return "board";
+      }
+      return undefined;
+    },
+  });
+
+  await delay(50);
+  await fs.writeFile(taskFile, "update");
+  await delay(300);
+
+  t.is(calls.length, 1);
+  t.true(calls[0]!.includes("hashtags_to_kanban.py"));
+
+  await watchers.boardWatcher.close();
+  await watchers.tasksWatcher.close();
+});
+
+test("ignores task changes caused by watcher", async (t) => {
+  process.env.NODE_ENV = "test";
+  const { root, boardFile, taskFile } = await setupTempRepo();
+  const calls: string[] = [];
+
+  const watchers = startFileWatcher({
+    repoRoot: root,
+    runPython: async (script) => {
+      calls.push(script);
+      if (script.includes("kanban_to_hashtags.py")) {
+        await fs.writeFile(taskFile, "updated");
+      }
+      return undefined;
+    },
+  });
+
+  await delay(50);
+  await fs.writeFile(boardFile, "change");
+  await delay(300);
+
+  t.is(calls.length, 1);
+  t.true(calls[0]!.includes("kanban_to_hashtags.py"));
+
+  await watchers.boardWatcher.close();
+  await watchers.tasksWatcher.close();
+});

--- a/services/ts/file-watcher/tests/dummy.test.ts
+++ b/services/ts/file-watcher/tests/dummy.test.ts
@@ -1,5 +1,0 @@
-import test from 'ava';
-
-test('placeholder', t => {
-  t.pass();
-});

--- a/services/ts/file-watcher/tsconfig.json
+++ b/services/ts/file-watcher/tsconfig.json
@@ -1,54 +1,54 @@
 {
-	"$schema": "https://json.schemastore.org/tsconfig.json",
-	// Mapped from https://www.typescriptlang.org/tsconfig
-	"compilerOptions": {
-		// Type Checking
-		"allowUnreachableCode": false,
-		"allowUnusedLabels": false,
-		"exactOptionalPropertyTypes": true,
-		"noFallthroughCasesInSwitch": true,
-		"noImplicitOverride": true,
-		"noImplicitReturns": true,
-		"noPropertyAccessFromIndexSignature": false,
-		"noUncheckedIndexedAccess": true,
-		"noUnusedLocals": true,
-		"noUnusedParameters": true,
-		"strict": true,
+  "$schema": "https://json.schemastore.org/tsconfig.json",
+  // Mapped from https://www.typescriptlang.org/tsconfig
+  "compilerOptions": {
+    // Type Checking
+    "allowUnreachableCode": false,
+    "allowUnusedLabels": false,
+    "exactOptionalPropertyTypes": true,
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitOverride": true,
+    "noImplicitReturns": true,
+    "noPropertyAccessFromIndexSignature": false,
+    "noUncheckedIndexedAccess": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "strict": true,
 
-		// Modules
-		"allowArbitraryExtensions": false,
-		"allowImportingTsExtensions": false,
-		"module": "ESNext",
-		"moduleResolution": "Bundler",
-		"resolveJsonModule": true,
-		"resolvePackageJsonExports": true,
-		"resolvePackageJsonImports": true,
+    // Modules
+    "allowArbitraryExtensions": false,
+    "allowImportingTsExtensions": false,
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "resolveJsonModule": true,
+    "resolvePackageJsonExports": true,
+    "resolvePackageJsonImports": true,
 
-		// Emit
-		"declaration": true,
-		"declarationMap": true,
-		"importHelpers": false,
-		"newLine": "lf",
-		"noEmitHelpers": true,
-		"outDir": "dist",
-		"removeComments": false,
-		"sourceMap": true,
+    // Emit
+    "declaration": true,
+    "declarationMap": true,
+    "importHelpers": false,
+    "newLine": "lf",
+    "noEmitHelpers": true,
+    "outDir": "dist",
+    "removeComments": false,
+    "sourceMap": true,
 
-		// Interop Constraints
-		"allowSyntheticDefaultImports": true,
-		"esModuleInterop": false,
-		"forceConsistentCasingInFileNames": true,
-		"isolatedModules": true,
+    // Interop Constraints
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": false,
+    "forceConsistentCasingInFileNames": true,
+    "isolatedModules": true,
 
-		// Language and Environment
-		"experimentalDecorators": true,
-		"lib": ["ESNext", "esnext.disposable"],
-		"target": "ESNext",
-		"useDefineForClassFields": true,
+    // Language and Environment
+    "experimentalDecorators": true,
+    "lib": ["ESNext", "esnext.disposable"],
+    "target": "ESNext",
+    "useDefineForClassFields": true,
 
-		// Completeness
-		"skipLibCheck": true
-	},
-	"include": ["src/*.ts"],
-	"exclude": ["node_modules"]
+    // Completeness
+    "skipLibCheck": true
+  },
+  "include": ["src/*.ts", "tests/**/*.ts"],
+  "exclude": ["node_modules"]
 }


### PR DESCRIPTION
## Summary
- debounce board and task watchers to ignore self-triggered changes
- build TS tests and run them through ava
- add regression tests for board/task change handling

## Testing
- `make install` *(fails: ENETUNREACH downloading onnxruntime-node)*
- `make test`
- `make build` *(fails: build-ts)*
- `make lint` *(fails: flake8 not found)*
- `make format`
- `npm test` (services/ts/file-watcher)


------
https://chatgpt.com/codex/tasks/task_e_688f0741afa4832493faed19514f4cdc