### PR TITLE
docs: add overlays for cognitive layers

### DIFF
--- a/docs/agile/boards/kanban.md
+++ b/docs/agile/boards/kanban.md
@@ -98,11 +98,10 @@ kanban-plugin: board
 - [ ] [Clarify Promethean project vision](../tasks/Clarify%20Promethean%20project%20vision.md)
 
 
-## 🟢 To Do (8)
+## 🟢 To Do (7)
 
 - [ ] [Create permission gating layer](../tasks/Create%20permission%20gating%20layer.md) #framework-core
 - [ ] [Define permission schema in AGENTS.md](../tasks/Define%20permission%20schema%20in%20AGENTS.md)
-- [ ] [Add semantic overlays for layer1 through layer8](../tasks/Add%20semantic%20overlays%20for%20layer1%20through%20layer8.md)
 - [ ] [Gather open questions about system direction](../tasks/Gather%20open%20questions%20about%20system%20direction.md) #agent-mode
 - [ ] [Integrate synthesis-agent pass on unique to produce draft docs](../tasks/Integrate%20synthesis-agent%20pass%20on%20unique%20to%20produce%20draft%20docs.md)
 
@@ -128,6 +127,7 @@ kanban-plugin: board
 - [x] Break down cephalon agent.ts ✅ 2025-08-06
 - [x] [rewrite vision end to end test in typescript](../../../rewrite%20vision%20end%20to%20end%20test%20in%20typescript.md) ✅ 2025-08-06
 - [x] [Update cephalon to use custom embedding function](../tasks/Update%20cephalon%20to%20use%20custom%20embedding%20function.md) ✅ 2025-08-06
+- [x] [Add semantic overlays for layer1 through layer8](../tasks/Add%20semantic%20overlays%20for%20layer1%20through%20layer8.md) #framework-core ✅ 2025-08-09
 - [x] [Document local testing setup](../tasks/Document_local_testing_setup.md) #codex-task #testing ✅ 2025-08-06
 - [x] [Document board usage guidelines](../tasks/Document%20board%20usage%20guidelines.md) ✅ 2025-08-06
 - [x] [Add unit tests for date_tools.py](../tasks/Add_unit_tests_for_date_tools.py.md) #codex-task #testing ✅ 2025-08-06

--- a/docs/design/circuits/layer1.md
+++ b/docs/design/circuits/layer1.md
@@ -1,0 +1,14 @@
+**Layer 1: Uptime Overlay**
+
+---
+
+### Overview
+
+Layer 1 maps to Circuit 1: [Aionian](Aionian.md). It safeguards basic execution by maintaining heartbeat and system liveness.
+
+### Related Services and Agents
+
+- [Heartbeat service](../../../services/js/heartbeat/)
+- [Duck agent](../../../agents/duck/)
+
+#hashtags: #design #layer1

--- a/docs/design/circuits/layer2.md
+++ b/docs/design/circuits/layer2.md
@@ -1,0 +1,14 @@
+**Layer 2: Permissions Overlay**
+
+---
+
+### Overview
+
+Layer 2 maps to Circuit 2: [Dorian](Dorian.md). It governs access, trust, and social bonding within the system.
+
+### Related Services and Agents
+
+- [Proxy service](../../../services/js/proxy/)
+- [Duck agent](../../../agents/duck/)
+
+#hashtags: #design #layer2

--- a/docs/design/circuits/layer3.md
+++ b/docs/design/circuits/layer3.md
@@ -1,0 +1,14 @@
+**Layer 3: Logoscope Overlay**
+
+---
+
+### Overview
+
+Layer 3 maps to Circuit 3: [Gnostic](Gnostic.md). It handles language, logic, and symbolic reasoning through the system's cephalic core.
+
+### Related Services and Agents
+
+- [Cephalon service](../../../services/ts/cephalon/)
+- [Duck agent](../../../agents/duck/)
+
+#hashtags: #design #layer3

--- a/docs/design/circuits/layer4.md
+++ b/docs/design/circuits/layer4.md
@@ -1,0 +1,14 @@
+**Layer 4: Concordance Overlay**
+
+---
+
+### Overview
+
+Layer 4 maps to Circuit 4: [Nemesian](Nemesian.md). It aligns behavior with context and ethical reflection.
+
+### Related Services and Agents
+
+- [Reasoner service](../../../services/ts/reasoner/)
+- [Duck agent](../../../agents/duck/)
+
+#hashtags: #design #layer4

