### PR TITLE
Fix embedding function usage in discord attachment embedder test

### DIFF
--- a/services/py/discord_attachment_embedder/tests/test_embedder.py
+++ b/services/py/discord_attachment_embedder/tests/test_embedder.py
@@ -11,8 +11,8 @@ import pytest
 from chromadb.utils.embedding_functions import EmbeddingFunction
 
 
-class EmbeddingFn:
-    def name():
+class EmbeddingFn(EmbeddingFunction):
+    def name(self) -> str:
         return "test"
 
     def __call__(self, input: list[str]) -> list[list[float]]:
@@ -60,7 +60,9 @@ def test_process_message(monkeypatch):
     monkeypatch.setattr(mod, "discord_message_collection", mem)
     client = chromadb.Client()
 
-    collection = client.get_or_create_collection("test", embedding_function=EmbeddingFn)
+    collection = client.get_or_create_collection(
+        "test", embedding_function=EmbeddingFn()
+    )
     mod.process_message(message, collection)
     assert collection.count() == 2
     assert mem.docs[0].get("embedded") is True


### PR DESCRIPTION
## Summary
- fix discord attachment embedder test by instantiating embedding function and subclassing EmbeddingFunction

## Testing
- `python -m pipenv run pytest tests`
- `make build` *(fails: Command 'npm run build' returned non-zero exit status 2)*

------
https://chatgpt.com/codex/tasks/task_e_689263f1b4f083249b1d5861dc1253a7