### PR TITLE
test: stub whisper dependencies in stt tests

### DIFF
--- a/services/py/stt/app.py
+++ b/services/py/stt/app.py
@@ -8,6 +8,7 @@ from fastapi import (
     WebSocketDisconnect,
 )
 from fastapi.responses import JSONResponse
+from starlette.websockets import WebSocketState
 
 import asyncio
 import base64
@@ -90,5 +91,5 @@ async def stream(ws: WebSocket):
     except WebSocketDisconnect:
         pass
     finally:
-        if ws.client_state.name != "CLOSED":
+        if ws.client_state != WebSocketState.DISCONNECTED:
             await ws.close()

--- a/services/py/stt/tests/test_stt_ws.py
+++ b/services/py/stt/tests/test_stt_ws.py
@@ -1,8 +1,9 @@
 import base64
-import base64
 import json
 import os
 import sys
+import types
+import importlib
 
 # Add repository root to path to allow 'services' imports
 sys.path.insert(
@@ -27,14 +28,11 @@ def test_websocket_transcription(monkeypatch):
         "shared.py.heartbeat_client.HeartbeatClient", lambda *a, **k: DummyHB()
     )
 
-    import importlib
+    stub = types.SimpleNamespace(transcribe_pcm=lambda pcm, sr: "hello world")
+    monkeypatch.setitem(sys.modules, "shared.py.speech.wisper_stt", stub)
 
     app_module = importlib.import_module("services.py.stt.app")
     client = TestClient(app_module.app)
-    import types
-
-    stub = types.SimpleNamespace(transcribe_pcm=lambda pcm, sr: "hello world")
-    monkeypatch.setitem(sys.modules, "shared.py.speech.wisper_stt", stub)
 
     data = base64.b64encode(b"abc").decode()
     with client.websocket_connect("/transcribe") as websocket:

--- a/services/py/stt/tests/test_whisper_stream_ws.py
+++ b/services/py/stt/tests/test_whisper_stream_ws.py
@@ -1,6 +1,7 @@
 import os
-import os
 import sys
+import types
+import importlib
 
 sys.path.insert(
     0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../../"))
@@ -34,7 +35,8 @@ def test_ws_stream(monkeypatch):
         "shared.py.heartbeat_client.HeartbeatClient", lambda *a, **k: DummyHB()
     )
 
-    import importlib
+    stub = types.SimpleNamespace(transcribe_pcm=lambda *a, **k: "")
+    monkeypatch.setitem(sys.modules, "shared.py.speech.wisper_stt", stub)
 
     app_module = importlib.import_module("services.py.stt.app")
     dummy = DummyStreamer()


### PR DESCRIPTION
## Summary
- stub out whisper STT dependency in websocket tests
- close websocket streams safely when already disconnected

## Testing
- `make test-python-service-stt`
- `pipenv run flake8 tests/ app.py`
- `make build` *(fails: Command 'npm run build' returned non-zero exit status 2)*

------
https://chatgpt.com/codex/tasks/task_e_689283bfbbc88324ba0de9363c469fed