### PR TITLE
docs: add missing service stubs

### DIFF
--- a/docs/services/discord-attachment-embedder/main.md
+++ b/docs/services/discord-attachment-embedder/main.md
@@ -1,0 +1,14 @@
+# main.py
+
+**Path**: `services/py/discord_attachment_embedder/main.py`
+
+**Description**: Scans Discord messages for text and image attachments, generates embeddings via an embedding service, and stores results in ChromaDB while marking messages as processed in MongoDB.
+
+## Dependencies
+- os
+- chromadb
+- shared.py.mongodb
+- shared.py.embedding_client
+
+## Dependents
+- `services/py/discord_attachment_embedder/tests/test_embedder.py`

--- a/docs/services/discord-attachment-embedder/tests/test_embedder.md
+++ b/docs/services/discord-attachment-embedder/tests/test_embedder.md
@@ -1,0 +1,16 @@
+# test_embedder.py
+
+**Path**: `services/py/discord_attachment_embedder/tests/test_embedder.py`
+
+**Description**: Unit tests validating that Discord messages and image attachments are embedded and marked in MongoDB using an in-memory Chroma collection.
+
+## Dependencies
+- chromadb
+- pytest
+- chromadb.utils.embedding_functions
+- importlib
+- pathlib
+- sys
+
+## Dependents
+- None

--- a/docs/services/discord-attachment-indexer/main.md
+++ b/docs/services/discord-attachment-indexer/main.md
@@ -1,0 +1,18 @@
+# main.py
+
+**Path**: `services/py/discord_attachment_indexer/main.py`
+
+**Description**: Discord client that scans channels for new messages, extracts attachment metadata, updates MongoDB records, and maintains per-channel cursors while reporting liveness via `HeartbeatClient`.
+
+## Dependencies
+- hy
+- discord.py
+- asyncio
+- random
+- shared.py.settings
+- shared.py.mongodb
+- shared.py.heartbeat_client
+- typing
+
+## Dependents
+- `services/py/discord_attachment_indexer/tests/test_discord_attachment_indexer.py`

--- a/docs/services/discord-attachment-indexer/tests/test_discord_attachment_indexer.md
+++ b/docs/services/discord-attachment-indexer/tests/test_discord_attachment_indexer.md
@@ -1,0 +1,17 @@
+# test_discord_attachment_indexer.py
+
+**Path**: `services/py/discord_attachment_indexer/tests/test_discord_attachment_indexer.py`
+
+**Description**: Tests that attachment metadata and channel cursors are stored in MongoDB using fake Discord objects and in-memory collections.
+
+## Dependencies
+- pytest
+- importlib
+- asyncio
+- random
+- discord
+- pathlib
+- sys
+
+## Dependents
+- None

--- a/docs/services/embedding-service/__init__.md
+++ b/docs/services/embedding-service/__init__.md
@@ -1,0 +1,11 @@
+# __init__.py
+
+**Path**: `services/py/embedding_service/__init__.py`
+
+**Description**: Package marker for the embedding service.
+
+## Dependencies
+- None
+
+## Dependents
+- `services/py/embedding_service/main.py`

--- a/docs/services/embedding-service/drivers/__init__.md
+++ b/docs/services/embedding-service/drivers/__init__.md
@@ -1,0 +1,14 @@
+# __init__.py
+
+**Path**: `services/py/embedding_service/drivers/__init__.py`
+
+**Description**: Registers available embedding drivers and exposes `get_driver` to retrieve them by name.
+
+## Dependencies
+- .base
+- .naive_driver
+- .transformers_driver
+- .ollama_driver
+
+## Dependents
+- `services/py/embedding_service/main.py`

--- a/docs/services/embedding-service/drivers/base.md
+++ b/docs/services/embedding-service/drivers/base.md
@@ -1,0 +1,15 @@
+# base.py
+
+**Path**: `services/py/embedding_service/drivers/base.py`
+
+**Description**: Abstract base class defining the interface for embedding drivers.
+
+## Dependencies
+- abc
+- typing
+
+## Dependents
+- `services/py/embedding_service/drivers/naive_driver.py`
+- `services/py/embedding_service/drivers/ollama_driver.py`
+- `services/py/embedding_service/drivers/transformers_driver.py`
+- `services/py/embedding_service/drivers/__init__.py`

--- a/docs/services/embedding-service/drivers/naive_driver.md
+++ b/docs/services/embedding-service/drivers/naive_driver.md
@@ -1,0 +1,13 @@
+# naive_driver.py
+
+**Path**: `services/py/embedding_service/drivers/naive_driver.py`
+
+**Description**: Simple embedding driver for testing that provides deterministic vector outputs via `simple` or `length` functions.
+
+## Dependencies
+- typing
+- functools.lru_cache
+- .base
+
+## Dependents
+- `services/py/embedding_service/drivers/__init__.py`

