### PR TITLE
feat: enforce heartbeat instance limits

### DIFF
--- a/services/js/heartbeat/README.md
+++ b/services/js/heartbeat/README.md
@@ -2,11 +2,13 @@
 
 Tracks process heartbeats via HTTP and terminates those that fail to report within a timeout.
 Backed by MongoDB for storage. Intended for detecting and cleaning up hung or orphaned worker processes.
+Also enforces the instance limits defined in a PM2 ecosystem file, rejecting registrations that exceed the configured count for a given app name.
 
 ## API
 
-- `POST /heartbeat` `{ pid: number }`
-  - Records a heartbeat for the given PID.
+- `POST /heartbeat` `{ pid: number, name: string }`
+  - Records a heartbeat for the given PID and PM2 app name.
+  - Returns `409` if the number of live instances for that name exceeds the limit in the ecosystem config.
 
 ## Environment
 
@@ -14,6 +16,7 @@ Backed by MongoDB for storage. Intended for detecting and cleaning up hung or or
 - `DB_NAME` (default `heartbeat_db`)
 - `HEARTBEAT_TIMEOUT` milliseconds before a process is considered stale (default `10000`)
 - `CHECK_INTERVAL` monitor interval in milliseconds (default `5000`)
+- `ECOSYSTEM_CONFIG` path to a PM2 ecosystem config file; defaults to `../../../ecosystem.config.js`
 
 ## Development
 

--- a/services/js/heartbeat/index.js
+++ b/services/js/heartbeat/index.js
@@ -1,5 +1,7 @@
 import express from "express";
 import { MongoClient } from "mongodb";
+import { createRequire } from "module";
+import path from "path";
 
 export const app = express();
 app.use(express.json());
@@ -14,18 +16,54 @@ let client;
 let collection;
 let interval;
 let server;
