### PR TITLE
feat: add redis-backed task queues

### DIFF
--- a/services/js/broker/README.md
+++ b/services/js/broker/README.md
@@ -27,6 +27,17 @@ Published messages are normalized to:
 
 Subscribers receive `{ "event": <normalized message> }` envelopes.
 
+## Task Queues
+
+The broker also provides simple task queue semantics. Clients may enqueue work items and workers may dequeue them one at a time.
+
+### Actions
+
+- `{"action":"enqueue","queue":"jobs","task":{...}}`
+- `{"action":"dequeue","queue":"jobs"}` → server responds with `{ "task": { ... } }` or `{ "task": null }` if empty
+
+If a Redis server is available (configured via `REDIS_URL` or default `redis://127.0.0.1:6379`), queues are persisted in Redis. Otherwise, an in-memory queue is used.
+
 ## Development
 
 ```

--- a/services/js/broker/package-lock.json
+++ b/services/js/broker/package-lock.json
@@ -8,6 +8,7 @@
       "name": "broker-service",
       "version": "0.0.1",
       "dependencies": {
+        "redis": "^4.6.7",
         "ws": "^8.18.0"
       },
       "devDependencies": {
@@ -185,6 +186,71 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@redis/bloom": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@redis/bloom/-/bloom-1.2.0.tgz",
+      "integrity": "sha512-HG2DFjYKbpNmVXsa0keLHp/3leGJz1mjh09f2RLGGLQZzSHpkmZWuwJbAvo3QcRY8p80m5+ZdXZdYOSBLlp7Cg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/client": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@redis/client/-/client-1.6.1.tgz",
+      "integrity": "sha512-/KCsg3xSlR+nCK8/8ZYSknYxvXHwubJrU82F3Lm1Fp6789VQ0/3RJKfsmRXjqfaTA++23CvC3hqmqe/2GEt6Kw==",
+      "license": "MIT",
+      "dependencies": {
+        "cluster-key-slot": "1.1.2",
+        "generic-pool": "3.9.0",
+        "yallist": "4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@redis/client/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "license": "ISC"
+    },
+    "node_modules/@redis/graph": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@redis/graph/-/graph-1.1.1.tgz",
+      "integrity": "sha512-FEMTcTHZozZciLRl6GiiIB4zGm5z5F3F6a6FZCyrfxdKOhFlGkiAqlexWMBzCi4DcRoyiOsuLfW+cjlGWyExOw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/json": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@redis/json/-/json-1.0.7.tgz",
+      "integrity": "sha512-6UyXfjVaTBTJtKNG4/9Z8PSpKE6XgSyEb8iwaqDcy+uKrd/DGYHTWkUdnQDyzm727V7p21WUMhsqz5oy65kPcQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/search": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@redis/search/-/search-1.2.0.tgz",
+      "integrity": "sha512-tYoDBbtqOVigEDMAcTGsRlMycIIjwMCgD8eR2t0NANeQmgK/lvxNAvYyb6bZDD4frHRhIHkJu2TBRvB0ERkOmw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/time-series": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@redis/time-series/-/time-series-1.1.0.tgz",
+      "integrity": "sha512-c1Q99M5ljsIuc4YdaCwfUEXsofakb9c8+Zse2qxTadu8TalLXuAESzLvFAvNVbkmSlvlzIQOLpBCmWI9wTOt+g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
       }
     },
     "node_modules/@rollup/pluginutils": {
@@ -732,6 +798,15 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
+    "node_modules/cluster-key-slot": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
+      "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/code-excerpt": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/code-excerpt/-/code-excerpt-4.0.0.tgz",
@@ -1099,6 +1174,15 @@
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/generic-pool": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-3.9.0.tgz",
+      "integrity": "sha512-hymDOu5B53XvN4QT9dBmZxPX4CWhBPPLguTZ9MMFeFa/Kg0xWVfylOVNlJji/E7yTZWFd/q9GO5TxDLq156D7g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
     },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
@@ -1942,6 +2026,23 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/redis": {
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/redis/-/redis-4.7.1.tgz",
+      "integrity": "sha512-S1bJDnqLftzHXHP8JsT5II/CtHWQrASX5K96REjWjlmWKrviSOLWmM7QnRLstAWsu1VBBV1ffV6DzCvxNP0UJQ==",
+      "license": "MIT",
+      "workspaces": [
+        "./packages/*"
+      ],
+      "dependencies": {
+        "@redis/bloom": "1.2.0",
+        "@redis/client": "1.6.1",
+        "@redis/graph": "1.1.1",
+        "@redis/json": "1.0.7",
+        "@redis/search": "1.2.0",
+        "@redis/time-series": "1.1.0"
+      }
     },
     "node_modules/require-directory": {
       "version": "2.1.1",

--- a/services/js/broker/package.json
+++ b/services/js/broker/package.json
@@ -9,6 +9,7 @@
     "coverage": "c8 ava"
   },
   "dependencies": {
+    "redis": "^4.6.7",
     "ws": "^8.18.0"
   },
   "devDependencies": {

--- a/services/js/broker/taskQueue.js
+++ b/services/js/broker/taskQueue.js
@@ -1,0 +1,49 @@
+import { createClient } from "redis";
+
+class InMemoryTaskQueue {
+  constructor() {
+    this.queues = new Map();
+  }
+  async enqueue(name, task) {
+    if (!this.queues.has(name)) this.queues.set(name, []);
+    this.queues.get(name).push(task);
+  }
+  async dequeue(name) {
+    const q = this.queues.get(name);
+    if (!q || q.length === 0) return null;
+    return q.shift();
+  }
+  async close() {}
+}
+
+class RedisTaskQueue {
+  constructor(client) {
+    this.client = client;
+  }
+  async enqueue(name, task) {
+    await this.client.rPush(name, JSON.stringify(task));
+  }
+  async dequeue(name) {
+    const result = await this.client.lPop(name);
+    return result ? JSON.parse(result) : null;
+  }
+  async close() {
+    try {
+      await this.client.quit();
+    } catch {}
+  }
+}
+
+export async function createTaskQueue() {
+  const url = process.env.REDIS_URL || "redis://127.0.0.1:6379";
+  try {
+    const client = createClient({ url });
+    await client.connect();
+    return new RedisTaskQueue(client);
+  } catch (err) {
+    console.warn("redis not available, using in-memory queue", err?.message);
+    return new InMemoryTaskQueue();
+  }
+}
+
+export { InMemoryTaskQueue, RedisTaskQueue };


### PR DESCRIPTION
## Summary
- add Redis and in-memory task queue implementations
- extend broker to enqueue/dequeue tasks and close queues on shutdown
- document task queue protocol and add tests for queue operations

## Testing
- `npm test --prefix services/js/broker`
- `npm run build --prefix services/js/broker` *(fails: Missing script: "build")*
- `npm run lint --prefix services/js/broker` *(fails: Missing script: "lint")*
- `npm run format --prefix services/js/broker` *(fails: Missing script: "format")*


------
https://chatgpt.com/codex/tasks/task_e_6893a0c5f86083249cbe0e72daaecb61