### PR TITLE
Fix discord indexer cursor update

### DIFF
--- a/services/py/discord_indexer/main.py
+++ b/services/py/discord_indexer/main.py
@@ -173,6 +173,7 @@ async def index_channel(channel: discord.TextChannel) -> None:
     for message in messages:
         await asyncio.sleep(0.1)
         index_message(message)
+        newest_message = message
     update_cursor(newest_message) if newest_message is not None else None
     return print(f"Newest message: {newest_message}")
 

--- a/services/py/stt_ws/app.py
+++ b/services/py/stt_ws/app.py
@@ -1,4 +1,3 @@
-import hy
 import base64
 import json
 from fastapi import FastAPI, WebSocket, WebSocketDisconnect
@@ -26,7 +25,6 @@ def shutdown_event():
 @app.websocket("/transcribe")
 @websocket_endpoint
 async def transcribe_ws(ws: WebSocket):
-    await ws.accept()
     try:
         msg = await ws.receive_text()
         payload = json.loads(msg)
@@ -34,17 +32,11 @@ async def transcribe_ws(ws: WebSocket):
         if pcm_b64 is None:
             await ws.close(code=1003)
             return
-            _hy_anon_var_1 = None
-        else:
-            _hy_anon_var_1 = None
         sample_rate = int(payload.get("sample_rate", 16000))
         pcm_bytes = base64.b64decode(pcm_b64)
         from shared.py.speech.wisper_stt import transcribe_pcm
 
         text = transcribe_pcm(bytearray(pcm_bytes), sample_rate)
-        _hy_anon_var_2 = await ws.send_json({"transcription": text})
+        await ws.send_json({"transcription": text})
     except WebSocketDisconnect:
-        _hy_anon_var_2 = None
-    finally:
-        await ws.close() if not ws.client_state.name == "CLOSED" else None
-    return _hy_anon_var_2
+        pass


### PR DESCRIPTION
## Summary
- track the last indexed message and update channel cursor in the Discord indexer
- remove redundant WebSocket accept and close in STT service

## Testing
- `pipenv run pytest services/py/stt_ws/tests/test_stt_ws.py -q`
- `pipenv run pytest services/py/discord_indexer/tests/test_discord_indexer.py -q`
- `make format` *(warns: Unknown env config "http-proxy")*
- `make lint` *(fails: ESLint: 9.32.0 -- all files matching pattern "." are ignored)*
- `make build` *(fails: Command 'npm run build' returned non-zero exit status 2)*
- `make install` *(fails: npm error onnxruntime-node: connect ENETUNREACH)*
- `make test` *(fails: Command '...pipenv run pytest tests/' returned non-zero exit status 1)*

------
https://chatgpt.com/codex/tasks/task_e_68901157c1048324bfae250f58b2d963