### PR TITLE
Add initial permission layer module

### DIFF
--- a/shared/py/__init__.py
+++ b/shared/py/__init__.py
@@ -1,0 +1,5 @@
+"""Shared Python utilities for the Promethean framework."""
+
+from .permissions import PermissionLayer, PermissionRule
+
+__all__ = ["PermissionLayer", "PermissionRule"]

--- a/shared/py/permissions.py
+++ b/shared/py/permissions.py
@@ -1,0 +1,39 @@
+"""Permission gating layer (Dorian).
+
+This module provides a simple in-memory permission layer used by the
+Promethean framework to check whether a given action is allowed. It
+represents the beginnings of Circuit 2: Dorian, which governs access and
+trust boundaries.
+"""
+
+from dataclasses import dataclass, field
+from typing import Dict
+
+
+@dataclass
+class PermissionRule:
+    """Represents a single permission rule for an action."""
+
+    action: str
+    allowed: bool
+
+
+@dataclass
+class PermissionLayer:
+    """In-memory permission store with default-allow semantics."""
+
+    rules: Dict[str, PermissionRule] = field(default_factory=dict)
+
+    def set_rule(self, action: str, allowed: bool) -> None:
+        """Add or update a permission rule."""
+
+        self.rules[action] = PermissionRule(action, allowed)
+
+    def check(self, action: str) -> bool:
+        """Return True if the action is permitted.
+
+        If no rule exists for the action, the layer defaults to allowing it.
+        """
+
+        rule = self.rules.get(action)
+        return rule.allowed if rule else True

--- a/shared/py/tests/test_permissions.py
+++ b/shared/py/tests/test_permissions.py
@@ -1,0 +1,16 @@
+import pytest
+
+from shared.py.permissions import PermissionLayer
+
+
+def test_default_allow():
+    layer = PermissionLayer()
+    assert layer.check("read") is True
+
+
+def test_set_and_check_rule():
+    layer = PermissionLayer()
+    layer.set_rule("delete", False)
+    layer.set_rule("write", True)
+    assert layer.check("write") is True
+    assert layer.check("delete") is False


### PR DESCRIPTION
## Summary
- scaffold permission gating layer (Dorian) with default-allow rules
- expose permission layer via shared Python utilities
- test permission defaults and rule overrides

## Testing
- `hy Makefile.hy setup-shared-python-quick` *(fails: Operation cancelled by user)*
- `hy Makefile.hy format-python`
- `hy Makefile.hy lint-python`
- `hy Makefile.hy build`
- `python -m pytest shared/py/tests/test_permissions.py`


------
https://chatgpt.com/codex/tasks/task_e_6892ec34477c8324a3956d7b2c0971f6