### PR TITLE
docs: fix AGENTS references and list services

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,6 +98,44 @@ docs/            # System-level documentation and markdown exports
 site/            # Website or UI content (optional)
 ```
 
+### Current Services
+
+The `services/` directory currently includes:
+
+**Python**
+- `services/py/discord_attachment_embedder`
+- `services/py/discord_attachment_indexer`
+- `services/py/discord_indexer`
+- `services/py/embedding_service`
+- `services/py/stt`
+- `services/py/tts`
+
+**Hy (legacy)**
+- `services/hy/discord_attachment_embedder`
+- `services/hy/discord_attachment_indexer`
+- `services/hy/discord_indexer`
+- `services/hy/stt`
+- `services/hy/tts`
+
+**JavaScript**
+- `services/js/broker`
+- `services/js/eidolon-field`
+- `services/js/health`
+- `services/js/heartbeat`
+- `services/js/proxy`
+- `services/js/vision`
+
+**TypeScript**
+- `services/ts/board-updater`
+- `services/ts/cephalon`
+- `services/ts/discord-embedder`
+- `services/ts/file-watcher`
+- `services/ts/kanban-processor`
+- `services/ts/llm`
+- `services/ts/markdown-graph`
+- `services/ts/reasoner`
+- `services/ts/voice`
+
 ---
 
 ## 🛠 Service Templates
@@ -329,7 +367,7 @@ Additionally, ensure that:
 * All new code is covered by tests
 * Documentation is updated in `/docs/` as needed
 * Migration plans are followed for any structural changes
-* [test workflows](.github/workflows/tests.yaml) all use `make` targets for consistency
+* [test workflows](.github/workflows/) all use `make` targets for consistency
 
 ---
 
@@ -337,14 +375,14 @@ Additionally, ensure that:
 
 * Use `.gitattributes` to track LFS-managed binaries (e.g., weights, wavs)
 * Do **not** store raw datasets or models directly—use `download.sh` or link instructions
-* All changes to `/models/`, `/data/`, or `/training/` must be documented in `MIGRATION_PLAN.md` or a note in `CHANGELOG.md`
+* All changes to `/models/`, `/data/`, or `/training/` must be documented in `MIGRATION_PLAN.md` or noted in a changelog (`CHANGELOG.md` when available)
 
 ---
 
 ## 📚 Documentation Standards
 
 * Markdown only
-* Use `[Wikilinks](Wikilinks.md)` in your Obsidian workflow, but ensure they are converted to regular markdown links for compatibility. Use `#hashtags` to support the Obsidian graph view.
+* Use Wikilinks in your Obsidian workflow, but ensure they are converted to regular markdown links for compatibility. Use `#hashtags` to support the Obsidian graph view.
 * Code paths must be written like: `services/cephalon/langstream.py`
 * All new modules must have a doc stub in `/docs/`
 * See `docs/vault-config-readme.md` for tips on configuring Obsidian to export

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -35,7 +35,7 @@ This is not passive documentation — it is an active *epistemic interface* thro
 - Obsidian vault logic
 - Codex prompt conventions
 - Agent-mode dialogue structure
-- `kanban.md`, `process_board_flow.md`, and other core docs
+- `agile/boards/kanban.md`, `agile/Process.md`, and other core docs
 - Vault symlinks to code mirrors
 
 ## Related Services

--- a/docs/agile/AGENTS.md
+++ b/docs/agile/AGENTS.md
@@ -1,6 +1,6 @@
 # 🤖 Agent: Board Manager
 
-This agent is responsible for maintaining and navigating the Kanban board in `agile/boards/kanban`.
+This agent is responsible for maintaining and navigating the Kanban board in `agile/boards/kanban.md`.
 It acts as the glue between human contributors and Codex by interpreting board
 states, enforcing WIP limits, and prompting Codex when a card carries the
 `#codex-task` tag. The board itself is generated from the task files in
