### PR TITLE
test: add queue manager coverage

### DIFF
--- a/tests/queueManager.test.js
+++ b/tests/queueManager.test.js
@@ -1,0 +1,40 @@
+import test from "ava";
+import { queueManager } from "../shared/js/queueManager.js";
+
+test.serial("ready and enqueue dispatches and acknowledges task", (t) => {
+  const messages = [];
+  const ws = { send: (msg) => messages.push(msg) };
+  const workerId = "worker1";
+  const queue = "alpha";
+
+  queueManager.ready(ws, workerId, queue);
+  const task = queueManager.enqueue(queue, { foo: "bar" });
+
+  t.is(messages.length, 1);
+  const msg = JSON.parse(messages[0]);
+  t.is(msg.action, "task-assigned");
+  t.is(msg.task.id, task.id);
+
+  const acked = queueManager.acknowledge(workerId, task.id);
+  t.true(acked);
+
+  const state = queueManager.getState();
+  t.is(state.assignments[workerId], undefined);
+  t.is(state.queues[queue], 0);
+  queueManager.unregisterWorker(workerId);
+});
+
+test.serial("heartbeat updates lastSeen", async (t) => {
+  const ws = { send: () => {} };
+  const workerId = "worker2";
+  const queue = "beta";
+
+  queueManager.ready(ws, workerId, queue);
+  const before = queueManager.getState().workers[workerId].lastSeen;
+
+  await new Promise((resolve) => setTimeout(resolve, 10));
+  queueManager.heartbeat(workerId);
+  const after = queueManager.getState().workers[workerId].lastSeen;
+  t.true(after >= before);
+  queueManager.unregisterWorker(workerId);
+});


### PR DESCRIPTION
## Summary
- increase test coverage for queueManager ready/enqueue/ack/heartbeat

## Testing
- `make test-js`
- `npm test`
- `make build`
- `make lint` *(fails: shared/py/tests/test_heartbeat_client.py:33:14: F821 undefined name 'threading')*
- `make lint-js`
- `make format`


------
https://chatgpt.com/codex/tasks/task_e_6897a6b6e5f083248803f87c9ce6977c