### PR TITLE
test: add coverage for intention and task queue

### DIFF
--- a/tests/intention.test.js
+++ b/tests/intention.test.js
@@ -18,7 +18,24 @@ test("RouterLLM falls back to next provider on failure", async (t) => {
   t.is(out, "ok:hi");
 });
 
+test("RouterLLM throws when all providers fail", async (t) => {
+  class BadLLM {
+    async generate() {
+      throw new Error("fail");
+    }
+  }
+  const router = new RouterLLM([new BadLLM()]);
+  await t.throwsAsync(() => router.generate({ system: "", prompt: "hi" }), {
+    message: "fail",
+  });
+});
+
 test("extractCode strips fences", (t) => {
   const s = "```js\nconsole.log(1);\n```";
   t.is(extractCode(s), "console.log(1);\n");
+});
+
+test("extractCode splits on triple-dash", (t) => {
+  const s = "console.log(1);\n---\nmore";
+  t.is(extractCode(s), "console.log(1);");
 });

--- a/tests/taskQueue.test.js
+++ b/tests/taskQueue.test.js
@@ -75,3 +75,9 @@ test("allQueues returns all active queues", (t) => {
   t.is(queues.length, 2);
   t.deepEqual(queues.map(([name]) => name).sort(), ["alpha", "beta"]);
 });
+
+test("ack returns false when task not inflight", (t) => {
+  const q = new TaskQueue();
+  const result = q.ack("missing-id");
+  t.false(result);
+});


### PR DESCRIPTION
## Summary
- test RouterLLM's behavior when all providers fail
- verify extractCode handles triple-dash separators
- ensure TaskQueue.ack returns false for unknown tasks

## Testing
- `npm test`
- `make build`
- `make lint` *(fails: biome.json schema version mismatch)*
- `make format` *(hangs: npm "http-proxy" env warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68979b64667c8324b892b2d1bc36e735