### PR TITLE
Refactor embedding service to service template

### DIFF
--- a/docs/embedding_service.md
+++ b/docs/embedding_service.md
@@ -1,6 +1,8 @@
 # Embedding Service
 
-Provides a configurable HTTP API for generating embeddings via multiple backends.
+Provides a broker-driven service for generating embeddings via multiple backends.
+Uses the shared Python `start_service` template and listens on the
+`embedding.generate` queue, publishing results to the `embedding.result` topic.
 Supports naive, transformers, and Ollama drivers, keeping only the last used model
 in an LRU cache.
 

--- a/docs/services/embedding-service/main.md
+++ b/docs/services/embedding-service/main.md
@@ -2,20 +2,16 @@
 
 **Path**: `services/py/embedding_service/main.py`
 
-**Description**: FastAPI application exposing `/embed` to generate vector
-embeddings using pluggable drivers such as naive, transformers, or Ollama
-implementations.
-
-### Endpoints
-
- - `POST /embed` – body:
-   `{ "items": [{"type": str, "data": str}], "driver": str?, "function": str? }`
-   returns `{ "embeddings": list[list[float]] }`.
+**Description**: Async worker built on the shared `start_service` template to
+generate vector embeddings. Listens for tasks on `embedding.generate` and
+publishes results to the `embedding.result` topic using pluggable drivers such
+as naive, transformers, or Ollama implementations.
 
 ## Dependencies
-- fastapi
-- pydantic
+- asyncio
+- os
 - functools.lru_cache
+- shared.py.service_template
 - services/py/embedding_service/drivers
 
 ## Dependents

--- a/docs/services/embedding-service/tests/test_service.md
+++ b/docs/services/embedding-service/tests/test_service.md
@@ -2,10 +2,11 @@
 
 **Path**: `services/py/embedding_service/tests/test_service.py`
 
-**Description**: Exercises the `/embed` endpoint with the naive driver to confirm that embeddings are generated and returned.
+**Description**: Ensures the task handler publishes embeddings using the naive
+driver when a task is received.
 
 ## Dependencies
-- fastapi.testclient
+- pytest
 - services/py/embedding_service/main
 - pathlib
 - sys

--- a/services/py/embedding_service/main.py
+++ b/services/py/embedding_service/main.py
@@ -1,29 +1,10 @@
+import asyncio
 import os
 from functools import lru_cache
 from typing import List
 
-from fastapi import FastAPI, WebSocket
-from pydantic import BaseModel
-
+from shared.py.service_template import start_service
 from .drivers import get_driver
-from shared.py.utils import websocket_endpoint
-
-app = FastAPI()
-
-
-class EmbedItem(BaseModel):
-    type: str
-    data: str
-
-
-class EmbedRequest(BaseModel):
-    items: List[EmbedItem]
-    driver: str | None = None
-    function: str | None = None
-
-
-class EmbedResponse(BaseModel):
-    embeddings: List[List[float]]
 
 
 @lru_cache(maxsize=1)
@@ -32,29 +13,38 @@ def _load(driver_name: str, function_name: str):
     return driver.load(function_name)
 
 
-@app.post("/embed", response_model=EmbedResponse)
-def embed(request: EmbedRequest) -> EmbedResponse:
-    driver_name = request.driver or os.environ.get("EMBEDDING_DRIVER", "naive")
-    function_name = request.function or os.environ.get("EMBEDDING_FUNCTION", "simple")
+def _embed(items, driver_name: str, function_name: str) -> List[List[float]]:
     driver = get_driver(driver_name)
     model = _load(driver_name, function_name)
