### PR TITLE
Ensure file watcher shuts down cleanly

### DIFF
--- a/services/ts/file-watcher/tests/debounce.test.ts
+++ b/services/ts/file-watcher/tests/debounce.test.ts
@@ -46,8 +46,7 @@ test("ignores board changes caused by watcher", async (t) => {
   t.is(calls.length, 1);
   t.true(calls[0]!.includes("hashtags_to_kanban.py"));
 
-  await watchers.boardWatcher.close();
-  await watchers.tasksWatcher.close();
+  await watchers.close();
 });
 
 test("ignores task changes caused by watcher", async (t) => {
@@ -73,6 +72,5 @@ test("ignores task changes caused by watcher", async (t) => {
   t.is(calls.length, 1);
   t.true(calls[0]!.includes("kanban_to_hashtags.py"));
 
-  await watchers.boardWatcher.close();
-  await watchers.tasksWatcher.close();
+  await watchers.close();
 });

--- a/services/ts/file-watcher/tests/kanban.test.ts
+++ b/services/ts/file-watcher/tests/kanban.test.ts
@@ -41,6 +41,5 @@ test("creates task and emits event for new card", async (t) => {
   t.true(files.length === 1);
   t.true(events.some((e) => e.evt === "kanban:cardCreated"));
 
-  await watchers.boardWatcher.close();
-  await watchers.tasksWatcher.close();
+  await watchers.close();
 });

--- a/services/ts/file-watcher/tests/populate.test.ts
+++ b/services/ts/file-watcher/tests/populate.test.ts
@@ -44,6 +44,5 @@ test("populates new task files", async (t) => {
     ),
   );
 
-  await watchers.boardWatcher.close();
-  await watchers.tasksWatcher.close();
+  await watchers.close();
 });


### PR DESCRIPTION
## Summary
- add `close` helper to file watcher to terminate watchers, sockets and Mongo clients
- stub Mongo and socket dependencies when running tests
- adjust tests to use the new close helper

## Testing
- `make setup-ts-service-file-watcher`
- `make test-ts-service-file-watcher`
- `npm run lint` (warnings about ignored files)
- `npm run build`
- `npm run format`

------
https://chatgpt.com/codex/tasks/task_e_6892b81751d8832495811597790da34c