### PR TITLE
refactor file watcher to use LLM service

### DIFF
--- a/services/ts/file-watcher/tests/populate.test.ts
+++ b/services/ts/file-watcher/tests/populate.test.ts
@@ -21,13 +21,13 @@ async function setupTempRepo() {
 test("populates new task files", async (t) => {
   process.env.NODE_ENV = "test";
   const { root, tasksDir } = await setupTempRepo();
-  const calls: { script: string; args?: string[] }[] = [];
+  const populateCalls: string[] = [];
 
   const watchers = startFileWatcher({
     repoRoot: root,
-    runPython: async (script, _capture, args) => {
-      calls.push({ script, ...(args ? { args } : {}) });
-      return undefined;
+    runPython: async () => undefined,
+    populateTask: async (path) => {
+      populateCalls.push(path);
     },
     writeFile: async () => {},
     mongoCollection: { updateOne: async () => {} } as any,
@@ -39,12 +39,7 @@ test("populates new task files", async (t) => {
   await fs.writeFile(newTask, "");
   await delay(300);
 
-  t.true(
-    calls.some(
-      (c) =>
-        c.script.includes("populate_task_ollama.py") && c.args?.[0] === newTask,
-    ),
-  );
+  t.true(populateCalls.includes(newTask));
 
   await watchers.close();
 });


### PR DESCRIPTION
## Summary
- call LLM service to populate new task files instead of python script
- add populateTask option to file watcher and wire through tasks watcher
- test coverage for populateTask invocation

## Testing
- `make test-ts-service-file-watcher`
- `npm run lint`
- `npm run format`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6892cf0daa488324b05c1f2a1054944f