### PR TITLE
feat: generate docs for orphaned files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,6 +6,12 @@ repos:
         entry: python scripts/convert_wikilinks.py
         language: system
         files: '\.md$'
+      - id: generate-orphan-docs
+        name: Generate docs for orphaned files
+        entry: python scripts/generate_orphan_docs.py
+        language: system
+        pass_filenames: false
+        files: ^orphaned-files-report\.md$
   - repo: https://github.com/psf/black
     rev: 24.4.2
     hooks:

--- a/docs/scripts/generate_orphan_docs.md
+++ b/docs/scripts/generate_orphan_docs.md
@@ -1,0 +1,12 @@
+# generate_orphan_docs.py
+
+Generates mirrored documentation files for entries listed in `orphaned-files-report.md`.
+For each listed path outside of `docs/`, the script creates a corresponding
+`docs/<path>.md` file and uses `ollama` to produce a short description based on
+the file's contents.
+
+Run it with:
+
+```bash
+python scripts/generate_orphan_docs.py
+```

--- a/scripts/generate_orphan_docs.py
+++ b/scripts/generate_orphan_docs.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Generate documentation for orphaned files using Ollama.
+
+This script reads the list of orphaned files from ``orphaned-files-report.md``.
+For each file that is not already within the ``docs`` directory, a mirrored
+markdown file is created under ``docs/``. The contents of the orphaned file are
+sent to ``ollama`` to generate concise documentation which is then written to
+that mirrored markdown file.
+"""
+
+from __future__ import annotations
+
+import re
+import shutil
+import subprocess
+from pathlib import Path
+
+REPORT_FILE = "orphaned-files-report.md"
+MODEL = "mistral"
+DOCS_DIR = Path("docs")
+
+
+def read_orphaned_paths(report: Path) -> list[Path]:
+    """Parse the orphaned files report and return a list of file paths."""
+    paths: list[Path] = []
+    pattern = re.compile(r"^- \[(.*?)\]")
+    for line in report.read_text(encoding="utf-8", errors="ignore").splitlines():
+        match = pattern.match(line.strip())
+        if match:
+            path_str = match.group(1)
+            if not path_str.startswith("docs/"):
+                paths.append(Path(path_str))
+    return paths
+
+
+def generate_doc(path: Path, content: str) -> str:
+    """Use Ollama to generate documentation for ``path`` based on ``content``."""
+    if shutil.which("ollama") is None:
+        return ""
+    prompt = f"Write concise documentation for the file `{path}`:\n\n{content}\n"
+    try:
+        result = subprocess.run(
+            ["ollama", "run", MODEL],
+            input=prompt,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except subprocess.CalledProcessError:
+        return ""
+    return result.stdout.strip()
+
+
+def process_file(path: Path) -> None:
+    """Create a mirrored documentation file for ``path`` if needed."""
+    doc_path = DOCS_DIR / path
+    doc_path = doc_path.with_name(doc_path.name + ".md")
+    if doc_path.exists():
+        return
+    try:
+        content = path.read_text(encoding="utf-8")
+    except Exception:
+        return
+    documentation = generate_doc(path, content)
+    if not documentation:
+        return
+    doc_path.parent.mkdir(parents=True, exist_ok=True)
+    doc_text = f"# {path}\n\n{documentation}\n"
+    doc_path.write_text(doc_text, encoding="utf-8")
+
+
+def main() -> None:
+    repo_root = Path(__file__).resolve().parent.parent
+    report_path = repo_root / REPORT_FILE
+    if not report_path.exists():
+        raise FileNotFoundError(f"{REPORT_FILE} not found")
+    for orphan_path in read_orphaned_paths(report_path):
+        source_path = repo_root / orphan_path
+        if source_path.exists():
+            process_file(source_path)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add script to mirror orphaned files into docs and populate entries via ollama
- document generate_orphan_docs script
- integrate orphan doc generator into pre-commit hooks

## Testing
- `make format` *(fails: Command 'npx prettier --write .' returned non-zero exit status 1)*
- `make lint` *(fails: Command 'npx eslint --ext .js,.ts . ' returned non-zero exit status 1)*
- `make build` *(fails: npm run build returned non-zero exit status 127)*
- `make test` *(fails: pipenv pytest command returned non-zero exit status 2)*
- `make setup` *(fails: interrupted)*
- `pre-commit run generate-orphan-docs --files orphaned-files-report.md` *(interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68928b6ab3a883249a8813f72cd45833