### PR TITLE
refactor tts service to use service template

### DIFF
--- a/docs/services/tts/app.md
+++ b/docs/services/tts/app.md
@@ -3,7 +3,9 @@
 **Path**: `services/py/tts/app.py`
 
 **Description**: FastAPI application exposing HTTP and WebSocket text-to-speech
-interfaces.
+interfaces. On startup it also connects to the internal message broker via
+`shared.py.service_template`, consuming tasks from the `tts.speak` queue and
+publishing base64-encoded audio on the `tts-output` event channel.
 
 ### Endpoints
 

--- a/services/py/tts/README.md
+++ b/services/py/tts/README.md
@@ -2,7 +2,10 @@
 
 This service converts text to speech using Tacotron and WaveRNN models.
 It exposes both an HTTP endpoint (`/synth_voice_pcm`) and a WebSocket
-endpoint (`/ws/tts`) on the same server.
+endpoint (`/ws/tts`) on the same server. On startup the service also uses
+`shared.py.service_template` to connect to the message broker, consuming
+text tasks from the `tts.speak` queue and publishing synthesized audio as
+`tts-output` events.
 
 ## Usage
 

--- a/services/py/tts/app.py
+++ b/services/py/tts/app.py
@@ -1,35 +1,54 @@
 from fastapi import FastAPI, Form, Response, WebSocket
+import base64
 import io
 import sys
 
 print(sys.path)
 from shared.py.heartbeat_client import HeartbeatClient
+from shared.py.service_template import start_service
 from shared.py.utils import websocket_endpoint
-
-from safetensors.torch import load_file
 
 import soundfile as sf
 
 import nltk
-import soundfile as sf
 import torch
 import numpy as np
-import os
 from transformers import FastSpeech2ConformerTokenizer, FastSpeech2ConformerWithHifiGan
 
 nltk.download("averaged_perceptron_tagger_eng")
 
 app = FastAPI()
 hb = HeartbeatClient()
+broker = None
 
 
 @app.on_event("startup")
 async def startup_event():
+    global broker
     try:
         hb.send_once()
     except Exception as exc:
         raise RuntimeError("heartbeat registration failed") from exc
     hb.start()
+
+    async def handle_task(task):
+        payload = task.get("payload", {})
+        text = payload.get("text")
+        if not text:
+            return
+        audio = synthesize(text)
+        buf = io.BytesIO()
+        sf.write(buf, audio, samplerate=22050, format="WAV")
+        audio_b64 = base64.b64encode(buf.getvalue()).decode("utf-8")
+        await broker.publish("tts-output", {"audio": audio_b64})
+
+    try:
+        broker = await start_service(
+            id="tts", queues=["tts.speak"], handle_task=handle_task
+        )
+    except Exception as e:
+        print(f"[tts] broker connection failed: {e}")
+        broker = None
 
 
 @app.on_event("shutdown")
@@ -38,11 +57,6 @@ def shutdown_event():
 
 
 # Load the model and processor
-from transformers import (
-    FastSpeech2ConformerTokenizer,
-    FastSpeech2ConformerWithHifiGan,
-)
-import torch
 
 # Ensure GPU usage
 device = "cuda" if torch.cuda.is_available() else "cpu"

--- a/services/py/tts/tests/test_tts_websocket.py
+++ b/services/py/tts/tests/test_tts_websocket.py
@@ -34,6 +34,13 @@ def test_websocket_tts_returns_wav_bytes():
     dummy_sf = types.SimpleNamespace(write=dummy_write)
     dummy_nltk = types.SimpleNamespace(download=lambda *a, **k: None)
 
+    class DummyBroker:
+        async def publish(self, *a, **k):
+            pass
+
+    async def dummy_start_service(*a, **k):
+        return DummyBroker()
+
     class DummyNoGrad:
         def __enter__(self):
             pass
@@ -83,6 +90,9 @@ def test_websocket_tts_returns_wav_bytes():
                 "speech.tts": dummy_module,
                 "shared.py.speech": dummy_package,
                 "shared.py.speech.tts": dummy_module,
+                "shared.py.service_template": types.SimpleNamespace(
+                    start_service=dummy_start_service
+                ),
                 "soundfile": dummy_sf,
                 "nltk": dummy_nltk,
                 "torch": dummy_torch,


### PR DESCRIPTION
## Summary
- refactor tts FastAPI service to initialize the shared Python service template and publish `tts-output` events
- document broker integration and queue usage for the tts service
- stub broker interactions in tts websocket test

## Testing
- `make setup-python-service-tts`
- `make test-python-service-tts`
- `make build`
- `make lint-python-service-tts`
- `black services/py/tts docs/services/tts`


------
https://chatgpt.com/codex/tasks/task_e_6893a141dc8083248e9bd6da343e0310