### PR TITLE
feat(emacs): add codex auto completion

### DIFF
--- a/.emacs/layers/promethean/config.el
+++ b/.emacs/layers/promethean/config.el
@@ -3,3 +3,6 @@
   (interactive)
   (save-buffer)
   (shell-command (format "hy %s" (shell-quote-argument (buffer-file-name)))))
+
+(dolist (hook '(python-mode-hook typescript-mode-hook js-mode-hook js2-mode-hook promethean-hy-mode-hook))
+  (add-hook hook #'promethean/add-codex-completion))

--- a/.emacs/layers/promethean/funcs.el
+++ b/.emacs/layers/promethean/funcs.el
@@ -18,3 +18,31 @@
       (insert-file-contents outputfile)
       (delete-file outputfile))
     (delete-file tmpfile)))
+
+(defun promethean/codex-complete-at-point ()
+  "Use codex CLI to generate completion at point for the current buffer.
+The language passed to codex is inferred from the major mode."
+  (interactive)
+  (let* ((tmpfile (make-temp-file "codex-input-" nil ".txt"))
+         (outputfile (make-temp-file "codex-output-" nil ".txt"))
+         (lang (cond
+                ((derived-mode-p 'python-mode) "python")
+                ((derived-mode-p 'typescript-mode) "typescript")
+                ((derived-mode-p 'js-mode 'js2-mode) "javascript")
+                ((derived-mode-p 'promethean-hy-mode) "hy")
+                (t "text")))
+         (code (buffer-substring-no-properties (point-min) (point))))
+    (with-temp-file tmpfile (insert code))
+    (shell-command
+     (format "codex complete --language %s --output %s %s"
+             lang
+             (shell-quote-argument outputfile)
+             (shell-quote-argument tmpfile)))
+    (when (file-exists-p outputfile)
+      (insert-file-contents outputfile)
+      (delete-file outputfile))
+    (delete-file tmpfile)))
+
+(defun promethean/add-codex-completion ()
+  "Bind `promethean/codex-complete-at-point' to a convenient key."
+  (local-set-key (kbd "C-c TAB") #'promethean/codex-complete-at-point))


### PR DESCRIPTION
## Summary
- add codex CLI completion function at point
- enable codex completion in Python, TypeScript, JavaScript, and Hy modes

## Testing
- `make lint`
- `make format` (fails: Command 'npx --yes @biomejs/biome format .' returned non-zero exit status 1)
- `make build`
- `make test` (fails: Command 'echo 'Running tests in $PWD...' && python -m pipenv run pytest tests/' returned non-zero exit status 2)

------
https://chatgpt.com/codex/tasks/task_e_6892d2fcecc88324a3469b0271e8e9d7