### PR TITLE
Add vision service end-to-end test

### DIFF
--- a/tests/e2e/test_vision_service.py
+++ b/tests/e2e/test_vision_service.py
@@ -1,0 +1,54 @@
+import asyncio
+import os
+import subprocess
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from threading import Thread
+
+import httpx
+import pytest
+
+
+class _HBHandler(BaseHTTPRequestHandler):
+    def do_POST(self):
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.end_headers()
+        self.wfile.write(b"{}")
+
+    def log_message(self, format, *args):  # pragma: no cover - silence logging
+        pass
+
+
+@pytest.mark.asyncio
+async def test_vision_capture_endpoint():
+    hb_port = 5064
+    hb_server = HTTPServer(("127.0.0.1", hb_port), _HBHandler)
+    hb_thread = Thread(target=hb_server.serve_forever, daemon=True)
+    hb_thread.start()
+
+    port = 5063
+    env = os.environ.copy()
+    env.update({"PORT": str(port), "VISION_STUB": "1", "HEARTBEAT_PORT": str(hb_port)})
+    proc = subprocess.Popen(["node", "services/js/vision/index.js"], env=env)
+    try:
+        async with httpx.AsyncClient() as client:
+            for _ in range(50):
+                try:
+                    resp = await client.get(f"http://127.0.0.1:{port}/capture")
+                    if resp.status_code == 200:
+                        break
+                except Exception:
+                    await asyncio.sleep(0.1)
+            else:
+                pytest.fail("vision service did not start in time")
+
+            assert resp.headers.get("Content-Type") == "image/png"
+            assert resp.content == b"stub"
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+        hb_server.shutdown()
+        hb_thread.join()


### PR DESCRIPTION
## Summary
- add e2e test verifying vision service capture returns stubbed PNG buffer

## Testing
- `pip install pytest pytest-asyncio httpx`
- `make setup-js-service-vision`
- `flake8 tests/e2e/test_vision_service.py`
- `make lint-js-service-vision`
- `make lint`
- `make build`
- `make test-js-service-vision`
- `make format` *(fails: Command 'npx --yes @biomejs/biome format .' returned non-zero exit status 1)*
- `make test-e2e`


------
https://chatgpt.com/codex/tasks/task_e_6892d3968ebc832483c5a18f08f26b58