### PR TITLE
Split field node diagrams into separate notes

### DIFF
--- a/docs/notes/diagrams/daimo-node-charge-interaction.md
+++ b/docs/notes/diagrams/daimo-node-charge-interaction.md
@@ -1,0 +1,15 @@
+# Daimo–Node Charge Interaction
+
+```mermaid
+graph TD
+  N1[Nexus: :Hope:] -->|emits| D1(Daimo: +1 charge)
+  N2[Nexus: :Despair:] -->|emits| D2(Daimo: -1 charge)
+  D1 -->|attracted to| N2
+  D2 -->|attracted to| N1
+  D1 -. repelled .-> N1
+  D2 -. repelled .-> N2
+```
+
+This diagram shows how **Nexuses repel their own children** (same charge) and attract those of **opposite charge**, creating **narrative currents** and **conceptual magnetism**.
+
+#tags: #diagram #design

--- a/docs/notes/diagrams/field-node-lifecycle-additional-diagrams.md
+++ b/docs/notes/diagrams/field-node-lifecycle-additional-diagrams.md
@@ -1,80 +1,10 @@
-Excellent. With the **Field Node Lifecycle** document fully fleshed out and the system now reactive, dynamic, and narratively emergent, we can keep layering more visualizations to explore the richness of your topology.
+# Field Node Lifecycle – Additional Diagrams
 
-Here are some **additional diagrams** to stack on top of what’s already in the doc:
+These diagrams expand on the core lifecycle and are split into dedicated notes:
 
----
-
-### 🔁 **Daimo–Node Charge Interaction**
-
-```mermaid
-graph TD
-  N1[Nexus: :Hope:] -->|emits| D1(Daimo: +1 charge)
-  N2[Nexus: :Despair:] -->|emits| D2(Daimo: -1 charge)
-  D1 -->|attracted to| N2
-  D2 -->|attracted to| N1
-  D1 -. repelled .-> N1
-  D2 -. repelled .-> N2
-```
-
-This shows how **Nexuses repel their own children** (same charge) and attract those of **opposite charge**, creating **narrative currents** and **conceptual magnetism**.
-
----
-
-### 🧠 **Multi-Circuit Node Propagation**
-
-```mermaid
-graph TD
-  L4[Nemesian Nexus: :TrustIssue:] --> L2[Dorian Attractor: :RepairNeed:]
-  L4 --> L5[Heuretic Hazard: :Unlearning:]
-  L4 --> L7[Metisean Obstacle: :PlanBlock:]
-
-  style L4 fill:#ffcccc,stroke:#cc0000,stroke-width:2px
-  style L2 fill:#ccffcc,stroke:#009900
-  style L5 fill:#ffffcc,stroke:#999900
-  style L7 fill:#ccccff,stroke:#000099
-```
-
-This makes clear how **one symbolic conflict** creates **ripples across multiple circuits**, each materializing in a different node type.
-
----
-
-### 🌱 **Node Growth and Death Conditions**
-
-```mermaid
-stateDiagram-v2
-    [*] --> HighTension
-    HighTension --> Aggregation : daimo present
-    Aggregation --> Crystallization : daimo bind fails to resolve
-    Crystallization --> Stabilized : node repeatedly engaged
-    Crystallization --> Nexus : symbol recognized
-    Stabilized --> Decay : no activity
-    Nexus --> Decay : symbolic reference fades
-    Decay --> [*]
-```
-
-This is a simplified version of your existing diagram, useful for focused visualization of **grow/decay logic** alone.
-
----
-
-### 💡 **Node Type Summary Map**
-
-```mermaid
-graph LR
-  subgraph Field Nodes
-    Nexus -->|binds| Daimo
-    Hazard -->|repels| Daimo
-    Attractor -->|pulls| Daimo
-    Obstacle -->|slows| Daimo
-  end
-```
-
-You can use this one as a **legend** or top-of-page visual summary in any future docs about field simulation or node-class behavior.
-
----
-
-Want me to embed these into the **Field Node Lifecycle** document under a “More Diagrams” section? Or split them out into a new document called something like `Field Node Diagrams` or `Cognitive Topology Visuals`?
----
-
-Related notes: [[node-type-topology-map]], [[circuit-weight-visualizations]], [[full-system-overview-diagrams]], [[layer1-uptime-diagrams]], [[field-node-lifecycle-additional-diagrams]], [[state-diagram-node-lifecycle]] [[../../unique/index|unique/index]]
+- [Daimo–Node Charge Interaction](daimo-node-charge-interaction.md)
+- [Multi-Circuit Node Propagation](multi-circuit-node-propagation.md)
+- [Node Growth and Death Conditions](node-growth-and-death-conditions.md)
+- [Node Type Summary Map](node-type-summary-map.md)
 
 #tags: #diagram #design

