### PR TITLE
Add heartbeat typing and fix embedding function

### DIFF
--- a/services/ts/discord-embedder/src/embedding.ts
+++ b/services/ts/discord-embedder/src/embedding.ts
@@ -3,8 +3,8 @@ import type { EmbeddingFunction, EmbeddingFunctionSpace } from 'chromadb';
 export class RemoteEmbeddingFunction implements EmbeddingFunction {
 	name = 'remote';
 	url: string;
-	driver?: string;
-	fn?: string;
+	driver: string | undefined;
+	fn: string | undefined;
 
 	constructor(
 		url = process.env.EMBEDDING_SERVICE_URL || 'http://localhost:8000/embed',

--- a/services/ts/discord-embedder/tsconfig.json
+++ b/services/ts/discord-embedder/tsconfig.json
@@ -48,6 +48,6 @@
 		// Completeness
 		"skipLibCheck": true
 	},
-	"include": ["src/**/*.ts", "tests/**/*.ts"],
+	"include": ["src/**/*.ts", "src/**/*.d.ts", "tests/**/*.ts"],
 	"exclude": ["node_modules"]
 }

--- a/shared/js/heartbeat/index.d.ts
+++ b/shared/js/heartbeat/index.d.ts
@@ -1,0 +1,13 @@
+export interface HeartbeatOptions {
+  url?: string;
+  pid?: number;
+  name?: string;
+  interval?: number;
+}
+
+export class HeartbeatClient {
+  constructor(options?: HeartbeatOptions);
+  sendOnce(): Promise<any>;
+  start(): void;
+  stop(): void;
+}


### PR DESCRIPTION
## Summary
- add TypeScript declarations for shared HeartbeatClient
- allow optional driver and fn values in RemoteEmbeddingFunction
- include `.d.ts` files in discord-embedder's tsconfig

## Testing
- `npm run --prefix services/ts/discord-embedder build`
- `npm test --prefix services/ts/discord-embedder`
- `npm run --prefix services/ts/discord-embedder lint` *(fails: Invalid option '--ext')*
- `npm install --prefix services/ts/file-watcher`
- `npm run --prefix services/ts/file-watcher build`
- `npm test --prefix services/ts/file-watcher` *(fails: Cannot find module '.../shared/js/heartbeat/index.js')*
- `npm run --prefix services/ts/file-watcher lint` *(fails: Missing script 'lint')*
- `npm install --prefix services/ts/cephalon`
- `npm run --prefix services/ts/cephalon build` *(fails: Cannot find module '@discordjs/voice' and others)*
- `make setup-ts-service-voice` *(fails: @discordjs/opus build errors)*

------
https://chatgpt.com/codex/tasks/task_e_68926b3e88fc832499ea33f334f0c7df