### PR TITLE
Add service endpoint e2e tests

### DIFF
--- a/docs/tests/e2e/service-endpoints.md
+++ b/docs/tests/e2e/service-endpoints.md
@@ -1,0 +1,25 @@
+# Service Endpoint E2E Tests
+
+## Overview
+
+These end-to-end tests verify that each networked service in the Promethean ecosystem responds as expected when the full system is running.
+
+## Services Covered
+
+- **TTS** – `/synth_voice_pcm` returns generated audio
+- **STT** – `/transcribe_pcm` returns transcription text
+- **Vision** – `/capture` returns a PNG frame
+- **LLM** – `/generate` returns a text reply
+- **Heartbeat** – `/heartbeat` echoes back process info
+
+## Running the Tests
+
+1. Install dependencies for each service as needed (`make setup-quick SERVICE=<name>`)
+2. Start the services: `pm2 start ecosystem.config.js`
+3. Execute: `pytest tests/e2e/test_service_endpoints.py`
+
+The tests will skip any service whose endpoint is unavailable.
+
+## Tags
+
+#tests #e2e

--- a/tests/e2e/test_service_endpoints.py
+++ b/tests/e2e/test_service_endpoints.py
@@ -1,0 +1,94 @@
+import os
+import asyncio
+import httpx
+import pytest
+
+
+async def _post_json(url, **kwargs):
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        return await client.post(url, **kwargs)
+
+
+async def _get(url, **kwargs):
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        return await client.get(url, **kwargs)
+
+
+def test_tts_synth_voice_pcm():
+    async def _run():
+        return await _post_json(
+            "http://127.0.0.1:5001/synth_voice_pcm", data={"input_text": "hello"}
+        )
+
+    try:
+        resp = asyncio.run(_run())
+    except Exception:
+        pytest.skip("tts service not running")
+    assert resp.status_code == 200
+    assert resp.headers.get("content-type") == "application/octet-stream"
+    assert len(resp.content) > 0
+
+
+def test_stt_transcribe_pcm():
+    pcm = b"\x00\x00" * 16000
+
+    async def _run():
+        return await _post_json(
+            "http://127.0.0.1:5002/transcribe_pcm",
+            headers={"X-Sample-Rate": "16000", "X-Dtype": "int16"},
+            content=pcm,
+        )
+
+    try:
+        resp = asyncio.run(_run())
+    except Exception:
+        pytest.skip("stt service not running")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "transcription" in data
+    assert isinstance(data["transcription"], str)
+
+
+def test_vision_capture_endpoint():
+    async def _run():
+        return await _get("http://127.0.0.1:9999/capture")
+
+    try:
+        resp = asyncio.run(_run())
+    except Exception:
+        pytest.skip("vision service not running")
+    assert resp.status_code == 200
+    assert resp.headers.get("content-type") == "image/png"
+    assert len(resp.content) > 0
+
+
+def test_llm_generate_endpoint():
+    payload = {"prompt": "hi", "context": [], "format": None}
+
+    async def _run():
+        return await _post_json("http://127.0.0.1:8888/generate", json=payload)
+
+    try:
+        resp = asyncio.run(_run())
+    except Exception:
+        pytest.skip("llm service not running")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "reply" in data
+    assert isinstance(data["reply"], str)
+
+
+def test_heartbeat_endpoint():
+    payload = {"pid": os.getpid(), "name": "test-e2e"}
+
+    async def _run():
+        return await _post_json("http://127.0.0.1:5005/heartbeat", json=payload)
+
+    try:
+        resp = asyncio.run(_run())
+    except Exception:
+        pytest.skip("heartbeat service not running")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data.get("pid") == payload["pid"]
+    assert data.get("name") == payload["name"]


### PR DESCRIPTION
## Summary
- add end-to-end test coverage for tts, stt, vision, llm, and heartbeat services
- each test exercises the running service endpoint and validates basic response structure
- document how to run the service endpoint tests and what services they cover

## Testing
- `make format`
- `make lint` *(fails: ESLint reports all files matching '.' are ignored)*
- `make build` *(fails: npm run build returned non-zero exit status 2)*
- `make test` *(fails: pipenv run pytest returned non-zero exit status)*
- `pipenv run pytest tests/e2e/test_service_endpoints.py` *(5 skipped: services not running)*
- `make setup` *(interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_689277d9df508324b58408dd562cb259