### PR TITLE
Replace numpy dependency in TTS tests

### DIFF
--- a/services/hy/tts/tests/test_tts_websocket.py
+++ b/services/hy/tts/tests/test_tts_websocket.py
@@ -1,31 +1,79 @@
-import os, sys
+import os, sys, types, importlib, wave
+from fastapi.testclient import TestClient
+from unittest.mock import patch
 
 ROOT_DIR = os.path.join(os.path.dirname(__file__), "../../../../")
 sys.path.insert(0, os.path.join(ROOT_DIR, "shared", "py"))
 sys.path.insert(0, ROOT_DIR)
 
-import numpy as np
-from fastapi.testclient import TestClient
-from unittest.mock import patch
-import types
-import importlib
+
+def dummy_write(file, audio, samplerate, format=None, subtype=None):
+    with wave.open(file, "wb") as wf:
+        wf.setnchannels(1)
+        wf.setsampwidth(2)
+        wf.setframerate(samplerate)
+        wf.writeframes(b"\x00\x00" * 10)
+
+
+class DummyHB:
+    def send_once(self):
+        pass
+
+    def start(self):
+        pass
+
+    def stop(self):
+        pass
 
 
 def test_websocket_tts_returns_wav_bytes():
-    dummy_audio = np.zeros(22050, dtype=np.float32)
-    dummy_module = types.SimpleNamespace(generate_voice=lambda text: dummy_audio)
+    dummy_module = types.SimpleNamespace(generate_voice=lambda text: None)
     dummy_package = types.ModuleType("speech")
     dummy_package.tts = dummy_module
 
-    class DummyHB:
-        def send_once(self):
+    dummy_sf = types.SimpleNamespace(write=dummy_write)
+    dummy_nltk = types.SimpleNamespace(download=lambda *a, **k: None)
+
+    class DummyNoGrad:
+        def __enter__(self):
             pass
 
-        def start(self):
+        def __exit__(self, exc_type, exc, tb):
             pass
 
-        def stop(self):
-            pass
+    dummy_torch = types.SimpleNamespace(
+        cuda=types.SimpleNamespace(is_available=lambda: False),
+        no_grad=lambda: DummyNoGrad(),
+    )
+
+    class DummyTokenizer:
+        @classmethod
+        def from_pretrained(cls, *a, **k):
+            return cls()
+
+        def __call__(self, text, return_tensors=None):
+            return types.SimpleNamespace(input_ids=None)
+
+    class DummyModel:
+        @classmethod
+        def from_pretrained(cls, *a, **k):
+            return cls()
+
+        def to(self, device):
+            return self
+
+        def __call__(self, input_ids, return_dict=True):
+            return types.SimpleNamespace(waveform=[0] * 10)
+
+    dummy_transformers = types.SimpleNamespace(
+        FastSpeech2ConformerTokenizer=DummyTokenizer,
+        FastSpeech2ConformerWithHifiGan=DummyModel,
+    )
+    dummy_safetensors_torch = types.SimpleNamespace(load_file=lambda *a, **k: None)
+    dummy_safetensors = types.ModuleType("safetensors")
+    dummy_safetensors.torch = dummy_safetensors_torch
+    dummy_numpy = types.ModuleType("numpy")
+    dummy_numpy.ndarray = list
 
     with patch("shared.py.heartbeat_client.HeartbeatClient", lambda *a, **k: DummyHB()):
         with patch.dict(
@@ -35,9 +83,16 @@ def test_websocket_tts_returns_wav_bytes():
                 "speech.tts": dummy_module,
                 "shared.py.speech": dummy_package,
                 "shared.py.speech.tts": dummy_module,
+                "soundfile": dummy_sf,
+                "nltk": dummy_nltk,
+                "torch": dummy_torch,
+                "transformers": dummy_transformers,
+                "safetensors": dummy_safetensors,
+                "safetensors.torch": dummy_safetensors_torch,
+                "numpy": dummy_numpy,
             },
         ):
-            app_module = importlib.import_module("services.py.tts.ws")
+            app_module = importlib.import_module("services.py.tts.app")
             client = TestClient(app_module.app)
             with client.websocket_connect("/ws/tts") as websocket:
                 websocket.send_text("hello")