--- a/docs/services/embedding-service/drivers/ollama_driver.md
+++ b/docs/services/embedding-service/drivers/ollama_driver.md
@@ -1,0 +1,14 @@
+# ollama_driver.py
+
+**Path**: `services/py/embedding_service/drivers/ollama_driver.py`
+
+**Description**: Embedding driver that proxies text inputs to an Ollama server and returns the resulting vectors.
+
+## Dependencies
+- functools.lru_cache
+- requests
+- typing
+- .base
+
+## Dependents
+- `services/py/embedding_service/drivers/__init__.py`

--- a/docs/services/embedding-service/drivers/transformers_driver.md
+++ b/docs/services/embedding-service/drivers/transformers_driver.md
@@ -1,0 +1,16 @@
+# transformers_driver.py
+
+**Path**: `services/py/embedding_service/drivers/transformers_driver.py`
+
+**Description**: Driver powered by `sentence-transformers` capable of embedding text and image URLs into vectors.
+
+## Dependencies
+- functools.lru_cache
+- sentence_transformers
+- requests
+- PIL
+- typing
+- .base
+
+## Dependents
+- `services/py/embedding_service/drivers/__init__.py`

--- a/docs/services/embedding-service/main.md
+++ b/docs/services/embedding-service/main.md
@@ -1,0 +1,14 @@
+# main.py
+
+**Path**: `services/py/embedding_service/main.py`
+
+**Description**: FastAPI application exposing `/embed` to generate vector embeddings using pluggable drivers such as naive, transformers, or Ollama implementations.
+
+## Dependencies
+- fastapi
+- pydantic
+- functools.lru_cache
+- services/py/embedding_service/drivers
+
+## Dependents
+- `services/py/embedding_service/tests/test_service.py`

--- a/docs/services/embedding-service/tests/test_service.md
+++ b/docs/services/embedding-service/tests/test_service.md
@@ -1,0 +1,14 @@
+# test_service.py
+
+**Path**: `services/py/embedding_service/tests/test_service.py`
+
+**Description**: Exercises the `/embed` endpoint with the naive driver to confirm that embeddings are generated and returned.
+
+## Dependencies
+- fastapi.testclient
+- services/py/embedding_service/main
+- pathlib
+- sys
+
+## Dependents
+- None

--- a/docs/services/heartbeat/index.md
+++ b/docs/services/heartbeat/index.md
@@ -1,0 +1,16 @@
+# index.js
+
+**Path**: `services/js/heartbeat/index.js`
+
+**Description**: Express service that records process heartbeats in MongoDB, enforcing per-app instance limits and capturing CPU, memory, and network metrics.
+
+## Dependencies
+- express
+- mongodb
+- pidusage
+- fs
+- path
+
+## Dependents
+- `services/js/heartbeat/tests/heartbeat.test.js`
+- `services/js/heartbeat/tests/client.test.js`

--- a/docs/services/heartbeat/tests/client.test.md
+++ b/docs/services/heartbeat/tests/client.test.md
@@ -1,0 +1,15 @@
+# client.test.js
+
+**Path**: `services/js/heartbeat/tests/client.test.js`
+
+**Description**: Tests the `HeartbeatClient` helper to verify it posts heartbeat data to the service and receives metrics.
+
+## Dependencies
+- ava
+- mongodb-memory-server
+- path
+- url
+- shared/js/heartbeat
+
+## Dependents
+- None

--- a/docs/services/heartbeat/tests/heartbeat.test.md
+++ b/docs/services/heartbeat/tests/heartbeat.test.md
@@ -1,0 +1,17 @@
+# heartbeat.test.js
+
+**Path**: `services/js/heartbeat/tests/heartbeat.test.js`
+
+**Description**: Integration tests that ensure the heartbeat service kills stale processes, enforces instance limits, and stores CPU, memory, and network metrics.
+
+## Dependencies
+- ava
+- supertest
+- mongodb-memory-server
+- mongodb
+- child_process
+- path
+- url
+
+## Dependents
+- None


### PR DESCRIPTION
## Summary
- document heartbeat service and tests
- add docs for discord attachment embedder and indexer services
- mirror embedding service modules and drivers

## Testing
- `make format`
- `make lint` (fails: ESLint reports glob pattern "." is ignored)
- `make build` (fails: ts compiler missing modules)
- `make test` (fails: pytest command returned non-zero exit status 2)


------
https://chatgpt.com/codex/tasks/task_e_689288d76ce88324839ff95403332728