### PR TITLE
chore: document markdownlint config

### DIFF
--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -1,0 +1,7 @@
+# Markdownlint configuration for Promethean docs
+# Enable default rules but allow longer lines and disable duplicate heading rule
+MD013:
+  line_length: 120
+MD041: false
+MD024:
+  siblings_only: true

--- a/docs/agile/Tasks/Ensure GitHub-compatible markdown settings are documented.md
+++ b/docs/agile/Tasks/Ensure GitHub-compatible markdown settings are documented.md
@@ -14,7 +14,7 @@ Some Obsidian features don't render well on GitHub. We need clear guidelines so 
 ## 📦 Requirements
 - [x] Add a section to `vault-config/README.md` describing recommended settings
 - [x] Mention any plugins used to export or format markdown
-- [ ] Include Prettier or markdownlint configuration if applicable
+- [x] Include Prettier or markdownlint configuration if applicable
 
 ---
 
@@ -40,4 +40,4 @@ Nothing
 
 ## 🔍 Relevant Links
 - [kanban](../boards/kanban.md)
-#todo
+#done

--- a/vault-config/README.md
+++ b/vault-config/README.md
@@ -22,25 +22,25 @@ options in **Settings → Files & Links**:
 
 * **Automatically update internal links** – keeps link paths tidy when files are
   moved.
-* **Use [[wikilinks]]** – preferred inside the vault for graph navigation.
+* **Use [wikilinks](wikilinks.md)** – preferred inside the vault for graph navigation.
 * **Default location for new attachments → Same folder as current file** – avoids
   absolute paths.
 
 Then, install the optional **Markdown Format Converter** plugin and run the
 `Convert all to Markdown` command before committing docs. This converts
-`[[wikilinks]]` to standard `[text](link.md)` syntax so everything renders on
+`[wikilinks](wikilinks.md)` to standard `[text](link.md)` syntax so everything renders on
 GitHub without broken links.
 
-If you prefer an automated approach, you can add a `markdownlint` or `Prettier`
-configuration in your editor to normalize code fences and line breaks. The repo
-does not currently enforce a style, but consistent formatting makes diffs
-cleaner.
+For automated formatting, the repository includes a `.markdownlint.yml`
+configuration. Enable a markdownlint plugin in your editor or run the CLI to
+apply these rules, ensuring consistent code fences and line wrapping. Prettier
+is also compatible if you prefer JS-based tooling.
 
 #hashtags: #obsidian #vault
 
 ## Automated Wikilink Conversion
 
-A small script `scripts/convert_wikilinks.py` converts `[[wikilinks]]` to standard markdown links. The repository provides a `.pre-commit-config.yaml` that runs this script automatically before each commit.
+A small script `scripts/convert_wikilinks.py` converts `[wikilinks](wikilinks.md)` to standard markdown links. The repository provides a `.pre-commit-config.yaml` that runs this script automatically before each commit.
 
 Install the `pre-commit` tool and enable the hook:
 


### PR DESCRIPTION
## Summary
- add `.markdownlint.yml` to standardize Markdown formatting across the repo
- explain markdownlint usage in vault-config README
- mark board task for documenting GitHub-friendly Markdown settings as complete

## Testing
- `make format`
- `make lint` *(fails: ESLint cannot find files; glob pattern "." ignored)*
- `make test` *(fails: ModuleNotFoundError: No module named 'chromadb')*
- `make build` *(fails: TypeScript compilation errors)*

------
https://chatgpt.com/codex/tasks/task_e_689276c923a88324b5014d091664d9e5