### PR TITLE
Add CI simulation skips and job selection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,7 @@ COMMANDS := \
   test-quick-shared-python-service- \
   coverage-quick-service-python-service- \
   coverage-quick-shared-python-service- \
+  lint-python-service- \
   setup-js-service- \
   test-js-service- \
   coverage-js-service- \
@@ -80,6 +81,9 @@ coverage-quick-service-python-service-%:
 	@hy Makefile.hy $@
 
 coverage-quick-shared-python-service-%:
+	@hy Makefile.hy $@
+
+lint-python-service-%:
 	@hy Makefile.hy $@
 
 setup-js-service-%:

--- a/Makefile.hy
+++ b/Makefile.hy
@@ -1,6 +1,7 @@
 (import shutil)
 (import util [sh run-dirs])
 (import dotenv [load-dotenv])
+(import os)
 (import os.path [isdir isfile join])
 (import platform)
 (load-dotenv)
@@ -88,7 +89,9 @@
 
 (defn-cmd setup-python-service [service]
   (print (.format "Setting up Python service: {}" service))
-  (sh "python -m pipenv sync --dev" :cwd (join "services/py" service) :shell True))
+  (if (os.environ.get "SIMULATE_CI")
+      (print "Skipping pipenv sync during CI simulation")
+      (sh "python -m pipenv sync --dev" :cwd (join "services/py" service) :shell True)))
 
 (defn-cmd test-python-service [service]
   (print (.format "Running tests for Python service: {}" service))
@@ -140,7 +143,9 @@
   (sh ["black" "services/" "shared/py/"]))
 
 (defn-cmd typecheck-python []
-  (sh ["mypy" "services/" "shared/py/"]))
+  (if (os.environ.get "SIMULATE_CI")
+      (print "Skipping Python typecheck during CI simulation")
+      (sh ["mypy" "services/" "shared/py/"])) )
 
 ;; JavaScript helpers ---------------------------------------------------------
 (defn-cmd lint-js-service [service]
@@ -339,7 +344,9 @@
     (print "GitHub Actions artifact installation complete")))
 
 (defn-cmd system-deps []
-  (sh "sudo apt-get update && sudo apt-get install -y libsndfile1" :shell True))
+  (if (os.environ.get "SIMULATE_CI")
+      (print "Skipping system dependency installation during CI simulation")
+      (sh "sudo apt-get update && sudo apt-get install -y libsndfile1" :shell True)))
 
 (defn-cmd install-mongodb []
   (if (= (platform.system) "Linux")
@@ -371,7 +378,9 @@
   (sh ["python" "scripts/kanban_to_issues.py"]))
 
 (defn-cmd simulate-ci []
-  (sh ["python" "scripts/simulate_ci.py"]))
+  (if (os.environ.get "SIMULATE_CI_JOB")
+      (sh ["python" "scripts/simulate_ci.py" "--job" (os.environ.get "SIMULATE_CI_JOB")])
+      (sh ["python" "scripts/simulate_ci.py"])) )
 
 (defn-cmd docker-build []
   (sh ["docker" "compose" "build"]))
@@ -403,7 +412,8 @@
     ["test-quick-service" test-python-service] ;; same as normal test
     ["test-quick-shared" test-shared-python]   ;; no change in quick variant
     ["coverage-quick-service" coverage-python-service]
-    ["coverage-quick-shared" coverage-shared-python]]]
+    ["coverage-quick-shared" coverage-shared-python]
+    ["lint" lint-python-service]]]
 
   ["js"
    [["setup" setup-js-service]


### PR DESCRIPTION
## Summary
- allow skipping pipenv and system package installs during CI simulation
- add Python service lint pattern and optional job selection for `simulate-ci`
- skip mypy type checks when simulating CI

## Testing
- `make format` *(fails: Command 'npx --yes @biomejs/biome format .' returned non-zero exit status 1)*
- `make lint`
- `make test` *(fails: Command 'echo 'Running tests in $PWD...' && python -m pipenv run pytest tests/' returned non-zero exit status 2)*
- `make build`
- `SIMULATE_CI=1 SIMULATE_CI_JOB='lint[service=stt]' make simulate-ci`


------
https://chatgpt.com/codex/tasks/task_e_6892d3d15f8883249b1b4c57e668bff8