### PR TITLE
feat(file-watcher): populate new tasks using ollama

### DIFF
--- a/scripts/populate_task_ollama.py
+++ b/scripts/populate_task_ollama.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""Populate a new task file with starter content using ollama."""
+import subprocess
+import shutil
+import sys
+from pathlib import Path
+
+PROMPT_TEMPLATE = (
+    "You are an engineering assistant. Given a task title, "
+    "produce a concise markdown task stub with headings for Goals, Requirements, and Subtasks."
+)
+
+
+def generate_content(title: str) -> str:
+    """Generate markdown content for the task."""
+    if shutil.which("ollama") is None:
+        return f"#Todo\n\n## 🛠️ Task: {title}\n\n- outline details here\n"
+    prompt = f"{PROMPT_TEMPLATE} Title: {title}"
+    try:
+        result = subprocess.run(
+            ["ollama", "run", "mistral"],
+            input=prompt,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except subprocess.CalledProcessError:
+        return f"#Todo\n\n## 🛠️ Task: {title}\n\n- outline details here\n"
+    content = result.stdout.strip()
+    if not content:
+        content = f"## 🛠️ Task: {title}\n\n- outline details here"
+    return content + "\n"
+
+
+def main() -> None:
+    if len(sys.argv) < 2:
+        print("usage: populate_task_ollama.py <path>")
+        return
+    path = Path(sys.argv[1])
+    if path.exists() and path.stat().st_size > 0:
+        return
+    title = path.stem.replace("_", " ")
+    content = generate_content(title)
+    if not content.lstrip().startswith("#"):
+        content = "#Todo\n\n" + content
+    path.write_text(content, encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main()

--- a/services/ts/file-watcher/src/index.ts
+++ b/services/ts/file-watcher/src/index.ts
@@ -11,7 +11,11 @@ export interface FileWatcherOptions {
   /** Root of the repository. Defaults to the REPO_ROOT env var or "". */
   repoRoot?: string;
   /** Function used to execute python scripts. */
-  runPython?: (script: string, capture?: boolean) => Promise<string | void>;
+  runPython?: (
+    script: string,
+    capture?: boolean,
+    args?: string[],
+  ) => Promise<string | void>;
   /** Function used to write the kanban board file. */
   writeFile?: (path: string, data: string) => Promise<void>;
 }
@@ -21,9 +25,10 @@ const defaultRepoRoot = process.env.REPO_ROOT || "";
 function defaultRunPython(
   script: string,
   capture = false,
+  args: string[] = [],
 ): Promise<string | void> {
   return new Promise((resolve, reject) => {
-    const proc = spawn("python", [script], { cwd: defaultRepoRoot });
+    const proc = spawn("python", [script, ...args], { cwd: defaultRepoRoot });
     let data = "";
 
     proc.stdout.on("data", (chunk) => {
@@ -107,6 +112,22 @@ export function startFileWatcher(options: FileWatcherOptions = {}): {
   });
 
   const tasksWatcher = chokidar.watch(tasksPath, { ignoreInitial: true });
+  tasksWatcher.on("add", (path) => {
+    if (updatingTasks) {
+      console.log("Ignoring task addition triggered by watcher");
+      return;
+    }
+    console.log("New task file added, populating stub...");
+    updatingTasks = true;
+    runPython(join("scripts", "populate_task_ollama.py"), false, [path])
+      .then(() => updateBoard())
+      .catch((err) => console.error("populate_task_ollama failed", err))
+      .finally(() => {
+        setTimeout(() => {
+          updatingTasks = false;
+        }, 100);
+      });
+  });
   tasksWatcher.on("change", () => {
     if (updatingTasks) {
       console.log("Ignoring task change triggered by watcher");

--- a/services/ts/file-watcher/tests/debounce.test.ts
+++ b/services/ts/file-watcher/tests/debounce.test.ts
@@ -30,7 +30,7 @@ test("ignores board changes caused by watcher", async (t) => {
 
   const watchers = startFileWatcher({
     repoRoot: root,
-    runPython: async (script) => {
+    runPython: async (script, _capture, _args) => {
       calls.push(script);
       if (script.includes("hashtags_to_kanban.py")) {
         return "board";
@@ -57,7 +57,7 @@ test("ignores task changes caused by watcher", async (t) => {
 
   const watchers = startFileWatcher({
     repoRoot: root,
-    runPython: async (script) => {
+    runPython: async (script, _capture, _args) => {
       calls.push(script);
       if (script.includes("kanban_to_hashtags.py")) {
         await fs.writeFile(taskFile, "updated");

--- a/services/ts/file-watcher/tests/populate.test.ts
+++ b/services/ts/file-watcher/tests/populate.test.ts
@@ -1,0 +1,49 @@
+import test from "ava";
+import { tmpdir } from "os";
+import { join } from "path";
+import { promises as fs } from "fs";
+import { startFileWatcher } from "../src/index.js";
+
+function delay(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function setupTempRepo() {
+  const root = await fs.mkdtemp(join(tmpdir(), "fw-"));
+  const boardDir = join(root, "docs", "agile", "boards");
+  const tasksDir = join(root, "docs", "agile", "tasks");
+  await fs.mkdir(boardDir, { recursive: true });
+  await fs.mkdir(tasksDir, { recursive: true });
+  await fs.writeFile(join(boardDir, "kanban.md"), "");
+  return { root, tasksDir };
+}
+
+test("populates new task files", async (t) => {
+  process.env.NODE_ENV = "test";
+  const { root, tasksDir } = await setupTempRepo();
+  const calls: { script: string; args?: string[] }[] = [];
+
+  const watchers = startFileWatcher({
+    repoRoot: root,
+    runPython: async (script, _capture, args) => {
+      calls.push({ script, ...(args ? { args } : {}) });
+      return undefined;
+    },
+    writeFile: async () => {},
+  });
+
+  await delay(50);
+  const newTask = join(tasksDir, "new_task.md");
+  await fs.writeFile(newTask, "");
+  await delay(300);
+
+  t.true(
+    calls.some(
+      (c) =>
+        c.script.includes("populate_task_ollama.py") && c.args?.[0] === newTask,
+    ),
+  );
+
+  await watchers.boardWatcher.close();
+  await watchers.tasksWatcher.close();
+});


### PR DESCRIPTION
## Summary
- auto-populate new docs/agile task files via Ollama
- watch task additions and regenerate Kanban board
- cover file watcher task population with tests

## Testing
- `npx --yes eslint . --ext .js,.ts` *(fails: all files ignored)*
- `npm test` *(fails: cannot find module services/shared/js/heartbeat)*
- `npm run build`
- `npm run format` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68928a0a900c8324af6124463a293390