### PR TITLE
feat: install from GitHub Actions artifacts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-COMMANDS := all build clean lint format test setup setup-quick install system-deps start stop start-tts start-stt stop-tts stop-stt \
+COMMANDS := all build clean lint format test setup setup-quick install install-gha-artifacts system-deps start stop start-tts start-stt stop-tts stop-stt \
         board-sync kanban-from-tasks kanban-to-hashtags kanban-to-issues coverage coverage-python coverage-js coverage-ts simulate-ci \
         generate-requirements setup-python-quick test-python test-js test-ts docker-build docker-up docker-down \
         setup-hy setup-python setup-js setup-ts typecheck-python typecheck-ts build-ts build-js setup-pipenv

--- a/Makefile.hy
+++ b/Makefile.hy
@@ -1,5 +1,6 @@
 (import subprocess)
 (import shutil)
+(import glob)
 (import os.path [isdir join])
 (import sys)
 
@@ -286,6 +287,15 @@
       (print "setup-quick failed; falling back to full setup")
       (setup))))
 
+(defn install-gha-artifacts []
+  "Download and install build artifacts from the latest GitHub Actions run."
+  (let [artifact-dir "gh-actions-artifacts"]
+    (print "Downloading GitHub Actions artifacts...")
+    (sh (.format "gh run download -R riatzukiza/promethean -n dist -D {}" artifact-dir) :shell True)
+    (for [wheel (glob.glob (join artifact-dir "*.whl"))]
+      (sh ["pip" "install" wheel]))
+    (print "GitHub Actions artifact installation complete")))
+
 (defn system-deps []
   (sh "sudo apt-get update && sudo apt-get install -y libsndfile1" :shell True))
 
@@ -345,6 +355,7 @@
        "setup" setup
        "setup-quick" setup-quick
        "install" install
+       "install-gha-artifacts" install-gha-artifacts
        "system-deps" system-deps
        "start" start
        "stop" stop


### PR DESCRIPTION
## Summary
- add `install-gha-artifacts` command to fetch and install artifacts from GitHub Actions runs
- expose new command via Makefile

## Testing
- `make install` *(fails: npm install error)*
- `make test` *(fails: pytest failure)*
- `make build` *(fails: npm build error)*
- `make lint` *(fails: ESLint error)*
- `make format`

------
https://chatgpt.com/codex/tasks/task_e_68902886fe648324ba9b2b311461ee19