### PR TITLE
feat(heartbeat): track session id and cleanup

### DIFF
--- a/docs/services/heartbeat/index.md
+++ b/docs/services/heartbeat/index.md
@@ -2,7 +2,7 @@
 
 **Path**: `services/js/heartbeat/index.js`
 
-**Description**: Express service that records process heartbeats in MongoDB, enforcing per-app instance limits and capturing CPU, memory, and network metrics.
+**Description**: Express service that records process heartbeats in MongoDB, enforcing per-app instance limits and capturing CPU, memory, and network metrics. Each document stores a service-instance session ID so restarts ignore stale entries and shutdowns mark them as killed.
 
 ## Dependencies
 - express

--- a/docs/services/heartbeat/tests/heartbeat.test.md
+++ b/docs/services/heartbeat/tests/heartbeat.test.md
@@ -2,7 +2,7 @@
 
 **Path**: `services/js/heartbeat/tests/heartbeat.test.js`
 
-**Description**: Integration tests that ensure the heartbeat service kills stale processes, enforces instance limits, and stores CPU, memory, and network metrics.
+**Description**: Integration tests that ensure the heartbeat service kills stale processes, enforces instance limits, stores CPU, memory, and network metrics, respects per-instance session IDs, and cleans up heartbeats on shutdown.
 
 ## Dependencies
 - ava

--- a/services/js/heartbeat/README.md
+++ b/services/js/heartbeat/README.md
@@ -4,6 +4,8 @@ Tracks process heartbeats via HTTP and terminates those that fail to report with
 Backed by MongoDB for storage. Intended for detecting and cleaning up hung or orphaned worker processes.
 Also enforces the instance limits defined in a PM2 ecosystem file, rejecting registrations that exceed the configured count for a given app name.
 Each heartbeat updates CPU, memory, and network byte counts for the process based on its PID.
+Heartbeats are tagged with a service-instance session ID so that restarts do not conflict with stale database entries.
+On shutdown the service marks all heartbeats from its current session as killed to allow clean restarts.
 
 ## API
 


### PR DESCRIPTION
## Summary
- track per-instance session IDs in heartbeat records and ignore stale sessions
- clean heartbeat records on shutdown and handle SIGINT/SIGTERM for pm2 restarts
- document heartbeat session handling and cleanup behavior

## Testing
- `make install-mongodb`
- `make setup-js-service-heartbeat`
- `make format`
- `make lint-js-service-heartbeat`
- `make build-js`
- `make test-js-service-heartbeat`


------
https://chatgpt.com/codex/tasks/task_e_6892caf283e8832483c0dbbe6ccb6ce6