### PR TITLE
feat: add permission gate

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -414,6 +414,32 @@ Agents should verify their work and reference any touched paths before exiting a
 
 ---
 
+## 🛡️ Permission Gate Configuration
+
+Permission rules live in `shared/permissions.yaml`. The file uses:
+
+```yaml
+beta: <softness>
+default:
+  threshold: <float>
+  weights:
+    <feature>: <weight>
+  actions:
+    default:
+      features:
+        <feature>: <value>
+agents:
+  <agent>:
+    weights: {...}
+    threshold: <float>
+    actions:
+      <action>:
+        features:
+          <feature>: <value>
+```
+
+`check_permission(agent, action)` combines weights and features with a sigmoid gate; results below 0.5 are denied and logged.
+
 ## ✅ Next Steps
 
 * [ ] Finalize `MIGRATION_PLAN.md`

--- a/services/ts/cephalon/src/bot.ts
+++ b/services/ts/cephalon/src/bot.ts
@@ -13,6 +13,7 @@ import { AIAgent } from './agent/index.js';
 import { AGENT_NAME, DESKTOP_CAPTURE_CHANNEL_ID } from '../../../../shared/js/env.js';
 import { ContextManager } from './contextManager';
 import { LLMService } from './llm-service';
+import { checkPermission } from '@shared/js/permissionGate.js';
 import { interaction, type Interaction } from './interactions';
 import {
 	joinVoiceChannel,
@@ -89,6 +90,10 @@ export class Bot extends EventEmitter {
 				if (!interaction.inCachedGuild() || !interaction.isChatInputCommand()) return;
 				if (!Bot.interactions.has(interaction.commandName)) {
 					await interaction.reply('Unknown command');
+					return;
+				}
+				if (!checkPermission(interaction.user.id, interaction.commandName)) {
+					await interaction.reply('Permission denied');
 					return;
 				}
 				try {

--- a/shared/js/package-lock.json
+++ b/shared/js/package-lock.json
@@ -9,7 +9,8 @@
         "dotenv": "^17.2.1",
         "execa": "^9.6.0",
         "fs-extra": "^11.3.0",
-        "ws": "^8.18.0"
+        "ws": "^8.18.0",
+        "yaml": "^2.7.0"
       },
       "devDependencies": {
         "@types/jest": "^30.0.0",
@@ -5757,6 +5758,18 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/yaml": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
+      "integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      }
     },
     "node_modules/yargs": {
       "version": "17.7.2",

--- a/shared/js/package.json
+++ b/shared/js/package.json
@@ -5,7 +5,8 @@
     "dotenv": "^17.2.1",
     "execa": "^9.6.0",
     "fs-extra": "^11.3.0",
-    "ws": "^8.18.0"
+    "ws": "^8.18.0",
+    "yaml": "^2.7.0"
   },
   "devDependencies": {
     "@types/jest": "^30.0.0",

--- a/shared/js/permissionGate.d.ts
+++ b/shared/js/permissionGate.d.ts
@@ -1,0 +1,1 @@
+export function checkPermission(agent: string, action: string): boolean;

--- a/shared/js/permissionGate.js
+++ b/shared/js/permissionGate.js
@@ -1,0 +1,51 @@
+import fs from "fs";
+import path from "path";
+import yaml from "yaml";
+
+let config;
+
+function loadConfig() {
+  if (!config) {
+    const file = fs.readFileSync(
+      path.resolve(
+        path.dirname(new URL(import.meta.url).pathname),
+        "../permissions.yaml",
+      ),
+      "utf8",
+    );
+    config = yaml.parse(file) || {};
+  }
+  return config;
+}
+
+function sigmoid(x) {
+  return 1 / (1 + Math.exp(-x));
+}
+
+export function checkPermission(agent, action) {
+  const cfg = loadConfig();
+  const beta = cfg.beta ?? 1.0;
+  const def = cfg.default || {};
+  const agentCfg = (cfg.agents || {})[agent] || {};
+  const weights = agentCfg.weights || def.weights || {};
+  const threshold = agentCfg.threshold ?? def.threshold ?? 0;
+  const actionCfg =
+    (agentCfg.actions || {})[action] || (def.actions || {}).default || {};
+  const features = actionCfg.features || {};
+  const featureNames = new Set([
+    ...Object.keys(weights),
+    ...Object.keys(features),
+  ]);
+  let score = 0;
+  for (const name of featureNames) {
+    score += (weights[name] || 0) * (features[name] || 0);
+  }
+  const probability = sigmoid((score - threshold) / beta);
+  const allowed = probability >= 0.5;
+  if (!allowed) {
+    console.warn(
+      `Permission denied agent=${agent} action=${action} prob=${probability}`,
+    );
+  }
+  return allowed;
+}

--- a/shared/permissions.yaml
+++ b/shared/permissions.yaml
@@ -1,0 +1,22 @@
+beta: 1.0
+default:
+  threshold: 0.5
+  weights:
+    access_level: 1.0
+    trust_level: 1.0
+  actions:
+    default:
+      features:
+        access_level: 0.0
+        trust_level: 0.0
+agents:
+  alice:
+    actions:
+      read:
+        features:
+          access_level: 1.0
+          trust_level: 1.0
+      delete:
+        features:
+          access_level: 0.0
+          trust_level: 0.0

--- a/shared/py/permission_gate.py
+++ b/shared/py/permission_gate.py
@@ -1,0 +1,65 @@
+import math
+import yaml
+import logging
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+_CONFIG_CACHE = None
+
+
+def _load_config(config_path: Path | None = None) -> dict:
+    global _CONFIG_CACHE
+    if _CONFIG_CACHE is None:
+        if config_path is None:
+            config_path = Path(__file__).resolve().parent.parent / "permissions.yaml"
+        with open(config_path, "r", encoding="utf-8") as f:
+            _CONFIG_CACHE = yaml.safe_load(f) or {}
+    return _CONFIG_CACHE
+
+
+def _sigmoid(x: float) -> float:
+    return 1 / (1 + math.exp(-x))
+
+
+def check_permission(
+    agent: str, action: str, *, config_path: str | None = None
+) -> bool:
+    """Check if *agent* is allowed to perform *action*.
+
+    Configuration is loaded from a YAML file. The schema expects:
+
+    - ``beta``: softness of the gate.
+    - ``default``: default weights, threshold, and action features.
+    - ``agents``: optional per-agent overrides with nested ``actions``.
+
+    Each action lists feature values. Weights and threshold are taken from the
+    agent definition or fall back to ``default``.
+    """
+    cfg = _load_config(Path(config_path) if config_path else None)
+    beta = cfg.get("beta", 1.0)
+    default = cfg.get("default", {})
+    agents = cfg.get("agents", {})
+
+    agent_cfg = agents.get(agent, {})
+    weights = agent_cfg.get("weights", default.get("weights", {}))
+    threshold = agent_cfg.get("threshold", default.get("threshold", 0))
+
+    action_cfg = agent_cfg.get("actions", {}).get(action) or default.get(
+        "actions", {}
+    ).get("default", {})
+    features = action_cfg.get("features", {})
+
+    feature_names = set(weights) | set(features)
+    score = sum(weights.get(n, 0) * features.get(n, 0) for n in feature_names)
+    probability = _sigmoid((score - threshold) / beta)
+    allowed = probability >= 0.5
+    if not allowed:
+        logger.warning(
+            "Permission denied",
+            extra={"agent": agent, "action": action, "probability": probability},
+        )
+    return allowed
+
+
+__all__ = ["check_permission"]

--- a/tests/test_permission_gate.py
+++ b/tests/test_permission_gate.py
@@ -1,0 +1,11 @@
+import importlib
+
+permission_gate = importlib.import_module("shared.py.permission_gate")
+
+
+def test_permission_granted():
+    assert permission_gate.check_permission("alice", "read")
+
+
+def test_permission_denied():
+    assert not permission_gate.check_permission("alice", "delete")


### PR DESCRIPTION
## Summary
- implement Dorian-based permission gate with YAML-configurable weights
- expose JS wrapper and integrate gate checks into Cephalon command router
- document permission schema and add unit coverage

## Testing
- `black shared/py/permission_gate.py`
- `npx prettier shared/js/permissionGate.js -w`
- `npx prettier services/ts/cephalon/src/bot.ts -w`
- `make lint-python`
- `make lint-ts-service-cephalon` *(fails: configuration schema mismatch)*
- `make build`
- `python -m pytest tests/test_permission_gate.py`
- `make test-ts-service-cephalon` *(fails: missing TypeScript modules)*


------
https://chatgpt.com/codex/tasks/task_e_6897c26d75688324acbd4d91e6b25dd6