### PR TITLE
Handle optional websockets for heartbeat client

### DIFF
--- a/shared/py/tests/test_heartbeat_client.py
+++ b/shared/py/tests/test_heartbeat_client.py
@@ -22,7 +22,11 @@ def test_send_once():
 
     loop = asyncio.new_event_loop()
     asyncio.set_event_loop(loop)
-    server = loop.run_until_complete(websockets.serve(handler, "127.0.0.1", 0))
+
+    async def start_server():
+        return await websockets.serve(handler, "127.0.0.1", 0)
+
+    server = loop.run_until_complete(start_server())
     port = server.sockets[0].getsockname()[1]
     thread = threading.Thread(target=loop.run_forever, daemon=True)
     thread.start()


### PR DESCRIPTION
## Summary
- Tolerate missing `websockets` dependency in `HeartbeatClient`
- Adjust heartbeat client test to start server on event loop

## Testing
- `make test-python-service-discord_attachment_indexer`
- `make test-shared-python`
- `make build`
- `make lint-python`


------
https://chatgpt.com/codex/tasks/task_e_6893cb534680832485640cb4da34c29f