### PR TITLE
feat(emacs): add hy intellisense

### DIFF
--- a/.emacs/layers/promethean/README.org
+++ b/.emacs/layers/promethean/README.org
@@ -6,6 +6,7 @@ This is a modular Emacs layer for building LLM-integrated, Lisp-native environme
 - Smartparens + rainbow delimiters for structural editing
 - Codex CLI integration (Copilot-like completion)
 - Eval buffer hooks for Hy and Sibilant
+- LSP-powered IntelliSense for Hy via `hyls`
 - Easy to extend per dialect
 
 ** Usage

--- a/.emacs/layers/promethean/hy.el
+++ b/.emacs/layers/promethean/hy.el
@@ -1,12 +1,24 @@
 ;;; hy.el --- Promethean support for Hy Lisp -*- lexical-binding: t -*-
 
 (require 'promethean-lisp-mode)
-
+(require 'lsp-mode)
+(require 'company)
 
 (define-derived-mode promethean-hy-mode promethean-lisp-mode "Hy"
   "Major mode for editing Hy code."
   (setq-local font-lock-defaults '((promethean-core-font-lock-defaults))))
 
 (add-to-list 'auto-mode-alist '("\\.hy\\'" . promethean-hy-mode))
+
+(with-eval-after-load 'lsp-mode
+  (add-to-list 'lsp-language-id-configuration '(promethean-hy-mode . "hy"))
+  (lsp-register-client
+   (make-lsp-client
+    :new-connection (lsp-stdio-connection '("hyls"))
+    :major-modes '(promethean-hy-mode)
+    :server-id 'hyls)))
+
+(add-hook 'promethean-hy-mode-hook #'lsp-deferred)
+(add-hook 'promethean-hy-mode-hook #'company-mode)
 
 (provide 'promethean-hy-mode)

--- a/.emacs/layers/promethean/packages.el
+++ b/.emacs/layers/promethean/packages.el
@@ -4,6 +4,8 @@
   '(
     smartparens
     rainbow-delimiters
+    lsp-mode
+    company
     promethean-hy-mode
     promethean-sibilant-mode
     promethean-lisp-mode


### PR DESCRIPTION
## Summary
- add lsp-mode and company to Promethean Emacs layer
- register hyls language server and enable company completions for Hy
- document Hy IntelliSense feature

## Testing
- `make format`
- `make lint` *(fails: ESLint ignoring files)*
- `make build` *(fails: npm run build exited with non-zero status)*
- `make test` *(fails: pytest command returned non-zero status)*
- `make setup` *(aborted after long runtime)*

------
https://chatgpt.com/codex/tasks/task_e_689281ebfba48324829b45fd2fbe6e1f