### PR TITLE
Refactor health service to use broker and throttle cephalon by message rate

### DIFF
--- a/docs/services/cephalon/src/index.md
+++ b/docs/services/cephalon/src/index.md
@@ -2,10 +2,13 @@
 
 **Path**: `services/cephalon/src/index.ts`
 
-**Description**: dotenv.config({ path: '../../.env' });  // 👈 resolve from wherever you want
+**Description**: Entry point for the Cephalon service. Starts the Discord bot,
+sends heartbeats, and initializes message-based throttling.
 
 ## Dependencies
 - ./bot
+- ../../../../shared/js/heartbeat/index.js
+- ./messageThrottler
 - source-map-support/register.js
 
 ## Dependents

--- a/docs/services/cephalon/src/messageThrottler.md
+++ b/docs/services/cephalon/src/messageThrottler.md
@@ -1,0 +1,13 @@
+# messageThrottler.ts
+
+**Path**: `services/cephalon/src/messageThrottler.ts`
+
+**Description**: Wraps the message broker client to adjust the agent's tick
+interval based on the rate of published messages.
+
+## Dependencies
+- ../../../../shared/js/brokerClient.js
+- ./agent
+
+## Dependents
+- `services/cephalon/src/index.ts`

--- a/docs/services/cephalon/tests/messageThrottler.test.md
+++ b/docs/services/cephalon/tests/messageThrottler.test.md
@@ -1,0 +1,13 @@
+# messageThrottler.test.ts
+
+**Path**: `services/cephalon/tests/messageThrottler.test.ts`
+
+**Description**: Verifies that publishing messages through the broker adjusts
+the agent's tick interval.
+
+## Dependencies
+- ava
+- ../../js/broker/index.js
+
+## Dependents
+- `services/cephalon/package.json`

--- a/docs/services/health/index.md
+++ b/docs/services/health/index.md
@@ -2,11 +2,11 @@
 
 **Path**: `services/js/health/index.js`
 
-**Description**: Express service that aggregates recent heartbeat metrics from MongoDB and returns overall CPU and memory load via a `/health` endpoint. The response includes total and normalized ratios so other services can determine when to throttle.
+**Description**: Express service that subscribes to heartbeat events from the message broker and returns overall CPU and memory load via a `/health` endpoint. The response includes total and normalized ratios so other services can determine when to throttle.
 
 ## Dependencies
 - express
-- mongodb
+- ws
 - os
 
 ## Dependents

--- a/services/js/health/README.md
+++ b/services/js/health/README.md
@@ -2,6 +2,6 @@
 
 **Path**: `services/js/health/index.js`
 
-Aggregates heartbeat metrics from MongoDB and exposes a `/health` endpoint with
-overall CPU and memory utilization. Other services can poll this endpoint to
-decide when to throttle their workloads.
+Listens for heartbeat events from the message broker and exposes a `/health`
+endpoint with aggregated CPU and memory utilization. Other services can poll
+this endpoint to decide when to throttle their workloads.

--- a/services/js/health/package-lock.json
+++ b/services/js/health/package-lock.json
@@ -9,12 +9,11 @@
       "version": "0.0.1",
       "dependencies": {
         "express": "^4.18.2",
-        "mongodb": "^6.8.0"
+        "ws": "^8.17.0"
       },
       "devDependencies": {
         "ava": "^6.4.1",
         "c8": "^9.1.0",
-        "mongodb-memory-server": "^10.1.4",
         "supertest": "^6.3.3"
       }
     },
@@ -141,15 +140,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/@mongodb-js/saslprep": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.3.0.tgz",
-      "integrity": "sha512-zlayKCsIjYb7/IdfqxorK5+xUMyi4vOKcFy10wKJYc63NSdKI8mNME+uJqfatkPmOSMMUiojrL58IePKBm3gvQ==",
-      "license": "MIT",
-      "dependencies": {
-        "sparse-bitfield": "^3.0.3"
-      }
-    },
     "node_modules/@noble/hashes": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
@@ -271,21 +261,6 @@
       "integrity": "sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@types/webidl-conversions": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-7.0.3.tgz",
