### PR TITLE
docs: add service template documentation

### DIFF
--- a/docs/templates/service-template.md
+++ b/docs/templates/service-template.md
@@ -1,0 +1,18 @@
+# Service Template
+
+The Promethean repository includes a reusable service template to help you bootstrap new services and keep documentation consistent.
+
+## Files
+
+- `docs/templates/service.README.template.md` – skeleton README for new service docs.
+- `services/templates` – boilerplate resources for service implementations.
+
+## Usage
+
+1. Copy `docs/templates/service.README.template.md` into `docs/services/<service>/README.md`.
+2. Replace `{{SERVICE_NAME}}` and fill in details such as purpose, usage, and file references.
+3. Mirror your service’s code structure under `services/<service>` and keep docs in sync.
+
+Following this template ensures a uniform layout across Promethean services.
+
+#hashtags: #template #service #docs


### PR DESCRIPTION
## Summary
- document how to use the service template when bootstrapping new services

## Testing
- `make format`
- `make lint` *(fails: npm run lint returned non-zero exit status 127)*
- `make test` *(fails: pytest command exited with status 2)*
- `make build`


------
https://chatgpt.com/codex/tasks/task_e_6893a11e83f08324818523a18c9b5048