### PR TITLE
docs: organize documentation structure

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -23,11 +23,17 @@ This `docs` directory houses internal documentation for the **Promethean Framewo
     - [`agile/tasks/`](agile/tasks/) – individual task files. Each document includes a description, goals, requirements and subtasks. The board links to these files; creating a new task means adding a markdown file here and linking it from the board.
         
 - **Vault configuration**
-    
+
     - [vault‑config README](vault-config/README.md) – guidance for using this repo as an Obsidian vault. It covers settings for GitHub‑compatible Markdown, recommended plugins and how to install the baseline configuration.
-        
+
     - [`vault-config/.obsidian/`](vault-config/.obsidian/) – a minimal Obsidian configuration with the Kanban plugin enabled. Copy it to the repository root (`cp -r vault-config/.obsidian .obsidian`) to activate the baseline setup.
-        
+
+- **Code-aligned documentation**
+
+    - [services](services/README.md) – docs for individual subsystems under `services/`.
+    - [agents](agents/README.md) – behaviour notes and prompts for each agent.
+    - [shared](shared/README.md) – reusable libraries and clients shared across services.
+
 - **Research and scripts**
     
     - Various notes under `docs/research/` summarize APIs or algorithms (e.g. `github_projects_api.md`).

--- a/docs/agents/README.md
+++ b/docs/agents/README.md
@@ -1,0 +1,8 @@
+# Agents Documentation
+
+Notes for individual agents. Each subdirectory mirrors an agent under `agents/` and stores prompts, configuration details, and behavior descriptions.
+
+## Current agents
+- duck – experimental resident implementing the voice_in → stt → cephalon → tts → voice_out loop.
+
+To document a new agent, create `docs/agents/<name>/` with a README and any supporting notes.

--- a/docs/services/README.md
+++ b/docs/services/README.md
@@ -1,0 +1,24 @@
+# Services Documentation
+
+This directory mirrors the `services/` code tree. Each subfolder captures design notes, APIs, and deployment instructions for a specific service.
+
+## Current service docs
+- broker
+- cephalon
+- discord-attachment-embedder
+- discord-attachment-indexer
+- discord-embedder
+- discord-indexer
+- eidolon-field
+- embedding-service
+- health
+- heartbeat
+- markdown_graph
+- proxy
+- reasoner
+- stt
+- tts
+- vision
+- voice
+
+Add a new folder named after your service and include a `README.md` describing its purpose, dependencies, and entry points.

--- a/docs/shared/README.md
+++ b/docs/shared/README.md
@@ -1,0 +1,9 @@
+# Shared Library Documentation
+
+Docs for code in the `shared/` directory. These utilities are reused across services and agents and are organized by language.
+
+## Layout
+- py – Python helpers such as `shared/py/settings.py` and service clients.
+- js, hy, sibilant – reserved for future shared modules.
+
+Add documentation alongside new shared components to explain their responsibilities and interfaces.


### PR DESCRIPTION
## Summary
- link agents, services, and shared docs from main README
- add README stubs under docs/agents, docs/services, and docs/shared

## Testing
- `make format`
- `make build`
- `make lint` *(fails: Code style issues found in 8 files. Run Prettier with --write to fix.)*
- `make test` *(fails: Command 'echo 'Running tests in $PWD...' && python -m pipenv run pytest tests/' returned non-zero exit status 2.)*

------
https://chatgpt.com/codex/tasks/task_e_6896b12588b883248e64fb00d3787788