### PR TITLE
refactor services to route via proxy

### DIFF
--- a/scripts/stt_request.py
+++ b/scripts/stt_request.py
@@ -4,17 +4,19 @@ from shared.py.speech.service_clients import send_wav_as_pcm
 
 
 if __name__ == "__main__":
-    send_wav_as_pcm("longer_recording.wav", url="http://localhost:5001/transcribe_pcm")
+    send_wav_as_pcm(
+        "longer_recording.wav", url="http://localhost:8080/stt/transcribe_pcm"
+    )
 
     send_wav_as_pcm(
         "longer_recording.wav",
-        url="http://localhost:5001/transcribe_pcm/equalized",
+        url="http://localhost:8080/stt/transcribe_pcm/equalized",
     )
 
     # Config 1 – Standard voice cleanup
     send_wav_as_pcm(
         "longer_recording.wav",
-        url="http://localhost:5001/transcribe_pcm/equalized",
+        url="http://localhost:8080/stt/transcribe_pcm/equalized",
         query_params={
             "highpass": 100,
             "lowpass": 7500,
@@ -26,7 +28,7 @@ if __name__ == "__main__":
     # Config 2 – Brighter voice, no lowpass
     send_wav_as_pcm(
         "longer_recording.wav",
-        url="http://localhost:5001/transcribe_pcm/equalized",
+        url="http://localhost:8080/stt/transcribe_pcm/equalized",
         query_params={
             "highpass": 120,
             "notch1": "180-280",
@@ -38,7 +40,7 @@ if __name__ == "__main__":
     # Config 3 – Softer high end
     send_wav_as_pcm(
         "longer_recording.wav",
-        url="http://localhost:5001/transcribe_pcm/equalized",
+        url="http://localhost:8080/stt/transcribe_pcm/equalized",
         query_params={
             "highpass": 80,
             "lowpass": 5000,
@@ -49,7 +51,7 @@ if __name__ == "__main__":
     # Config 4 – No notch filters, just broad shaping
     send_wav_as_pcm(
         "longer_recording.wav",
-        url="http://localhost:5001/transcribe_pcm/equalized",
+        url="http://localhost:8080/stt/transcribe_pcm/equalized",
         query_params={
             "highpass": 90,
             "lowpass": 6800,

--- a/scripts/vision_request.py
+++ b/scripts/vision_request.py
@@ -1,6 +1,6 @@
 import requests
 
-url = "http://localhost:5003/capture"
+url = "http://localhost:8080/vision/capture"
 response = requests.get(url)
 
 if response.status_code == 200:

--- a/services/ts/cephalon/src/desktop/desktopLoop.ts
+++ b/services/ts/cephalon/src/desktop/desktopLoop.ts
@@ -1,7 +1,7 @@
 import * as discord from 'discord.js';
 import { captureAndRenderWaveform, AudioImageData } from '../audioProcessing/waveform';
 
-const VISION_HOST = process.env.VISION_HOST || 'http://localhost:9999';
+const VISION_HOST = process.env.VISION_HOST || 'http://localhost:8080/vision';
 export async function captureScreen(): Promise<Buffer> {
 	if (process.env.NO_SCREENSHOT === '1') {
 		return Buffer.alloc(0);

--- a/services/ts/cephalon/src/llm-service.ts
+++ b/services/ts/cephalon/src/llm-service.ts
@@ -17,7 +17,13 @@ export class LLMService {
 	host: string;
 	port: number;
 	endpoint: string;
-	constructor(options: LLMClientOptions = { host: 'localhost', port: 8888, endpoint: '/generate' }) {
+	constructor(
+		options: LLMClientOptions = {
+			host: 'localhost',
+			port: Number(process.env.PROXY_PORT) || 8080,
+			endpoint: '/llm/generate',
+		},
+	) {
 		this.host = options.host;
 		this.port = options.port;
 		this.endpoint = options.endpoint;

--- a/services/ts/cephalon/src/transcriber.ts
+++ b/services/ts/cephalon/src/transcriber.ts
@@ -30,8 +30,8 @@ export class Transcriber extends EventEmitter {
 	constructor(
 		options: TranscriberOptions = {
 			hostname: 'localhost',
-			port: 5002,
-			endpoint: '/transcribe_pcm',
+			port: Number(process.env.PROXY_PORT) || 8080,
+			endpoint: '/stt/transcribe_pcm',
 		},
 	) {
 		super();

--- a/services/ts/cephalon/src/voice-synth.ts
+++ b/services/ts/cephalon/src/voice-synth.ts
@@ -14,8 +14,8 @@ export class VoiceSynth extends EventEmitter {
 	constructor(
 		options: VoiceSynthOptions = {
 			host: 'localhost',
-			endpoint: '/synth-voice', // fix this later
-			port: 5001,
+			endpoint: '/tts/synth_voice_pcm',
+			port: Number(process.env.PROXY_PORT) || 8080,
 		},
 	) {
 		super();
@@ -25,9 +25,9 @@ export class VoiceSynth extends EventEmitter {
 	}
 	async generateAndUpsampleVoice(text: string): Promise<{ stream: Readable; cleanup: () => void }> {
 		const req = request({
-			hostname: 'localhost',
-			port: 5001,
-			path: '/synth_voice_pcm',
+			hostname: this.host,
+			port: this.port,
+			path: this.endpoint,
 			method: 'POST',
 			headers: {
 				'Content-Type': 'application/x-www-form-urlencoded',
@@ -84,9 +84,9 @@ export class VoiceSynth extends EventEmitter {
 		return new Promise((resolve, reject) => {
 			const req = request(
 				{
-					hostname: 'localhost',
-					port: 5001,
-					path: '/synth_voice_pcm',
+					hostname: this.host,
+					port: this.port,
+					path: this.endpoint,
 					method: 'POST',
 					headers: {
 						'Content-Type': 'application/x-www-form-urlencoded',

--- a/services/ts/file-watcher/src/index.ts
+++ b/services/ts/file-watcher/src/index.ts
@@ -90,7 +90,7 @@ export function startFileWatcher(options: FileWatcherOptions = {}): {
         // ignore
       }
       const title = basename(path, ".md").replace(/_/g, " ");
-      const llmUrl = process.env.LLM_URL || "http://localhost:5003";
+      const llmUrl = process.env.LLM_URL || "http://localhost:8080/llm";
       const prompt =
         "You are an engineering assistant. Given a task title, produce a concise markdown task stub with headings for Goals, Requirements, and Subtasks.";
       try {

--- a/services/ts/voice/src/transcriber.ts
+++ b/services/ts/voice/src/transcriber.ts
@@ -30,8 +30,8 @@ export class Transcriber extends EventEmitter {
   constructor(
     options: TranscriberOptions = {
       hostname: "localhost",
-      port: 5001,
-      endpoint: "/transcribe_pcm",
+      port: Number(process.env.PROXY_PORT) || 8080,
+      endpoint: "/stt/transcribe_pcm",
     },
   ) {
     super();

--- a/services/ts/voice/src/voice-synth.ts
+++ b/services/ts/voice/src/voice-synth.ts
@@ -14,8 +14,8 @@ export class VoiceSynth extends EventEmitter {
   constructor(
     options: VoiceSynthOptions = {
       host: "localhost",
-      endpoint: "/synth-voice", // fix this later
-      port: 5002,
+      endpoint: "/tts/synth_voice",
+      port: Number(process.env.PROXY_PORT) || 8080,
     },
   ) {
     super();
@@ -27,9 +27,9 @@ export class VoiceSynth extends EventEmitter {
     text: string,
   ): Promise<{ stream: Readable; cleanup: () => void }> {
     const req = request({
-      hostname: "localhost",
-      port: 5002,
-      path: "/synth_voice_pcm",
+      hostname: this.host,
+      port: this.port,
+      path: "/tts/synth_voice_pcm",
       method: "POST",
       headers: {
         "Content-Type": "application/x-www-form-urlencoded",
@@ -88,9 +88,9 @@ export class VoiceSynth extends EventEmitter {
     return new Promise((resolve, reject) => {
       const req = request(
         {
-          hostname: "localhost",
-          port: 5002,
-          path: "/synth_voice",
+          hostname: this.host,
+          port: this.port,
+          path: "/tts/synth_voice",
           method: "POST",
           headers: {
             "Content-Type": "application/x-www-form-urlencoded",

--- a/shared/js/heartbeat/index.js
+++ b/shared/js/heartbeat/index.js
@@ -5,10 +5,10 @@
  * to the service on a fixed interval. Uses the global `fetch` available in
  * modern Node.js versions, avoiding external dependencies.
  */
-const HEARTBEAT_PORT = process.env.HEARTBEAT_PORT || 5005;
+const PROXY_PORT = process.env.PROXY_PORT || 8080;
 export class HeartbeatClient {
   constructor({
-    url = `http://127.0.0.1:${HEARTBEAT_PORT}/heartbeat`,
+    url = `http://127.0.0.1:${PROXY_PORT}/heartbeat/heartbeat`,
     pid = process.pid,
     name = process.env.name,
     interval = 3000,

--- a/shared/py/heartbeat_client.py
+++ b/shared/py/heartbeat_client.py
@@ -14,7 +14,7 @@ from dataclasses import dataclass
 from typing import Optional
 from urllib import request
 
-HEARTBEAT_PORT = os.environ.get("HEARTBEAT_PORT", 5005)
+PROXY_PORT = os.environ.get("PROXY_PORT", 8080)
 
 
 @dataclass
@@ -31,7 +31,7 @@ class HeartbeatClient:
         Seconds between heartbeats when :meth:`start` is used.
     """
 
-    url: str = f"http://127.0.0.1:{HEARTBEAT_PORT}/heartbeat"
+    url: str = f"http://127.0.0.1:{PROXY_PORT}/heartbeat/heartbeat"
     pid: int = os.getpid()
     interval: float = 3.0
 
@@ -44,9 +44,11 @@ class HeartbeatClient:
         Returns the parsed JSON response from the service.
         """
 
-        data = json.dumps(
-            {"pid": self.pid, "name": os.environ.get("PM2_PROCESS_NAME")}
-        ).encode("utf-8")
+        payload = {"pid": self.pid}
+        name = os.environ.get("PM2_PROCESS_NAME")
+        if name:
+            payload["name"] = name
+        data = json.dumps(payload).encode("utf-8")
         req = request.Request(
             self.url,
             data=data,

--- a/shared/py/speech/service_clients.py
+++ b/shared/py/speech/service_clients.py
@@ -17,7 +17,7 @@ from scipy.io import wavfile
 
 def send_wav_as_pcm(
     file_path: str | Path,
-    url: str = "http://localhost:5001/transcribe_pcm",
+    url: str = "http://localhost:8080/stt/transcribe_pcm",
     query_params: Optional[Dict[str, Any]] = None,
 ) -> str:
     """Send a 16-bit PCM WAV file to the STT service.
@@ -59,7 +59,7 @@ def send_wav_as_pcm(
 def synthesize_text_to_file(
     text: str,
     output_path: str | Path,
-    url: str = "http://localhost:5000/synth_voice",
+    url: str = "http://localhost:8080/tts/synth_voice_pcm",
 ) -> Path:
     """Request speech synthesis and save the audio to ``output_path``.
 


### PR DESCRIPTION
## Summary
- update shared clients and services to call other modules through the proxy
- point scripts and file watcher to proxy-based service URLs
- adjust heartbeat client defaults for proxy routing

## Testing
- `make format`
- `make lint`
- `make build`
- `make test-ts-service-cephalon`
- `make test-ts-service-file-watcher`
- `make test-ts-service-voice`
- `make test-js-service-heartbeat`
- `python -m pytest shared/py/tests/test_heartbeat_client.py`


------
https://chatgpt.com/codex/tasks/task_e_6892d3c1f9888324a36626438f899e31