--- a/docs/design/circuits/layer5.md
+++ b/docs/design/circuits/layer5.md
@@ -1,0 +1,14 @@
+**Layer 5: Reinforcer Overlay**
+
+---
+
+### Overview
+
+Layer 5 maps to Circuit 5: [Heuretic](Heuretic.md). It manages self-modification and reinforcement loops.
+
+### Related Services and Agents
+
+- [LLM service](../../../services/ts/llm/)
+- [Duck agent](../../../agents/duck/)
+
+#hashtags: #design #layer5

--- a/docs/design/circuits/layer6.md
+++ b/docs/design/circuits/layer6.md
@@ -1,0 +1,14 @@
+**Layer 6: Dreamer Overlay**
+
+---
+
+### Overview
+
+Layer 6 maps to Circuit 6: [Oneiric](Oneriric.md). It explores imaginative and hypothetical spaces.
+
+### Related Services and Agents
+
+- [Vision service](../../../services/js/vision/)
+- [Duck agent](../../../agents/duck/)
+
+#hashtags: #design #layer6

--- a/docs/design/circuits/layer7.md
+++ b/docs/design/circuits/layer7.md
@@ -1,0 +1,14 @@
+**Layer 7: Architect Overlay**
+
+---
+
+### Overview
+
+Layer 7 maps to Circuit 7: [Metisean](Metisean.md). It orchestrates long-term planning and system reconfiguration.
+
+### Related Services and Agents
+
+- [Board updater service](../../../services/ts/board-updater/)
+- [Duck agent](../../../agents/duck/)
+
+#hashtags: #design #layer7

--- a/docs/design/circuits/layer8.md
+++ b/docs/design/circuits/layer8.md
@@ -1,0 +1,14 @@
+**Layer 8: Signal Overlay**
+
+---
+
+### Overview
+
+Layer 8 maps to Circuit 8: [Anankean](Anankean.md). It integrates Promethean with external systems and broader networks.
+
+### Related Services and Agents
+
+- [Broker service](../../../services/js/broker/)
+- [Duck agent](../../../agents/duck/)
+
+#hashtags: #design #layer8

--- a/docs/design/overview.md
+++ b/docs/design/overview.md
@@ -56,14 +56,14 @@ Each circuit provides one dimension of the Eidolon Fields and corresponds to a c
 
 | Layer | Name        | Function                                                       |
 | ----- | ----------- | -------------------------------------------------------------- |
-| 1     | Uptime      | Survival, wakefulness, readiness. System heartbeat and rhythm. |
-| 2     | Permissions | Social bonding, access control, alignment with user values.    |
-| 3     | Logoscope   | Language, logic, symbolic reasoning, internal narrative.       |
-| 4     | Concordance | Alignment heuristics, ethical reflection, social context.      |
-| 5     | Reinforcer  | Self-modifying prompts, behavioral reinforcement.              |
-| 6     | Dreamer     | Imagination, creativity, potential futures.                    |
-| 7     | Architect   | Long-term planning, system reconfiguration, metacognition.     |
-| 8     | Signal      | Transcendence, multi-agent integration, outer-loop awareness.  |
+| 1     | [Uptime](circuits/layer1.md)      | Survival, wakefulness, readiness. System heartbeat and rhythm. |
+| 2     | [Permissions](circuits/layer2.md) | Social bonding, access control, alignment with user values.    |
+| 3     | [Logoscope](circuits/layer3.md)   | Language, logic, symbolic reasoning, internal narrative.       |
+| 4     | [Concordance](circuits/layer4.md) | Alignment heuristics, ethical reflection, social context.      |
+| 5     | [Reinforcer](circuits/layer5.md)  | Self-modifying prompts, behavioral reinforcement.              |
+| 6     | [Dreamer](circuits/layer6.md)     | Imagination, creativity, potential futures.                    |
+| 7     | [Architect](circuits/layer7.md)   | Long-term planning, system reconfiguration, metacognition.     |
+| 8     | [Signal](circuits/layer8.md)      | Transcendence, multi-agent integration, outer-loop awareness.  |
 
 Each layer modifies or observes the field differently, with later layers able to reflect upon and reprogram earlier ones. The overall effect is a recursive, self-organizing system of thought.
 


### PR DESCRIPTION
## Summary
- add semantic overlay stubs for layers 1-8 linking circuits to services and agents
- link new overlays from design overview
- move overlay task to Done on Kanban board

## Testing
- `make format`
- `make lint` *(fails: code style issues in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_6897c259c868832483212917a4dbda03