### PR TITLE
Use broker for cephalon transcriber

### DIFF
--- a/services/ts/cephalon/src/tests/transcriber.test.ts
+++ b/services/ts/cephalon/src/tests/transcriber.test.ts
@@ -1,0 +1,42 @@
+import test from 'ava';
+import { PassThrough } from 'node:stream';
+import EventEmitter from 'node:events';
+import { Transcriber } from '../transcriber.js';
+
+class DummyBroker extends EventEmitter {
+	lastEnqueue: { queue: string; task: any } | null = null;
+	async connect() {}
+	subscribe(_topic: string, handler: (event: any) => void) {
+		this.on('event', handler);
+	}
+	unsubscribe() {}
+	publish() {}
+	enqueue(queue: string, task: any) {
+		this.lastEnqueue = { queue, task };
+	}
+	ready() {}
+	ack() {}
+	heartbeat() {}
+	onTaskReceived() {}
+	emitTranscription(text: string) {
+		this.emit('event', { payload: { text } });
+	}
+}
+
+test('transcriber enqueues pcm and emits transcript', async (t) => {
+	const broker = new DummyBroker();
+	const transcriber = new Transcriber({ broker });
+	const speaker: any = { user: { username: 'test-user' } };
+	const events: any[] = [];
+	transcriber.on('transcriptStart', (e) => events.push(['start', e]));
+	transcriber.on('transcriptEnd', (e) => events.push(['end', e]));
+	const pcmStream = new PassThrough();
+	transcriber.transcribePCMStream(0, speaker, pcmStream);
+	pcmStream.end(Buffer.from([1, 2, 3, 4]));
+	broker.emitTranscription('hello world');
+	t.is(broker.lastEnqueue?.queue, 'stt.transcribe');
+	t.is(broker.lastEnqueue?.task.pcm, Buffer.from([1, 2, 3, 4]).toString('base64'));
+	t.is(events[0][0], 'start');
+	t.is(events[1][0], 'end');
+	t.is(events[1][1].transcript, 'hello world');
+});

--- a/services/ts/cephalon/src/transcriber.ts
+++ b/services/ts/cephalon/src/transcriber.ts
@@ -1,20 +1,21 @@
 import { User } from 'discord.js';
 import EventEmitter from 'node:events';
-import http, { RequestOptions } from 'node:http';
 import { PassThrough } from 'node:stream';
+import { BrokerClient } from '../../../../shared/js/brokerClient.js';
 import { Speaker } from './speaker';
 
 export type TranscriberOptions = {
-	hostname: string;
-	port: number;
-	endpoint: string;
+	brokerUrl?: string;
+	broker?: BrokerClient;
 };
+
 export type TranscriptChunk = {
 	speaker: Speaker;
 	startTime: number;
 	endTime: number;
 	text: string;
 };
