### PR TITLE
docs: outline layer1 metrics and daimo actions

### DIFF
--- a/docs/notes/chats/eidolon-layer-1-design.md
+++ b/docs/notes/chats/eidolon-layer-1-design.md
@@ -10,4 +10,20 @@ Let's start talking about the implementation of the Eidolon fields. Layer 1 mana
 - Proposed Python scaffold uses MongoDB for shared state with modules like `field.py`, `heartbeat.py`, and `constraints.py`.
 - Optional add-ons include visualizers, process evictors, and generators for simulating node arrangements.
 
-#tags: #eidolon #layer1 #resource-management #promethean
+- Heartbeat and Health services feed uptime and resource metrics into Layer 1. Heartbeat tracks per-process signals while Health aggregates the data.
+- Cephalon and the file watcher register with these services so their activity influences the field through these metrics.
+- Each event from Cephalon or the file watcher is projected into the field as a `daimo`, making every system action traceable.
+
+### PSF sketch
+
+```lisp
+(memory-state
+  (layer 1
+    (metric heartbeat)
+    (metric health)
+    (daimo "cephalon-event" (trigger cephalon.action))
+    (daimo "file-change" (trigger file-watcher.change)))
+)
+```
+
+#tags: #eidolon #layer1 #resource-management #promethean #heartbeat #health #cephalon #file-watcher #daimo


### PR DESCRIPTION
## Summary
- describe how heartbeat and health metrics feed Layer 1
- note that cephalon and the file watcher project actions as daimo
- sketch PSF snippet wiring services into Layer 1

## Testing
- `make format` *(fails: found 39 errors)*
- `make lint` *(fails: biome not found)*
- `make build`
- `make test` *(fails: ModuleNotFoundError: chromadb)*


------
https://chatgpt.com/codex/tasks/task_e_6892ebfaabfc8324a0181d7338a3cb2c