### PR TITLE
Add import path setup for discord attachment indexer tests

### DIFF
--- a/services/py/discord_attachment_indexer/tests/test_discord_attachment_indexer.py
+++ b/services/py/discord_attachment_indexer/tests/test_discord_attachment_indexer.py
@@ -1,11 +1,17 @@
 import os
 import sys
+from pathlib import Path
 import importlib
 
 
 import pytest
 import asyncio
 import discord
+
+
+# Ensure service and repository roots are on the import path
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+sys.path.insert(0, str(Path(__file__).resolve().parents[4]))
 
 
 class MemoryCollection:


### PR DESCRIPTION
## Summary
- ensure discord_attachment_indexer tests can locate shared modules by inserting repo root into `sys.path`

## Testing
- `pipenv install --dev`
- `pipenv run pytest tests/`
- `make format`
- `make lint` *(fails: ESLint configuration - files ignored)*
- `make build` *(fails: `npm run build` exit status 2)*

------
https://chatgpt.com/codex/tasks/task_e_689162f2e2648324bc3b9f44c48faee9