### PR TITLE
Add process metrics tracking to heartbeat service

### DIFF
--- a/services/js/heartbeat/README.md
+++ b/services/js/heartbeat/README.md
@@ -3,11 +3,13 @@
 Tracks process heartbeats via HTTP and terminates those that fail to report within a timeout.
 Backed by MongoDB for storage. Intended for detecting and cleaning up hung or orphaned worker processes.
 Also enforces the instance limits defined in a PM2 ecosystem file, rejecting registrations that exceed the configured count for a given app name.
+Each heartbeat updates CPU, memory, and network byte counts for the process based on its PID.
 
 ## API
 
 - `POST /heartbeat` `{ pid: number, name: string }`
   - Records a heartbeat for the given PID and PM2 app name.
+  - Responds with `{ cpu, memory, netRx, netTx }` metrics.
   - Returns `409` if the number of live instances for that name exceeds the limit in the ecosystem config.
 
 ## Environment

--- a/services/js/heartbeat/package-lock.json
+++ b/services/js/heartbeat/package-lock.json
@@ -9,7 +9,8 @@
       "version": "0.0.1",
       "dependencies": {
         "express": "^4.18.2",
-        "mongodb": "^6.8.0"
+        "mongodb": "^6.8.0",
+        "pidusage": "^3.0.2"
       },
       "devDependencies": {
         "ava": "^6.4.1",
@@ -2938,6 +2939,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pidusage": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/pidusage/-/pidusage-3.0.2.tgz",
+      "integrity": "sha512-g0VU+y08pKw5M8EZ2rIGiEBaB8wrQMjYGFfW2QVIfyT8V+fq8YFLkvlz4bz5ljvFDJYNFCWT3PWqcRr2FKO81w==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "^5.2.1"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/pkg-dir": {

--- a/services/js/heartbeat/package.json
+++ b/services/js/heartbeat/package.json
@@ -10,7 +10,8 @@
   },
   "dependencies": {
     "express": "^4.18.2",
-    "mongodb": "^6.8.0"
+    "mongodb": "^6.8.0",
+    "pidusage": "^3.0.2"
   },
   "devDependencies": {
     "ava": "^6.4.1",

--- a/services/js/heartbeat/tests/client.test.js
+++ b/services/js/heartbeat/tests/client.test.js
@@ -32,4 +32,8 @@ test("heartbeat client posts pid", async (t) => {
   const res = await client.sendOnce();
   t.is(res.pid, 999);
   t.is(res.name, "test-app");
+  t.is(typeof res.cpu, "number");
+  t.is(typeof res.memory, "number");
+  t.is(typeof res.netRx, "number");
+  t.is(typeof res.netTx, "number");
 });

--- a/services/js/heartbeat/tests/heartbeat.test.js
+++ b/services/js/heartbeat/tests/heartbeat.test.js
@@ -1,6 +1,7 @@
 import test from "ava";
 import request from "supertest";
 import { MongoMemoryServer } from "mongodb-memory-server";
+import { MongoClient } from "mongodb";
 import { spawn } from "child_process";
 import path from "path";
 import { fileURLToPath } from "url";
@@ -69,4 +70,30 @@ test.serial("rejects excess instances", async (t) => {
     .post("/heartbeat")
     .send({ pid: child2.pid, name: "test-app" });
   t.is(res.status, 409);
+});
+
+test.serial("records process metrics", async (t) => {
+  const child = spawn("node", ["-e", "setInterval(()=>{},1000)"]);
+  t.teardown(() => {
+    if (!child.killed) {
+      try {
+        child.kill();
+      } catch {}
+    }
+  });
+  await request(server)
+    .post("/heartbeat")
+    .send({ pid: child.pid, name: "metric-app" })
+    .expect(200);
+  const client = new MongoClient(process.env.MONGO_URL);
+  await client.connect();
+  const doc = await client
+    .db("heartbeat_db")
+    .collection("heartbeats")
+    .findOne({ pid: child.pid });
+  await client.close();
+  t.is(typeof doc.cpu, "number");
+  t.is(typeof doc.memory, "number");
+  t.is(typeof doc.netRx, "number");
+  t.is(typeof doc.netTx, "number");
 });


### PR DESCRIPTION
## Summary
- record CPU, memory, and network byte stats for each PID in the heartbeat service
- include collected metrics in heartbeat responses and database documents
- document new metrics and add tests validating their presence

## Testing
- `make setup-js-service-heartbeat`
- `make test-js-service-heartbeat`
- `make lint-js-service-heartbeat`
- `make build-js`
- `make format`
- `make lint` *(fails: You are linting '.', but all of the files matching the glob pattern '.' are ignored.)*


------
https://chatgpt.com/codex/tasks/task_e_68926bce77988324875e69fe6bd8d166