### PR TITLE
refactor tts service imports

### DIFF
--- a/services/py/tts/app.py
+++ b/services/py/tts/app.py
@@ -1,32 +1,18 @@
 from fastapi import FastAPI, Form, Response
-import torch
 import io
-
-from safetensors.torch import load_file
-
-import soundfile as sf
 import nltk
+import soundfile as sf
+import torch
+import numpy as np
+from transformers import FastSpeech2ConformerTokenizer, FastSpeech2ConformerWithHifiGan
 
 nltk.download("averaged_perceptron_tagger_eng")
 
-
-# from huggingface_hub import hf_hub_download
-# print(hf_hub_download(repo_id="facebook/fastspeech2-en-ljspeech", filename="vocab.txt", cache_dir=None, local_files_only=True))
-
 app = FastAPI()
 
-# Load the model and processor
-from transformers import (
-    FastSpeech2ConformerTokenizer,
-    FastSpeech2ConformerWithHifiGan,
-)
-import torch
-
-# Ensure GPU usage
-device = "cuda" if torch.cuda.is_available() else "cpu"
+device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 print("Running on device", device)
 
-# Load tokenizer and model
 tokenizer = FastSpeech2ConformerTokenizer.from_pretrained(
     "espnet/fastspeech2_conformer"
 )
@@ -35,21 +21,16 @@ model = FastSpeech2ConformerWithHifiGan.from_pretrained(
 ).to(device)
 
 
-# Generate waveform
-def synthesize(text: str):
+def synthesize(text: str) -> np.ndarray:
+    """Generate a waveform for the provided text."""
     input_ids = tokenizer(text, return_tensors="pt").input_ids.to(device)
     with torch.no_grad():
-        output = model(input_ids, return_dict=True)
-        return output.waveform.squeeze().cpu().numpy()
-
-
-
+        waveform = model(input_ids, return_dict=True).waveform
+    return waveform.squeeze().cpu().numpy()
 
 
 @app.post("/synth_voice_pcm")
 def synth_voice_pcm(input_text: str = Form(...)):
-
-    # Resample to 22050Hz mono using soundfile (which auto-downsamples)
     pcm_bytes_io = io.BytesIO()
     sf.write(
         pcm_bytes_io,
@@ -58,7 +39,6 @@ def synth_voice_pcm(input_text: str = Form(...)):
         format="RAW",
         subtype="PCM_16",
     )
-
     return Response(
         content=pcm_bytes_io.getvalue(), media_type="application/octet-stream"
     )


### PR DESCRIPTION
## Summary
- streamline imports in TTS service
- centralize model/device setup
- add helper for waveform synthesis

## Testing
- `make install` *(fails: interrupted during shared python dependency install)*
- `make format-python`
- `make lint` *(fails: eslint configuration issue)*
- `make test` *(fails: ModuleNotFoundError: scipy)*
- `make build` *(fails: TypeScript compilation errors)*

------
https://chatgpt.com/codex/tasks/task_e_688efdf7d56c8324ae995051e42ab4bb