### PR TITLE
Skip TypeScript typecheck for services without configs

### DIFF
--- a/Makefile.hy
+++ b/Makefile.hy
@@ -204,9 +204,15 @@
 
 (defn-cmd typecheck-ts []
   (setv svc (or (os.environ.get "service") (os.environ.get "SERVICE")))
+  (defn run [path]
+    (if (and (isfile (join path "tsconfig.json"))
+             (isdir (join path "node_modules")))
+      (sh "npx tsc --noEmit" :cwd path :shell True)
+      (print (.format "Skipping typecheck for {}" path))))
   (if svc
-    (sh "npx tsc --noEmit" :cwd (join "services/ts" svc) :shell True)
-    (run-dirs SERVICES_TS "npx tsc --noEmit" :shell True)))
+    (run (join "services/ts" svc))
+    (for [d SERVICES_TS]
+      (run d))))
 
 (defn-cmd setup-ts-service [service]
   (print (.format "Setting up TS service: {}" service))


### PR DESCRIPTION
## Summary
- guard `make typecheck-ts` so it only runs `tsc` in services that have a `tsconfig.json` and installed dependencies

## Testing
- `make lint-ts-service-file-watcher`
- `cd services/ts/file-watcher && npm run format && cd -`
- `make test-ts-service-markdown-graph`
- `cd services/ts/markdown-graph && npm run build && cd -`
- `make typecheck-ts`


------
https://chatgpt.com/codex/tasks/task_e_6892ea612e3c8324bb0a8acac36b193d