### PR TITLE
docs: document HTTP endpoints

### DIFF
--- a/docs/services/embedding-service/main.md
+++ b/docs/services/embedding-service/main.md
@@ -2,7 +2,15 @@
 
 **Path**: `services/py/embedding_service/main.py`
 
-**Description**: FastAPI application exposing `/embed` to generate vector embeddings using pluggable drivers such as naive, transformers, or Ollama implementations.
+**Description**: FastAPI application exposing `/embed` to generate vector
+embeddings using pluggable drivers such as naive, transformers, or Ollama
+implementations.
+
+### Endpoints
+
+ - `POST /embed` – body:
+   `{ "items": [{"type": str, "data": str}], "driver": str?, "function": str? }`
+   returns `{ "embeddings": list[list[float]] }`.
 
 ## Dependencies
 - fastapi

--- a/docs/services/heartbeat/index.md
+++ b/docs/services/heartbeat/index.md
@@ -4,6 +4,12 @@
 
 **Description**: Express service that records process heartbeats in MongoDB, enforcing per-app instance limits and capturing CPU, memory, and network metrics. Each document stores a service-instance session ID so restarts ignore stale entries and shutdowns mark them as killed.
 
+### Endpoints
+
+- `POST /heartbeat` – record a heartbeat with `{ pid, name }` and resource
+  metrics.
+- `GET /heartbeats` – return all heartbeat documents.
+
 ## Dependencies
 - express
 - mongodb

--- a/docs/services/markdown_graph/README.md
+++ b/docs/services/markdown_graph/README.md
@@ -2,8 +2,10 @@
 
 Maintains a graph of markdown links and `#hashtags` in an SQLite database.
 
-- **Cold start:** traverses from `readme.md` and indexes all linked markdown files.
-- **Updates:** file watcher services POST file contents to `/update`.
-- **Query:** other services access `/links/{path}` or `/hashtags/{tag}`.
+### Endpoints
+
+- `POST /update` – supply `{ path, content }` to update the graph.
+- `GET /links/{path}` – return links from the given markdown file.
+- `GET /hashtags/{tag}` – return all files referencing the tag.
 
 #markdown #service

--- a/docs/services/proxy/index.md
+++ b/docs/services/proxy/index.md
@@ -4,6 +4,16 @@
 
 **Description**: Express-based HTTP proxy that forwards requests to Promethean services so they can be accessed through a single port and domain.
 
+### Proxied Routes
+
+By default requests are forwarded to local services:
+
+- `/tts` → `http://127.0.0.1:5001`
+- `/stt` → `http://127.0.0.1:5002`
+- `/vision` → `http://127.0.0.1:9999`
+- `/llm` → `http://127.0.0.1:8888`
+- `/heartbeat` → `http://127.0.0.1:5005`
+
 ## Dependencies
 - express
 - http-proxy-middleware

--- a/docs/services/stt/app.md
+++ b/docs/services/stt/app.md
@@ -3,8 +3,17 @@
 **Path**: `services/py/stt/app.py`
 
 **Description**: FastAPI application providing HTTP and WebSocket speech-to-text
-APIs. Supports single-shot transcription via `/transcribe` and streaming
-transcription via `/stream`.
+APIs. Supports raw PCM transcription and real-time streaming.
+
+### Endpoints
+
+- `POST /transcribe_pcm` – accepts 16‑bit PCM audio in the request body with
+  `x-sample-rate` and `x-dtype` headers. Returns `{ "transcription": str }`.
+- `WS /transcribe` – WebSocket endpoint for single-shot transcription. Send
+  `{ "pcm": base64, "sample_rate": int }` and receive the transcription as
+  JSON.
+- `WS /stream` – WebSocket endpoint for streaming audio chunks. Send raw PCM
+  bytes and receive incremental transcriptions.
 
 ## Dependencies
 - fastapi

--- a/docs/services/tts/app.md
+++ b/docs/services/tts/app.md
@@ -2,8 +2,14 @@
 
 **Path**: `services/py/tts/app.py`
 
-**Description**: FastAPI application exposing `/synth_voice_pcm` for HTTP
-text-to-speech and `/ws/tts` for WebSocket streaming.
+**Description**: FastAPI application exposing HTTP and WebSocket text-to-speech
+interfaces.
+
+### Endpoints
+
+- `POST /synth_voice_pcm` – form field `input_text`; responds with 16‑bit PCM
+  audio bytes.
+- `WS /ws/tts` – send text frames and receive WAV audio bytes.
 
 ## Dependencies
 - fastapi

--- a/docs/services/vision/index.md
+++ b/docs/services/vision/index.md
@@ -2,7 +2,13 @@
 
 **Path**: `services/vision/index.js`
 
-**Description**: Express endpoint `/capture` returns a PNG screenshot via `screenshot-desktop`. The module exports `app`, `start()`, and `setCaptureFn()` for testing.
+**Description**: Express endpoint `/capture` returns a PNG screenshot via
+`screenshot-desktop`. The module exports `app`, `start()`, and `setCaptureFn()`
+for testing.
+
+### Endpoints
+
+- `GET /capture` – respond with a PNG screenshot.
 
 ## Dependencies
 - express


### PR DESCRIPTION
## Summary
- document STT endpoints for PCM, single-shot, and streaming transcription
- describe request/response for `/embed` API
- note TTS, heartbeat, markdown graph, vision, and proxy routes

## Testing
- `make format` *(fails: Found 39 errors)*
- `make lint`
- `pre-commit run --files docs/services/embedding-service/main.md docs/services/heartbeat/index.md docs/services/markdown_graph/README.md docs/services/proxy/index.md docs/services/stt/app.md docs/services/tts/app.md docs/services/vision/index.md`


------
https://chatgpt.com/codex/tasks/task_e_6892e336fb5c8324a77e32a5fff03a94