### PR TITLE
Add Linux-only MongoDB setup and documentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,13 @@
 # Auto-generated Makefile. DO NOT EDIT MANUALLY.
 
 COMMANDS := \
-  all build clean lint format test test-e2e setup setup-quick install \
+  all build clean lint format test setup setup-quick install install-mongodb \
   install-gha-artifacts system-deps start stop \
   start-tts start-stt stop-tts stop-stt \
   board-sync kanban-from-tasks kanban-to-hashtags kanban-to-issues \
   coverage coverage-python coverage-js coverage-ts simulate-ci \
   docker-build docker-up docker-down \
-  typecheck-python typecheck-ts build-ts build-js \
+  typecheck-python test-e2e typecheck-ts build-ts build-js \
   setup-pipenv compile-hy \
   setup-python setup-python-quick setup-js setup-ts setup-hy \
   test-python test-js test-ts test-hy test-integration \

--- a/Makefile.hy
+++ b/Makefile.hy
@@ -2,6 +2,7 @@
 (import util [sh run-dirs])
 (import dotenv [load-dotenv])
 (import os.path [isdir join])
+(import platform)
 (load-dotenv)
 (require macros [ define-service-list defn-cmd ])
 
@@ -333,6 +334,11 @@
 (defn-cmd system-deps []
   (sh "sudo apt-get update && sudo apt-get install -y libsndfile1" :shell True))
 
+(defn-cmd install-mongodb []
+  (if (= (platform.system) "Linux")
+      (sh "curl -fsSL https://pgp.mongodb.com/server-7.0.asc | sudo gpg --dearmor --yes -o /usr/share/keyrings/mongodb-server-7.0.gpg && echo 'deb [ signed-by=/usr/share/keyrings/mongodb-server-7.0.gpg ] https://repo.mongodb.org/apt/ubuntu jammy/mongodb-org/7.0 multiverse' | sudo tee /etc/apt/sources.list.d/mongodb-org-7.0.list && sudo apt-get update && sudo apt-get install -y mongodb-org" :shell True)
+      (print "MongoDB installation is only supported on Linux")))
+
 (defn-cmd start []
   (sh ["pm2" "start" "ecosystem.config.js"]))
 
@@ -425,7 +431,7 @@
   (setv header
         "# Auto-generated Makefile. DO NOT EDIT MANUALLY.\n\n"
         command-section
-        "COMMANDS := \\\n  all build clean lint format test setup setup-quick install \\\n  install-gha-artifacts system-deps start stop \\\n  start-tts start-stt stop-tts stop-stt \\\n  board-sync kanban-from-tasks kanban-to-hashtags kanban-to-issues \\\n  coverage coverage-python coverage-js coverage-ts simulate-ci \\\n  docker-build docker-up docker-down \\\n  typecheck-python test-e2e typecheck-ts build-ts build-js \\\n  setup-pipenv compile-hy \\\n  setup-python setup-python-quick setup-js setup-ts setup-hy \\\n  test-python test-js test-ts test-hy test-integration \\\n  generate-requirements generate-python-services-requirements generate-makefile\n\n")
+        "COMMANDS := \\\n  all build clean lint format test setup setup-quick install install-mongodb \\\n  install-gha-artifacts system-deps start stop \\\n  start-tts start-stt stop-tts stop-stt \\\n  board-sync kanban-from-tasks kanban-to-hashtags kanban-to-issues \\\n  coverage coverage-python coverage-js coverage-ts simulate-ci \\\n  docker-build docker-up docker-down \\\n  typecheck-python test-e2e typecheck-ts build-ts build-js \\\n  setup-pipenv compile-hy \\\n  setup-python setup-python-quick setup-js setup-ts setup-hy \\\n  test-python test-js test-ts test-hy test-integration \\\n  generate-requirements generate-python-services-requirements generate-makefile\n\n")
 
   ;; Group rules by prefix for PHONY
   (setv phony-lines []

--- a/readme.md
+++ b/readme.md
@@ -75,6 +75,19 @@ The service management targets `make start`, `make start-tts` and
 `make start-stt` require PM2. You can install it globally as shown above or add
 it as a project dependency.
 
+### MongoDB
+
+Some services (for example `heartbeat`) require a running MongoDB instance.
+On Linux you can install and start MongoDB with:
+
+```bash
+make install-mongodb
+```
+
+This target adds the MongoDB apt repository and installs the `mongodb-org` package.
+On Windows, install [MongoDB Community Edition](https://www.mongodb.com/try/download/community)
+and ensure the `mongod` service is running locally before starting PM2.
+
 ## Running Services
 
 Scripts in `agents/scripts/` launch commonly used services:


### PR DESCRIPTION
## Summary
- add a Linux-only `install-mongodb` target to the Makefile
- document MongoDB installation steps and PM2 usage in the README

## Testing
- `make lint` *(fails: ESLint could not find files)*
- `make build` *(fails: `npm run build` exited with code 2)*
- `make test` *(fails: pipenv tests exited with code 2)*
- `make format`
- `make install-mongodb`
- `pm2 start ecosystem.config.js`


------
https://chatgpt.com/codex/tasks/task_e_6892b90eeb3c8324b04d19ebcbbd5c1f