-      "integrity": "sha512-CiJJvcRtIgzadHCYXw7dqEnMNRjhGZlYK05Mj9OyktqV8uVT8fD2BFOB7S1uwBE3Kj2Z+4UyPmFw/Ixgw/LAlA==",
-      "license": "MIT"
-    },
-    "node_modules/@types/whatwg-url": {
-      "version": "11.0.5",
-      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-11.0.5.tgz",
-      "integrity": "sha512-coYR071JRaHa+xoEvvYqvnIHaVqaYrLPbsufM9BF63HkwI5Lgmy2QR8Q5K/lYDYo5AK82wOvSOS0UsLTpTG7uQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/webidl-conversions": "*"
-      }
     },
     "node_modules/@vercel/nft": {
       "version": "0.29.4",
@@ -465,16 +440,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/async-mutex": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.5.0.tgz",
-      "integrity": "sha512-1A94B18jkJ3DYq284ohPxoXbfTA5HsQ7/Mf4DEhcyLx3Bz27Rh59iScbB6EPiP+B+joue6YCxcMXSbFC1tZKwA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/async-sema": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/async-sema/-/async-sema-3.1.1.tgz",
@@ -552,27 +517,12 @@
         }
       }
     },
-    "node_modules/b4a": {
-      "version": "1.6.7",
-      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.6.7.tgz",
-      "integrity": "sha512-OnAYlL5b7LEkALw87fUVafQw5rVR9RjwGd4KUwNQ6DrrNmaVaUCgLipfVlzrPQ4tWOR9P0IXGNOx50jYCCdSJg==",
-      "dev": true,
-      "license": "Apache-2.0"
-    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/bare-events": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.6.0.tgz",
-      "integrity": "sha512-EKZ5BTXYExaNqi3I3f9RtEsaI/xBSGjE0XZCZilPzFAV/goswFHuPd9jEZlPIZ/iNZJwDSao9qRiScySz7MbQg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true
     },
     "node_modules/bindings": {
       "version": "1.5.0",
@@ -653,25 +603,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/bson": {
-      "version": "6.10.4",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-6.10.4.tgz",
-      "integrity": "sha512-WIsKqkSC0ABoBJuT1LEX+2HEvNmNKKgnTAyd0fL8qzK4SH2i9NXg+t08YtdZp/V9IZ33cxe3iV4yM0qg8lMQng==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=16.20.1"
-      }
-    },
-    "node_modules/buffer-crc32": {
-      "version": "0.2.13",
-      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
-      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/bytes": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
@@ -744,19 +675,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=12.20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/camelcase": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
-      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -1001,13 +919,6 @@
       "integrity": "sha512-QE33hToZseCH3jS0qN96O/bSh3kaw/h+Tq7ngyY9eWDUnTlTNUyqfqvCXioLe5Na5jFsL78ra/wuBU4iuEgd4w==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/commondir": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
-      "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/component-emitter": {
       "version": "1.3.1",
@@ -1464,13 +1375,6 @@
       "dev": true,
       "license": "Apache-2.0"
     },
-    "node_modules/fast-fifo": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
-      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/fast-glob": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
@@ -1574,50 +1478,6 @@
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
     },
-    "node_modules/find-cache-dir": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.2.tgz",
-      "integrity": "sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "commondir": "^1.0.1",
-        "make-dir": "^3.0.2",
-        "pkg-dir": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/avajs/find-cache-dir?sponsor=1"
-      }
-    },
-    "node_modules/find-cache-dir/node_modules/make-dir": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
-      "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "semver": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/find-cache-dir/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
     "node_modules/find-up": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
@@ -1646,27 +1506,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/RubenVerborgh"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=4.0"
-      },
-      "peerDependenciesMeta": {
-        "debug": {
-          "optional": true
-        }
       }
     },
     "node_modules/foreground-child": {
@@ -2350,12 +2189,6 @@
         "url": "https://github.com/sindresorhus/memoize?sponsor=1"
       }
     },
-    "node_modules/memory-pager": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
-      "integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==",
-      "license": "MIT"
-    },
     "node_modules/merge-descriptors": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
