### PR TITLE
Mark messages embedded when no content is added

### DIFF
--- a/services/py/discord_attachment_embedder/main.py
+++ b/services/py/discord_attachment_embedder/main.py
@@ -39,9 +39,11 @@ def process_message(message: dict, collection) -> None:
             metadatas=metadatas,
             ids=ids,
         )
-        discord_message_collection.update_one(
-            {"id": message["id"]}, {"$set": {"embedded": True}}
-        )
+
+    # Mark the message as processed even if no embeddings were generated
+    discord_message_collection.update_one(
+        {"id": message["id"]}, {"$set": {"embedded": True}}
+    )
 
 
 def main() -> None:

--- a/services/py/discord_attachment_embedder/tests/test_embedder.py
+++ b/services/py/discord_attachment_embedder/tests/test_embedder.py
@@ -66,3 +66,28 @@ def test_process_message(monkeypatch):
     mod.process_message(message, collection)
     assert collection.count() == 2
     assert mem.docs[0].get("embedded") is True
+
+
+def test_process_message_no_image(monkeypatch):
+    mod = importlib.import_module("main")
+    message = {
+        "id": 2,
+        "attachments": [
+            {
+                "id": 3,
+                "filename": "doc.pdf",
+                "url": "http://example.com/doc.pdf",
+                "content_type": "application/pdf",
+            }
+        ],
+    }
+    mem = MemoryCollection([message])
+    monkeypatch.setattr(mod, "discord_message_collection", mem)
+    client = chromadb.Client()
+
+    collection = client.get_or_create_collection(
+        "test-no-image", embedding_function=EmbeddingFn()
+    )
+    mod.process_message(message, collection)
+    assert collection.count() == 0
+    assert mem.docs[0].get("embedded") is True


### PR DESCRIPTION
## Summary
- Ensure discord attachment embedder marks messages as processed even if no embeddings are created
- Add regression test for messages with non-image attachments

## Testing
- `pipenv run flake8 .`
- `pipenv run pytest tests -q`
- `make build`
- `make lint`
- `make format` *(fails: Command 'npx --yes @biomejs/biome format .' returned non-zero exit status 1)*

------
https://chatgpt.com/codex/tasks/task_e_6897b773c10083249e9a4372cc723160