### PR TITLE
fix desktop capture test

### DIFF
--- a/services/ts/cephalon/tests/desktop_channel.test.ts
+++ b/services/ts/cephalon/tests/desktop_channel.test.ts
@@ -4,24 +4,24 @@ import { DesktopCaptureManager } from '../src/desktop/desktopLoop.js';
 // Ensure desktop captures are sent to configured channel
 
 test('uploads desktop captures to configured channel', async (t) => {
-        let sent: any = null;
-        const manager = new DesktopCaptureManager({
-                captureScreen: async () => Buffer.from('screen'),
-                captureAndRenderWaveform: async () => ({
-                        waveForm: Buffer.from('wave'),
-                        spectrogram: Buffer.from('spec'),
-                }),
-        } as any);
-        manager.setChannel({
-                send: async (data: any) => {
-                        sent = data;
-                },
-        } as any);
-        manager.step = 0;
-        const run = manager.start();
-        await new Promise((res) => setTimeout(res, 10));
-        manager.stop();
-        await run;
-        t.truthy(sent);
-        t.is(sent.files.length, 3);
+	let sent: any = null;
+	const manager = new DesktopCaptureManager({
+		captureScreen: async () => Buffer.from('screen'),
+		captureAndRenderWaveform: async () => ({
+			waveForm: Buffer.from('wave'),
+			spectrogram: Buffer.from('spec'),
+		}),
+	} as any);
+	manager.setChannel({
+		send: async (data: any) => {
+			sent = data;
+		},
+	} as any);
+	manager.step = 0;
+	const run = manager.start();
+	await new Promise((res) => setTimeout(res, 10));
+	manager.stop();
+	await run;
+	t.truthy(sent);
+	t.is(sent.files.length, 4);
 });


### PR DESCRIPTION
## Summary
- adjust desktop capture test to match implementation's four uploaded files

## Testing
- `npm install` *(fails: downloading onnxruntime due to network/CUDA errors)*
- `npm run lint` *(fails: Prettier reports formatting issues)*
- `npm run format` *(fails: ESLint warns files ignored)*
- `npm run build` *(fails: missing module and type definitions)*
- `npm test` *(fails: missing type definitions and modules)*
- `make test` *(fails: pipenv pytest command returns non-zero exit status)*
- `make lint` *(fails: ESLint ignored files)*
- `make build` *(fails: npm run build exit status 2)*
- `make format`
- `make install` *(interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_689017306a8c8324a8bbcf14871f1472