### PR TITLE
feat: centralize event definitions

### DIFF
--- a/bridge/__init__.py
+++ b/bridge/__init__.py
@@ -1,0 +1,1 @@
+"""Bridge modules for inter-service events and protocols."""

--- a/bridge/events/__init__.py
+++ b/bridge/events/__init__.py
@@ -1,0 +1,35 @@
+"""Event name constants loaded from events.json."""
+
+from enum import Enum
+import json
+from pathlib import Path
+
+_EVENTS_PATH = Path(__file__).with_name("events.json")
+with _EVENTS_PATH.open(encoding="utf-8") as f:
+    _DATA = json.load(f)
+
+
+class Event(str, Enum):
+    STT_INPUT = _DATA["STT_INPUT"]["name"]
+    STT_OUTPUT = _DATA["STT_OUTPUT"]["name"]
+    CEPHALON_ROUTE = _DATA["CEPHALON_ROUTE"]["name"]
+    TTS_OUTPUT = _DATA["TTS_OUTPUT"]["name"]
+
+
+# Direct access to string values
+STT_INPUT = Event.STT_INPUT.value
+STT_OUTPUT = Event.STT_OUTPUT.value
+CEPHALON_ROUTE = Event.CEPHALON_ROUTE.value
+TTS_OUTPUT = Event.TTS_OUTPUT.value
+
+# Mapping from event enum name to associated protocol key (if any)
+EVENT_TO_PROTOCOL = {key: value.get("protocol") for key, value in _DATA.items()}
+
+__all__ = [
+    "Event",
+    "STT_INPUT",
+    "STT_OUTPUT",
+    "CEPHALON_ROUTE",
+    "TTS_OUTPUT",
+    "EVENT_TO_PROTOCOL",
+]

--- a/bridge/events/events.json
+++ b/bridge/events/events.json
@@ -1,0 +1,6 @@
+{
+  "STT_INPUT": { "name": "stt-input", "protocol": "stt_ws_request" },
+  "STT_OUTPUT": { "name": "stt-output", "protocol": "stt_ws_response" },
+  "CEPHALON_ROUTE": { "name": "cephalon-route" },
+  "TTS_OUTPUT": { "name": "tts-output" }
+}

--- a/bridge/events/events.md
+++ b/bridge/events/events.md
@@ -1,0 +1,10 @@
+# Event Definitions
+
+Event names use **kebab-case** and are prefixed by the service or routing target. Versioning is handled in the protocol schema files under `bridge/protocols/`.
+
+| Event            | Description                                          | Protocol                                                          |
+| ---------------- | ---------------------------------------------------- | ----------------------------------------------------------------- |
+| `stt-input`      | Audio frames sent to STT service.                    | [`stt-ws-request-v1.json`](../protocols/stt-ws-request-v1.json)   |
+| `stt-output`     | Transcription emitted by STT service.                | [`stt-ws-response-v1.json`](../protocols/stt-ws-response-v1.json) |
+| `cephalon-route` | Text routed through Cephalon for language reasoning. | –                                                                 |
+| `tts-output`     | Synthesized audio emitted by TTS service.            | –                                                                 |

--- a/bridge/events/index.js
+++ b/bridge/events/index.js
@@ -1,0 +1,21 @@
+import { readFileSync } from "fs";
+import { fileURLToPath } from "url";
+import path from "path";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const events = JSON.parse(
+  readFileSync(path.join(__dirname, "events.json"), "utf8"),
+);
+
+export const EventName = {
+  STT_INPUT: events.STT_INPUT.name,
+  STT_OUTPUT: events.STT_OUTPUT.name,
+  CEPHALON_ROUTE: events.CEPHALON_ROUTE.name,
+  TTS_OUTPUT: events.TTS_OUTPUT.name,
+};
+
+export const EVENT_TO_PROTOCOL = Object.fromEntries(
+  Object.entries(events).map(([key, value]) => [key, value.protocol || null]),
+);
+
+export default EventName;

--- a/bridge/protocols/__init__.py
+++ b/bridge/protocols/__init__.py
@@ -1,0 +1,10 @@
+"""Protocol manifest loader."""
+
+import json
+from pathlib import Path
+
+_MANIFEST_PATH = Path(__file__).with_name("manifest.json")
+with _MANIFEST_PATH.open(encoding="utf-8") as f:
+    PROTOCOLS = json.load(f)
+
+__all__ = ["PROTOCOLS"]

--- a/bridge/protocols/manifest.json
+++ b/bridge/protocols/manifest.json
@@ -1,0 +1,10 @@
+{
+  "stt_ws_request": {
+    "version": 1,
+    "schema": "stt-ws-request-v1.json"
+  },
+  "stt_ws_response": {
+    "version": 1,
+    "schema": "stt-ws-response-v1.json"
+  }
+}

--- a/pseudo/modular-agent-network.hy
+++ b/pseudo/modular-agent-network.hy
@@ -3,6 +3,7 @@
 ;; across shared cognitive services.
 
 (import [promethean.bridge [send-event]])
+(import [promethean.bridge.events [STT_INPUT CEPHALON_ROUTE TTS_OUTPUT]])
 
 ;; --- Agent Node Object ---
 (defclass AgentNode [object]
@@ -21,9 +22,9 @@
 
 (defn handle-utterance [node msg]
   ;; Pass utterance to STT, Cephalon, TTS
-  (send-event "stt-input" msg.content)
-  (let [thought (send-event "cephalon-route" msg.content)]
-    (send-event "tts-output" thought)))
+  (send-event STT_INPUT msg.content)
+  (let [thought (send-event CEPHALON_ROUTE msg.content)]
+    (send-event TTS_OUTPUT thought)))
 
 (defn schedule-action [node msg]
   ;; Placeholder for action scheduling


### PR DESCRIPTION
## Summary
- centralize inter-service events under `bridge/`
- expose event names and protocol versions for Python and JS
- update modular agent pseudocode to consume shared event constants

## Testing
- `make lint`
- `make format` *(fails: Biome formatting errors in unrelated TypeScript sources)*
- `make test` *(fails: ModuleNotFoundError: No module named 'chromadb')*
- `make build`


------
https://chatgpt.com/codex/tasks/task_e_6892eec3af148324945174c31b6fe19a