### PR TITLE
handle conditional GitHub Actions steps in simulate-ci

### DIFF
--- a/Makefile.hy
+++ b/Makefile.hy
@@ -1,6 +1,7 @@
 (import shutil)
 (import util [sh run-dirs])
 (import dotenv [load-dotenv])
+(import os)
 (import os.path [isdir isfile join])
 (import platform)
 (load-dotenv)
@@ -201,11 +202,14 @@
   (run-dirs SERVICES_TS "npx --yes @biomejs/biome format ." :shell True))
 
 (defn-cmd typecheck-ts []
-  (run-dirs SERVICES_TS "npx tsc --noEmit" :shell True))
+  (setv svc (or (os.environ.get "service") (os.environ.get "SERVICE")))
+  (if svc
+    (sh "npx tsc --noEmit" :cwd (join "services/ts" svc) :shell True)
+    (run-dirs SERVICES_TS "npx tsc --noEmit" :shell True)))
 
 (defn-cmd setup-ts-service [service]
   (print (.format "Setting up TS service: {}" service))
-  (sh "npm install --no-package-lock" :cwd (join "services/ts" service) :shell True))
+  (sh "npm install --no-package-lock --ignore-scripts" :cwd (join "services/ts" service) :shell True))
 
 (defn-cmd setup-ts []
   (print "Setting up TypeScript services...")


### PR DESCRIPTION
## Summary
- teach simulate-ci to respect `if` conditionals and matrix includes
- allow TypeScript typecheck per-service and skip install scripts

## Testing
- `python scripts/simulate_ci.py --job "lint[service=cephalon]"`
- `make format` *(fails: Formatter would have printed content)*
- `make lint`
- `make test` *(fails: Command 'echo 'Running tests in $PWD...' && python -m pipenv run pytest tests/' returned non-zero exit status 2)*
- `make build`


------
https://chatgpt.com/codex/tasks/task_e_6892d3d15f8883249b1b4c57e668bff8