### PR TITLE
Preserve task bodies when syncing kanban statuses

### DIFF
--- a/scripts/kanban_to_hashtags.py
+++ b/scripts/kanban_to_hashtags.py
@@ -38,24 +38,38 @@ def parse_board(path: Path = BOARD_PATH) -> dict[Path, str]:
     return mapping
 
 
-def _remove_status_tokens(line: str) -> str:
-    tokens = [tok for tok in line.split() if tok not in STATUS_SET]
-    return " ".join(tokens)
+def _remove_status_tokens(tokens: list[str]) -> list[str]:
+    """Return tokens with any status hashtags removed."""
+    return [tok for tok in tokens if tok not in STATUS_SET]
 
 
 def set_status(path: Path, status: str) -> None:
     """Update a task file with the given status hashtag."""
     if not path.exists():
         return
-    lines = [
-        _remove_status_tokens(line.rstrip())
-        for line in path.read_text(encoding="utf-8").splitlines()
-    ]
-    while lines and lines[-1] == "":
-        lines.pop()
-    lines.append(status)
-    lines.append("")
-    path.write_text("\n".join(lines), encoding="utf-8")
+
+    text = path.read_text(encoding="utf-8")
+    ends_with_newline = text.endswith("\n")
+    lines = text.splitlines()
+
+    status_idx: int | None = None
+    for i in range(len(lines) - 1, -1, -1):
+        tokens = lines[i].split()
+        if any(tok in STATUS_SET for tok in tokens):
+            status_idx = i
+            lines[i] = " ".join(_remove_status_tokens(tokens))
+            break
+
+    if status_idx is None:
+        lines.append(status)
+    else:
+        prefix = lines[status_idx].strip()
+        lines[status_idx] = f"{prefix} {status}".strip()
+
+    out = "\n".join(lines)
+    if ends_with_newline or status_idx is None:
+        out += "\n"
+    path.write_text(out, encoding="utf-8")
 
 
 def update_tasks(board: Path = BOARD_PATH) -> None:

--- a/tests/scripts/test_kanban_to_hashtags.py
+++ b/tests/scripts/test_kanban_to_hashtags.py
@@ -14,12 +14,14 @@ def test_parse_board(tmp_path):
     (tasks_dir / "a.md").write_text("content", encoding="utf-8")
     (tasks_dir / "b.md").write_text("content", encoding="utf-8")
     board.write_text(
-        "\n".join([
-            "## Todo",
-            "- [ ] [A](../tasks/a.md)",
-            "## In Progress",
-            "- [ ] [B](../tasks/b.md)",
-        ]),
+        "\n".join(
+            [
+                "## Todo",
+                "- [ ] [A](../tasks/a.md)",
+                "## In Progress",
+                "- [ ] [B](../tasks/b.md)",
+            ]
+        ),
         encoding="utf-8",
     )
     mapping = kh.parse_board(board)
@@ -32,7 +34,10 @@ def test_update_tasks(tmp_path):
     tasks_dir = tmp_path / "tasks"
     tasks_dir.mkdir()
     task = tasks_dir / "a.md"
-    task.write_text("initial", encoding="utf-8")
-    board.write_text("## Done\n- [ ] [A](tasks/a.md)", encoding="utf-8")
+    original = "First line with #todo inside\nSecond line\n#todo\n"
+    task.write_text(original, encoding="utf-8")
+    board.write_text("## Done\n- [ ] [A](tasks/a.md)\n", encoding="utf-8")
     kh.update_tasks(board)
-    assert task.read_text(encoding="utf-8").strip().splitlines()[-1] == "#done"
+    updated = task.read_text(encoding="utf-8")
+    assert updated.splitlines()[:-1] == original.splitlines()[:-1]
+    assert updated.splitlines()[-1] == "#done"


### PR DESCRIPTION
## Summary
- Avoid rewriting task body text when syncing kanban statuses; only status hashtags are touched
- Cover edge cases with a regression test to ensure body lines remain unchanged

## Testing
- `flake8 scripts/kanban_to_hashtags.py tests/scripts/test_kanban_to_hashtags.py`
- `pytest tests/scripts/test_kanban_to_hashtags.py`
- `make format` *(succeeded)*
- `make lint` *(failed: ESLint configuration ignored all files)*
- `make test` *(failed: pipenv not found / virtualenv setup issues)*
- `make install` *(aborted during environment setup)*
- `make build` *(failed: build-ts error)*

------
https://chatgpt.com/codex/tasks/task_e_688f1562b5fc8324a036b9e81b8362a1