### PR TITLE
fix file watcher tests

### DIFF
--- a/services/ts/file-watcher/src/index.ts
+++ b/services/ts/file-watcher/src/index.ts
@@ -2,7 +2,6 @@ import { spawn } from "child_process";
 import chokidar from "chokidar";
 import { join } from "path";
 import { writeFile as fsWriteFile } from "fs/promises";
-import { HeartbeatClient } from "../../../../shared/js/heartbeat/index.js";
 
 /**
  * Options for {@link startFileWatcher} allowing injection of dependencies for testing.
@@ -120,15 +119,20 @@ export function startFileWatcher(options: FileWatcherOptions = {}): {
 }
 
 if (process.env.NODE_ENV !== "test") {
-  const hb = new HeartbeatClient();
-  hb.sendOnce()
-    .then(() => {
+  (async () => {
+    try {
+      const repoRoot = defaultRepoRoot || process.cwd();
+      const { HeartbeatClient } = await import(
+        join(repoRoot, "shared", "js", "heartbeat", "index.js")
+      );
+      const hb = new HeartbeatClient();
+      await hb.sendOnce();
       hb.start();
       startFileWatcher();
       console.log("File watcher running...");
-    })
-    .catch((err) => {
+    } catch (err) {
       console.error("failed to register heartbeat", err);
       process.exit(1);
-    });
+    }
+  })();
 }


### PR DESCRIPTION
## Summary
- load heartbeat client dynamically so tests don't fail if shared module missing

## Testing
- `npm run build --prefix services/ts/file-watcher`
- `make test-ts-service-file-watcher` *(fails: none)*
- `make lint-ts-service-file-watcher` *(fails: ESLint ignores all files)*

------
https://chatgpt.com/codex/tasks/task_e_689283abb4ac8324b9ef6d5de299fd1d