@@ -2512,101 +2345,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/mongodb": {
-      "version": "6.18.0",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.18.0.tgz",
-      "integrity": "sha512-fO5ttN9VC8P0F5fqtQmclAkgXZxbIkYRTUi1j8JO6IYwvamkhtYDilJr35jOPELR49zqCJgXZWwCtW7B+TM8vQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@mongodb-js/saslprep": "^1.1.9",
-        "bson": "^6.10.4",
-        "mongodb-connection-string-url": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=16.20.1"
-      },
-      "peerDependencies": {
-        "@aws-sdk/credential-providers": "^3.188.0",
-        "@mongodb-js/zstd": "^1.1.0 || ^2.0.0",
-        "gcp-metadata": "^5.2.0",
-        "kerberos": "^2.0.1",
-        "mongodb-client-encryption": ">=6.0.0 <7",
-        "snappy": "^7.2.2",
-        "socks": "^2.7.1"
-      },
-      "peerDependenciesMeta": {
-        "@aws-sdk/credential-providers": {
-          "optional": true
-        },
-        "@mongodb-js/zstd": {
-          "optional": true
-        },
-        "gcp-metadata": {
-          "optional": true
-        },
-        "kerberos": {
-          "optional": true
-        },
-        "mongodb-client-encryption": {
-          "optional": true
-        },
-        "snappy": {
-          "optional": true
-        },
-        "socks": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/mongodb-connection-string-url": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-3.0.2.tgz",
-      "integrity": "sha512-rMO7CGo/9BFwyZABcKAWL8UJwH/Kc2x0g72uhDWzG48URRax5TCIcJ7Rc3RZqffZzO/Gwff/jyKwCU9TN8gehA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@types/whatwg-url": "^11.0.2",
-        "whatwg-url": "^14.1.0 || ^13.0.0"
-      }
-    },
-    "node_modules/mongodb-memory-server": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/mongodb-memory-server/-/mongodb-memory-server-10.2.0.tgz",
-      "integrity": "sha512-FG4OVoXjBHC7f8Mdyj1TZ6JyTtMex+qniEzoY1Rsuo/FvHSOHYzGYVbuElamjHuam+HLxWTWEpc43fqke8WNGw==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "mongodb-memory-server-core": "10.2.0",
-        "tslib": "^2.8.1"
-      },
-      "engines": {
-        "node": ">=16.20.1"
-      }
-    },
-    "node_modules/mongodb-memory-server-core": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/mongodb-memory-server-core/-/mongodb-memory-server-core-10.2.0.tgz",
-      "integrity": "sha512-IsgWlsXdZxbMNoa3hqazMQ/QeMazEztMBr/fK6OrHefJLlZtCEtIIYoAKJDYDQjcwId0CRkW3WRy05WEuyClDg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "async-mutex": "^0.5.0",
-        "camelcase": "^6.3.0",
-        "debug": "^4.4.1",
-        "find-cache-dir": "^3.3.2",
-        "follow-redirects": "^1.15.9",
-        "https-proxy-agent": "^7.0.6",
-        "mongodb": "^6.9.0",
-        "new-find-package-json": "^2.0.0",
-        "semver": "^7.7.2",
-        "tar-stream": "^3.1.7",
-        "tslib": "^2.8.1",
-        "yauzl": "^3.2.0"
-      },
-      "engines": {
-        "node": ">=16.20.1"
-      }
-    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -2620,19 +2358,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/new-find-package-json": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/new-find-package-json/-/new-find-package-json-2.0.0.tgz",
-      "integrity": "sha512-lDcBsjBSMlj3LXH2v/FW3txlh2pYTjmbOXPYJD93HI5EwuLzI11tdHSIpUMmfq/IOsldj4Ps8M8flhm+pCK4Ew==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.3.4"
-      },
-      "engines": {
-        "node": ">=12.22.0"
       }
     },
     "node_modules/node-fetch": {
@@ -2798,16 +2523,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/p-try": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/package-config": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/package-config/-/package-config-5.0.0.tgz",
@@ -2920,13 +2635,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/pend": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
-      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/picomatch": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
@@ -2938,75 +2646,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/pkg-dir": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
-      "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "find-up": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/pkg-dir/node_modules/find-up": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "locate-path": "^5.0.0",
-        "path-exists": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/pkg-dir/node_modules/locate-path": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "p-locate": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/pkg-dir/node_modules/p-limit": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "p-try": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/pkg-dir/node_modules/p-locate": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "p-limit": "^2.2.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/plur": {
@@ -3052,15 +2691,6 @@
       },
       "engines": {
         "node": ">= 0.10"
-      }
-    },
-    "node_modules/punycode": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
-      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/qs": {
@@ -3453,15 +3083,6 @@
         "url": "https://github.com/chalk/slice-ansi?sponsor=1"
       }
     },
