### PR TITLE
Add coverage for agile status utilities

### DIFF
--- a/tests/scripts/test_agile_statuses.py
+++ b/tests/scripts/test_agile_statuses.py
@@ -1,0 +1,22 @@
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parent))
+from utils import load_script_module
+
+agile = load_script_module("agile_statuses")
+
+
+def test_status_order_is_unique_and_matches_set():
+    """STATUS_ORDER should contain unique statuses and match STATUS_SET."""
+    assert len(agile.STATUS_ORDER) == len(set(agile.STATUS_ORDER))
+    assert agile.STATUS_SET == set(agile.STATUS_ORDER)
+
+
+def test_statuses_have_hashtags_and_expected_order():
+    """Every status should start with a hashtag and preserve defined order."""
+    for status in agile.STATUS_ORDER:
+        assert status.startswith("#")
+    # spot-check order: first and last elements
+    assert agile.STATUS_ORDER[0] == "#ice-box"
+    assert agile.STATUS_ORDER[-1] == "#done"


### PR DESCRIPTION
## Summary
- add tests for shared agile status constants

## Testing
- `pytest tests/scripts --cov=scripts`
- `make lint`
- `make format` *(fails: Command 'npx --yes @biomejs/biome format .' returned non-zero exit status 1)*
- `make build`
- `make test` *(fails: pipenv run pytest tests/ returned non-zero exit status 2)*

------
https://chatgpt.com/codex/tasks/task_e_6893aeba22a8832480dd495dbd32bf26