### PR TITLE
feat(site): add markdown graph frontend

### DIFF
--- a/docs/site/markdown_graph_frontend.md
+++ b/docs/site/markdown_graph_frontend.md
@@ -1,0 +1,5 @@
+# Markdown Graph Frontend
+
+Renders the markdown link graph produced by the Markdown Graph Service in a browser using a force-directed layout.
+
+#site #frontend

--- a/site/README.md
+++ b/site/README.md
@@ -6,3 +6,7 @@ The source files have not yet been migrated into the Promethean monorepo.
 For now the folder only contains this README. References to `npm` scripts from the original project have been removed until the site assets and build configuration are restored.
 
 Progress on migrating the site can be tracked in [docs/MIGRATION_PLAN.md](../docs/MIGRATION_PLAN.md).
+
+## Markdown Link Graph
+
+`graph.html` renders the markdown link graph produced by the `markdown_graph` service. Open the file in a browser while the service is running to explore the connected documents in a force-directed view.

--- a/site/graph.html
+++ b/site/graph.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Markdown Link Graph</title>
+    <style>
+      html,
+      body,
+      #graph {
+        height: 100%;
+        margin: 0;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="graph"></div>
+    <script type="module">
+      import { renderGraph } from "./graph.mjs";
+      renderGraph("#graph");
+    </script>
+  </body>
+</html>

--- a/site/graph.mjs
+++ b/site/graph.mjs
@@ -1,0 +1,41 @@
+export async function fetchGraph(baseUrl = "") {
+  const visited = new Set();
+  const nodes = [];
+  const links = [];
+  const queue = ["readme.md"];
+  while (queue.length) {
+    const path = queue.shift();
+    if (visited.has(path)) continue;
+    visited.add(path);
+    nodes.push({ id: path });
+    try {
+      const res = await fetch(`${baseUrl}/links/${encodeURIComponent(path)}`);
+      if (!res.ok) continue;
+      const data = await res.json();
+      for (const target of data.links || []) {
+        links.push({ source: path, target });
+        if (!visited.has(target)) queue.push(target);
+      }
+    } catch (err) {
+      // Swallow network errors to allow partial graphs
+    }
+  }
+  return { nodes, links };
+}
+
+export async function renderGraph(selector, baseUrl = "") {
+  const ForceGraph = (
+    await import("https://unpkg.com/force-graph@1.45.0/dist/force-graph.esm.js")
+  ).default;
+  const element =
+    typeof selector === "string" ? document.querySelector(selector) : selector;
+  const data = await fetchGraph(baseUrl);
+  const graph = ForceGraph()(element);
+  graph
+    .graphData(data)
+    .nodeId("id")
+    .nodeLabel("id")
+    .linkSource("source")
+    .linkTarget("target");
+  return graph;
+}

--- a/tests/site/markdown_graph_frontend.test.mjs
+++ b/tests/site/markdown_graph_frontend.test.mjs
@@ -1,0 +1,33 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import http from "node:http";
+import { fetchGraph } from "../../site/graph.mjs";
+
+test("fetchGraph collects nodes and links", async () => {
+  const routes = {
+    "/links/readme.md": { links: ["docs/a.md"] },
+    "/links/docs/a.md": { links: [] },
+  };
+
+  const server = http.createServer((req, res) => {
+    const data = routes[req.url];
+    if (!data) {
+      res.statusCode = 404;
+      res.end();
+      return;
+    }
+    res.setHeader("Content-Type", "application/json");
+    res.end(JSON.stringify(data));
+  });
+
+  await new Promise((resolve) => server.listen(0, resolve));
+  const { port } = server.address();
+  const baseUrl = `http://127.0.0.1:${port}`;
+  const graph = await fetchGraph(baseUrl);
+  server.close();
+
+  assert.deepEqual(graph, {
+    nodes: [{ id: "readme.md" }, { id: "docs/a.md" }],
+    links: [{ source: "readme.md", target: "docs/a.md" }],
+  });
+});


### PR DESCRIPTION
## Summary
- add module to retrieve markdown link graph from the markdown_graph service and render it with a force-directed layout
- expose a simple `graph.html` page in the site directory and document its usage
- cover the graph fetcher with a small node test

## Testing
- `make setup-js`
- `make format` *(fails: Command 'npx --yes @biomejs/biome format .' returned non-zero exit status 1)*
- `make lint`
- `make build`
- `make test` *(fails: Command 'echo 'Running tests in $PWD...' && python -m pipenv run pytest tests/' returned non-zero exit status 2)*
- `node --test tests/site/markdown_graph_frontend.test.mjs`


------
https://chatgpt.com/codex/tasks/task_e_6892d3681af48324a2055b847eb5a25a