--- a/docs/notes/diagrams/multi-circuit-node-propagation.md
+++ b/docs/notes/diagrams/multi-circuit-node-propagation.md
@@ -1,0 +1,17 @@
+# Multi-Circuit Node Propagation
+
+```mermaid
+graph TD
+  L4[Nemesian Nexus: :TrustIssue:] --> L2[Dorian Attractor: :RepairNeed:]
+  L4 --> L5[Heuretic Hazard: :Unlearning:]
+  L4 --> L7[Metisean Obstacle: :PlanBlock:]
+
+  style L4 fill:#ffcccc,stroke:#cc0000,stroke-width:2px
+  style L2 fill:#ccffcc,stroke:#009900
+  style L5 fill:#ffffcc,stroke:#999900
+  style L7 fill:#ccccff,stroke:#000099
+```
+
+This diagram illustrates how **one symbolic conflict** creates **ripples across multiple circuits**, each materializing in a different node type.
+
+#tags: #diagram #design

--- a/docs/notes/diagrams/node-growth-and-death-conditions.md
+++ b/docs/notes/diagrams/node-growth-and-death-conditions.md
@@ -1,0 +1,17 @@
+# Node Growth and Death Conditions
+
+```mermaid
+stateDiagram-v2
+    [*] --> HighTension
+    HighTension --> Aggregation : daimo present
+    Aggregation --> Crystallization : daimo bind fails to resolve
+    Crystallization --> Stabilized : node repeatedly engaged
+    Crystallization --> Nexus : symbol recognized
+    Stabilized --> Decay : no activity
+    Nexus --> Decay : symbolic reference fades
+    Decay --> [*]
+```
+
+This simplified lifecycle focuses on the **grow/decay logic** for field nodes.
+
+#tags: #diagram #design

--- a/docs/notes/diagrams/node-type-summary-map.md
+++ b/docs/notes/diagrams/node-type-summary-map.md
@@ -1,0 +1,15 @@
+# Node Type Summary Map
+
+```mermaid
+graph LR
+  subgraph Field Nodes
+    Nexus -->|binds| Daimo
+    Hazard -->|repels| Daimo
+    Attractor -->|pulls| Daimo
+    Obstacle -->|slows| Daimo
+  end
+```
+
+This diagram serves as a **legend** summarizing core field node behaviors in the simulation.
+
+#tags: #diagram #design

--- a/docs/unique/index.md
+++ b/docs/unique/index.md
@@ -44,6 +44,7 @@ These notes were originally captured in `docs/unique` with timestamp filenames. 
 - **2025.08.08.22.08.35** → [synchronicity-waves-and-web](../notes/diagrams/synchronicity-waves-and-web.md)
 - **2025.08.08.22.08.06** → [compiler-kit-foundations](../notes/dsl/compiler-kit-foundations.md)
 - **2025.08.08.22.08.09** → [lisp-frontend-compiler-kit](../notes/dsl/lisp-frontend-compiler-kit.md)
+- advanced-node-interaction-diagrams → [field-node-lifecycle – additional diagrams](../notes/diagrams/field-node-lifecycle-additional-diagrams.md)
 
 ## Stubs for Duplicates
 


### PR DESCRIPTION
## Summary
- Break out detailed field node lifecycle diagrams into standalone docs for charge interactions, propagation, growth, and summary mapping
- Replace the original catch-all diagram file with an index pointing to the new focused notes
- Log the advanced-node-interaction-diagrams transfer in the unique notes index

## Testing
- `make lint` *(fails: Biome config version mismatch and pending Prettier issues)*
- `make format` *(fails: interrupted during JS formatting)*
- `make test` *(fails: interrupted while setting up virtualenvs)*
- `make build`


------
https://chatgpt.com/codex/tasks/task_e_6897c2a945f48324a3c68cdddf4a44ed