### PR TITLE
feat: add heartbeat client to services

### DIFF
--- a/services/py/discord_attachment_indexer/main.py
+++ b/services/py/discord_attachment_indexer/main.py
@@ -13,12 +13,21 @@ import discord
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../"))
 from shared.py import settings
 from shared.py.mongodb import discord_message_collection, discord_channel_collection
+from shared.py.heartbeat_client import HeartbeatClient
 
 AGENT_NAME = os.environ.get("AGENT_NAME", "duck")
 print(f"Discord attachment indexer running for {AGENT_NAME}")
 intents = discord.Intents.default()
 client = discord.Client(intents=intents)
 intents.message_content = True
+
+hb = HeartbeatClient()
+try:
+    hb.send_once()
+except Exception as exc:
+    print(f"failed to register heartbeat: {exc}")
+    sys.exit(1)
+hb.start()
 
 
 def format_attachment(attachment: discord.Attachment) -> dict:

--- a/services/py/discord_attachment_indexer/tests/test_discord_attachment_indexer.py
+++ b/services/py/discord_attachment_indexer/tests/test_discord_attachment_indexer.py
@@ -106,6 +106,20 @@ def setup_env(monkeypatch):
     monkeypatch.setenv("DISCORD_CLIENT_USER_NAME", "client")
     monkeypatch.setattr(discord.Client, "run", lambda self, token: None)
 
+    class DummyHB:
+        def send_once(self):
+            pass
+
+        def start(self):
+            pass
+
+        def stop(self):
+            pass
+
+    monkeypatch.setattr(
+        "shared.py.heartbeat_client.HeartbeatClient", lambda *a, **k: DummyHB()
+    )
+
 
 def load_indexer(monkeypatch):
     mod = importlib.import_module("main")

--- a/services/ts/cephalon/src/index.ts
+++ b/services/ts/cephalon/src/index.ts
@@ -1,14 +1,26 @@
 import 'source-map-support/register.js';
-
-console.log('Stuff and things...');
 import { Bot } from './bot';
 import { AGENT_NAME } from '../../../../shared/js/env.js';
+import { HeartbeatClient } from '../../../../shared/js/heartbeat/index.js';
 
-console.log('Starting', AGENT_NAME, 'Cephalon');
+async function main() {
+	console.log('Starting', AGENT_NAME, 'Cephalon');
+	const hb = new HeartbeatClient();
+	try {
+		await hb.sendOnce();
+	} catch (err) {
+		console.error('failed to register heartbeat', err);
+		process.exit(1);
+	}
+	hb.start();
+	const bot = new Bot({
+		token: process.env.DISCORD_TOKEN as string,
+		applicationId: process.env.DISCORD_CLIENT_USER_ID as string,
+	});
+	bot.start();
+	console.log(`Cephalon started for ${AGENT_NAME}`);
+}
 
-const bot = new Bot({
-	token: process.env.DISCORD_TOKEN as string,
-	applicationId: process.env.DISCORD_CLIENT_USER_ID as string,
-});
-bot.start();
-console.log(`Cephalon started for ${AGENT_NAME}`);
+if (process.env.NODE_ENV !== 'test') {
+	main();
+}

--- a/services/ts/discord-embedder/src/index.ts
+++ b/services/ts/discord-embedder/src/index.ts
@@ -2,6 +2,7 @@ import { ChromaClient } from 'chromadb';
 import { SimpleEmbeddingFunction } from './embedding';
 import { MongoClient, ObjectId, Collection } from 'mongodb';
 import { AGENT_NAME } from '../../../../shared/js/env.js';
+import { HeartbeatClient } from '../../../../shared/js/heartbeat/index.js';
 
 const chromaClient = new ChromaClient();
 
