### PR TITLE
feat: extract intention code from docs

### DIFF
--- a/shared/js/prom-lib/intention/boot-local.ts
+++ b/shared/js/prom-lib/intention/boot-local.ts
@@ -1,0 +1,33 @@
+import { promises as fs } from "node:fs";
+import { RouterLLM } from "./router";
+import { FileCacheLLM } from "./cache";
+import { OllamaLLM } from "./ollama";
+import { OpenAICompatLLM } from "./openai_compat";
+
+interface Cfg {
+  cacheDir?: string;
+  rounds?: number;
+  providers: any[];
+  targets?: { jsDir?: string; pyDir?: string };
+}
+
+export async function loadLocalLLM(cfgPath = ".promirror/intent.config.json") {
+  const raw = await fs.readFile(cfgPath, "utf8");
+  const cfg = JSON.parse(raw) as Cfg;
+
+  const providers = cfg.providers.map((p) => {
+    if (p.type === "ollama")
+      return new OllamaLLM({
+        model: p.model,
+        host: p.host,
+        options: p.options,
+      });
+    if (p.type === "openai_compat")
+      return new OpenAICompatLLM(p.baseUrl, p.model, "sk-local", p.params);
+    throw new Error("unknown provider " + p.type);
+  });
+
+  const router = new RouterLLM(providers);
+  const llm = new FileCacheLLM(router, cfg.cacheDir ?? ".promirror/cache");
+  return { llm, cfg };
+}

--- a/shared/js/prom-lib/intention/cache.ts
+++ b/shared/js/prom-lib/intention/cache.ts
@@ -1,0 +1,27 @@
+import { createHash } from "node:crypto";
+import { promises as fs } from "node:fs";
+import * as path from "node:path";
+import type { LLM } from "./llm";
+
+export class FileCacheLLM implements LLM {
+  constructor(
+    private inner: LLM,
+    private dir = ".promirror/cache",
+  ) {}
+
+  private key(s: string) {
+    return createHash("sha256").update(s).digest("hex");
+  }
+
+  async generate({ system, prompt }: { system: string; prompt: string }) {
+    await fs.mkdir(this.dir, { recursive: true });
+    const k = this.key(system + "\n---\n" + prompt);
+    const p = path.join(this.dir, k + ".txt");
+    try {
+      return await fs.readFile(p, "utf8");
+    } catch {}
+    const out = await this.inner.generate({ system, prompt });
+    await fs.writeFile(p, out, "utf8");
+    return out;
+  }
+}

--- a/shared/js/prom-lib/intention/llm.ts
+++ b/shared/js/prom-lib/intention/llm.ts
@@ -1,0 +1,20 @@
+export type LLM = {
+  generate(opts: { system: string; prompt: string }): Promise<string>;
+};
+
+export class DummyLLM implements LLM {
+  async generate({
+    prompt,
+  }: {
+    system: string;
+    prompt: string;
+  }): Promise<string> {
+    if (prompt.includes("normalize2d") && prompt.includes("language=js")) {
+      return "export function normalize2d(x,y){const m=Math.hypot(x,y)||0;return {mag:m,nx:m?x/m:0,ny:m?y/m:0};}";
+    }
+    if (prompt.includes("normalize2d") && prompt.includes("language=py")) {
+      return 'def normalize2d(x,y):\n    import math\n    m = math.hypot(x,y)\n    return {"mag":m,"nx":(x/m if m else 0),"ny":(y/m if m else 0)}\n';
+    }
+    return "// TODO: implement";
+  }
+}

--- a/shared/js/prom-lib/intention/ollama.ts
+++ b/shared/js/prom-lib/intention/ollama.ts
@@ -1,0 +1,105 @@
+import type { LLM } from "./llm";
+
+type OllamaOpts = {
+  model: string;
+  host?: string;
+  options?: {
+    temperature?: number;
+    top_p?: number;
+    num_predict?: number;
+    num_ctx?: number;
+    seed?: number;
+    stop?: string[];
+  };
+  timeoutMs?: number;
+};
+
+export class OllamaLLM implements LLM {
+  private host: string;
+  private model: string;
+  private options: OllamaOpts["options"];
+  private timeoutMs: number;
+
+  constructor(opts: OllamaOpts) {
+    this.model = opts.model;
+    this.host = opts.host ?? "http://127.0.0.1:11434";
+    this.options = {
+      temperature: 0.2,
+      top_p: 0.95,
+      num_predict: 512,
+      stop: ["```", "</code>", "END_OF_CODE"],
+      ...opts.options,
+    };
+    this.timeoutMs = opts.timeoutMs ?? 90_000;
+  }
+
+  async generate({
+    system,
+    prompt,
+  }: {
+    system: string;
+    prompt: string;
+  }): Promise<string> {
+    const ctrl = new AbortController();
+    const to = setTimeout(() => ctrl.abort(), this.timeoutMs);
+    try {
+      const res = await fetch(`${this.host}/api/chat`, {
+        method: "POST",
+        signal: ctrl.signal,
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          model: this.model,
+          stream: true,
+          messages: [
+            {
+              role: "system",
+              content: `${system}\nReturn ONLY the code. No fences.`,
+            },
+            { role: "user", content: prompt },
+          ],
+          options: this.options,
+        }),
+      });
+      if (!res.ok || !res.body) {
+        throw new Error(
+          `ollama http ${res.status} ${await res
+            .text()
+            .catch(() => "<no body>")}`,
+        );
+      }
+      const reader = res.body.getReader();
+      const td = new TextDecoder();
+      let buf = "";
+      let out = "";
+      while (true) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        buf += td.decode(value, { stream: true });
+        let nl;
+        while ((nl = buf.indexOf("\n")) >= 0) {
+          const line = buf.slice(0, nl).trim();
+          buf = buf.slice(nl + 1);
+          if (!line) continue;
+          let obj: any;
+          try {
+            obj = JSON.parse(line);
+          } catch {
+            continue;
+          }
+          if (obj.done) break;
+          const chunk = obj?.message?.content ?? "";
+          out += chunk;
+        }
+      }
+      return stripFences(out.trim());
+    } finally {
+      clearTimeout(to);
+    }
+  }
+}
+
+function stripFences(s: string): string {
+  const fence = s.match(/^```[\w-]*\n([\s\S]*?)\n```$/);
+  if (fence) return fence[1];
+  return s.replace(/^```|```$/g, "");
+}

