### PR TITLE
feat: broker task queue for markdown graph

### DIFF
--- a/docs/services/markdown_graph/README.md
+++ b/docs/services/markdown_graph/README.md
@@ -2,12 +2,17 @@
 
 Maintains a graph of markdown links and `#hashtags` in a MongoDB database.
 
+### Task Queue
+
+- `markdown_graph.update` – enqueue `{ path, content }` to update the graph.
+
 ### Endpoints
 
-- `POST /update` – supply `{ path, content }` to update the graph.
 - `GET /links/{path}` – return links from the given markdown file.
 - `GET /hashtags/{tag}` – return all files referencing the tag.
 
-Implemented in TypeScript at `services/ts/markdown-graph`.
+Implemented in TypeScript at `services/ts/markdown-graph`. A `POST /update`
+route remains for manual testing but production updates flow through the task
+queue.
 
 #markdown #service

--- a/services/ts/markdown-graph/src/serviceTemplate.d.ts
+++ b/services/ts/markdown-graph/src/serviceTemplate.d.ts
@@ -1,0 +1,1 @@
+declare module "*.js";

--- a/services/ts/markdown-graph/tests/graph.test.ts
+++ b/services/ts/markdown-graph/tests/graph.test.ts
@@ -4,7 +4,7 @@ import request from "supertest";
 import { promises as fs } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
-import { createApp } from "../src/index.js";
+import { createApp, handleTask } from "../src/index.js";
 
 test("cold start and update", async (t) => {
   const repo = await fs.mkdtemp(join(tmpdir(), "mg-"));
@@ -24,10 +24,9 @@ test("cold start and update", async (t) => {
   const tag = await agent.get("/hashtags/tag1");
   t.deepEqual(tag.body.files, ["docs/one.md"]);
 
-  await agent
-    .post("/update")
-    .send({ path: "docs/two.md", content: "[One](../docs/one.md) #tag2" })
-    .set("Content-Type", "application/json");
+  await handleTask(app, {
+    payload: { path: "docs/two.md", content: "[One](../docs/one.md) #tag2" },
+  });
 
   const links2 = await agent.get("/links/docs/two.md");
   t.deepEqual(links2.body.links, ["docs/one.md"]);

--- a/services/ts/markdown-graph/tsconfig.json
+++ b/services/ts/markdown-graph/tsconfig.json
@@ -28,6 +28,6 @@
     "useDefineForClassFields": true,
     "skipLibCheck": true
   },
-  "include": ["src/**/*.ts", "tests/**/*.ts"],
+  "include": ["src/**/*.ts", "src/**/*.d.ts", "tests/**/*.ts"],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
## Summary
- allow markdown-graph to process `markdown_graph.update` tasks via the shared broker
- expose `handleTask` and `start` helpers and adjust tests accordingly
- document queue-based workflow and include TS type support

## Testing
- `npm run format` *(fails: Invalid option '--ext')*
- `npm run lint` *(fails: Invalid option '--ext')*
- `npx eslint src --fix --cache` *(fails: files ignored)*
- `npx prettier --cache --write .`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68979e87d6348324bdc840d712e1cbde