### PR TITLE
ci: run service tests per service

### DIFF
--- a/.github/workflows/test-js.yml
+++ b/.github/workflows/test-js.yml
@@ -10,13 +10,19 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        service:
+          - vision
+          - heartbeat
 
     steps:
       - uses: actions/checkout@v3
 
       - uses: actions/setup-node@v3
         with:
-          node-version: '20'
+          node-version: "20"
 
       - uses: actions/setup-python@v4
         with:
@@ -37,23 +43,22 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ~/.npm
-          key: ${{ runner.os }}-npm-${{ hashFiles('package-lock.json') }}
+          key: ${{ runner.os }}-npm-${{ hashFiles('services/js/' + matrix.service + '/package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-npm-
 
       - name: Install dependencies
-        run: make system-deps  setup-js
+        run: make system-deps setup-js-service-${{ matrix.service }}
 
       - name: Run tests
-        run: make test-js
+        run: make test-js-service-${{ matrix.service }}
 
       - name: Generate coverage report
-        run: make coverage-js
+        run: make coverage-js-service-${{ matrix.service }}
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          files: services/js/**/coverage/lcov.info
-          flags: js
-
+          files: services/js/${{ matrix.service }}/coverage/lcov.info
+          flags: js-${{ matrix.service }}

--- a/.github/workflows/test-py.yml
+++ b/.github/workflows/test-py.yml
@@ -10,6 +10,17 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        service:
+          - stt
+          - tts
+          - discord_indexer
+          - discord_attachment_indexer
+          - discord_attachment_embedder
+          - stt_ws
+          - whisper_stream_ws
 
     steps:
       - uses: actions/checkout@v3
@@ -25,7 +36,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('Pipfile.lock') }}
+          key: ${{ runner.os }}-pip-${{ hashFiles('services/py/' + matrix.service + '/Pipfile.lock') }}
           restore-keys: |
             ${{ runner.os }}-pip-
 
@@ -38,20 +49,19 @@ jobs:
             ${{ runner.os }}-npm-
 
       - name: Install dependencies
-        run: make system-deps  setup-python
-
+        run: make system-deps setup-python-service-${{ matrix.service }}
 
       - name: Run tests
-        run: make test-python
+        run: make test-python-service-${{ matrix.service }}
 
       - name: Generate coverage
-        run: make coverage-python
+        run: make coverage-python-service-${{ matrix.service }}
 
       - name: Upload Python coverage
         uses: actions/upload-artifact@v4
         with:
-          name: python-coverage
-          path: coverage.xml
+          name: python-coverage-${{ matrix.service }}
+          path: services/py/${{ matrix.service }}/coverage.xml
 
       # - name: Upload JS coverage
       #   uses: actions/upload-artifact@v4

--- a/.github/workflows/test-ts.yml
+++ b/.github/workflows/test-ts.yml
@@ -10,13 +10,22 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        service:
+          - cephalon
+          - discord-embedder
+          - llm
+          - voice
+          - file-watcher
 
     steps:
       - uses: actions/checkout@v3
 
       - uses: actions/setup-node@v3
         with:
-          node-version: '20'
+          node-version: "20"
 
       - uses: actions/setup-python@v4
         with:
@@ -37,22 +46,22 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ~/.npm
-          key: ${{ runner.os }}-npm-${{ hashFiles('package-lock.json') }}
+          key: ${{ runner.os }}-npm-${{ hashFiles('services/ts/' + matrix.service + '/package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-npm-
 
       - name: Install dependencies
-        run: make system-deps setup-ts
+        run: make system-deps setup-ts-service-${{ matrix.service }}
 
       - name: Run tests
-        run: make test-ts
+        run: make test-ts-service-${{ matrix.service }}
 
       - name: Generate coverage report
-        run: make coverage-ts
+        run: make coverage-ts-service-${{ matrix.service }}
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          files: services/ts/**/coverage/lcov.info
-          flags: ts
+          files: services/ts/${{ matrix.service }}/coverage/lcov.info
+          flags: ts-${{ matrix.service }}

--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,16 @@ COMMANDS := all build clean lint format test setup setup-quick install system-de
         generate-requirements setup-python-quick test-python test-js test-ts docker-build docker-up docker-down \
         setup-hy setup-python setup-js setup-ts typecheck-python typecheck-ts build-ts build-js setup-pipenv
 
-.PHONY: $(COMMANDS) generate-requirements-service-% setup-hy-service-%
+.PHONY: $(COMMANDS) generate-requirements-service-% setup-hy-service-% \
+        setup-python-service-% test-python-service-% coverage-python-service-% \
+        setup-js-service-%    test-js-service-%    coverage-js-service-% \
+        setup-ts-service-%    test-ts-service-%    coverage-ts-service-%
 
 $(COMMANDS):
 	@hy Makefile.hy $@
 
-generate-requirements-service-% setup-hy-service-%:
+generate-requirements-service-% setup-hy-service-% \
+setup-python-service-% test-python-service-% coverage-python-service-% \
+setup-js-service-%    test-js-service-%    coverage-js-service-% \
+setup-ts-service-%    test-ts-service-%    coverage-ts-service-%:
 	@hy Makefile.hy $@

--- a/Makefile.hy
+++ b/Makefile.hy
@@ -4,7 +4,7 @@
 (import sys)
 
 (setv SERVICES_PY ["services/py/stt" "services/py/tts" "services/py/discord_indexer" "services/py/discord_attachment_indexer" "services/py/discord_attachment_embedder" "services/py/stt_ws" "services/py/whisper_stream_ws"])
-(setv SERVICES_JS ["services/js/vision"])
+(setv SERVICES_JS ["services/js/vision" "services/js/heartbeat"])
 (setv SERVICES_TS ["services/ts/cephalon" "services/ts/discord-embedder" "services/ts/llm" "services/ts/voice" "services/ts/file-watcher"])
 
 (defn sh [cmd [cwd None] [shell False]]
@@ -151,6 +151,10 @@
 (defn test-js []
   (test-js-services))
 
+(defn coverage-js-service [service]
+  (print (.format "Running coverage for JS service: {}" service))
+  (sh "npm run coverage && npx c8 report -r lcov" :cwd (join "services/js" service) :shell True))
+
 (defn coverage-js-services []
   (run-dirs SERVICES_JS "npm run coverage && npx c8 report -r lcov" :shell True))
 
@@ -194,6 +198,10 @@
 
 (defn test-ts []
   (test-ts-services))
+
+(defn coverage-ts-service [service]
+  (print (.format "Running coverage for TS service: {}" service))
+  (sh "npm run coverage && npx c8 report -r lcov" :cwd (join "services/ts" service) :shell True))
 
 (defn coverage-ts-services []
   (run-dirs SERVICES_TS "npm run coverage && npx c8 report -r lcov" :shell True))
@@ -392,9 +400,11 @@
   ["setup-js-service-" setup-js-service]
   ["lint-js-service-" lint-js-service]
   ["test-js-service-" test-js-service]
+  ["coverage-js-service-" coverage-js-service]
   ["setup-ts-service-" setup-ts-service]
   ["lint-ts-service-" lint-ts-service]
   ["test-ts-service-" test-ts-service]
+  ["coverage-ts-service-" coverage-ts-service]
   ["setup-hy-service-" setup-hy-service]
   ["setup-sibilant-service-" setup-sibilant-service]
   ["start-" start-service]


### PR DESCRIPTION
## Summary
- run Python, JS, and TS service tests independently in GitHub Actions
- expose service-level setup, test, and coverage make targets
- add coverage helpers for JS and TS services

## Testing
- `make test-python-service-stt` *(fails: Command 'python -m pipenv run pytest tests/' returned non-zero exit status 1)*
- `make test-js-service-vision` *(fails: Command 'npm test' returned non-zero exit status 1)*
- `make test-ts-service-cephalon` *(fails: Command 'npm test' returned non-zero exit status 2)*
- `make lint` *(fails: Command 'npx eslint . --no-warn-ignored --ext .js,.ts' returned non-zero exit status 2)*

------
https://chatgpt.com/codex/tasks/task_e_689028318ec0832486883d8cc5d7100c