@@ -78,9 +78,9 @@ The board columns are derived from these hashtags in each task file:
 ## 📁 File Locations
 
 - Board file: `agile/boards/kanban.md`
-- Epics: `agile/boards/epic.md`
+- Epics: `agile/boards/epics.md`
 - Tasks: `agile/tasks/*.md`
-- Process flow: `process.md`
+- Process flow: `agile/Process.md`
 
 The board file is regenerated whenever `make kanban-from-tasks` is run. **Do not edit `kanban.md` manually.** To move a task between columns, edit the status hashtag in its corresponding task file and rerun `make kanban-to-hashtags`.
 

--- a/docs/prompts/AGENTS.md
+++ b/docs/prompts/AGENTS.md
@@ -34,9 +34,6 @@ Reusable prompt blueprints. Start here when unsure how to frame a prompt.
 
 Logs and records of past prompt sessions—especially those with major consequences.
 
-### `tasks/`
-
-Current or proposed task-level prompts, tied to the Kanban and agent assignments.
 
 ### `scratch/`
 
@@ -76,7 +73,7 @@ You don’t have to use all of them. But you should know when and why you skip o
 Eventually, you will be able to:
 
 * Generate your own prompts from these structures.
-* Propose new tasks and insert them into `tasks/`.
+* Propose new tasks and insert them into `../agile/tasks/`.
 * Use `meta/` to reflect on your own cognitive behavior.
 * Learn and evolve your own role from what’s written in `agents/`.
 

--- a/tests/e2e/AGENTS.md
+++ b/tests/e2e/AGENTS.md
@@ -2,10 +2,8 @@
 
 ## Overview
 
-This folder `/workspace/tests/e2e` is for whole syste/cross service e2e tests.
-As in, we want to test the complete system from end to end here.
-
-validate the system is working as intended.
+This folder `tests/e2e` is for whole system/cross-service end-to-end tests.
+As in, we want to test the complete system from end to end here to validate it works as intended.
 User facing features are often tested here.
 
 For example, the discord bot has a "start_dialog" command that initiates a voice conversation with the bot that involves:
@@ -14,7 +12,7 @@ For example, the discord bot has a "start_dialog" command that initiates a voice
 - potentially capturing the users screen to feed to a multi modal network
 - feeding that text/image to the LLM service
 - sending the LLMs generated response to a text to speech system
-- sending that voice stream to discord for the user to here.
+- sending that voice stream to discord for the user to hear.
 
 Most if not all of the systems services are involved in a flow like this. 
 If we want to automatically validate that this complicated pipeline works correctly, you'd write an e2e test here.

--- a/tests/integration/AGENTS.md
+++ b/tests/integration/AGENTS.md
@@ -2,5 +2,5 @@
 
 ## Overview
 
-This folder `/workspace/tests/integration` is for cross service integration tests.
-As in, if there is a specific interaction between `/workspace/services/` that needs validation.
+This folder `tests/integration` is for cross-service integration tests.
+As in, if there is a specific interaction between `services/` that needs validation.

--- a/tests/scripts/AGENTS.md
+++ b/tests/scripts/AGENTS.md
@@ -2,4 +2,4 @@
 
 ## Overview
 
-This folder `/workspace/tests/scripts` is for testing the systems standalone scripts EG `/workspace/scripts`
+This folder `tests/scripts` is for testing the system's standalone scripts, e.g., `scripts/`


### PR DESCRIPTION
## Summary
- fix outdated file links across all AGENTS files
- document available services in root AGENTS

## Testing
- `make lint` *(fails: Command 'npm run lint' returned non-zero exit status 127)*
- `make format`
- `make test` *(fails: Command 'echo 'Running tests in $PWD...' && python -m pipenv run pytest tests/' returned non-zero exit status 2)*

------
https://chatgpt.com/codex/tasks/task_e_6893c40de4a88324bfb2d731e0fc213b