### PR TITLE
fix ts workflow

### DIFF
--- a/.github/workflows/test-ts.yml
+++ b/.github/workflows/test-ts.yml
@@ -1,4 +1,3 @@
-
 name: TS Test Suite
 permissions:
   contents: read
@@ -36,18 +35,17 @@ jobs:
             ${{ runner.os }}-npm-
 
       - name: Install dependencies
-        run: make system-deps  setup-ts
+        run: make system-deps setup-ts
 
+      - name: Run tests
+        run: make test-ts
 
-        - name: Run tests
-          run: make test-ts
+      - name: Generate coverage report
+        run: make coverage-ts
 
-        - name: Generate coverage report
-          run: make coverage-ts
-
-        - name: Upload coverage to Codecov
-          uses: codecov/codecov-action@v3
-          with:
-            token: ${{ secrets.CODECOV_TOKEN }}
-            files: services/ts/**/coverage/lcov.info
-            flags: ts
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: services/ts/**/coverage/lcov.info
+          flags: ts


### PR DESCRIPTION
## Summary
- fix ts workflow actions indent so test and coverage steps run

## Testing
- `make install` *(fails: Interrupt)*
- `make test` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `make build` *(fails: Cannot find module 'child_process'...)*
- `make lint` *(fails: flake8 not found)*
- `make format` *(fails: Interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_688f152e23d0832494bf114027a013a4