### PR TITLE
refactor: modularize cephalon bot non-discord logic

### DIFF
--- a/services/ts/cephalon/src/interactions.ts
+++ b/services/ts/cephalon/src/interactions.ts
@@ -1,0 +1,16 @@
+import * as discord from 'discord.js';
+
+type Interaction = discord.ChatInputCommandInteraction<'cached'>;
+
+export function interaction(commandConfig: Omit<discord.RESTPostAPIChatInputApplicationCommandsJSONBody, 'name'>) {
+	return function (target: any, key: string, describer: PropertyDescriptor) {
+		const ctor = target.constructor;
+		const originalMethod = describer.value;
+		const name = key.replace(/[A-Z]/g, (l) => `_${l.toLowerCase()}`).toLowerCase();
+		ctor.interactions.set(name, { name, ...commandConfig });
+		ctor.handlers.set(name, (bot: any, interaction: Interaction) => originalMethod.call(bot, interaction));
+		return describer;
+	};
+}
+
+export type { Interaction };

--- a/services/ts/cephalon/src/voiceCommands.ts
+++ b/services/ts/cephalon/src/voiceCommands.ts
@@ -1,0 +1,142 @@
+import * as discord from 'discord.js';
+import { VoiceSession } from './voice-session';
+import { FinalTranscript } from './transcriber';
+import { CollectionManager } from './collectionManager';
+import { AGENT_NAME } from '../../../../shared/js/env.js';
+import type { Interaction } from './interactions';
+import type { Bot } from './bot';
+
+export async function joinVoiceChannel(bot: Bot, interaction: Interaction): Promise<any> {
+	await interaction.deferReply();
+	let textChannel: discord.TextChannel | null;
+	if (interaction?.channel?.id) {
+		const channel = await bot.client.channels.fetch(interaction?.channel?.id);
+		if (channel?.isTextBased()) {
+			textChannel = channel as discord.TextChannel;
+		}
+	}
+	if (bot.currentVoiceSession) {
+		return interaction.followUp('Cannot join a new voice session with out leaving the current one.');
+	}
+	if (!interaction.member.voice?.channel?.id) {
+		return interaction.followUp('Join a voice channel then try that again.');
+	}
+	bot.currentVoiceSession = new VoiceSession({
+		bot: bot,
+		guild: interaction.guild,
+		voiceChannelId: interaction.member.voice.channel.id,
+	});
+	bot.currentVoiceSession.transcriber.on('transcriptEnd', async (transcript: FinalTranscript) => {
+		const transcripts = bot.context.getCollection('transcripts') as CollectionManager<'text', 'createdAt'>;
+		await transcripts.addEntry({
+			text: transcript.transcript,
+			createdAt: transcript.startTime || Date.now(),
+			metadata: {
+				createdAt: Date.now(),
+				endTime: transcript.endTime,
+				userId: transcript.user?.id,
+				userName: transcript.user?.username,
+				is_transcript: true,
+				channel: bot.currentVoiceSession?.voiceChannelId,
+				recipient: bot.applicationId,
+			},
+		});
+		if (textChannel && transcript.transcript.trim().length > 0 && transcript.speaker?.logTranscript)
+			await textChannel.send(`${transcript.user?.username}:${transcript.transcript}`);
+	});
+	bot.currentVoiceSession.start();
+	return interaction.followUp('DONE!');
+}
+
+export async function leaveVoiceChannel(bot: Bot, interaction: Interaction) {
+	if (bot.currentVoiceSession) {
+		bot.currentVoiceSession.stop();
+		if (bot.voiceStateHandler) {
+			bot.client.off(discord.Events.VoiceStateUpdate, bot.voiceStateHandler);
+			bot.voiceStateHandler = (_1: discord.VoiceState, _2: discord.VoiceState) => {
+				throw new Error('Voice channel left, voice state update called after leaving voice channel');
+			};
+		}
+		return interaction.followUp('Successfully left voice channel');
+	}
+	return interaction.followUp('No voice channel to leave.');
+}
+
+export async function beginRecordingUser(bot: Bot, interaction: Interaction) {
+	if (bot.currentVoiceSession) {
+		const user = interaction.options.getUser('speaker', true);
+		bot.currentVoiceSession.addSpeaker(user);
+		bot.currentVoiceSession.startSpeakerRecord(user);
+	}
+	return interaction.reply('Recording!');
+}
+
+export async function stopRecordingUser(bot: Bot, interaction: Interaction) {
+	if (bot.currentVoiceSession) {
+		const user = interaction.options.getUser('speaker', true);
+		bot.currentVoiceSession.stopSpeakerRecord(user);
+	}
+	return interaction.reply("I'm not recording you any more... I promise...");
+}
+
+export async function beginTranscribingUser(bot: Bot, interaction: Interaction) {
+	if (bot.currentVoiceSession) {
+		const user = interaction.options.getUser('speaker', true);
+		bot.currentVoiceSession.addSpeaker(user);
+		bot.currentVoiceSession.startSpeakerTranscribe(user, interaction.options.getBoolean('log') || false);
+		return interaction.reply(`I will faithfully transcribe every word ${user.displayName} says... I promise.`);
+	}
+	return interaction.reply("I can't transcribe what I can't hear. Join a voice channel.");
+}
+
+export async function tts(bot: Bot, interaction: Interaction) {
+	if (bot.currentVoiceSession) {
+		await interaction.deferReply({ ephemeral: true });
+		await bot.currentVoiceSession.playVoice(interaction.options.getString('message', true));
+	} else {
+		await interaction.reply("That didn't work... try again?");
+	}
+	await interaction.deleteReply().catch(() => {});
+}
+
+export async function startDialog(bot: Bot, interaction: Interaction) {
+	if (bot.currentVoiceSession) {
+		await interaction.deferReply({ ephemeral: true });
+		bot.currentVoiceSession.transcriber
+			.on('transcriptEnd', async () => {
+				if (bot.agent) {
+					bot.agent.newTranscript = true;
+					bot.agent.userSpeaking = false;
+				}
+			})
+			.on('transcriptStart', async () => {
+				if (bot.agent) {
+					bot.agent.newTranscript = false;
+					bot.agent.userSpeaking = true;
+				}
+			});
+		const channel = await interaction.guild.channels.fetch(bot.currentVoiceSession.voiceChannelId);
+		if (channel?.isVoiceBased()) {
+			for (const [, member] of channel.members) {
+				if (member.user.bot) continue;
+				await bot.currentVoiceSession.addSpeaker(member.user);
+				await bot.currentVoiceSession.startSpeakerTranscribe(member.user);
+			}
+		}
+		if (bot.voiceStateHandler) bot.client.off(discord.Events.VoiceStateUpdate, bot.voiceStateHandler);
+		bot.voiceStateHandler = (oldState, newState) => {
+			const id = bot.currentVoiceSession?.voiceChannelId;
+			const user = newState.member?.user || oldState.member?.user;
+			if (!id || !user || user.bot) return;
+			if (oldState.channelId !== id && newState.channelId === id) {
+				bot.currentVoiceSession?.addSpeaker(user);
+				bot.currentVoiceSession?.startSpeakerTranscribe(user);
+			} else if (oldState.channelId === id && newState.channelId !== id) {
+				bot.currentVoiceSession?.stopSpeakerTranscribe(user);
+				bot.currentVoiceSession?.removeSpeaker(user);
+			}
+		};
+		bot.client.on(discord.Events.VoiceStateUpdate, bot.voiceStateHandler);
+		return bot.agent?.start();
+	}
+}


### PR DESCRIPTION
## Summary
- extract command decorator to its own interactions module
- move voice session command implementations into voiceCommands
- shrink bot.ts to focus on discord wiring

## Testing
- `make setup` *(fails: KeyboardInterrupt)*
- `make format`
- `make lint` *(fails: Command 'npx eslint . --no-warn-ignored --ext .js,.ts' returned non-zero exit status 2)*
- `make build` *(fails: Command 'npm run build' returned non-zero exit status 2)*
- `make test` *(fails: Command 'echo 'Running tests in $PWD...' && python -m pipenv run pytest tests/' returned non-zero exit status 1)*

------
https://chatgpt.com/codex/tasks/task_e_68916a301be08324979cb646363b476d