### PR TITLE
feat(broker): add task ttl and pull semantics

### DIFF
--- a/docs/services/broker/index.md
+++ b/docs/services/broker/index.md
@@ -2,7 +2,7 @@
 
 **Path**: `services/js/broker/index.js`
 
-**Description**: WebSocket-based message broker providing a simple pub/sub event bus. It normalizes published messages and routes them to subscribers based on topic. Supports optional correlation IDs and reply topics for request/response patterns.
+**Description**: WebSocket-based message broker providing a simple pub/sub event bus. It normalizes published messages and routes them to subscribers based on topic. Supports optional correlation IDs and reply topics for request/response patterns. Includes a lightweight task queue with TTL-based expiration and pull-based retrieval.
 
 ## Dependencies
 - ws

--- a/services/js/broker/README.md
+++ b/services/js/broker/README.md
@@ -29,12 +29,14 @@ Subscribers receive `{ "event": <normalized message> }` envelopes.
 
 ## Task Queues
 
-The broker also provides simple task queue semantics. Clients may enqueue work items and workers may dequeue them one at a time.
+The broker also provides simple task queue semantics. Clients may enqueue work items and workers may pull them one at a time. Each task receives an ID and optional TTL (default 60s). Expired tasks decay out of the buffer and are not delivered.
 
 ### Actions
 
-- `{"action":"enqueue","queue":"jobs","task":{...}}`
-- `{"action":"dequeue","queue":"jobs"}` → server responds with `{ "task": { ... } }` or `{ "task": null }` if empty
+- `{"action":"enqueue","queue":"jobs","task":{...},"ttl":1000}`
+- `{"action":"pull","queue":"jobs"}` → server responds with `{ "task": { "id": "...", "payload": { ... }, "queue": "jobs" } }` or `{ "task": null, "queue": "jobs" }` if empty or expired
+- `{"action":"ack","taskId":"..."}` (optional no-op)
+- `{"action":"fail","taskId":"...","reason":"..."}` (optional no-op)
 
 If a Redis server is available (configured via `REDIS_URL` or default `redis://127.0.0.1:6379`), queues are persisted in Redis. Otherwise, an in-memory queue is used.
 

--- a/services/js/broker/taskQueue.js
+++ b/services/js/broker/taskQueue.js
@@ -1,18 +1,37 @@
 import { createClient } from "redis";
+import { randomUUID } from "crypto";
+
+const DEFAULT_TTL = 60000; // 60s
 
 class InMemoryTaskQueue {
   constructor() {
     this.queues = new Map();
   }
-  async enqueue(name, task) {
+
+  async enqueue(name, payload, ttl = DEFAULT_TTL) {
     if (!this.queues.has(name)) this.queues.set(name, []);
+    const task = {
+      id: randomUUID(),
+      payload,
+      queue: name,
+      expiresAt: Date.now() + ttl,
+    };
     this.queues.get(name).push(task);
   }
+
   async dequeue(name) {
     const q = this.queues.get(name);
     if (!q || q.length === 0) return null;
-    return q.shift();
+    while (q.length > 0) {
+      const task = q.shift();
+      if (task.expiresAt > Date.now()) {
+        return task;
+      }
+      // drop expired tasks
+    }
+    return null;
   }
+
   async close() {}
 }
 
@@ -20,13 +39,34 @@ class RedisTaskQueue {
   constructor(client) {
     this.client = client;
   }
-  async enqueue(name, task) {
+
+  async enqueue(name, payload, ttl = DEFAULT_TTL) {
+    const task = {
+      id: randomUUID(),
+      payload,
+      queue: name,
+      expiresAt: Date.now() + ttl,
+    };
     await this.client.rPush(name, JSON.stringify(task));
   }
+
   async dequeue(name) {
-    const result = await this.client.lPop(name);
-    return result ? JSON.parse(result) : null;
+    while (true) {
+      const result = await this.client.lPop(name);
+      if (!result) return null;
+      let task;
+      try {
+        task = JSON.parse(result);
+      } catch {
+        continue;
+      }
+      if (task.expiresAt > Date.now()) {
+        return task;
+      }
+      // drop expired task and continue
+    }
   }
+
   async close() {
     try {
       await this.client.quit();


### PR DESCRIPTION
## Summary
- extend broker queue with task TTL and ID generation
- add pull/ack/fail actions and graceful empty-task handling
- document broker task queues and update shared client helpers

## Testing
- `make setup-js-service-broker`
- `make test-js-service-broker`
- `make build-js`
- `make lint-js`
- `make format-js`


------
https://chatgpt.com/codex/tasks/task_e_6893b3f455ac832486c19b454a70a43e