### PR TITLE
Add lint target for python services

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,7 @@ COMMANDS := \
   test-shared-python-service- \
   coverage-python-service- \
   coverage-shared-python-service- \
+  lint-python-service- \
   test-quick-service-python-service- \
   test-quick-shared-python-service- \
   coverage-quick-service-python-service- \
@@ -68,6 +69,9 @@ coverage-python-service-%:
 	@hy Makefile.hy $@
 
 coverage-shared-python-service-%:
+	@hy Makefile.hy $@
+
+lint-python-service-%:
 	@hy Makefile.hy $@
 
 test-quick-service-python-service-%:

--- a/Makefile.hy
+++ b/Makefile.hy
@@ -400,6 +400,7 @@
     ["test-shared" test-shared-python]
     ["coverage" coverage-python-service]
     ["coverage-shared" coverage-shared-python]
+    ["lint" lint-python-service]
     ["test-quick-service" test-python-service] ;; same as normal test
     ["test-quick-shared" test-shared-python]   ;; no change in quick variant
     ["coverage-quick-service" coverage-python-service]


### PR DESCRIPTION
## Summary
- include python service lint pattern when generating Makefile
- regenerate Makefile to expose `lint-python-service-*` target

## Testing
- `make setup-quick-service-python-service-discord_indexer` *(fails: Operation cancelled by user)*
- `make test-python-service-discord_indexer` *(fails: ModuleNotFoundError: No module named 'discord')*
- `make build`
- `make lint` *(fails: KeyboardInterrupt during TS lint)*
- `make lint-python-service-discord_indexer`
- `make format` *(fails: KeyboardInterrupt during JS formatting)*

------
https://chatgpt.com/codex/tasks/task_e_6892e75b436083249479c64ad176355f