### PR TITLE
stabilize heartbeat service tests

### DIFF
--- a/services/js/heartbeat/tests/websocket.test.js
+++ b/services/js/heartbeat/tests/websocket.test.js
@@ -4,9 +4,15 @@ import { fileURLToPath } from "url";
 import { MongoMemoryServer } from "mongodb-memory-server";
 import { WebSocket } from "ws";
 import { start, stop } from "../index.js";
+import {
+  start as startBroker,
+  stop as stopBroker,
+} from "../../broker/index.js";
 
 let server;
 let mongo;
+let broker;
+let brokerPort;
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -17,11 +23,15 @@ test.before(async () => {
   );
   mongo = await MongoMemoryServer.create();
   process.env.MONGO_URL = mongo.getUri();
+  broker = await startBroker(0);
+  brokerPort = broker.address().port;
+  process.env.BROKER_URL = `ws://127.0.0.1:${brokerPort}`;
   server = await start(0);
 });
 
 test.after.always(async () => {
   await stop();
+  if (broker) await stopBroker(broker);
   if (mongo) await mongo.stop();
 });
 


### PR DESCRIPTION
## Summary
- ensure heartbeat client tests wait for database writes
- start a broker in websocket and lifecycle tests
- assert heartbeat cleanup via database fields and enforce duplicate rejection

## Testing
- `make setup-js-service-heartbeat` *(fails: name 'service' is not defined)*
- `make format-js-service-heartbeat` *(fails: No rule to make target)*
- `make lint-js-service-heartbeat`
- `npm run build` *(fails: Missing script: "build")*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6896b6840e248324be32e4c2e044b4e1