--- a/services/py/tts/tests/test_tts_websocket.py
+++ b/services/py/tts/tests/test_tts_websocket.py
@@ -1,31 +1,79 @@
-import os, sys
+import os, sys, types, importlib, wave
+from fastapi.testclient import TestClient
+from unittest.mock import patch
 
 ROOT_DIR = os.path.join(os.path.dirname(__file__), "../../../../")
 sys.path.insert(0, os.path.join(ROOT_DIR, "shared", "py"))
 sys.path.insert(0, ROOT_DIR)
 
-import numpy as np
-from fastapi.testclient import TestClient
-from unittest.mock import patch
-import types
-import importlib
+
+def dummy_write(file, audio, samplerate, format=None, subtype=None):
+    with wave.open(file, "wb") as wf:
+        wf.setnchannels(1)
+        wf.setsampwidth(2)
+        wf.setframerate(samplerate)
+        wf.writeframes(b"\x00\x00" * 10)
+
+
+class DummyHB:
+    def send_once(self):
+        pass
+
+    def start(self):
+        pass
+
+    def stop(self):
+        pass
 
 
 def test_websocket_tts_returns_wav_bytes():
-    dummy_audio = np.zeros(22050, dtype=np.float32)
-    dummy_module = types.SimpleNamespace(generate_voice=lambda text: dummy_audio)
+    dummy_module = types.SimpleNamespace(generate_voice=lambda text: None)
     dummy_package = types.ModuleType("speech")
     dummy_package.tts = dummy_module
 
-    class DummyHB:
-        def send_once(self):
+    dummy_sf = types.SimpleNamespace(write=dummy_write)
+    dummy_nltk = types.SimpleNamespace(download=lambda *a, **k: None)
+
+    class DummyNoGrad:
+        def __enter__(self):
             pass
 
-        def start(self):
+        def __exit__(self, exc_type, exc, tb):
             pass
 
-        def stop(self):
-            pass
+    dummy_torch = types.SimpleNamespace(
+        cuda=types.SimpleNamespace(is_available=lambda: False),
+        no_grad=lambda: DummyNoGrad(),
+    )
+
+    class DummyTokenizer:
+        @classmethod
+        def from_pretrained(cls, *a, **k):
+            return cls()
+
+        def __call__(self, text, return_tensors=None):
+            return types.SimpleNamespace(input_ids=None)
+
+    class DummyModel:
+        @classmethod
+        def from_pretrained(cls, *a, **k):
+            return cls()
+
+        def to(self, device):
+            return self
+
+        def __call__(self, input_ids, return_dict=True):
+            return types.SimpleNamespace(waveform=[0] * 10)
+
+    dummy_transformers = types.SimpleNamespace(
+        FastSpeech2ConformerTokenizer=DummyTokenizer,
+        FastSpeech2ConformerWithHifiGan=DummyModel,
+    )
+    dummy_safetensors_torch = types.SimpleNamespace(load_file=lambda *a, **k: None)
+    dummy_safetensors = types.ModuleType("safetensors")
+    dummy_safetensors.torch = dummy_safetensors_torch
+    dummy_numpy = types.ModuleType("numpy")
+    dummy_numpy.ndarray = list
 
     with patch("shared.py.heartbeat_client.HeartbeatClient", lambda *a, **k: DummyHB()):
         with patch.dict(
@@ -35,6 +83,13 @@ def test_websocket_tts_returns_wav_bytes():
                 "speech.tts": dummy_module,
                 "shared.py.speech": dummy_package,
                 "shared.py.speech.tts": dummy_module,
+                "soundfile": dummy_sf,
+                "nltk": dummy_nltk,
+                "torch": dummy_torch,
+                "transformers": dummy_transformers,
+                "safetensors": dummy_safetensors,
+                "safetensors.torch": dummy_safetensors_torch,
+                "numpy": dummy_numpy,
             },
         ):
             app_module = importlib.import_module("services.py.tts.app")


### PR DESCRIPTION
## Summary
- remove numpy requirement from TTS websocket tests
- mock heavy libraries and provide dummy WAV writer for isolated TTS testing

## Testing
- `pytest services/py/tts/tests/test_tts_websocket.py -q`
- `pytest services/hy/tts/tests/test_tts_websocket.py -q`
- `make lint` *(fails: npx eslint . --no-warn-ignored --ext .js,.ts returned non-zero exit status 2)*
- `make format`
- `make build` *(fails: Command 'npm run build' returned non-zero exit status 2)*

------
https://chatgpt.com/codex/tasks/task_e_689283a454408324bf2f8b2d7fc86619