### PR TITLE
docs: summarize chat logs into notes

### DIFF
--- a/docs/notes/chats/eidolon-layer-1-design.md
+++ b/docs/notes/chats/eidolon-layer-1-design.md
@@ -1,0 +1,13 @@
+> Based on chat log `docs/chats/2025-08-03_03-07-18_ChatGPT_Promethean - Eidolon Layer 1 Design....md`.
+
+## User
+Let's start talking about the implementation of the Eidolon fields. Layer 1 manages processing resources so the system doesn't crash.
+
+## ChatGPT
+- Layer 1 acts as the uptime layer, monitoring CPU, GPU, NPU, RAM, and latency to prevent overload.
+- Resources are modeled as a vector field where tasks become agents with mass, velocity, and drag.
+- Core components: sensors, field model, task agents, resource governor, feedback loop, and kill switch.
+- Proposed Python scaffold uses MongoDB for shared state with modules like `field.py`, `heartbeat.py`, and `constraints.py`.
+- Optional add-ons include visualizers, process evictors, and generators for simulating node arrangements.
+
+#tags: #eidolon #layer1 #resource-management #promethean

--- a/docs/notes/chats/gemma3-thinking-model.md
+++ b/docs/notes/chats/gemma3-thinking-model.md
@@ -1,0 +1,12 @@
+> Based on chat log `docs/chats/2025-08-03_03-56-40_ChatGPT_Promethean - Gemma3 thinking capabilities....md`.
+
+## User
+Is Gemma3 a "thinking" model?
+
+## ChatGPT
+- Gemma models are language models that simulate thought by predicting tokens; they don't possess real cognition.
+- With proper prompting they perform chain-of-thought reasoning, limited tree-of-thought, and tool use via external scaffolds.
+- They lack built-in agentic memory or planning across turns without additional context management.
+- Building a thinking system requires layering fields that influence prompt construction and feedback loops beyond the base model.
+
+#tags: #gemma #llm #reasoning #promethean

--- a/docs/notes/chats/promethean-architecture-overview.md
+++ b/docs/notes/chats/promethean-architecture-overview.md
@@ -1,0 +1,13 @@
+> Based on chat log `docs/chats/2025-08-03_03-45-37_ChatGPT_Promethean - Building Promethean Architecture....md`.
+
+## User
+We need a deep-dive conversation about what we're building after getting lost in CI/CD and tests.
+
+## ChatGPT
+- Promethean is a modular multi-agent architecture aligned with an eight-layer consciousness model.
+- Layers represent cognitive subsystems and interact through dynamic Eidolon fields.
+- Agents like Duck operate within services orchestrated via a monorepo with Makefile-driven workflows across Sibilant, Hy, Python, and TypeScript.
+- Cephalon streams data between STT, LLM, and TTS while embeddings and OpenVINO-accelerated models run on the Intel NPU.
+- Context flows like ant trails; memory is an emergent field of pressures rather than static storage, forming "contextual gravity."
+
+#tags: #architecture #promethean #cephalon #eidolon

--- a/docs/notes/chats/using-npu-in-docker.md
+++ b/docs/notes/chats/using-npu-in-docker.md
@@ -1,0 +1,12 @@
+> Based on chat log `docs/chats/2025-08-03_03-57-58_ChatGPT_Promethean - Using NPU in Docker....md`.
+
+## User
+Is there any way to use an NPU from Docker?
+
+## ChatGPT
+- Containers can access host NPUs by installing drivers on the host, mounting runtime libraries, and passing device nodes with `--device` or runtime plugins.
+- Vendor examples include Huawei Ascend with the Ascend docker runtime, Intel's OpenVINO via `--device /dev/dri`, and Google Coral using `--device /dev/apex_0`.
+- Ensure environment variables expose the desired device IDs and use images preloaded with the vendor SDK.
+- On Windows with WSL, invoke `python.exe` or `node.exe` to run host-side NPU drivers from WSL paths.
+
+#tags: #npu #docker #openvino #promethean

--- a/docs/notes/chats/vision-models-multiple-images.md
+++ b/docs/notes/chats/vision-models-multiple-images.md
@@ -1,0 +1,12 @@
+> Based on chat log `docs/chats/2025-08-03_03-58-19_ChatGPT_Promethean - Vision models and multiple images....md`.
+
+## User
+Can vision models handle multiple images? Ollama's API accepts an array but doesn't show examples.
+
+## ChatGPT
+- Many multimodal models process multiple images by encoding each through a vision encoder and feeding embeddings sequentially into the LLM.
+- Support depends on training; models not fine-tuned for multi-image reasoning may ignore all but the first image or exceed context limits.
+- Ollama's API accepts multiple images, but behavior varies by model; testing is required to confirm reasoning across images.
+- The broader goal is building a system where accumulating cognition and embodied feedback create a sense of presence.
+
+#tags: #vision #multimodal #ollama #promethean

--- a/docs/notes/chats/voice-logic-split-analysis.md
+++ b/docs/notes/chats/voice-logic-split-analysis.md
@@ -1,0 +1,11 @@
+> Based on chat log `docs/chats/2025-08-03_03-57-36_ChatGPT_Promethean - Voice logic split analysis....md`.
+
+## User
+These bots split the voice logic from the Discord bot and removed the old path before testing latency. I'm unsure if it's useful.
+
+## ChatGPT
+- Splitting voice handling may aim for separation of concerns, modularity, or testability, but Node's async design already handles much of this.
+- Without the original implementation there's no baseline for latency comparisons; reverting or running both versions is advised.
+- Options: roll back, keep both via configuration, or fully define boundaries with a `VoiceService` class and dependency injection.
+
+#tags: #voice #discord #architecture #promethean


### PR DESCRIPTION
## Summary
- distill chat transcripts into concise notes for future reference

## Testing
- `make setup` (failed: KeyboardInterrupt)
- `make format`
- `make lint` (failed: ESLint configuration)
- `make build` (failed: missing TypeScript modules)
- `make test` (failed: missing fastapi module)
- `pre-commit run --files docs/notes/chats/eidolon-layer-1-design.md docs/notes/chats/promethean-architecture-overview.md docs/notes/chats/gemma3-thinking-model.md docs/notes/chats/voice-logic-split-analysis.md docs/notes/chats/using-npu-in-docker.md docs/notes/chats/vision-models-multiple-images.md`

------
https://chatgpt.com/codex/tasks/task_e_689276f342fc8324b9d4ef3e48331eae