### PR TITLE
fix(file-watcher): ensure ava runs compiled tests

### DIFF
--- a/services/ts/discord-embedder/ava.config.mjs
+++ b/services/ts/discord-embedder/ava.config.mjs
@@ -1,0 +1,3 @@
+export default {
+	files: ['dist/tests/**/*.js'],
+};

--- a/services/ts/discord-embedder/package.json
+++ b/services/ts/discord-embedder/package.json
@@ -4,9 +4,9 @@
 	"description": "A proof-of-concept basic bot using @discordjs/voice",
 	"main": "dist/index.js",
 	"type": "module",
-    "scripts": {
-        "build": "tsc && node scripts/patch-imports.js",
-		"test": "ava",
+	"scripts": {
+		"build": "tsc && node scripts/patch-imports.js",
+		"test": "npm run build && ava",
 		"coverage": "npm run build && c8 ava",
 		"build:check": "tsc --noEmit --incremental false",
 		"deploy": "npm run build && node --env-file=../../.env dist/util/deploy.js",
@@ -49,13 +49,5 @@
 		"ts-node": "^10.9.2",
 		"typescript": "5.7.3",
 		"c8": "^9.1.0"
-	},
-	"ava": {
-		"extensions": {
-			"ts": "module"
-		},
-		"files": [
-			"./dist/tests/**/*.js"
-		]
 	}
 }

--- a/services/ts/discord-embedder/tests/converter.ts
+++ b/services/ts/discord-embedder/tests/converter.ts
@@ -1,5 +1,5 @@
 import test from 'ava';
-import { convert } from '../src/converter.ts';
+import { convert } from '../src/converter.js';
 
 const sample = Buffer.from('sample');
 

--- a/services/ts/discord-embedder/tsconfig.json
+++ b/services/ts/discord-embedder/tsconfig.json
@@ -48,6 +48,6 @@
 		// Completeness
 		"skipLibCheck": true
 	},
-	"include": ["src/**/*.ts"],
+	"include": ["src/**/*.ts", "tests/**/*.ts"],
 	"exclude": ["node_modules"]
 }

--- a/services/ts/file-watcher/ava.config.mjs
+++ b/services/ts/file-watcher/ava.config.mjs
@@ -1,0 +1,3 @@
+export default {
+  files: ['dist/tests/**/*.js']
+};

--- a/services/ts/file-watcher/package.json
+++ b/services/ts/file-watcher/package.json
@@ -20,13 +20,5 @@
     "c8": "^9.1.0",
     "ts-node": "^10.9.2",
     "typescript": "5.7.3"
-  },
-  "ava": {
-    "extensions": {
-      "ts": "module"
-    },
-    "files": [
-      "dist/tests/**/*.ts"
-    ]
   }
 }


### PR DESCRIPTION
## Summary
- avoid running TypeScript declaration files by moving AVA config to dedicated file
- keep test scripts simple and rely on new config for compiled JS tests

## Testing
- `npm test`
- `npm run coverage`


------
https://chatgpt.com/codex/tasks/task_e_688f2a33e3188324b2d1b91c58d42595