### PR TITLE
Refactor sentence splitting utility

### DIFF
--- a/shared/py/utils/__init__.py
+++ b/shared/py/utils/__init__.py
@@ -1,5 +1,10 @@
 """Shared utility functions used across Promethean services."""
 
-from .websocket import websocket_endpoint
+__all__: list[str] = []
 
-__all__ = ["websocket_endpoint"]
+try:  # pragma: no cover - optional dependency
+    from .websocket import websocket_endpoint
+
+    __all__.append("websocket_endpoint")
+except ModuleNotFoundError:  # FastAPI or other deps might be missing
+    pass


### PR DESCRIPTION
## Summary
- simplify sentence chunking by handling long sentences and merging short ones
- make utils package skip websocket helpers when optional deps are missing

## Testing
- `python -m black shared/py/utils/split_sentences.py shared/py/utils/__init__.py`
- `flake8 shared/py/utils/split_sentences.py shared/py/utils/__init__.py && echo 'flake8 ok'`
- `python -m pytest shared/py/tests/test_split_sentences.py`
- `hy Makefile.hy build-python`

------
https://chatgpt.com/codex/tasks/task_e_6892d33a4e188324b1d7fb252de3c581