-    "node_modules/sparse-bitfield": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
-      "integrity": "sha512-kvzhi7vqKTfkh0PZU+2D2PIllw2ymqJKujUcyPMd9Y75Nv4nPbGJZXNhxsgdQab2BmlDct1YnfQCguEvHr7VsQ==",
-      "license": "MIT",
-      "dependencies": {
-        "memory-pager": "^1.0.2"
-      }
-    },
     "node_modules/sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -3499,20 +3120,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/streamx": {
-      "version": "2.22.1",
-      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.22.1.tgz",
-      "integrity": "sha512-znKXEBxfatz2GBNK02kRnCXjV+AA4kjZIUxeWSr3UGirZMJfTE9uiwKHobnbgxWyL/JWro8tTq+vOqAK1/qbSA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fast-fifo": "^1.3.2",
-        "text-decoder": "^1.1.0"
-      },
-      "optionalDependencies": {
-        "bare-events": "^2.2.0"
       }
     },
     "node_modules/string-width": {
@@ -3727,18 +3334,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/tar-stream": {
-      "version": "3.1.7",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.7.tgz",
-      "integrity": "sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "b4a": "^1.6.4",
-        "fast-fifo": "^1.2.0",
-        "streamx": "^2.15.0"
-      }
-    },
     "node_modules/temp-dir": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-3.0.0.tgz",
@@ -3810,16 +3405,6 @@
         "node": "*"
       }
     },
-    "node_modules/text-decoder": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.3.tgz",
-      "integrity": "sha512-3/o9z3X0X0fTupwsYvR03pJ/DjWuqqrfwBgTQzdWDiQSm9KitAyz/9WqsT2JQW7KV2m+bC2ol/zqpW37NHxLaA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "b4a": "^1.6.4"
-      }
-    },
     "node_modules/time-zone": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/time-zone/-/time-zone-1.0.0.tgz",
@@ -3851,25 +3436,6 @@
       "engines": {
         "node": ">=0.6"
       }
-    },
-    "node_modules/tr46": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
-      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
-      "license": "MIT",
-      "dependencies": {
-        "punycode": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tslib": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
-      "license": "0BSD"
     },
     "node_modules/type-fest": {
       "version": "0.13.1",
@@ -3952,15 +3518,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/webidl-conversions": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
-      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/well-known-symbols": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/well-known-symbols/-/well-known-symbols-2.0.0.tgz",
@@ -3969,19 +3526,6 @@
       "license": "ISC",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/whatwg-url": {
-      "version": "14.2.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
-      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
-      "license": "MIT",
-      "dependencies": {
-        "tr46": "^5.1.0",
-        "webidl-conversions": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/which": {
@@ -4154,6 +3698,27 @@
         "node": "^18.17.0 || >=20.5.0"
       }
     },
+    "node_modules/ws": {
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/y18n": {
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
@@ -4256,20 +3821,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/yauzl": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-3.2.0.tgz",
-      "integrity": "sha512-Ow9nuGZE+qp1u4JIPvg+uCiUr7xGQWdff7JQSk5VGYTAZMDe2q8lxJ10ygv10qmSj031Ty/6FNJpLO4o1Sgc+w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "buffer-crc32": "~0.2.3",
-        "pend": "~1.2.0"
-      },
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/yocto-queue": {

