### PR TITLE
doc: document permission schema

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -412,6 +412,37 @@ When invoking agent-mode, frame prompts with:
 
 Agents should verify their work and reference any touched paths before exiting agent-mode.
 
+## 🔐 Permission Schema
+
+Agents declare what they can do and where via a minimal permissions file. The parser reads these rules to gate runtime behavior.
+
+### Required Fields
+
+- **default** – `allow` or `deny` when no rule matches.
+- **rules** – list of entries, each with:
+  - **action** – capability identifier (`file.read`, `network.request`).
+  - **scope** – path or pattern the action applies to (`docs/**`, `*`).
+
+### YAML Example
+```yaml
+default: deny
+rules:
+  - action: file.read
+    scope: docs/**
+```
+
+### JSON Example
+```json
+{
+  "default": "allow",
+  "rules": [
+    {"action": "*", "scope": "*"}
+  ]
+}
+```
+
+Example permission files live in `agents/*/config/permissions.yaml`. For background reasoning see [docs/notes/math/aionian-pulse-rhythm-model.md](docs/notes/math/aionian-pulse-rhythm-model.md).
+
 ---
 
 ## ✅ Next Steps

--- a/agents/duck/config/permissions.yaml
+++ b/agents/duck/config/permissions.yaml
@@ -1,0 +1,3 @@
+# Duck has unrestricted access.
+default: allow
+rules: []

--- a/agents/templates/config/permissions.yaml
+++ b/agents/templates/config/permissions.yaml
@@ -1,0 +1,5 @@
+# Template agent can only read docs.
+default: deny
+rules:
+  - action: file.read
+    scope: docs/**

--- a/bridge/protocols/permission-schema.md
+++ b/bridge/protocols/permission-schema.md
@@ -1,0 +1,30 @@
+# Permission Schema
+
+Defines how agents declare allowed actions and resource access.
+
+## Fields
+
+- **default**: `allow` or `deny` applied when no rule matches.
+- **rules**: list of permission entries, each with:
+  - **action**: action identifier (e.g., `file.read`, `network.request`).
+  - **scope**: resource pattern or path (`"docs/**"`, `"*"`).
+
+## YAML Example
+```yaml
+default: deny
+rules:
+  - action: file.read
+    scope: docs/**
+```
+
+## JSON Example
+```json
+{
+  "default": "allow",
+  "rules": [
+    {"action": "*", "scope": "*"}
+  ]
+}
+```
+
+See [docs/notes/math/aionian-pulse-rhythm-model.md](../../docs/notes/math/aionian-pulse-rhythm-model.md) for related mathematical reasoning.


### PR DESCRIPTION
## Summary
- document permission rule schema and examples in `AGENTS.md`
- add sample `permissions.yaml` for agents including read-only template and full-access duck
- mirror schema in `bridge/protocols/permission-schema.md` for future API use

## Testing
- `make lint` *(failed: KeyboardInterrupt)*
- `make format`
- `make build`
- `make test` *(failed: commands failed: test-python-services test-hy-services test-js-services test-ts-services)*

------
https://chatgpt.com/codex/tasks/task_e_6897c2648694832490357fec809bb370