### PR TITLE
test: expand date_tools coverage

### DIFF
--- a/shared/py/tests/test_date_tools.py
+++ b/shared/py/tests/test_date_tools.py
@@ -32,3 +32,21 @@ def test_days_ago():
     now = datetime(2024, 1, 10, tzinfo=timezone.utc)
     past = now - timedelta(days=2)
     assert time_ago(past, now) == "2 days ago"
+
+
+def test_single_second_ago_default_now():
+    """Ensure singular seconds are handled when ``now`` is omitted."""
+    past = datetime.now(timezone.utc) - timedelta(seconds=1)
+    assert time_ago(past) == "1 second ago"
+
+
+def test_single_hour_ago():
+    now = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    past = now - timedelta(hours=1)
+    assert time_ago(past, now) == "1 hour ago"
+
+
+def test_single_day_ago():
+    now = datetime(2024, 1, 2, tzinfo=timezone.utc)
+    past = now - timedelta(days=1)
+    assert time_ago(past, now) == "1 day ago"


### PR DESCRIPTION
## Summary
- add unit tests for singular second, hour, and day cases in `time_ago`
- cover default `now` parameter handling in `time_ago`

## Testing
- `make setup-shared-python`
- `make format-python`
- `make lint-python` *(fails: shared/py/tests/test_heartbeat_client.py missing imports)*
- `flake8 shared/py/tests/test_date_tools.py`
- `make build-python`
- `make test-shared-python` *(fails: tests/test_heartbeat_client.py NameError: asyncio not defined)*
- `python -m pipenv run pytest tests/test_date_tools.py`


------
https://chatgpt.com/codex/tasks/task_e_689796fa5dc88324827ec94f4f04ae19