+
 export type FinalTranscript = {
 	speaker?: Speaker;
 	user?: User;
@@ -24,70 +25,79 @@ export type FinalTranscript = {
 	transcript: string;
 	originalTranscript?: string;
 };
-export class Transcriber extends EventEmitter {
-	httpOptions: RequestOptions;
 
-	constructor(
-		options: TranscriberOptions = {
-			hostname: 'localhost',
-			port: Number(process.env.PROXY_PORT) || 8080,
-			endpoint: '/stt/transcribe_pcm',
-		},
-	) {
+type PendingRequest = {
+	startTime: number;
+	speaker: Speaker;
+};
+
+export class Transcriber extends EventEmitter {
+	broker: BrokerClient;
+	#ready: Promise<void>;
+	#pending: PendingRequest[] = [];
+
+	constructor(options: TranscriberOptions = {}) {
 		super();
-		this.httpOptions = {
-			hostname: options.hostname,
-			port: options.port,
-			path: options.endpoint,
-			method: 'POST',
-			headers: {
-				'Content-Type': 'application/octet-stream',
-				'Transfer-Encoding': 'chunked',
-				'X-Sample-Rate': 48000,
-				'X-Dtype': 'int16',
-			},
-		};
+		this.broker =
+			options.broker ||
+			new BrokerClient({
+				url: options.brokerUrl || process.env.BROKER_URL || 'ws://localhost:7000',
+				id: 'cephalon-transcriber',
+			});
+		this.#ready = this.broker
+			.connect()
+			.then(() => {
+				this.broker.subscribe('stt.transcribed', (event: any) => {
+					const { payload } = event || {};
+					const data = this.#pending.shift();
+					if (!data) return;
+					const { startTime, speaker } = data;
+					const text = payload?.text || '';
+					const endTime = Date.now();
+					const chunk: TranscriptChunk = {
+						startTime,
+						speaker,
+						text,
+						endTime,
+					};
+					this.emit('transcriptChunk', chunk);
+					this.emit('transcriptEnd', {
+						startTime,
+						speaker,
+						originalTranscript: text,
+						user: speaker.user,
+						userName: speaker.user.username,
+						transcript: text,
+						endTime,
+					});
+				});
+			})
+			.catch((err: unknown) => {
+				console.error('Failed to connect to broker', err);
+			});
 	}
+
 	transcribePCMStream(startTime: number, speaker: Speaker, pcmStream: PassThrough) {
 		this.emit('transcriptStart', { startTime, speaker });
-		// ✅ Pipe PCM directly into the HTTP request
-		return pcmStream.pipe(
-			http
-				.request(this.httpOptions, (res) => {
-					const transcriptChunks: TranscriptChunk[] = [];
-					res.on('data', (chunk) => {
-						const chunkStr = chunk.toString();
-						console.log(chunkStr);
-						const transcript = JSON.parse(chunkStr).transcription;
-						console.log(`Transcription chunk: ${transcript}`);
-						const transcriptObject: TranscriptChunk = {
-							startTime,
-							speaker,
-							text: transcript,
-							endTime: Date.now(),
-						};
-						transcriptChunks.push(transcriptObject);
-						this.emit('transcriptChunk', transcriptObject);
-					});
-					res.on('end', async () => {
-						console.log('Transcription ended');
-
-						const originalTranscript = transcriptChunks.map((t) => t.text).join(' ');
-
-						this.emit('transcriptEnd', {
-							startTime,
-							speaker,
-							originalTranscript,
-							user: speaker.user,
-							userName: speaker.user.username,
-							transcript: originalTranscript,
-							endTime: Date.now(),
-						});
-					});
-				})
-				.on('error', (err) => {
-					console.error('Transcription request error:', err);
-				}),
-		);
+		const buffers: Buffer[] = [];
+		pcmStream.on('data', (chunk) => buffers.push(chunk));
+		pcmStream.on('end', async () => {
+			const pcm = Buffer.concat(buffers);
+			const pcm_b64 = pcm.toString('base64');
+			this.#pending.push({ startTime, speaker });
+			try {
+				await this.#ready;
+				this.broker.enqueue('stt.transcribe', {
+					pcm: pcm_b64,
+					sample_rate: 48000,
+				});
+			} catch (err: unknown) {
+				console.error('Transcription request error:', err);
+			}
+		});
+		pcmStream.on('error', (err: unknown) => {
+			console.error('Transcription stream error:', err);
+		});
+		return pcmStream;
 	}
 }

--- a/shared/js/brokerClient.d.ts
+++ b/shared/js/brokerClient.d.ts
@@ -1,0 +1,12 @@
+export class BrokerClient {
+  constructor(options?: { url?: string; id?: string });
+  connect(): Promise<void>;
+  subscribe(topic: string, handler: (event: any) => void): void;
+  unsubscribe(topic: string): void;
+  publish(type: string, payload: any, opts?: any): void;
+  enqueue(queue: string, task: any): void;
+  ready(queue: string): void;
+  ack(taskId: string): void;
+  heartbeat(): void;
+  onTaskReceived(callback: (task: any) => void): void;
+}


### PR DESCRIPTION
## Summary
- Route Cephalon transcriber audio through the internal message broker and handle broker responses
- Cover transcriber broker workflow with new unit test
- Provide TypeScript declarations for the shared BrokerClient

## Testing
- `make setup-ts-service-cephalon`
- `make lint-ts-service-cephalon`
- `npm --prefix services/ts/cephalon run format` *(fails: Some errors were emitted while running checks)*
- `make test-ts-service-cephalon`
- `npm --prefix services/ts/cephalon run build`


------
https://chatgpt.com/codex/tasks/task_e_68978ed4bb588324a4faa31d95b746c2