### PR TITLE
Fix discord indexer cursor update

### DIFF
--- a/services/py/discord_indexer/main.py
+++ b/services/py/discord_indexer/main.py
@@ -173,6 +173,7 @@ async def index_channel(channel: discord.TextChannel) -> None:
     for message in messages:
         await asyncio.sleep(0.1)
         index_message(message)
+        newest_message = message
     update_cursor(newest_message) if newest_message is not None else None
     return print(f"Newest message: {newest_message}")
 


### PR DESCRIPTION
## Summary
- track the last indexed message and update channel cursor in the Discord indexer

## Testing
- `pipenv run pytest tests/test_discord_indexer.py -q`
- `make format` *(fails: npm warn Unknown env config "http-proxy". This will stop working in the next major version of npm.)*
- `make lint` *(fails: ESLint: 9.32.0 -- you are linting ".", but all of the files matching the glob pattern "." are ignored.)*
- `make build` *(fails: Command 'npm run build' returned non-zero exit status 2.)*
- `make install` *(fails: Command 'npm install' returned non-zero exit status 1.)*
- `make test` *(fails: ModuleNotFoundError: No module named 'hy')*

------
https://chatgpt.com/codex/tasks/task_e_68901157c1048324bfae250f58b2d963