### PR TITLE
Enable company-based auto completion

### DIFF
--- a/.emacs/layers/promethean/funcs.el
+++ b/.emacs/layers/promethean/funcs.el
@@ -3,7 +3,8 @@
 (defun promethean/setup-lispy-env ()
   (smartparens-strict-mode 1)
   (rainbow-delimiters-mode 1)
-  (electric-pair-mode -1))
+  (electric-pair-mode -1)
+  (company-mode 1))
 
 (defun promethean/codex-complete-buffer ()
   "Run codex-cli on the current buffer and insert completion."

--- a/.emacs/layers/promethean/hy.el
+++ b/.emacs/layers/promethean/hy.el
@@ -7,6 +7,8 @@
   "Major mode for editing Hy code."
   (setq-local font-lock-defaults '((promethean-core-font-lock-defaults))))
 
+(add-hook 'promethean-hy-mode-hook #'promethean/setup-lispy-env)
+
 (add-to-list 'auto-mode-alist '("\\.hy\\'" . promethean-hy-mode))
 
 (provide 'promethean-hy-mode)

--- a/.emacs/layers/promethean/packages.el
+++ b/.emacs/layers/promethean/packages.el
@@ -4,6 +4,7 @@
   '(
     smartparens
     rainbow-delimiters
+    company
     promethean-hy-mode
     promethean-sibilant-mode
     promethean-lisp-mode

--- a/.emacs/layers/promethean/sibilant.el
+++ b/.emacs/layers/promethean/sibilant.el
@@ -15,6 +15,8 @@
   (setq font-lock-defaults '(sibilant-font-lock-keywords))
   (setq-local comment-start ";"))
 
+(add-hook 'promethean-sibilant-mode-hook #'promethean/setup-lispy-env)
+
 (add-to-list 'auto-mode-alist '("\\.sibilant\\'" . promethean-sibilant-mode))
 (add-to-list 'auto-mode-alist '("\\.prompt\\.sibilant\\'" . promethean-sibilant-mode))
 


### PR DESCRIPTION
## Summary
- add company to Promethean Spacemacs layer package list
- enable company-mode in the shared lispy environment
- hook Hy and Sibilant modes to the lispy env for completions

## Testing
- `make lint` *(fails: npx eslint . --no-warn-ignored --ext .js,.ts)*
- `make format`
- `make build` *(fails: npm run build)*
- `make test` *(fails: python -m pipenv run pytest tests/)*

------
https://chatgpt.com/codex/tasks/task_e_68927751b31c832491a03a5ae1b23946