### PR TITLE
ci: split lint workflow per service

### DIFF
--- a/.github/workflows/lint-js.yml
+++ b/.github/workflows/lint-js.yml
@@ -1,0 +1,54 @@
+name: JS Lint Suite
+permissions:
+  contents: read
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        service:
+          - vision
+          - heartbeat
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-node@v3
+        with:
+          node-version: "20"
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+
+      - name: Install Hy
+        run: python -m pip install hy dotenv
+
+      - name: Cache pip dependencies
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('Pipfile.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
+      - name: Cache npm dependencies
+        uses: actions/cache@v3
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-npm-${{ hashFiles(format('services/js/{0}/package-lock.json', matrix.service)) }}
+          restore-keys: |
+            ${{ runner.os }}-npm-
+
+      - name: Install dependencies
+        run: make system-deps setup-js-service-${{ matrix.service }}
+
+      - name: Lint
+        run: make lint-js-service-${{ matrix.service }}

--- a/.github/workflows/lint-py.yml
+++ b/.github/workflows/lint-py.yml
@@ -1,0 +1,59 @@
+name: Python Lint Suite
+permissions:
+  contents: read
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        service:
+          - stt
+          - tts
+          - discord_indexer
+          - discord_attachment_indexer
+          - discord_attachment_embedder
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+
+      - name: Install Hy
+        run: python -m pip install hy dotenv
+
+      - name: Cache pip dependencies
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles(format('services/py/{0}/Pipfile.lock', matrix.service)) }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
+      - name: Cache npm dependencies
+        uses: actions/cache@v3
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-npm-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-npm-
+
+      - name: Install dependencies
+        run: make system-deps setup-pipenv setup-python-service-${{ matrix.service }}
+
+      - name: Install lint dependencies
+        run: python -m pip install flake8
+
+      - name: Lint
+        run: make lint-python-service-${{ matrix.service }}
+
+      - name: Typecheck
+        run: make typecheck-python

--- a/.github/workflows/lint-ts.yml
+++ b/.github/workflows/lint-ts.yml
@@ -1,4 +1,4 @@
-name: Linter
+name: TS Lint Suite
 permissions:
   contents: read
 
@@ -8,11 +8,24 @@ on:
     branches: [main]
 
 jobs:
-  test:
+  lint:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        service:
+          - cephalon
+          - discord-embedder
+          - llm
+          - voice
+          - file-watcher
 
     steps:
       - uses: actions/checkout@v3
+
+      - uses: actions/setup-node@v3
+        with:
+          node-version: "20"
 
       - uses: actions/setup-python@v4
         with:
@@ -20,13 +33,6 @@ jobs:
 
       - name: Install Hy
         run: python -m pip install hy dotenv
-
-      - name: Install system dependencies
-        run: make system-deps
-
-      - uses: actions/setup-node@v3
-        with:
-          node-version: "20"
 
       - name: Cache pip dependencies
         uses: actions/cache@v3
@@ -40,27 +46,15 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ~/.npm
-          key: ${{ runner.os }}-npm-${{ hashFiles('package-lock.json') }}
+          key: ${{ runner.os }}-npm-${{ hashFiles(format('services/ts/{0}/package-lock.json', matrix.service)) }}
           restore-keys: |
             ${{ runner.os }}-npm-
 
       - name: Install dependencies
-        run: make setup
-
-      - name: Install lint dependencies
-        run: python -m pip install flake8
-
-      - name: Build project
-        run: make build
+        run: make system-deps setup-ts-service-${{ matrix.service }}
 
       - name: Lint
-        run: make lint
+        run: make lint-ts-service-${{ matrix.service }}
 
-      - name: Typecheck Python
-        run: make typecheck-python
-
-      - name: Typecheck TypeScript
+      - name: Typecheck
         run: make typecheck-ts
-
-      # - name: Format
-      #   run: make format


### PR DESCRIPTION
## Summary
- split lint workflow into JS, Python, and TypeScript workflows
- run lint & type checks per service via matrix strategies

## Testing
- `make setup` *(fails: KeyboardInterrupt)*
- `make test` *(fails: ModuleNotFoundError: No module named 'chromadb')*
- `make build` *(fails: npm run build returned non-zero exit status 2)*
- `make lint` *(fails: ESLint: You are linting '.', but all of the files matching the glob pattern '.' are ignored)*
- `make format`

------
https://chatgpt.com/codex/tasks/task_e_6892b8706608832483a2513358bafd52