### PR TITLE
refactor: share websocket endpoint boilerplate

### DIFF
--- a/services/py/stt_ws/app.py
+++ b/services/py/stt_ws/app.py
@@ -1,29 +1,25 @@
 import base64
 import json
-from fastapi import FastAPI, WebSocket, WebSocketDisconnect
+from fastapi import FastAPI, WebSocket
+
+from shared.py.utils import websocket_endpoint
 
 
 app = FastAPI()
 
 
 @app.websocket("/transcribe")
+@websocket_endpoint
 async def transcribe_ws(ws: WebSocket):
-    await ws.accept()
-    try:
-        msg = await ws.receive_text()
-        payload = json.loads(msg)
-        pcm_b64 = payload.get("pcm")
-        if pcm_b64 is None:
-            await ws.close(code=1003)
-            return
-        sample_rate = int(payload.get("sample_rate", 16000))
-        pcm_bytes = base64.b64decode(pcm_b64)
-        from shared.py.speech.wisper_stt import transcribe_pcm
+    msg = await ws.receive_text()
+    payload = json.loads(msg)
+    pcm_b64 = payload.get("pcm")
+    if pcm_b64 is None:
+        await ws.close(code=1003)
+        return
+    sample_rate = int(payload.get("sample_rate", 16000))
+    pcm_bytes = base64.b64decode(pcm_b64)
+    from shared.py.speech.wisper_stt import transcribe_pcm
 
-        text = transcribe_pcm(bytearray(pcm_bytes), sample_rate)
-        await ws.send_json({"transcription": text})
-    except WebSocketDisconnect:
-        pass
-    finally:
-        if not ws.client_state.name == "CLOSED":
-            await ws.close()
+    text = transcribe_pcm(bytearray(pcm_bytes), sample_rate)
+    await ws.send_json({"transcription": text})

--- a/services/py/tts/ws.py
+++ b/services/py/tts/ws.py
@@ -1,23 +1,20 @@
-from fastapi import FastAPI, WebSocket, WebSocketDisconnect
+from fastapi import FastAPI, WebSocket
 import io
 import soundfile as sf
+
+from shared.py.utils import websocket_endpoint
 
 app = FastAPI()
 
 
 @app.websocket("/ws/tts")
+@websocket_endpoint
 async def tts_websocket(ws: WebSocket):
-    await ws.accept()
-    try:
-        from shared.py.speech import tts
+    from shared.py.speech import tts
 
-        while True:
-            text = await ws.receive_text()
-            audio = tts.generate_voice(text)
-            buf = io.BytesIO()
-            sf.write(buf, audio, samplerate=22050, format="WAV")
-            await ws.send_bytes(buf.getvalue())
-    except WebSocketDisconnect:
-        pass
-    finally:
-        await ws.close()
+    while True:
+        text = await ws.receive_text()
+        audio = tts.generate_voice(text)
+        buf = io.BytesIO()
+        sf.write(buf, audio, samplerate=22050, format="WAV")
+        await ws.send_bytes(buf.getvalue())

--- a/services/py/whisper_stream_ws/app.py
+++ b/services/py/whisper_stream_ws/app.py
@@ -1,23 +1,19 @@
-from fastapi import FastAPI, WebSocket, WebSocketDisconnect
+from fastapi import FastAPI, WebSocket
+
 from shared.py.speech.whisper_stream import WhisperStreamer
+from shared.py.utils import websocket_endpoint
 
 app = FastAPI()
 streamer = None
 
 
 @app.websocket("/stream")
+@websocket_endpoint
 async def stream(ws: WebSocket):
-    await ws.accept()
-    try:
-        while True:
-            global streamer
-            if streamer is None:
-                streamer = WhisperStreamer()
-            data = await ws.receive_bytes()
-            text = next(streamer.transcribe_chunks([data]))
-            await ws.send_json({"transcription": text})
-    except WebSocketDisconnect:
-        pass
-    finally:
-        if not ws.client_state.name == "CLOSED":
-            await ws.close()
+    global streamer
+    while True:
+        if streamer is None:
+            streamer = WhisperStreamer()
+        data = await ws.receive_bytes()
+        text = next(streamer.transcribe_chunks([data]))
+        await ws.send_json({"transcription": text})

--- a/shared/py/utils/__init__.py
+++ b/shared/py/utils/__init__.py
@@ -1,1 +1,5 @@
 """Shared utility functions used across Promethean services."""
+
+from .websocket import websocket_endpoint
+
+__all__ = ["websocket_endpoint"]

--- a/shared/py/utils/websocket.py
+++ b/shared/py/utils/websocket.py
@@ -1,0 +1,24 @@
+"""Utilities for consistent WebSocket handling across services."""
+
+from typing import Awaitable, Callable
+from functools import wraps
+from fastapi import WebSocket, WebSocketDisconnect
+
+WebSocketHandler = Callable[[WebSocket], Awaitable[None]]
+
+
+def websocket_endpoint(func: WebSocketHandler) -> WebSocketHandler:
+    """Wrap a WebSocket endpoint to handle accept, disconnect, and close."""
+
+    @wraps(func)
+    async def wrapper(ws: WebSocket, *args, **kwargs):
+        await ws.accept()
+        try:
+            return await func(ws, *args, **kwargs)
+        except WebSocketDisconnect:
+            pass
+        finally:
+            if not ws.client_state.name == "CLOSED":
+                await ws.close()
+
+    return wrapper


### PR DESCRIPTION
## Summary
- create `websocket_endpoint` decorator to manage WebSocket connect/close
- refactor STT, whisper-stream, and TTS services to use shared decorator

## Testing
- `make format`
- `make lint` *(fails: ESLint ignored pattern)*
- `make test` *(fails: error during shared-python tests)*
- `make build` *(fails: TypeScript build error)*
- `make install` *(fails: setup aborted)*

------
https://chatgpt.com/codex/tasks/task_e_688efe1249408324bbf0ef4714fbbda8