### PR TITLE
docs: add stubs for shared py modules

### DIFF
--- a/docs/shared/py/heartbeat_client.md
+++ b/docs/shared/py/heartbeat_client.md
@@ -1,0 +1,12 @@
+# shared/py/heartbeat_client.py
+
+**Path**: `shared/py/heartbeat_client.py`
+
+Lightweight client for sending periodic PID heartbeats to a monitoring service.
+
+## Dependencies
+- json
+- urllib.request
+
+## Notes
+- Runs in a background thread when `start()` is called.

--- a/docs/shared/py/mongodb.md
+++ b/docs/shared/py/mongodb.md
@@ -1,0 +1,11 @@
+# shared/py/mongodb.py
+
+**Path**: `shared/py/mongodb.py`
+
+Helper utilities for connecting to MongoDB and exposing common collections.
+
+## Dependencies
+- pymongo
+
+## Dependents
+- Modules that persist Discord data and generated messages.

--- a/docs/shared/py/settings.md
+++ b/docs/shared/py/settings.md
@@ -1,0 +1,9 @@
+# shared/py/settings.py
+
+**Path**: `shared/py/settings.py`
+
+Centralizes environment variable access for agents and services.
+
+## Notes
+- Supplies default values for agent configuration and temperature ranges.
+- Exposes Discord identifiers and MongoDB connection settings.

--- a/docs/shared/py/utils/gui.md
+++ b/docs/shared/py/utils/gui.md
@@ -1,0 +1,8 @@
+# shared/py/utils/gui.py
+
+**Path**: `shared/py/utils/gui.py`
+
+Tkinter-based helper that provides a simple interface for adjusting TTS runtime parameters.
+
+## Dependencies
+- tkinter

--- a/docs/shared/py/utils/wav_processing.md
+++ b/docs/shared/py/utils/wav_processing.md
@@ -1,0 +1,8 @@
+# shared/py/utils/wav_processing.py
+
+**Path**: `shared/py/utils/wav_processing.py`
+
+NumPy helpers for padding tensors and folding or unfolding audio batches during WaveRNN-style processing.
+
+## Dependencies
+- numpy


### PR DESCRIPTION
## Summary
- document shared settings, mongodb, and heartbeat_client modules
- add docs for gui and wav_processing helpers

## Testing
- `make format`
- `make lint` *(fails: ESLint reports all files ignored)*
- `make test` *(fails: pipenv test command exited with status 2)*
- `make build` *(fails: npm run build exited with status 2)*

------
https://chatgpt.com/codex/tasks/task_e_689288d76ce88324839ff95403332728