### PR TITLE
fix(ts): run service lint via npm

### DIFF
--- a/Makefile.hy
+++ b/Makefile.hy
@@ -188,14 +188,15 @@
   (print "No build step for JavaScript services"))
 
 ;; TypeScript helpers ---------------------------------------------------------
+
 (defn-cmd lint-ts-service [service]
   (print (.format "Linting TS service: {}" service))
-  (sh "npx --yes @biomejs/biome lint ." :cwd (join "services/ts" service) :shell True))
+  (sh "npm run lint" :cwd (join "services/ts" service) :shell True))
 
 (defn-cmd lint-ts []
   (for [d SERVICES_TS]
-    (when (isfile (join d "biome.json"))
-      (sh "npx --yes @biomejs/biome lint ." :cwd d :shell True))))
+    (when (isfile (join d "package.json"))
+      (sh "npm run lint" :cwd d :shell True))))
 
 (defn-cmd format-ts []
   (run-dirs SERVICES_TS "npx --yes @biomejs/biome format ." :shell True))


### PR DESCRIPTION
## Summary
- run `npm run lint` for TypeScript services so cephalon uses its local script

## Testing
- `make test-ts-service-cephalon`
- `make build-ts`
- `make lint-ts-service-cephalon`
- `make format` *(fails: Found 39 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6892d466cc188324b326d7690770df61