--- a/services/js/health/package.json
+++ b/services/js/health/package.json
@@ -10,13 +10,12 @@
   },
   "dependencies": {
     "express": "^4.18.2",
-    "mongodb": "^6.8.0"
+    "ws": "^8.17.0"
   },
   "devDependencies": {
     "ava": "^6.4.1",
     "supertest": "^6.3.3",
-    "c8": "^9.1.0",
-    "mongodb-memory-server": "^10.1.4"
+    "c8": "^9.1.0"
   },
   "ava": {
     "extensions": {

--- a/services/js/health/tests/health.test.js
+++ b/services/js/health/tests/health.test.js
@@ -1,45 +1,49 @@
 import test from "ava";
 import request from "supertest";
-import { MongoMemoryServer } from "mongodb-memory-server";
-import { MongoClient } from "mongodb";
+import WebSocket from "ws";
 import os from "os";
-import { start, stop } from "../index.js";
+import { start, stop, reset } from "../index.js";
+import {
+  start as startBroker,
+  stop as stopBroker,
+} from "../../broker/index.js";
 
 let server;
-let mongo;
+let broker;
+let brokerPort;
 
-async function clear() {
-  const client = new MongoClient(process.env.MONGO_URL);
-  await client.connect();
-  await client.db("heartbeat_db").collection("heartbeats").deleteMany({});
-  await client.close();
+async function sendHeartbeat(payload) {
+  const ws = new WebSocket(`ws://127.0.0.1:${brokerPort}`);
+  await new Promise((resolve) => ws.once("open", resolve));
+  ws.send(
+    JSON.stringify({
+      action: "publish",
+      message: { type: "heartbeat", payload },
+    }),
+  );
+  await new Promise((r) => setTimeout(r, 50));
+  ws.close();
 }
 
 test.before(async () => {
-  mongo = await MongoMemoryServer.create();
-  process.env.MONGO_URL = mongo.getUri();
+  broker = await startBroker(0);
+  brokerPort = broker.address().port;
+  process.env.BROKER_URL = `ws://127.0.0.1:${brokerPort}`;
   process.env.HEARTBEAT_TIMEOUT = "10000";
   server = await start(0);
 });
 
 test.after.always(async () => {
   await stop();
-  if (mongo) await mongo.stop();
+  if (broker) await stopBroker(broker);
 });
 
-test.beforeEach(async () => {
-  await clear();
+test.beforeEach(() => {
+  reset();
 });
 
 test.serial("returns aggregated metrics", async (t) => {
-  const client = new MongoClient(process.env.MONGO_URL);
-  await client.connect();
-  const now = Date.now();
-  await client
-    .db("heartbeat_db")
-    .collection("heartbeats")
-    .insertOne({ pid: 1, name: "svc", last: now, cpu: 10, memory: 1024 });
-  await client.close();
+  await sendHeartbeat({ name: "svc", cpu: 10, memory: 1024 });
   const res = await request(server).get("/health").expect(200);
   t.is(res.body.status, "ok");
   t.true(res.body.cpu.total >= 10);
@@ -47,20 +51,7 @@ test.serial("returns aggregated metrics", async (t) => {
 });
 
 test.serial("reports critical when load high", async (t) => {
-  const client = new MongoClient(process.env.MONGO_URL);
-  await client.connect();
-  const now = Date.now();
-  await client
-    .db("heartbeat_db")
-    .collection("heartbeats")
-    .insertOne({
-      pid: 2,
-      name: "svc",
-      last: now,
-      cpu: 0,
-      memory: os.totalmem() * 0.95,
-    });
-  await client.close();
+  await sendHeartbeat({ name: "svc", cpu: 0, memory: os.totalmem() * 0.95 });
   const res = await request(server).get("/health").expect(200);
   t.is(res.body.status, "critical");
 });

--- a/services/ts/cephalon/src/index.ts
+++ b/services/ts/cephalon/src/index.ts
@@ -2,34 +2,27 @@ import 'source-map-support/register.js';
 import { Bot } from './bot';
 import { AGENT_NAME } from '../../../../shared/js/env.js';
 import { HeartbeatClient } from '../../../../shared/js/heartbeat/index.js';
+import { initMessageThrottler } from './messageThrottler';
 
 async function main() {
-	  console.log('Starting', AGENT_NAME, 'Cephalon');
-	  const bot = new Bot({
-		    token: process.env.DISCORD_TOKEN as string,
-		    applicationId: process.env.DISCORD_CLIENT_USER_ID as string,
-	  });
-	  const hb = new HeartbeatClient({
-		    onHeartbeat: (heartbeat:any) => {
-            console.log(heartbeat)
-            // const { cpu }: { cpu: number } = heartbeat
-			      // const delay = Math.min(1000, 100 + Math.round(cpu));
-            const delay = 1000; // fix the heartbaet client to provide health data.
-			      bot.agent.updateTickInterval(delay);
-		    },
-	  });
-	  try {
-		    const data = await hb.sendOnce();
-		    hb.onHeartbeat?.(data);
-	  } catch (err) {
-		    console.error('failed to register heartbeat', err);
-		    process.exit(1);
-	  }
-	  hb.start();
-	  bot.start();
-	  console.log(`Cephalon started for ${AGENT_NAME}`);
+	console.log('Starting', AGENT_NAME, 'Cephalon');
+	const bot = new Bot({
+		token: process.env.DISCORD_TOKEN as string,
+		applicationId: process.env.DISCORD_CLIENT_USER_ID as string,
+	});
+	const hb = new HeartbeatClient();
+	try {
+		await hb.sendOnce();
+	} catch (err) {
+		console.error('failed to register heartbeat', err);
+		process.exit(1);
+	}
+	hb.start();
+	await initMessageThrottler(bot.agent, process.env.BROKER_URL);
+	bot.start();
+	console.log(`Cephalon started for ${AGENT_NAME}`);
 }
 
 if (process.env.NODE_ENV !== 'test') {
-	  main();
+	main();
 }

--- a/services/ts/cephalon/src/messageThrottler.ts
+++ b/services/ts/cephalon/src/messageThrottler.ts
@@ -1,0 +1,26 @@
+// @ts-ignore
+import { BrokerClient } from '../../../../../shared/js/brokerClient.js';
+import type { AIAgent } from './agent';
+
+export async function initMessageThrottler(agent: AIAgent, url?: string) {
+	const client = new BrokerClient({ url });
+	let count = 0;
+	let windowStart = Date.now();
+	const base = 100;
+	const publish = client.publish.bind(client);
+	client.publish = (type: string, payload: any, opts: any = {}) => {
+		count++;
+		const now = Date.now();
+		const elapsed = now - windowStart;
+		if (elapsed >= 1000) {
+			const rate = count / (elapsed / 1000);
+			const delay = Math.min(1000, base + Math.round(rate));
+			agent.updateTickInterval(delay);
+			count = 0;
+			windowStart = now;
+		}
+		return publish(type, payload, opts);
+	};
+	await client.connect();
+	return client;
+}

--- a/services/ts/cephalon/tests/messageThrottler.test.ts
+++ b/services/ts/cephalon/tests/messageThrottler.test.ts
@@ -1,0 +1,29 @@
+import test from 'ava';
+import { AIAgent } from '../src/agent';
+import type { Bot } from '../src/bot';
+import type { ContextManager } from '../src/contextManager';
+import { initMessageThrottler } from '../src/messageThrottler';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+// @ts-ignore dynamic import of JS module without types
+const brokerModule = await import(path.resolve(__dirname, '../../../../js/broker/index.js'));
+const { start: startBroker, stop: stopBroker } = brokerModule;
+
+test('throttles tick interval based on messages', async (t) => {
+	const context = {} as unknown as ContextManager;
+	const bot = { context } as unknown as Bot;
+	const agent = new AIAgent({ bot, context });
+	const broker = await startBroker(0);
+	const port = broker.address().port;
+	const client = await initMessageThrottler(agent, `ws://127.0.0.1:${port}`);
+	for (let i = 0; i < 5; i++) {
+		client.publish('test', {});
+	}
+	await new Promise((r) => setTimeout(r, 1100));
+	client.publish('test', {});
+	t.true((agent as any).tickInterval > 100);
+	client.socket.close();
+	await stopBroker(broker);
+});


### PR DESCRIPTION
## Summary
- switch health service to aggregate broker heartbeats
- throttle cephalon agent based on messages published
- add message-rate throttler test and docs

## Testing
- `make lint-js-service-health`
- `make lint-ts-service-cephalon`
- `make test-js-service-health`
- `make test-ts-service-cephalon`
- `make build-js`
- `make build-ts`


------
https://chatgpt.com/codex/tasks/task_e_689795641c6c83248f58018a78376520