### PR TITLE
Optimize make install with quick setup fallback

### DIFF
--- a/Makefile.hy
+++ b/Makefile.hy
@@ -24,9 +24,12 @@
 
 ;; Python helpers --------------------------------------------------------------
 (defn setup-pipenv []
-  (sh ["python" "-m" "pip" "install" "--upgrade" "pip"])
-  (print "installing pipenv")
-  (sh ["python" "-m" "pip" "install" "pipenv"]))
+  (if (shutil.which "pipenv")
+      (print "pipenv already installed, skipping")
+      (do
+        (sh ["python" "-m" "pip" "install" "--upgrade" "pip"])
+        (print "installing pipenv")
+        (sh ["python" "-m" "pip" "install" "pipenv"]))))
 
 (defn setup-python-services []
   (print "Setting up Python services...")
@@ -274,7 +277,11 @@
     )
 
 (defn install []
-  (setup))
+  (try
+    (setup-quick)
+    (except [Exception]
+      (print "setup-quick failed; falling back to full setup")
+      (setup))))
 
 (defn system-deps []
   (sh "sudo apt-get update && sudo apt-get install -y libsndfile1" :shell True))

--- a/readme.md
+++ b/readme.md
@@ -93,6 +93,7 @@ all available settings.
 
 Common tasks are wrapped in the root `Makefile`:
 
+- `make install` – attempt a quick dependency install and fall back to full setup if needed
 - `make setup` – install dependencies across all services
 - `make build` – transpile Hy, Sibilant and TypeScript sources
 - `make start` – launch shared services defined in `ecosystem.config.js` via PM2


### PR DESCRIPTION
## Summary
- skip pipenv installation when already available
- attempt quick dependency install before full setup
- document install shortcut in README

## Testing
- `make install` *(fails: KeyboardInterrupt)*
- `make format`
- `make lint` *(fails: flake8 undefined name)*
- `make build` *(fails: TypeScript compile errors)*
- `make test` *(fails: ModuleNotFoundError: fastapi)*

------
https://chatgpt.com/codex/tasks/task_e_688fc90812848324b0f3c7d3ea258995