+let allowedInstances = {};
+
+function loadConfig() {
+  try {
+    const require = createRequire(import.meta.url);
+    const configPath =
+      process.env.ECOSYSTEM_CONFIG ||
+      path.resolve(process.cwd(), "../../../ecosystem.config.js");
+    const ecosystem = require(configPath);
+    allowedInstances = {};
+    for (const app of ecosystem.apps || []) {
+      if (app?.name) {
+        allowedInstances[app.name] = app.instances || 1;
+      }
+    }
+  } catch (err) {
+    console.warn("failed to load ecosystem config", err);
+    allowedInstances = {};
+  }
+}
 
 app.post("/heartbeat", async (req, res) => {
   const pid = parseInt(req.body?.pid, 10);
-  if (!pid) {
-    return res.status(400).json({ error: "pid required" });
+  const name = req.body?.name;
+  if (!pid || !name) {
+    return res.status(400).json({ error: "pid and name required" });
+  }
+  const now = Date.now();
+  const existing = await collection.findOne({ pid });
+  if (!existing) {
+    const allowed = allowedInstances[name] ?? Infinity;
+    const count = await collection.countDocuments({
+      name,
+      last: { $gte: now - HEARTBEAT_TIMEOUT },
+      killedAt: { $exists: false },
+    });
+    if (count >= allowed) {
+      return res
+        .status(409)
+        .json({ error: `instance limit exceeded for ${name}` });
+    }
   }
   await collection.updateOne(
     { pid },
-    { $set: { last: Date.now() } },
+    { $set: { last: now, name }, $unset: { killedAt: "" } },
     { upsert: true },
   );
-  res.json({ status: "ok", pid });
+  res.json({ status: "ok", pid, name });
 });
 
 export async function monitor(now = Date.now()) {
@@ -49,6 +87,8 @@ export async function start(port = process.env.PORT || 5000) {
   MONGO_URL = process.env.MONGO_URL || MONGO_URL;
   DB_NAME = process.env.DB_NAME || DB_NAME;
   COLLECTION = process.env.COLLECTION || COLLECTION;
+
+  loadConfig();
 
   client = new MongoClient(MONGO_URL);
   await client.connect();

--- a/services/js/heartbeat/tests/client.test.js
+++ b/services/js/heartbeat/tests/client.test.js
@@ -1,5 +1,7 @@
 import test from "ava";
 import { MongoMemoryServer } from "mongodb-memory-server";
+import path from "path";
+import { fileURLToPath } from "url";
 import { start, stop } from "../index.js";
 import { HeartbeatClient } from "../../../../shared/js/heartbeat/index.js";
 
@@ -7,6 +9,11 @@ let server;
 let mongo;
 
 test.before(async () => {
+  const __dirname = path.dirname(fileURLToPath(import.meta.url));
+  process.env.ECOSYSTEM_CONFIG = path.resolve(
+    __dirname,
+    "test-ecosystem.config.cjs",
+  );
   mongo = await MongoMemoryServer.create();
   process.env.MONGO_URL = mongo.getUri();
   process.env.HEARTBEAT_TIMEOUT = "1000";
@@ -21,7 +28,8 @@ test.after.always(async () => {
 
 test("heartbeat client posts pid", async (t) => {
   const url = `http://127.0.0.1:${server.address().port}/heartbeat`;
-  const client = new HeartbeatClient({ url, pid: 999 });
+  const client = new HeartbeatClient({ url, pid: 999, name: "test-app" });
   const res = await client.sendOnce();
   t.is(res.pid, 999);
+  t.is(res.name, "test-app");
 });

--- a/services/js/heartbeat/tests/heartbeat.test.js
+++ b/services/js/heartbeat/tests/heartbeat.test.js
@@ -2,12 +2,19 @@ import test from "ava";
 import request from "supertest";
 import { MongoMemoryServer } from "mongodb-memory-server";
 import { spawn } from "child_process";
+import path from "path";
+import { fileURLToPath } from "url";
 import { start, stop } from "../index.js";
 
 let server;
 let mongo;
 
 test.before(async () => {
+  const __dirname = path.dirname(fileURLToPath(import.meta.url));
+  process.env.ECOSYSTEM_CONFIG = path.resolve(
+    __dirname,
+    "test-ecosystem.config.cjs",
+  );
   mongo = await MongoMemoryServer.create();
   process.env.MONGO_URL = mongo.getUri();
   process.env.HEARTBEAT_TIMEOUT = "100";
@@ -20,7 +27,7 @@ test.after.always(async () => {
   if (mongo) await mongo.stop();
 });
 
-test("stale process is killed", async (t) => {
+test.serial("stale process is killed", async (t) => {
   const child = spawn("node", ["-e", "setInterval(()=>{},1000)"]);
   t.teardown(() => {
     if (!child.killed) {
@@ -29,7 +36,9 @@ test("stale process is killed", async (t) => {
       } catch {}
     }
   });
-  await request(server).post("/heartbeat").send({ pid: child.pid });
+  await request(server)
+    .post("/heartbeat")
+    .send({ pid: child.pid, name: "test-app" });
   const exit = await new Promise((resolve, reject) => {
     const timer = setTimeout(() => reject(new Error("not killed")), 2000);
     child.on("exit", (code, signal) => {
@@ -38,4 +47,26 @@ test("stale process is killed", async (t) => {
     });
   });
   t.is(exit.signal, "SIGKILL");
+});
+
+test.serial("rejects excess instances", async (t) => {
+  const child1 = spawn("node", ["-e", "setInterval(()=>{},1000)"]);
+  const child2 = spawn("node", ["-e", "setInterval(()=>{},1000)"]);
+  t.teardown(() => {
+    for (const child of [child1, child2]) {
+      if (!child.killed) {
+        try {
+          child.kill();
+        } catch {}
+      }
+    }
+  });
+  await request(server)
+    .post("/heartbeat")
+    .send({ pid: child1.pid, name: "test-app" })
+    .expect(200);
+  const res = await request(server)
+    .post("/heartbeat")
+    .send({ pid: child2.pid, name: "test-app" });
+  t.is(res.status, 409);
 });

--- a/services/js/heartbeat/tests/test-ecosystem.config.cjs
+++ b/services/js/heartbeat/tests/test-ecosystem.config.cjs
@@ -1,0 +1,3 @@
+module.exports = {
+  apps: [{ name: "test-app", instances: 1 }],
+};

--- a/services/js/vision/index.js
+++ b/services/js/vision/index.js
@@ -13,7 +13,7 @@ export function setCaptureFn(fn) {
 }
 
 export async function start(port = process.env.PORT || 5003) {
-  const hb = new HeartbeatClient();
+  const hb = new HeartbeatClient({ name: process.env.name || "vision" });
   await hb.sendOnce();
   hb.start();
   return app.listen(port, () => {

--- a/shared/js/heartbeat/index.js
+++ b/shared/js/heartbeat/index.js
@@ -10,19 +10,24 @@ export class HeartbeatClient {
   constructor({
     url = `http://127.0.0.1:${HEARTBEAT_PORT}/heartbeat`,
     pid = process.pid,
+    name = process.env.name,
     interval = 3000,
   } = {}) {
     this.url = url;
     this.pid = pid;
+    this.name = name;
     this.interval = interval;
     this._timer = null;
+    if (!this.name) {
+      throw new Error("name required for HeartbeatClient");
+    }
   }
 
   async sendOnce() {
     const res = await fetch(this.url, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ pid: this.pid }),
+      body: JSON.stringify({ pid: this.pid, name: this.name }),
     });
     if (!res.ok) {
       throw new Error(`heartbeat failed with status ${res.status}`);


### PR DESCRIPTION
## Summary
- enforce per-app instance limits in heartbeat service via pm2 ecosystem config
- send pm2 name from heartbeat client; vision service passes its name
- add tests for duplicate registrations and update docs

## Testing
- `npm test` (in services/js/heartbeat)
- `make install` *(fails: Error: connect ENETUNREACH 140.82.113.3:443)*
- `make lint` *(fails: ESLint no files to lint / exit 2)*
- `make build` *(fails: npm run build returned non-zero exit status 2)*
- `make test` *(fails: pipenv run pytest returned non-zero exit status 1)*


------
https://chatgpt.com/codex/tasks/task_e_6890293176e883248d0db245f254e74d