@@ -35,6 +36,14 @@ type DiscordMessage = {
 const MONGO_CONNECTION_STRING = process.env.MONGODB_URI || `mongodb://localhost`;
 
 (async () => {
+	const hb = new HeartbeatClient();
+	try {
+		await hb.sendOnce();
+	} catch (err) {
+		console.error('failed to register heartbeat', err);
+		process.exit(1);
+	}
+	hb.start();
 	const mongoClient = new MongoClient(MONGO_CONNECTION_STRING);
 	try {
 		await mongoClient.connect();

--- a/services/ts/file-watcher/src/index.ts
+++ b/services/ts/file-watcher/src/index.ts
@@ -2,6 +2,7 @@ import { spawn } from "child_process";
 import chokidar from "chokidar";
 import { join } from "path";
 import { writeFile as fsWriteFile } from "fs/promises";
+import { HeartbeatClient } from "../../../../shared/js/heartbeat/index.js";
 
 /**
  * Options for {@link startFileWatcher} allowing injection of dependencies for testing.
@@ -119,6 +120,15 @@ export function startFileWatcher(options: FileWatcherOptions = {}): {
 }
 
 if (process.env.NODE_ENV !== "test") {
-  startFileWatcher();
-  console.log("File watcher running...");
+  const hb = new HeartbeatClient();
+  hb.sendOnce()
+    .then(() => {
+      hb.start();
+      startFileWatcher();
+      console.log("File watcher running...");
+    })
+    .catch((err) => {
+      console.error("failed to register heartbeat", err);
+      process.exit(1);
+    });
 }

--- a/services/ts/llm/src/index.js
+++ b/services/ts/llm/src/index.js
@@ -1,5 +1,6 @@
 import express from "express";
 import ollama from "ollama";
+import { HeartbeatClient } from "../../../../shared/js/heartbeat/index.js";
 
 export const MODEL = process.env.LLM_MODEL || "gemma3:latest";
 
@@ -48,12 +49,18 @@ app.post("/generate", async (req, res) => {
 
 export const port = process.env.LLM_PORT || 5003;
 
-export function start(listenPort = port) {
+export async function start(listenPort = port) {
+  const hb = new HeartbeatClient();
+  await hb.sendOnce();
+  hb.start();
   return app.listen(listenPort, () => {
     console.log(`LLM service listening on ${listenPort}`);
   });
 }
 
 if (process.env.NODE_ENV !== "test") {
-  start();
+  start().catch((err) => {
+    console.error("Failed to start LLM service", err);
+    process.exit(1);
+  });
 }

--- a/services/ts/voice/dist/index.js
+++ b/services/ts/voice/dist/index.js
@@ -1,6 +1,7 @@
 import express from "express";
 import { Client, GatewayIntentBits } from "discord.js";
 import { VoiceSession } from "./voice-session.js";
+import { HeartbeatClient } from "../../../../shared/js/heartbeat/index.js";
 export function createVoiceService(token = process.env.DISCORD_TOKEN || "") {
   if (!token) {
     throw new Error("DISCORD_TOKEN env required");
@@ -93,6 +94,9 @@ export function createVoiceService(token = process.env.DISCORD_TOKEN || "") {
     }
   });
   async function start(port = parseInt(process.env.PORT || "4000")) {
+    const hb = new HeartbeatClient();
+    await hb.sendOnce();
+    hb.start();
     await client.login(token);
     return new Promise((resolve) => {
       const server = app.listen(port, () => {
@@ -103,5 +107,12 @@ export function createVoiceService(token = process.env.DISCORD_TOKEN || "") {
   }
   return { app, client, start, getSession: () => session };
 }
-createVoiceService().start();
+if (process.env.NODE_ENV !== "test") {
+  createVoiceService()
+    .start()
+    .catch((err) => {
+      console.error("Failed to start voice service", err);
+      process.exit(1);
+    });
+}
 //# sourceMappingURL=index.js.map


### PR DESCRIPTION
## Summary
- ensure Discord attachment indexer registers and starts a heartbeat before processing
- require heartbeat initialization for TypeScript services before starting
- update compiled voice service bundle with heartbeat support

## Testing
- `python -m pytest services/py/discord_attachment_indexer/tests/test_discord_attachment_indexer.py -q`
- `make test` *(fails: httpx package missing)*
- `make build` *(fails: npm run build returned non-zero exit status 2)*
- `make lint` *(fails: flake8 returned non-zero exit status 1)*
- `make format`
- `npm test` (services/ts/llm) *(fails: Cannot find package 'ava')*


------
https://chatgpt.com/codex/tasks/task_e_689018d34be883249204ca9f83f81725