### PR TITLE
Refactor discord indexer history retrieval

### DIFF
--- a/services/py/discord_indexer/tests/test_discord_indexer.py
+++ b/services/py/discord_indexer/tests/test_discord_indexer.py
@@ -138,6 +138,19 @@ def test_index_message(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_next_messages_with_cursor(monkeypatch):
+    mod = load_indexer(monkeypatch)
+    chan = FakeChannel(10, [])
+    messages = [FakeMessage(i, f"m{i}", chan, FakeUser(9, "x")) for i in range(4)]
+    chan._messages = messages
+    ch_coll = mod.discord_channel_collection
+    # cursor points to the first message
+    ch_coll.insert_one({"id": 10, "cursor": messages[0].id})
+    result = await mod.next_messages(chan)
+    assert [m.id for m in result] == [m.id for m in messages[1:]]
+
+
+@pytest.mark.asyncio
 async def test_index_channel(monkeypatch):
     mod = load_indexer(monkeypatch)
     chan = FakeChannel(10, [])


### PR DESCRIPTION
## Summary
- centralize Discord history fetching with `fetch_history`
- simplify `next_messages` and indexing flow
- cover cursor behavior with additional unit test

## Testing
- `make setup-python-service-discord_indexer`
- `make lint SERVICE=discord_indexer`
- `make build SERVICE=discord_indexer`
- `make test-python-service-discord_indexer`
- `make format SERVICE=discord_indexer` *(fails: Command 'npx --yes @biomejs/biome format .' returned non-zero exit status 1)*
- `pipenv run black main.py tests/test_discord_indexer.py`


------
https://chatgpt.com/codex/tasks/task_e_6897b76d29a083248001537d286a121d