### PR TITLE
refactor broker to event-driven handlers

### DIFF
--- a/docs/services/broker/index.md
+++ b/docs/services/broker/index.md
@@ -2,7 +2,7 @@
 
 **Path**: `services/js/broker/index.js`
 
-**Description**: WebSocket-based message broker providing a simple pub/sub event bus. It normalizes published messages and routes them to subscribers based on topic. Supports optional correlation IDs and reply topics for request/response patterns.
+**Description**: WebSocket-based message broker providing a simple pub/sub event bus. It normalizes published messages and routes them to subscribers based on topic. Message actions are dispatched through an internal event emitter rather than `if` chains, and the service supports optional correlation IDs and reply topics for request/response patterns.
 
 ## Dependencies
 - ws


### PR DESCRIPTION
## Summary
- refactor broker service to dispatch actions through an EventEmitter
- document event-driven message handling for broker

## Testing
- `make setup-js-service-broker`
- `make lint-js-service-broker`
- `make format-js`
- `make build-js`
- `npm test` (hangs on exit after 4 passing tests)


------
https://chatgpt.com/codex/tasks/task_e_6897a8fe37c08324934c32d89649fa03