--- a/shared/js/prom-lib/intention/openai_compat.ts
+++ b/shared/js/prom-lib/intention/openai_compat.ts
@@ -1,0 +1,48 @@
+import type { LLM } from "./llm";
+
+export class OpenAICompatLLM implements LLM {
+  constructor(
+    private baseUrl = "http://127.0.0.1:1234/v1",
+    private model = "qwen2.5-coder:7b",
+    private apiKey = "sk-local",
+    private params: Partial<{
+      temperature: number;
+      top_p: number;
+      max_tokens: number;
+      stop: string[];
+    }> = {},
+  ) {}
+
+  async generate({ system, prompt }: { system: string; prompt: string }) {
+    const r = await fetch(`${this.baseUrl}/chat/completions`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${this.apiKey}`,
+      },
+      body: JSON.stringify({
+        model: this.model,
+        messages: [
+          {
+            role: "system",
+            content: `${system}\nReturn ONLY code. No fences.`,
+          },
+          { role: "user", content: prompt },
+        ],
+        temperature: 0.1,
+        top_p: 0.95,
+        max_tokens: 1024,
+        stop: ["```", ...(this.params.stop ?? [])],
+        ...this.params,
+        stream: false,
+      }),
+    });
+    if (!r.ok)
+      throw new Error(
+        `openai-compat ${r.status}: ${await r.text().catch(() => "<no body>")}`,
+      );
+    const j: any = await r.json();
+    const text = j.choices?.[0]?.message?.content ?? "";
+    return text.replace(/^```[\w-]*\n?|\n?```$/g, "");
+  }
+}

--- a/shared/js/prom-lib/intention/router.ts
+++ b/shared/js/prom-lib/intention/router.ts
@@ -1,0 +1,17 @@
+import type { LLM } from "./llm";
+
+export class RouterLLM implements LLM {
+  constructor(private providers: LLM[]) {}
+
+  async generate(io: { system: string; prompt: string }): Promise<string> {
+    let lastErr: any;
+    for (const p of this.providers) {
+      try {
+        return await p.generate(io);
+      } catch (e) {
+        lastErr = e;
+      }
+    }
+    throw lastErr ?? new Error("No providers responded");
+  }
+}

--- a/shared/js/prom-lib/intention/utils.ts
+++ b/shared/js/prom-lib/intention/utils.ts
@@ -1,0 +1,6 @@
+export function extractCode(s: string) {
+  const fence = s.match(/```[a-zA-Z-]*\n([\s\S]*?)```/);
+  if (fence) return fence[1];
+  const triple = s.split(/\n-{3,}\n/)[0];
+  return triple.trim();
+}

--- a/shared/js/prom-lib/tsconfig.json
+++ b/shared/js/prom-lib/tsconfig.json
@@ -11,5 +11,10 @@
     "outDir": "dist",
     "lib": ["ES2022"]
   },
-  "include": ["event/**/*.ts", "ds/**/*.ts", "worker/**/*.ts"]
+  "include": [
+    "event/**/*.ts",
+    "ds/**/*.ts",
+    "worker/**/*.ts",
+    "intention/**/*.ts"
+  ]
 }

--- a/tests/intention.test.js
+++ b/tests/intention.test.js
@@ -1,0 +1,24 @@
+import test from "ava";
+import { RouterLLM } from "../shared/js/prom-lib/dist/intention/router.js";
+import { extractCode } from "../shared/js/prom-lib/dist/intention/utils.js";
+
+test("RouterLLM falls back to next provider on failure", async (t) => {
+  class BadLLM {
+    async generate() {
+      throw new Error("fail");
+    }
+  }
+  class GoodLLM {
+    async generate({ prompt }) {
+      return `ok:${prompt}`;
+    }
+  }
+  const router = new RouterLLM([new BadLLM(), new GoodLLM()]);
+  const out = await router.generate({ system: "", prompt: "hi" });
+  t.is(out, "ok:hi");
+});
+
+test("extractCode strips fences", (t) => {
+  const s = "```js\nconsole.log(1);\n```";
+  t.is(extractCode(s), "console.log(1);\n");
+});


### PR DESCRIPTION
## Summary
- port LLM interface and local providers from `docs/unique`
- add router, cache, and provider utilities for intention transpiler
- include basic tests for router fallback and code fence stripping

## Testing
- `make setup-js`
- `npx tsc -p shared/js/prom-lib/tsconfig.json`
- `npm test`
- `make lint-js`
- `make format-js`


------
https://chatgpt.com/codex/tasks/task_e_68978f4a055883249b05959fd6459d10