### PR TITLE
feat: add eidolon field service

### DIFF
--- a/docs/services/eidolon-field/index.md
+++ b/docs/services/eidolon-field/index.md
@@ -1,0 +1,5 @@
+# Eidolon Field Service
+
+Implements an 8-dimensional vector field that updates on a constant tick and
+stores each tick's field snapshot in MongoDB. Configure the connection via
+`MONGO_URL`, `DB_NAME`, and `COLLECTION` environment variables.

--- a/services/js/eidolon-field/README.md
+++ b/services/js/eidolon-field/README.md
@@ -1,0 +1,5 @@
+# eidolon-field
+
+Runs an 8-dimensional vector field on a constant tick and persists each
+tick's field snapshot to MongoDB. Configure the connection with
+`MONGO_URL`, `DB_NAME`, and `COLLECTION` environment variables.

--- a/services/js/eidolon-field/eslint.config.js
+++ b/services/js/eidolon-field/eslint.config.js
@@ -1,0 +1,10 @@
+export default [
+  {
+    files: ["**/*.js"],
+    languageOptions: {
+      ecmaVersion: 2020,
+      sourceType: "module",
+    },
+    rules: {},
+  },
+];

--- a/services/js/eidolon-field/index.js
+++ b/services/js/eidolon-field/index.js
@@ -1,0 +1,160 @@
+import { MongoClient } from "mongodb";
+
+export class VectorN {
+  constructor(values) {
+    this.values = values;
+  }
+  static zero(n) {
+    return new VectorN(Array(n).fill(0));
+  }
+  add(other) {
+    return new VectorN(this.values.map((v, i) => v + other.values[i]));
+  }
+  subtract(other) {
+    return new VectorN(this.values.map((v, i) => v - other.values[i]));
+  }
+  scale(f) {
+    return new VectorN(this.values.map((v) => v * f));
+  }
+  magnitude() {
+    return Math.sqrt(this.values.reduce((s, v) => s + v ** 2, 0));
+  }
+  normalize() {
+    const m = this.magnitude();
+    return m === 0 ? this : this.scale(1 / m);
+  }
+  toIndexKey() {
+    return this.values.map(Math.floor).join(",");
+  }
+}
+
+export class FieldN {
+  constructor(dimensions, decay = 0.98) {
+    this.dimensions = dimensions;
+    this.decay = decay;
+    this.grid = new Map();
+  }
+  get(pos) {
+    const key = pos.toIndexKey();
+    return this.grid.get(key) ?? VectorN.zero(this.dimensions);
+  }
+  inject(pos, vec) {
+    const key = pos.toIndexKey();
+    const current = this.get(pos);
+    this.grid.set(key, current.add(vec));
+  }
+  decayAll() {
+    for (const [key, vec] of this.grid.entries()) {
+      this.grid.set(key, vec.scale(this.decay));
+    }
+  }
+  sampleRegion(center, radius) {
+    const ranges = center.values.map((c) => {
+      const start = Math.floor(c - radius);
+      const end = Math.ceil(c + radius);
+      return Array.from({ length: end - start + 1 }, (_, i) => i + start);
+    });
+    const results = [];
+    const recurse = (acc, dim) => {
+      if (dim === ranges.length) {
+        const pos = new VectorN(acc);
+        results.push({ pos, vec: this.get(pos) });
+        return;
+      }
+      for (const val of ranges[dim]) {
+        recurse([...acc, val], dim + 1);
+      }
+    };
+    recurse([], 0);
+    return results;
+  }
+}
+
+export class FieldNode {
+  constructor(position, strength = 1.0, radius = 1) {
+    this.position = position;
+    this.strength = strength;
+    this.radius = radius;
+  }
+  apply(field) {
+    for (const { pos } of field.sampleRegion(this.position, this.radius)) {
+      const dir = pos.subtract(this.position).normalize().scale(this.strength);
+      field.inject(pos, dir);
+    }
+  }
+}
+
+export class VectorFieldService {
+  constructor(dim = 8, tickMs = 100) {
+    this.field = new FieldN(dim);
+    this.nodes = [];
+    this.tickMs = tickMs;
+    this.timer = null;
+    this.tickCount = 0;
+    this.mongoUrl = process.env.MONGO_URL || "mongodb://127.0.0.1:27017";
+    this.dbName = process.env.DB_NAME || "eidolon_field";
+    this.collectionName = process.env.COLLECTION || "fields";
+    this.client = null;
+    this.collection = null;
+    this.currentSave = Promise.resolve();
+  }
+  addNode(node) {
+    this.nodes.push(node);
+  }
+  async connect() {
+    this.client = new MongoClient(this.mongoUrl);
+    await this.client.connect();
+    this.collection = this.client
+      .db(this.dbName)
+      .collection(this.collectionName);
+  }
+  async saveField() {
+    if (!this.collection) return;
+    const fieldDoc = {
+      tick: this.tickCount,
+      grid: Array.from(this.field.grid.entries()).map(([key, vec]) => ({
+        key,
+        values: vec.values,
+      })),
+    };
+    await this.collection.insertOne(fieldDoc);
+  }
+  tick() {
+    this.field.decayAll();
+    for (const node of this.nodes) node.apply(this.field);
+    this.tickCount += 1;
+    this.currentSave = this.saveField().catch((err) =>
+      console.error("failed to save field", err),
+    );
+  }
+  async start() {
+    if (!this.timer) {
+      await this.connect();
+      this.timer = setInterval(() => this.tick(), this.tickMs);
+    }
+  }
+  async stop() {
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+    await this.currentSave;
+    if (this.client) {
+      await this.client.close();
+      this.client = null;
+      this.collection = null;
+    }
+  }
+}
+
+if (process.env.NODE_ENV !== "test") {
+  const service = new VectorFieldService();
+  service.addNode(new FieldNode(VectorN.zero(8), 1.0, 1));
+  service
+    .start()
+    .then(() => console.log("eidolon-field service started"))
+    .catch((err) => {
+      console.error("failed to start service", err);
+      process.exit(1);
+    });
+}

