### PR TITLE
feat: add pm2 entries for new services

### DIFF
--- a/agents/duck/ecosystem.config.js
+++ b/agents/duck/ecosystem.config.js
@@ -58,6 +58,12 @@ module.exports = {
         ...discord_env,
       },
     }),
+    defineApp("duck_voice", ".", [], {
+      cwd: path.join(__dirname, "../../services/ts/voice"),
+      env: {
+        ...discord_env,
+      },
+    }),
     defineApp(
       "duck_attachment_indexer",
       "pipenv",

--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -67,5 +67,23 @@ module.exports = {
         PORT: 8080,
       },
     }),
+    defineApp(
+      "discord_attachment_embedder",
+      "pipenv",
+      ["run", "python", "-m", "main"],
+      {
+        cwd: "./services/py/discord_attachment_embedder",
+        watch: ["./services/py/discord_attachment_embedder"],
+      },
+    ),
+    defineApp("eidolon-field", ".", [], {
+      cwd: "./services/js/eidolon-field",
+      watch: ["./services/js/eidolon-field/"],
+    }),
+    defineApp("markdown-graph", ".", [], {
+      cwd: "./services/ts/markdown-graph",
+      watch: ["./services/ts/markdown-graph/src"],
+      env: { PORT: 8000 },
+    }),
   ],
 };


### PR DESCRIPTION
## Summary
- register discord attachment embedder, eidolon-field, and markdown-graph in the root PM2 config
- add duck voice service to agent PM2 config

## Testing
- `make setup-js-service-eidolon-field`
- `make test-js-service-eidolon-field`
- `make setup-ts-service-markdown-graph`
- `make test-ts-service-markdown-graph`
- `make setup-ts-service-voice`
- `make test-ts-service-voice`
- `make build`
- `make format` *(fails: Command 'npx --yes @biomejs/biome format .' returned non-zero exit status 1)*
- `make setup-quick SERVICE=discord_attachment_embedder` *(fails: Operation cancelled by user)*

------
https://chatgpt.com/codex/tasks/task_e_6892e9399e5c8324943ccb2ebf367565