### PR TITLE
Add TaskQueue and RouterLLM edge case tests

### DIFF
--- a/tests/intention.test.js
+++ b/tests/intention.test.js
@@ -39,3 +39,10 @@ test("extractCode splits on triple-dash", (t) => {
   const s = "console.log(1);\n---\nmore";
   t.is(extractCode(s), "console.log(1);");
 });
+
+test("RouterLLM throws when no providers", async (t) => {
+  const router = new RouterLLM([]);
+  await t.throwsAsync(() => router.generate({ system: "", prompt: "hi" }), {
+    message: "No providers responded",
+  });
+});

--- a/tests/taskQueue.test.js
+++ b/tests/taskQueue.test.js
@@ -81,3 +81,18 @@ test("ack returns false when task not inflight", (t) => {
   const result = q.ack("missing-id");
   t.false(result);
 });
+
+test("pull increments attempts and tracks worker", (t) => {
+  const q = new TaskQueue();
+  const task = q.enqueue("alpha", { a: 1 });
+  t.is(task.attempts, 0);
+
+  q.pull("alpha", "worker1");
+  t.is(task.attempts, 1);
+  t.is(q.inflightTasks()[0].assignedTo, "worker1");
+
+  q.fail(task.id);
+  q.pull("alpha", "worker2");
+  t.is(task.attempts, 2);
+  t.is(q.inflightTasks()[0].assignedTo, "worker2");
+});


### PR DESCRIPTION
## Summary
- cover TaskQueue attempt counter and worker tracking
- exercise RouterLLM behaviour when no providers are available

## Testing
- `make setup-js`
- `make test-js`
- `npm test`
- `make build-js`
- `make lint-js`
- `npx --yes eslint tests`
- `make format-js`
- `npx --yes prettier --write tests`
- `npm run coverage`


------
https://chatgpt.com/codex/tasks/task_e_6897b274f0488324ba63979dff368d06