--- a/services/js/eidolon-field/package.json
+++ b/services/js/eidolon-field/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "eidolon-field",
+  "version": "0.0.1",
+  "type": "module",
+  "main": "index.js",
+  "scripts": {
+    "start": "node index.js",
+    "test": "ava",
+    "coverage": "c8 ava"
+  },
+  "dependencies": {
+    "mongodb": "^6.8.0"
+  },
+  "devDependencies": {
+    "ava": "^6.4.1",
+    "c8": "^9.1.0",
+    "mongodb-memory-server": "^10.1.4"
+  }
+}

--- a/services/js/eidolon-field/tests/tick.test.js
+++ b/services/js/eidolon-field/tests/tick.test.js
@@ -1,0 +1,29 @@
+import test from "ava";
+import { MongoMemoryServer } from "mongodb-memory-server";
+import { MongoClient } from "mongodb";
+import { VectorN, FieldNode, VectorFieldService } from "../index.js";
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+test("service ticks on interval and persists field", async (t) => {
+  const mongod = await MongoMemoryServer.create();
+  const uri = mongod.getUri();
+  process.env.MONGO_URL = uri;
+  const svc = new VectorFieldService(8, 10);
+  svc.addNode(new FieldNode(VectorN.zero(8), 1.0, 1));
+  await svc.start();
+  await sleep(35);
+  const client = new MongoClient(uri);
+  await client.connect();
+  const docs = await client
+    .db("eidolon_field")
+    .collection("fields")
+    .find()
+    .toArray();
+  t.true(docs.length >= 2);
+  await client.close();
+  await svc.stop();
+  await mongod.stop();
+  t.true(svc.tickCount >= 2);
+  t.true(svc.field.grid.size > 0);
+});


### PR DESCRIPTION
## Summary
- add mongodb persistence to eidolon-field service
- test field snapshots saved to MongoDB
- document persistence options

## Testing
- `make setup-js-service-eidolon-field`
- `make test-js-service-eidolon-field`
- `make build-js`
- `make lint-js-service-eidolon-field`
- `make format`


------
https://chatgpt.com/codex/tasks/task_e_689276b9e2c48324ba39da983cddc3e0