-    embeddings = driver.embed(request.items, function_name, model)
-    return EmbedResponse(embeddings=embeddings)
+    return driver.embed(items, function_name, model)
 
 
-@app.websocket("/ws/embed")
-@websocket_endpoint
-async def embed_ws(ws: WebSocket) -> None:
-    """WebSocket endpoint for generating embeddings.
+async def handle_task(task, client):
+    payload = task.get("payload", {})
+    driver_name = payload.get("driver") or os.environ.get("EMBEDDING_DRIVER", "naive")
+    function_name = payload.get("function") or os.environ.get(
+        "EMBEDDING_FUNCTION", "simple"
+    )
+    items = payload.get("items", [])
+    embeddings = _embed(items, driver_name, function_name)
+    reply_to = payload.get("replyTo") or task.get("replyTo")
+    if reply_to:
+        await client.publish(
+            "embedding.result",
+            {"embeddings": embeddings},
+            replyTo=reply_to,
+            correlationId=task.get("id"),
+        )
 
-    Expects a JSON payload matching :class:`EmbedRequest` and returns the
-    embeddings as JSON, mirroring the REST ``/embed`` endpoint.
-    """
-    data = await ws.receive_json()
-    request = EmbedRequest(**data)
-    driver_name = request.driver or os.environ.get("EMBEDDING_DRIVER", "naive")
-    function_name = request.function or os.environ.get("EMBEDDING_FUNCTION", "simple")
-    driver = get_driver(driver_name)
-    model = _load(driver_name, function_name)
-    embeddings = driver.embed(request.items, function_name, model)
-    await ws.send_json({"embeddings": embeddings})
+
+async def main():
+    await start_service(
+        id="embedding",
+        queues=["embedding.generate"],
+        handle_task=handle_task,
+    )
+    await asyncio.Event().wait()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/shared/py/service_template.py
+++ b/shared/py/service_template.py
@@ -8,8 +8,8 @@ async def start_service(
     id,
     queues=None,
     topics=None,
-    handle_event=lambda event: None,
-    handle_task=lambda task: None,
+    handle_event=lambda event, client: None,
+    handle_task=lambda task, client: None,
 ):
     queues = queues or []
     topics = topics or []
@@ -24,7 +24,7 @@ async def start_service(
         async def event_handler(event, topic=topic):
             print(f"[{id}] received event: {event['type']}")
             try:
-                await handle_event(event)
+                await handle_event(event, client)
             except Exception as e:
                 print(f"[{id}] error handling event {event['type']}: {e}")
 
@@ -34,7 +34,7 @@ async def start_service(
     async def task_handler(task):
         print(f"[{id}] received task from {task['queue']}")
         try:
-            await handle_task(task)
+            await handle_task(task, client)
             await client.ack(task["id"])
         except Exception as e:
             print(f"[{id}] task failed: {e}")

--- a/shared/py/tests/test_service_template.py
+++ b/shared/py/tests/test_service_template.py
@@ -1,0 +1,58 @@
+import asyncio
+
+from shared.py import service_template
+
+
+class DummyClient:
+    def __init__(self, client_id=None):
+        self.client_id = client_id
+        self.task_handler = None
+        self.pulled = False
+
+    async def connect(self):
+        pass
+
+    async def subscribe(self, topic, handler):
+        await handler({"type": topic})
+
+    def on_task(self, handler):
+        self.task_handler = handler
+
+    async def pull(self, queue):
+        if not self.pulled and self.task_handler:
+            self.pulled = True
+            await self.task_handler({"id": "1", "queue": queue, "payload": {}})
+
+    async def publish(self, *args, **kwargs):
+        pass
+
+    async def ack(self, *args, **kwargs):
+        pass
+
+    async def fail(self, *args, **kwargs):
+        pass
+
+
+def test_handlers_receive_client(monkeypatch):
+    dummy = DummyClient()
+    monkeypatch.setattr(service_template, "BrokerClient", lambda client_id: dummy)
+    events: list = []
+    tasks: list = []
+
+    async def handle_event(event, client):
+        events.append((event, client))
+
+    async def handle_task(task, client):
+        tasks.append((task, client))
+
+    client = asyncio.run(
+        service_template.start_service(
+            id="svc",
+            queues=["q"],
+            topics=["t"],
+            handle_event=handle_event,
+            handle_task=handle_task,
+        )
+    )
+    assert events and events[0][1] is client
+    assert tasks and tasks[0][1] is client


### PR DESCRIPTION
## Summary
- route broker events through service_template with client context
- refactor embedding service to handle broker tasks and publish embeddings
- document broker-based embedding workflow and add tests

## Testing
- `make test-shared-python`
- `make test-python-service-embedding_service`
- `make lint-python`
- `make format-python`
- `make build-python`


------
https://chatgpt.com/codex/tasks/task_e_6893a1b304d88324a0dcfcf108377ad9