### PR TITLE
feat: add manual ack option to event bus

### DIFF
--- a/shared/js/prom-lib/event/types.ts
+++ b/shared/js/prom-lib/event/types.ts
@@ -46,6 +46,7 @@ export interface SubscribeOptions {
   maxInFlight?: number; // default 1000
   ackTimeoutMs?: number; // default 30_000
   maxAttempts?: number; // default 5
+  manualAck?: boolean; // if true, caller must ack explicitly
   filter?(e: EventRecord): boolean;
   topics?: string[]; // if adapter supports multi-topic fan-in
 }


### PR DESCRIPTION
## Summary
- allow consumers to opt into manual acknowledgements via `manualAck` flag
- avoid auto-ack when manual mode is enabled in `InMemoryEventBus`
- cover manual ack flow with a new test case

## Testing
- `npx prettier --write shared/js/prom-lib/event/types.ts shared/js/prom-lib/event/memory.ts shared/js/prom-lib/event/event.bus.test.ts`
- `npx eslint --no-ignore shared/js/prom-lib/event/types.ts shared/js/prom-lib/event/memory.ts shared/js/prom-lib/event/event.bus.test.ts` *(warn: no matching configuration was supplied)*
- `make build-js`
- `make build-ts`
- `npx --yes jest -c shared/js/prom-lib/jest.config.ts --runInBand --forceExit` *(hangs, output shows passing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68979c3ccf008324b7b2da19eb17b740