### PR TITLE
Add coverage tests for TaskQueue edge cases

### DIFF
--- a/tests/taskQueue.test.js
+++ b/tests/taskQueue.test.js
@@ -39,6 +39,28 @@ test("fail without requeue drops task", (t) => {
   t.is(q.inflightTasks().length, 0);
 });
 
+test("fail returns false when task not inflight", (t) => {
+  const q = new TaskQueue();
+  const result = q.fail("missing-id");
+  t.false(result);
+});
+
+test("fail requeues task when original queue removed", (t) => {
+  const q = new TaskQueue();
+  const task = q.enqueue("delta", { n: 4 });
+  q.pull("delta", "worker1");
+  q.queues.delete("delta");
+
+  const failed = q.fail(task.id);
+  t.true(failed);
+  t.is(q.list("delta").length, 1);
+});
+
+test("list returns empty array for unknown queue", (t) => {
+  const q = new TaskQueue();
+  t.deepEqual(q.list("omega"), []);
+});
+
 test("pull returns null when queue empty", (t) => {
   const q = new TaskQueue();
   const result = q.pull("delta", "worker1");


### PR DESCRIPTION
## Summary
- extend TaskQueue tests to cover missing branches and queue edge cases

## Testing
- `npm test`
- `npm run coverage`
- `make build`
- `make lint` *(fails: biome not found)*


------
https://chatgpt.com/codex/tasks/task_e_6897903f28748324978dcf0872e2594f