### PR TITLE
Refactor currency pluralization in number normalization

### DIFF
--- a/shared/py/tests/test_heartbeat_client.py
+++ b/shared/py/tests/test_heartbeat_client.py
@@ -1,10 +1,9 @@
-import asyncio
 import json
 import os
 import sys
 import threading
 
-import websockets
+from websockets.sync.server import serve
 
 sys.path.insert(
     0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../"))
@@ -16,27 +15,20 @@ from shared.py.heartbeat_client import HeartbeatClient
 def test_send_once():
     received = {}
 
-    async def handler(ws):
-        msg = await ws.recv()
+    def handler(ws):
+        msg = ws.recv()
         received.update(json.loads(msg))
 
-    loop = asyncio.new_event_loop()
-    asyncio.set_event_loop(loop)
-    server = loop.run_until_complete(websockets.serve(handler, "127.0.0.1", 0))
-    port = server.sockets[0].getsockname()[1]
-    thread = threading.Thread(target=loop.run_forever, daemon=True)
-    thread.start()
-
-    client = HeartbeatClient(url=f"ws://127.0.0.1:{port}", pid=1234, name="test")
-    client.send_once()
-
-    # give the server a moment to receive the message
-    loop.call_soon_threadsafe(lambda: None)
-    threading.Event().wait(0.1)
+    with serve(handler, "127.0.0.1", 0) as server:
+        port = server.socket.getsockname()[1]
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        client = HeartbeatClient(url=f"ws://127.0.0.1:{port}", pid=1234, name="test")
+        client.send_once()
+        # give the server a moment to receive the message
+        threading.Event().wait(0.1)
+        server.shutdown()
+        thread.join()
 
     assert received["action"] == "publish"
     assert received["message"]["payload"] == {"pid": 1234, "name": "test"}
-
-    loop.call_soon_threadsafe(server.close)
-    loop.call_soon_threadsafe(loop.stop)
-    thread.join()

--- a/shared/py/tests/test_numbers.py
+++ b/shared/py/tests/test_numbers.py
@@ -22,3 +22,9 @@ def test_normalize_money_and_ordinal():
 def test_decimal_number():
     text = "Pi is 3.14"
     assert normalize_numbers(text) == "Pi is three point fourteen"
+
+
+def test_plural_dollars_and_cents():
+    text = "He found $2.01 on the street."
+    expected = "He found two dollars, one cent on the street."
+    assert normalize_numbers(text) == expected

--- a/shared/py/utils/numbers.py
+++ b/shared/py/utils/numbers.py
@@ -41,6 +41,16 @@ def _expand_decimal_point(m: re.Match) -> str:
     return m.group(1).replace(".", " point ")
 
 
+def _pluralize(unit: str, amount: int) -> str:
+    """Return ``unit`` in singular or plural form based on ``amount``."""
+    return unit if amount == 1 else unit + "s"
+
+
+def _format_currency(amount: int, unit: str) -> str:
+    """Format a currency amount with correct pluralization."""
+    return f"{amount} {_pluralize(unit, amount)}"
+
+
 def _expand_dollars(m: re.Match) -> str:
     """Expand a currency amount into spoken words."""
     match = m.group(1)
@@ -50,15 +60,13 @@ def _expand_dollars(m: re.Match) -> str:
     dollars = int(parts[0]) if parts[0] else 0
     cents = int(parts[1]) if len(parts) > 1 and parts[1] else 0
     if dollars and cents:
-        dollar_unit = "dollar" if dollars == 1 else "dollars"
-        cent_unit = "cent" if cents == 1 else "cents"
-        return "%s %s, %s %s" % (dollars, dollar_unit, cents, cent_unit)
+        return (
+            f"{_format_currency(dollars, 'dollar')}, {_format_currency(cents, 'cent')}"
+        )
     elif dollars:
-        dollar_unit = "dollar" if dollars == 1 else "dollars"
-        return "%s %s" % (dollars, dollar_unit)
+        return _format_currency(dollars, "dollar")
     elif cents:
-        cent_unit = "cent" if cents == 1 else "cents"
-        return "%s %s" % (cents, cent_unit)
+        return _format_currency(cents, "cent")
     else:
         return "zero dollars"
 


### PR DESCRIPTION
## Summary
- abstract currency pluralization with `_pluralize` and `_format_currency`
- add tests for plural dollar and cent amounts
- fix heartbeat client test by running a sync server in a background thread

## Testing
- `make build`
- `hy Makefile.hy lint-python`
- `hy Makefile.hy format-python`
- `hy Makefile.hy test-shared-python`

------
https://chatgpt.com/codex/tasks/task_e_6897b76d29a083248001537d286a121d