### PR TITLE
Add missing service lint patterns

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,15 +4,15 @@ COMMANDS := all build clean lint format test setup setup-quick install install-g
         setup-hy setup-python setup-js setup-ts typecheck-python typecheck-ts build-ts build-js setup-pipenv compile-hy
 
 .PHONY: $(COMMANDS) generate-requirements-service-% setup-hy-service-% \
-        setup-python-service-% test-python-service-% coverage-python-service-% \
-        setup-js-service-%    test-js-service-%    coverage-js-service-% \
-        setup-ts-service-%    test-ts-service-%    coverage-ts-service-%
+        setup-python-service-% test-python-service-% coverage-python-service-% lint-python-service-% \
+        setup-js-service-%    test-js-service-%    coverage-js-service-%    lint-js-service-% \
+        setup-ts-service-%    test-ts-service-%    coverage-ts-service-%    lint-ts-service-%
 
 $(COMMANDS):
 	@hy Makefile.hy $@
 
 generate-requirements-service-% setup-hy-service-% \
-setup-python-service-% test-python-service-% coverage-python-service-% \
-setup-js-service-%    test-js-service-%    coverage-js-service-% \
-setup-ts-service-%    test-ts-service-%    coverage-ts-service-%:
+setup-python-service-% test-python-service-% coverage-python-service-% lint-python-service-% \
+setup-js-service-%    test-js-service-%    coverage-js-service-%    lint-js-service-% \
+setup-ts-service-%    test-ts-service-%    coverage-ts-service-%    lint-ts-service-%:
 	@hy Makefile.hy $@


### PR DESCRIPTION
## Summary
- support lint targets for individual services in root Makefile

## Testing
- `make install` *(fails: pip install interrupted)*
- `make build` *(fails: npm run build exit 2)*
- `make lint` *(fails: eslint returned non-zero exit status)*
- `make typecheck-python` *(fails: mypy exit status 2)*
- `make typecheck-ts` *(fails: npx tsc --noEmit exit status 2)*
- `make test` *(fails: pipenv tests exit status 2)*
- `make format`


------
https://chatgpt.com/codex/tasks/task_e_689169e2f130832483d71b47aa4c0e0d