### PR TITLE
Add wav processing tests and update coverage docs

### DIFF
--- a/docs/untested-code.md
+++ b/docs/untested-code.md
@@ -8,7 +8,6 @@ This document lists modules in the `shared/py` package that currently have no au
 | `shared/py/mongodb.py` | 19 | MongoDB wrapper utilities |
 | `shared/py/settings.py` | 17 | Global application settings loader |
 | `shared/py/utils/gui.py` | 25 | Tkinter GUI helpers |
-| `shared/py/utils/wav_processing.py` | 83 | Audio batch and resampling routines |
 
 Coverage generated with `pytest --cov` showed these modules at **0%** coverage. Adding unit tests will ensure these utilities remain stable as the project evolves.
 

--- a/shared/py/tests/test_wav_processing.py
+++ b/shared/py/tests/test_wav_processing.py
@@ -1,0 +1,69 @@
+import os
+import sys
+import pytest
+import numpy as np
+
+sys.path.insert(
+    0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../"))
+)
+
+from shared.py.utils.wav_processing import (
+    pad_tensor,
+    fold_with_overlap,
+    xfade_and_unfold,
+    get_one_hot,
+    infer_from_discretized_mix_logistic,
+)
+
+
+def test_pad_tensor_behaviour():
+    x = np.arange(1, 6).reshape(1, 5, 1).astype(float)
+    both = pad_tensor(x, 2, "both")
+    after = pad_tensor(x, 2, "after")
+    before = pad_tensor(x, 2, "before")
+
+    assert both.shape == (1, 9, 1)
+    assert after.shape == (1, 7, 1)
+    assert before.shape == (1, 7, 1)
+    np.testing.assert_array_equal(both[:, 2:7, :], x)
+    np.testing.assert_array_equal(after[:, :5, :], x)
+    np.testing.assert_array_equal(before[:, 2:, :], x)
+
+
+def test_fold_with_overlap_and_error():
+    x = np.arange(1, 11).reshape(1, 10, 1).astype(float)
+    folded, (target, overlap) = fold_with_overlap(x, target=2, overlap=1)
+    assert folded.shape == (3, 4, 1)
+    np.testing.assert_array_equal(folded[0, :, 0], [1, 2, 3, 4])
+    np.testing.assert_array_equal(folded[1, :, 0], [4, 5, 6, 7])
+    np.testing.assert_array_equal(folded[2, :, 0], [7, 8, 9, 10])
+
+    short = np.arange(1, 4).reshape(1, 3, 1).astype(float)
+    with pytest.raises(ValueError):
+        fold_with_overlap(short, target=2, overlap=1)
+
+
+def test_xfade_and_unfold():
+    folded = np.array(
+        [
+            [1, 2, 3, 4],
+            [4, 5, 6, 7],
+            [7, 8, 9, 10],
+        ],
+        dtype=float,
+    )
+    result = xfade_and_unfold(folded, overlap=1)
+    assert result.shape == (10,)
+    assert not np.isnan(result).any()
+
+
+def test_get_one_hot_and_infer_from_dml():
+    arr = np.array([0, 2])
+    one_hot = get_one_hot(arr, 4)
+    expected = np.array([[1, 0, 0, 0], [0, 0, 1, 0]], dtype=float)
+    np.testing.assert_array_equal(one_hot, expected)
+
+    params = np.random.rand(1, 6, 2)
+    output = infer_from_discretized_mix_logistic(params)
+    assert output.shape == (1, 2)
+    assert np.all(output >= -1.0) and np.all(output <= 1.0)


### PR DESCRIPTION
## Summary
- test WAV utility helpers like padding, folding, crossfade, and sampling
- document reduced list of untested modules

## Testing
- `pytest shared/py/tests/test_wav_processing.py`
- `pytest shared/py/tests/test_wav_processing.py --cov=shared.py.utils.wav_processing --cov-report=term --cov-report=xml`


------
https://chatgpt.com/codex/tasks/task_e_6892c7ed941083249e673af840066f55