### PR TITLE
feat: throttle cephalon tickrate via heartbeat

### DIFF
--- a/services/js/heartbeat/tests/client.test.js
+++ b/services/js/heartbeat/tests/client.test.js
@@ -37,3 +37,21 @@ test("heartbeat client posts pid", async (t) => {
   t.is(typeof res.netRx, "number");
   t.is(typeof res.netTx, "number");
 });
+
+test("heartbeat client invokes callback", async (t) => {
+  const url = `http://127.0.0.1:${server.address().port}/heartbeat`;
+  await new Promise((resolve) => {
+    const client = new HeartbeatClient({
+      url,
+      pid: 1000,
+      name: "test-app",
+      interval: 50,
+      onHeartbeat(data) {
+        t.is(data.pid, 1000);
+        client.stop();
+        resolve(null);
+      },
+    });
+    client.start();
+  });
+});

--- a/services/ts/cephalon/src/agent/index.ts
+++ b/services/ts/cephalon/src/agent/index.ts
@@ -153,10 +153,14 @@ export class AIAgent extends EventEmitter {
 			prompt,
 		}) as Promise<string>;
 	}
+	tickInterval = 100;
+	updateTickInterval(ms: number) {
+		this.tickInterval = ms;
+	}
 	async startTicker() {
 		while (this.state === 'running') {
 			this.emit('tick');
-			await sleep(100);
+			await sleep(this.tickInterval);
 		}
 	}
 

--- a/services/ts/cephalon/src/index.ts
+++ b/services/ts/cephalon/src/index.ts
@@ -10,7 +10,7 @@ async function main() {
 		applicationId: process.env.DISCORD_CLIENT_USER_ID as string,
 	});
 	const hb = new HeartbeatClient({
-		onHeartbeat: ({ cpu }) => {
+		onHeartbeat: ({ cpu }: { cpu: number }) => {
 			const delay = Math.min(1000, 100 + Math.round(cpu));
 			bot.agent.updateTickInterval(delay);
 		},

--- a/services/ts/cephalon/src/index.ts
+++ b/services/ts/cephalon/src/index.ts
@@ -5,18 +5,24 @@ import { HeartbeatClient } from '../../../../shared/js/heartbeat/index.js';
 
 async function main() {
 	console.log('Starting', AGENT_NAME, 'Cephalon');
-	const hb = new HeartbeatClient();
+	const bot = new Bot({
+		token: process.env.DISCORD_TOKEN as string,
+		applicationId: process.env.DISCORD_CLIENT_USER_ID as string,
+	});
+	const hb = new HeartbeatClient({
+		onHeartbeat: ({ cpu }) => {
+			const delay = Math.min(1000, 100 + Math.round(cpu));
+			bot.agent.updateTickInterval(delay);
+		},
+	});
 	try {
-		await hb.sendOnce();
+		const data = await hb.sendOnce();
+		hb.onHeartbeat?.(data);
 	} catch (err) {
 		console.error('failed to register heartbeat', err);
 		process.exit(1);
 	}
 	hb.start();
-	const bot = new Bot({
-		token: process.env.DISCORD_TOKEN as string,
-		applicationId: process.env.DISCORD_CLIENT_USER_ID as string,
-	});
 	bot.start();
 	console.log(`Cephalon started for ${AGENT_NAME}`);
 }

--- a/services/ts/cephalon/tests/tickrate.test.ts
+++ b/services/ts/cephalon/tests/tickrate.test.ts
@@ -1,0 +1,13 @@
+import test from 'ava';
+import { AIAgent } from '../src/agent';
+import type { Bot } from '../src/bot';
+import type { ContextManager } from '../src/contextManager';
+
+test('agent updates tick interval', (t) => {
+	const context = {} as unknown as ContextManager;
+	const bot = { context } as unknown as Bot;
+	const agent = new AIAgent({ bot, context });
+	t.is((agent as any).tickInterval, 100);
+	agent.updateTickInterval(250);
+	t.is((agent as any).tickInterval, 250);
+});

--- a/shared/js/heartbeat/index.d.ts
+++ b/shared/js/heartbeat/index.d.ts
@@ -3,11 +3,28 @@ export interface HeartbeatOptions {
   pid?: number;
   name?: string;
   interval?: number;
+  onHeartbeat?: (data: HeartbeatData) => void;
+}
+
+export interface HeartbeatData {
+  pid: number;
+  name: string;
+  cpu: number;
+  memory: number;
+  netRx: number;
+  netTx: number;
+  status?: string;
+  [key: string]: any;
 }
 
 export class HeartbeatClient {
   constructor(options?: HeartbeatOptions);
-  sendOnce(): Promise<any>;
+  url: string;
+  pid: number;
+  name: string;
+  interval: number;
+  onHeartbeat?: (data: HeartbeatData) => void;
+  sendOnce(): Promise<HeartbeatData>;
   start(): void;
   stop(): void;
 }

--- a/shared/js/heartbeat/index.js
+++ b/shared/js/heartbeat/index.js
@@ -12,11 +12,13 @@ export class HeartbeatClient {
     pid = process.pid,
     name = process.env.name,
     interval = 3000,
+    onHeartbeat,
   } = {}) {
     this.url = url;
     this.pid = pid;
     this.name = name;
     this.interval = interval;
+    this.onHeartbeat = onHeartbeat;
     this._timer = null;
     if (!this.name) {
       throw new Error("name required for HeartbeatClient");
@@ -37,11 +39,15 @@ export class HeartbeatClient {
 
   start() {
     if (this._timer) return;
-    this._timer = setInterval(() => {
-      this.sendOnce().catch(() => {
+    const tick = async () => {
+      try {
+        const data = await this.sendOnce();
+        if (this.onHeartbeat) this.onHeartbeat(data);
+      } catch {
         /* ignore errors */
-      });
-    }, this.interval);
+      }
+    };
+    this._timer = setInterval(tick, this.interval);
   }
 
   stop() {


### PR DESCRIPTION
## Summary
- throttle cephalon tick loop according to heartbeat CPU metrics
- expose heartbeat responses via callback
- test heartbeat callback and tick interval update

## Testing
- `make setup-ts-service-cephalon` *(fails: `npm warn deprecated @humanwhocodes/config-array@0.13.0` and other deprecation warnings)*
- `make format-ts-service-cephalon` *(fails: No rule to make target)*
- `make lint-ts-service-cephalon` *(fails: Command 'npx eslint  --ext .js,.ts . ' returned non-zero exit status 2)*
- `make build-ts-service-cephalon` *(fails: No rule to make target)*
- `make test-ts-service-cephalon` *(fails: Cannot find type definition file for 'wav')*
- `make setup-js-service-heartbeat`
- `make format-js-service-heartbeat` *(fails: No rule to make target)*
- `make lint-js-service-heartbeat`
- `make build-js-service-heartbeat` *(fails: No rule to make target)*
- `make test-js-service-heartbeat` *(fails: MongoClientClosedError: Operation interrupted because client was closed)*

------
https://chatgpt.com/codex/tasks/task_e_68927683e65c83249c98a9607056fda6