### PR TITLE
Refactor cephalon embedding to broker client

### DIFF
--- a/docs/services/cephalon/src/embedding.md
+++ b/docs/services/cephalon/src/embedding.md
@@ -2,11 +2,12 @@
 
 **Path**: `services/cephalon/src/embedding.ts`
 
-Embedding function that forwards requests to the shared embedding service.
+Embedding function that forwards requests to the embedding service through the
+message broker.
 
 ## Dependencies
 - chromadb
-- global fetch
+- `../../../../shared/js/brokerClient.js`
 
 ## Dependents
 - `collectionManager.ts`

--- a/services/ts/cephalon/src/embedding.ts
+++ b/services/ts/cephalon/src/embedding.ts
@@ -1,36 +1,62 @@
 import type { EmbeddingFunction, EmbeddingFunctionSpace } from 'chromadb';
+// @ts-ignore import js module without types
+import { BrokerClient } from '../../../../../shared/js/brokerClient.js';
+import { randomUUID } from 'crypto';
 
 export class RemoteEmbeddingFunction implements EmbeddingFunction {
 	name = 'remote';
-	url: string;
 	driver: string | undefined;
 	fn: string | undefined;
+	broker: BrokerClient;
+	#ready: Promise<void>;
+	#pending: ((embeddings: number[][]) => void)[] = [];
+	#replyId: string;
 
 	constructor(
-		url = process.env.EMBEDDING_SERVICE_URL || 'http://localhost:8000/embed',
+		brokerUrl = process.env.BROKER_URL || 'ws://localhost:7000',
 		driver = process.env.EMBEDDING_DRIVER,
 		fn = process.env.EMBEDDING_FUNCTION,
+		broker?: BrokerClient,
 	) {
-		this.url = url;
 		this.driver = driver;
 		this.fn = fn;
+		this.#replyId = randomUUID();
+		this.broker =
+			broker ||
+			new BrokerClient({
+				url: brokerUrl,
+				id: `cephalon-embed-${this.#replyId}`,
+			});
+		this.#ready = this.broker
+			.connect()
+			.then(() => {
+				this.broker.subscribe('embedding.result', (event: any) => {
+					if (event.replyTo !== this.#replyId) return;
+					const resolve = this.#pending.shift();
+					if (resolve) {
+						resolve(event.payload.embeddings);
+					}
+				});
+			})
+			.catch((err: unknown) => {
+				console.error('Failed to connect to broker', err);
+			});
 	}
 
 	async generate(texts: string[]): Promise<number[][]> {
 		const items = texts.map((t) =>
 			t.startsWith('img:') ? { type: 'image_url', data: t.slice(4) } : { type: 'text', data: t },
 		);
-		const body: any = { items };
-		if (this.driver) body.driver = this.driver;
-		if (this.fn) body.function = this.fn;
-		const fetchFn = (globalThis as any).fetch;
-		const res = await fetchFn(this.url, {
-			method: 'POST',
-			headers: { 'Content-Type': 'application/json' },
-			body: JSON.stringify(body),
+		await this.#ready;
+		return new Promise((resolve) => {
+			this.#pending.push(resolve);
+			this.broker.enqueue('embedding.generate', {
+				items,
+				driver: this.driver,
+				function: this.fn,
+				replyTo: this.#replyId,
+			});
 		});
-		const json = await res.json();
-		return json.embeddings;
 	}
 
 	defaultSpace(): EmbeddingFunctionSpace {

--- a/services/ts/cephalon/tests/embedding.test.ts
+++ b/services/ts/cephalon/tests/embedding.test.ts
@@ -1,0 +1,45 @@
+import test from 'ava';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { RemoteEmbeddingFunction } from '../src/embedding';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+// dynamic imports for broker server and client
+// @ts-ignore dynamic import of JS modules
+const brokerModule = await import(path.resolve(__dirname, '../../../../js/broker/index.js'));
+const { start: startBroker, stop: stopBroker } = brokerModule;
+// @ts-ignore dynamic import of JS modules
+const clientModule = await import(path.resolve(__dirname, '../../../../../shared/js/brokerClient.js'));
+const { BrokerClient } = clientModule;
+
+test('requests embeddings via broker', async (t) => {
+	const broker = await startBroker(0);
+	const port = broker.address().port;
+	const worker = new BrokerClient({
+		url: `ws://127.0.0.1:${port}`,
+		id: 'embed-worker',
+	});
+	await worker.connect();
+	worker.onTaskReceived(async (task: any) => {
+		await worker.ack(task.id);
+		const items = task.payload.items || [];
+		const embeddings = items.map((_: unknown, i: number) => [i]);
+		await worker.publish(
+			'embedding.result',
+			{ embeddings },
+			{
+				replyTo: task.payload.replyTo,
+				correlationId: task.id,
+			},
+		);
+		await worker.ready(task.queue);
+	});
+	await worker.ready('embedding.generate');
+	process.env.BROKER_URL = `ws://127.0.0.1:${port}`;
+	const fn = new RemoteEmbeddingFunction();
+	const result = await fn.generate(['a', 'b']);
+	t.deepEqual(result, [[0], [1]]);
+	fn.broker.socket.close();
+	worker.socket.close();
+	await stopBroker(broker);
+});


### PR DESCRIPTION
## Summary
- use BrokerClient to request embeddings through the broker
- document embedding module dependencies
- add broker-backed embedding unit test

## Testing
- `make lint-ts-service-cephalon`
- `make test-ts-service-cephalon`
- `make build-ts`
- `npx --yes @biomejs/biome format src/embedding.ts tests/embedding.test.ts --write`

------
https://chatgpt.com/codex/tasks/task_e_6897bae42fcc8324981b8b02c12c8cec