### PR TITLE
docs: add agent-mode prompt guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -319,6 +319,19 @@ Agents like Duck must:
 
 ---
 
+## 🕹️ Agent-Mode Prompt Guidance
+
+When invoking agent-mode, frame prompts with:
+
+* **Goal** – the outcome the agent should achieve.
+* **Context** – relevant files, docs, or history.
+* **Constraints** – boundaries such as runtime or style requirements.
+* **Exit Criteria** – the signals that mark completion.
+
+Agents should verify their work and reference any touched paths before exiting agent-mode.
+
+---
+
 ## ✅ Next Steps
 
 * [ ] Finalize `MIGRATION_PLAN.md`

--- a/docs/MIGRATION_PLAN.md
+++ b/docs/MIGRATION_PLAN.md
@@ -67,7 +67,7 @@ This document outlines the migration steps from the legacy `duck/` folder and `r
 * [ ] Update `README.md` at root
 * [x] Write and maintain `AGENTS.md`
 * [x] Define `Promethean File Structure` canvas
-* [ ] Add `agent-mode` prompt guidance to `AGENTS.md`
+* [x] Add `agent-mode` prompt guidance to `AGENTS.md`
 
 ### 8. 📦 Model Asset Management
 


### PR DESCRIPTION
## Summary
- add agent-mode prompt guidance to repository AGENTS document
- mark migration plan task for agent-mode guidance complete

## Testing
- `make setup` *(failed: KeyboardInterrupt)*
- `make test` *(failed: Command 'pipenv run pytest tests/' returned non-zero exit status 2)*
- `make build`
- `make lint`
- `make format` *(failed: Command 'npx --yes @biomejs/biome format .' returned non-zero exit status 1)*

------
https://chatgpt.com/codex/tasks/task_e_6897b77e3b2c83249f60edff623bfc95