### PR TITLE
Rename placeholder markdown files

### DIFF
--- a/Write meaningful tests for Cephalon.md
+++ b/Write meaningful tests for Cephalon.md
@@ -1,1 +1,0 @@
-#incoming

--- a/cephalon-tests-plan.md
+++ b/cephalon-tests-plan.md
@@ -1,0 +1,3 @@
+# Cephalon test plan
+
+#incoming

--- a/orphaned-files-report.md
+++ b/orphaned-files-report.md
@@ -1,3 +1,5 @@
+# Orphaned files report
+
 - [[services/py/stt/whisper-npu/models/whisper_medium/whisper_medium_decoder_static_kvcache_224_lm_QKs.bin]]
 - [[services/py/stt/whisper-npu/models/whisper_medium/whisper_medium_encoder.bin]]
 - [[services/py/stt/whisper-npu/models/whisper_medium/whisper_medium_encoder_decoder_cross_kv.bin]]

--- a/placeholder.md
+++ b/placeholder.md
@@ -1,0 +1,1 @@
+# Placeholder

--- a/rewrite vision end to end test in typescript.md
+++ b/rewrite vision end to end test in typescript.md
@@ -1,1 +1,0 @@
-#incoming

--- a/vision-e2e-test-rewrite.md
+++ b/vision-e2e-test-rewrite.md
@@ -1,0 +1,3 @@
+# Vision end-to-end tests in TypeScript
+
+#incoming


### PR DESCRIPTION
## Summary
- Rename empty and placeholder markdown documents to clearer names
- Add headings to placeholder markdown files for clarity

## Testing
- `make install` *(fails: Interrupt)*
- `make test` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `make build` *(fails: No rule to make target 'build-python')*
- `make lint` *(fails: line too long, too many blank lines, etc.)*
- `make format` *(fails: 2 files failed to reformat)*

------
https://chatgpt.com/codex/tasks/task_e_688f948dfbf08324840ec9d4db36ff0e