### PR TITLE
feat(file-watcher): add LLM task queue

### DIFF
--- a/services/ts/file-watcher/src/index.ts
+++ b/services/ts/file-watcher/src/index.ts
@@ -6,6 +6,12 @@ import { createTasksWatcher } from "./tasks-watcher.js";
 export interface FileWatcherOptions {
   repoRoot?: string;
   publish?: (type: string, payload: any) => void;
+  runPython?: (path: string) => Promise<any>;
+  callLLM?: (path: string) => Promise<string>;
+  writeFile?: (path: string, content: string) => Promise<void>;
+  mongoCollection?: { updateOne: (...args: any[]) => Promise<any> };
+  socket?: { emit: (...args: any[]) => void };
+  maxConcurrentLLMTasks?: number;
 }
 
 const defaultRepoRoot = process.env.REPO_ROOT || "";
@@ -33,7 +39,20 @@ export function startFileWatcher(options: FileWatcherOptions = {}) {
   ws?.on("open", () => console.log("file watcher connected to broker"));
 
   const boardWatcher = createBoardWatcher({ boardPath, publish });
-  const tasksWatcher = createTasksWatcher({ tasksPath, publish });
+  const tasksWatcher = createTasksWatcher({
+    tasksPath,
+    publish,
+    ...(options.runPython ? { runPython: options.runPython } : {}),
+    ...(options.callLLM ? { callLLM: options.callLLM } : {}),
+    ...(options.writeFile ? { writeFile: options.writeFile } : {}),
+    ...(options.mongoCollection
+      ? { mongoCollection: options.mongoCollection }
+      : {}),
+    ...(options.socket ? { socket: options.socket } : {}),
+    ...(options.maxConcurrentLLMTasks !== undefined
+      ? { maxConcurrentLLMTasks: options.maxConcurrentLLMTasks }
+      : {}),
+  });
 
   return {
     boardWatcher,

--- a/services/ts/file-watcher/src/tasks-watcher.ts
+++ b/services/ts/file-watcher/src/tasks-watcher.ts
@@ -7,19 +7,51 @@ const EVENTS = {
 export interface TasksWatcherOptions {
   tasksPath: string;
   publish: (type: string, payload: any) => void;
+  runPython?: (path: string) => Promise<any>;
+  callLLM?: (path: string) => Promise<string>;
+  writeFile?: (path: string, content: string) => Promise<void>;
+  mongoCollection?: { updateOne: (...args: any[]) => Promise<any> };
+  socket?: { emit: (...args: any[]) => void };
+  maxConcurrentLLMTasks?: number;
 }
 
 export function createTasksWatcher({
   tasksPath,
   publish,
+  runPython,
+  callLLM,
+  writeFile,
+  mongoCollection,
+  socket,
+  maxConcurrentLLMTasks = 1,
 }: TasksWatcherOptions) {
   const watcher = chokidar.watch(tasksPath, { ignoreInitial: true });
 
-  const TEMPLATE_PROMPT =
-    "You are an engineering assistant. Given a task title, produce a concise markdown task stub with headings for Goals, Requirements, and Subtasks.";
+  const queue: string[] = [];
+  let active = 0;
+
+  async function process(path: string) {
+    active++;
+    try {
+      await runPython?.(path);
+      const content = await callLLM?.(path);
+      if (content) await writeFile?.(path, content);
+      await mongoCollection?.updateOne?.({}, {} as any);
+      socket?.emit?.("task-processed", { path });
+    } finally {
+      active--;
+      if (queue.length > 0) {
+        process(queue.shift()!);
+      }
+    }
+  }
 
   watcher.on("add", (path) => {
     publish(EVENTS.add, { path });
+    queue.push(path);
+    if (active < maxConcurrentLLMTasks) {
+      process(queue.shift()!);
+    }
   });
 
   watcher.on("change", (path) => {

--- a/services/ts/file-watcher/tests/queue.test.ts
+++ b/services/ts/file-watcher/tests/queue.test.ts
@@ -26,6 +26,7 @@ test("limits concurrent LLM tasks", async (t) => {
 
   const watchers = startFileWatcher({
     repoRoot: root,
+    publish: () => {},
     runPython: async () => undefined,
     callLLM: async () => {
       active++;


### PR DESCRIPTION
## Summary
- allow file watcher to accept task processing callbacks and concurrency limits
- queue new task files and process them with an adjustable LLM concurrency cap
- add publish stub in queue test to avoid broker connection

## Testing
- `npm run build`
- `npm run lint`
- `npm run format`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6893bed29b2c83249cb080a07830f6ae