### PR TITLE
Add util function tests

### DIFF
--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,0 +1,32 @@
+import os
+import sys
+
+import hy  # noqa: F401
+
+sys.path.append(os.getcwd())
+
+import util
+from unittest.mock import patch
+
+
+def test_sh_without_shell_calls_subprocess_run_with_list_and_cwd():
+    with patch("util.subprocess.run") as mock_run:
+        util.sh(["echo", "hi"], cwd="/tmp")
+        mock_run.assert_called_once_with(["echo", "hi"], cwd="/tmp", check=True)
+
+
+def test_sh_with_shell_true_passes_shell_flag():
+    with patch("util.subprocess.run") as mock_run:
+        util.sh("echo hi", cwd="/tmp", shell=True)
+        mock_run.assert_called_once_with("echo hi", cwd="/tmp", check=True, shell=True)
+
+
+def test_run_dirs_calls_sh_for_existing_directories(tmp_path):
+    existing = tmp_path / "existing"
+    existing.mkdir()
+    missing = tmp_path / "missing"
+    with patch("util.sh") as mock_sh:
+        util.run_dirs([str(existing), str(missing)], ["echo", "test"])
+        mock_sh.assert_called_once_with(
+            ["echo", "test"], cwd=str(existing), shell=False
+        )


### PR DESCRIPTION
## Summary
- add tests for util.sh and run_dirs covering shell and directory behaviors

## Testing
- `make setup-python` (fails: KeyboardInterrupt)
- `make test` (fails: ModuleNotFoundError for discord, requests, numpy, etc.)
- `make lint` (fails: KeyboardInterrupt)
- `pytest tests/test_util.py`
- `pytest tests/test_util.py --cov=util` (warning: No data to report)

------
https://chatgpt.com/codex/tasks/task_e_6897b274f0488324ba63979dff368d06