### PR TITLE
Generate task stubs from docs/unique TODO items

### DIFF
--- a/docs/agile/tasks/add_dev_harness_int_test_ts_to_ci_integration_stag.md
+++ b/docs/agile/tasks/add_dev_harness_int_test_ts_to_ci_integration_stag.md
@@ -1,0 +1,22 @@
+## 🛠️ Task: Add `dev.harness.int.test.ts` to CI integration stage
+
+Generated from [../unique/2025.08.08.20.08.83.md](../unique/2025.08.08.20.08.83.md)
+
+---
+
+## 🎯 Goals
+- [ ] TODO
+
+---
+
+## 📦 Requirements
+- [ ] TODO
+
+---
+
+## 📋 Subtasks
+- [ ] TODO
+
+---
+
+#Todo

--- a/docs/agile/tasks/add_lag_checks_to_ci_smoke_ensure_small_lag_after_.md
+++ b/docs/agile/tasks/add_lag_checks_to_ci_smoke_ensure_small_lag_after_.md
@@ -1,0 +1,22 @@
+## 🛠️ Task: Add `/lag` checks to CI smoke (ensure small lag after publishing bursts)
+
+Generated from [../unique/2025.08.08.19.08.49.md](../unique/2025.08.08.19.08.49.md)
+
+---
+
+## 🎯 Goals
+- [ ] TODO
+
+---
+
+## 📦 Requirements
+- [ ] TODO
+
+---
+
+## 📋 Subtasks
+- [ ] TODO
+
+---
+
+#Todo

--- a/docs/agile/tasks/add_manualack_to_event_bus_and_re_run_tests.md
+++ b/docs/agile/tasks/add_manualack_to_event_bus_and_re_run_tests.md
@@ -1,0 +1,22 @@
+## 🛠️ Task: Add `manualAck` to event bus and re-run tests
+
+Generated from [../unique/2025.08.08.15.08.47.md](../unique/2025.08.08.15.08.47.md)
+
+---
+
+## 🎯 Goals
+- [ ] TODO
+
+---
+
+## 📦 Requirements
+- [ ] TODO
+
+---
+
+## 📋 Subtasks
+- [ ] TODO
+
+---
+
+#Todo

--- a/docs/agile/tasks/add_mongodedupe_and_replace_critical_consumers_wit.md
+++ b/docs/agile/tasks/add_mongodedupe_and_replace_critical_consumers_wit.md
@@ -1,0 +1,22 @@
+## 🛠️ Task: Add `MongoDedupe` and replace critical consumers with `subscribeExactlyOnce`
+
+Generated from [../unique/2025.08.08.19.08.25.md](../unique/2025.08.08.19.08.25.md)
+
+---
+
+## 🎯 Goals
+- [ ] TODO
+
+---
+
+## 📦 Requirements
+- [ ] TODO
+
+---
+
+## 📋 Subtasks
+- [ ] TODO
+
+---
+
+#Todo

--- a/docs/agile/tasks/add_mongooutbox_to_any_service_that_writes_db_chan.md
+++ b/docs/agile/tasks/add_mongooutbox_to_any_service_that_writes_db_chan.md
@@ -1,0 +1,22 @@
+## 🛠️ Task: Add `MongoOutbox` to any service that writes DB changes; swap local app emits → outbox writes
+
+Generated from [../unique/2025.08.08.19.08.49.md](../unique/2025.08.08.19.08.49.md)
+
+---
+
+## 🎯 Goals
+- [ ] TODO
+
+---
+
+## 📦 Requirements
+- [ ] TODO
+
+---
+
+## 📋 Subtasks
+- [ ] TODO
+
+---
+
+#Todo

--- a/docs/agile/tasks/add_obsidian_to_gitignore.md
+++ b/docs/agile/tasks/add_obsidian_to_gitignore.md
@@ -1,0 +1,22 @@
+## 🛠️ Task: Add `.obsidian/` to `.gitignore`
+
+Generated from [../unique/2025.07.28.18.07.20.md](../unique/2025.07.28.18.07.20.md)
+
+---
+
+## 🎯 Goals
+- [ ] TODO
+
+---
+
+## 📦 Requirements
+- [ ] TODO
+
+---
+
+## 📋 Subtasks
+- [ ] TODO
+
+---
+
+#Todo

--- a/docs/agile/tasks/add_ollama_formally_to_pipeline.md
+++ b/docs/agile/tasks/add_ollama_formally_to_pipeline.md
@@ -1,0 +1,22 @@
+## 🛠️ Task: Add Ollama formally to pipeline
+
+Generated from [../unique/2025.07.28.18.07.20.md](../unique/2025.07.28.18.07.20.md)
+
+---
+
+## 🎯 Goals
+- [ ] TODO
+
+---
+
+## 📦 Requirements
+- [ ] TODO
+
+---
+
+## 📋 Subtasks
+- [ ] TODO
+
+---
+
+#Todo

--- a/docs/agile/tasks/add_ops_endpoint_to_list_partition_assignments_opt.md
+++ b/docs/agile/tasks/add_ops_endpoint_to_list_partition_assignments_opt.md
@@ -1,0 +1,22 @@
+## 🛠️ Task: Add `/ops` endpoint to list **partition assignments** (optional: dump coordinator state)
+
+Generated from [../unique/2025.08.08.20.08.56.md](../unique/2025.08.08.20.08.56.md)
+
+---
+
+## 🎯 Goals
+- [ ] TODO
+
+---
+
+## 📦 Requirements
+- [ ] TODO
+
+---
+
+## 📋 Subtasks
+- [ ] TODO
+
+---
+
+#Todo

--- a/docs/agile/tasks/add_process_txn_projector_to_upsert_processes_host.md
+++ b/docs/agile/tasks/add_process_txn_projector_to_upsert_processes_host.md
@@ -1,0 +1,22 @@
+## 🛠️ Task: Add `process.txn` projector to upsert `processes` + `host_stats` atomically
+
+Generated from [../unique/2025.08.08.20.08.83.md](../unique/2025.08.08.20.08.83.md)
+
+---
+
+## 🎯 Goals
+- [ ] TODO
+
+---
+
+## 📦 Requirements
+- [ ] TODO
+
+---
+
+## 📋 Subtasks
+- [ ] TODO
+
+---
+
+#Todo

--- a/docs/agile/tasks/add_prometheus_events_counters_in_ws_server_hook_p.md
+++ b/docs/agile/tasks/add_prometheus_events_counters_in_ws_server_hook_p.md
@@ -1,0 +1,22 @@
+## 🛠️ Task: Add Prometheus `events_*` counters in WS server hook points
+
+Generated from [../unique/2025.08.08.15.08.47.md](../unique/2025.08.08.15.08.47.md)
+
+---
+
+## 🎯 Goals
+- [ ] TODO
+
+---
+
+## 📦 Requirements
+- [ ] TODO
+
+---
+
+## 📋 Subtasks
+- [ ] TODO
+
+---
+
+#Todo

--- a/docs/agile/tasks/add_snapshot_consumer_to_warm_cache_on_boot.md
+++ b/docs/agile/tasks/add_snapshot_consumer_to_warm_cache_on_boot.md
@@ -1,0 +1,22 @@
+## 🛠️ Task: Add snapshot consumer to warm cache on boot
+
+Generated from [../unique/2025.08.08.15.08.47.md](../unique/2025.08.08.15.08.47.md)
+
+---
+
+## 🎯 Goals
+- [ ] TODO
+
+---
+
+## 📦 Requirements
+- [ ] TODO
+
+---
+
+## 📋 Subtasks
+- [ ] TODO
+
+---
+
+#Todo

--- a/docs/agile/tasks/add_startchangelogprojector_for_any_compaction_lik.md
+++ b/docs/agile/tasks/add_startchangelogprojector_for_any_compaction_lik.md
@@ -1,0 +1,22 @@
+## 🛠️ Task: Add **startChangelogProjector** for any compaction-like topic you want live-queryable
+
+Generated from [../unique/2025.08.08.20.08.56.md](../unique/2025.08.08.20.08.56.md)
+
+---
+
+## 🎯 Goals
+- [ ] TODO
+
+---
+
+## 📦 Requirements
+- [ ] TODO
+
+---
+
+## 📋 Subtasks
+- [ ] TODO
+
+---
+
+#Todo

--- a/docs/agile/tasks/add_tokenbucket_to_ws_server_conn_per_topic.md
+++ b/docs/agile/tasks/add_tokenbucket_to_ws_server_conn_per_topic.md
@@ -1,0 +1,22 @@
+## 🛠️ Task: Add `TokenBucket` to WS server (conn + per-topic)
+
+Generated from [../unique/2025.08.08.19.08.25.md](../unique/2025.08.08.19.08.25.md)
+
+---
+
+## 🎯 Goals
+- [ ] TODO
+
+---
+
+## 📦 Requirements
+- [ ] TODO
+
+---
+
+## 📋 Subtasks
+- [ ] TODO
+
+---
+
+#Todo

--- a/docs/agile/tasks/add_ttls_per_topic_via_migration_script.md
+++ b/docs/agile/tasks/add_ttls_per_topic_via_migration_script.md
@@ -1,0 +1,22 @@
+## 🛠️ Task: Add TTLs per topic via migration script
+
+Generated from [../unique/2025.08.08.19.08.25.md](../unique/2025.08.08.19.08.25.md)
+
+---
+
+## 🎯 Goals
+- [ ] TODO
+
+---
+
+## 📦 Requirements
+- [ ] TODO
+
+---
+
+## 📋 Subtasks
+- [ ] TODO
+
+---
+
+#Todo

--- a/docs/agile/tasks/add_vault_instructions_to_main_readme_md_duplicate.md
+++ b/docs/agile/tasks/add_vault_instructions_to_main_readme_md_duplicate.md
@@ -1,0 +1,22 @@
+## 🛠️ Task: Add vault instructions to main `README.md` *(duplicate flag—may be Rejected)*
+
+Generated from [../unique/2025.07.28.18.07.20.md](../unique/2025.07.28.18.07.20.md)
+
+---
+
+## 🎯 Goals
+- [ ] TODO
+
+---
+
+## 📦 Requirements
+- [ ] TODO
+
+---
+
+## 📋 Subtasks
+- [ ] TODO
+
+---
+
+#Todo

--- a/docs/agile/tasks/add_withdlq_around_risky_consumers_set_maxattempts.md
+++ b/docs/agile/tasks/add_withdlq_around_risky_consumers_set_maxattempts.md
@@ -1,0 +1,22 @@
+## 🛠️ Task: Add **withDLQ** around risky consumers; set `maxAttempts`
+
+Generated from [../unique/2025.08.08.20.08.52.md](../unique/2025.08.08.20.08.52.md)
+
+---
+
+## 🎯 Goals
+- [ ] TODO
+
+---
+
+## 📦 Requirements
+- [ ] TODO
+
+---
+
+## 📋 Subtasks
+- [ ] TODO
+
+---
+
+#Todo

--- a/docs/agile/tasks/annotate_legacy_code_with_migration_tags.md
+++ b/docs/agile/tasks/annotate_legacy_code_with_migration_tags.md
@@ -1,0 +1,22 @@
+## 🛠️ Task: Annotate legacy code with migration tags
+
+Generated from [../unique/2025.07.28.18.07.20.md](../unique/2025.07.28.18.07.20.md)
+
+---
+
+## 🎯 Goals
+- [ ] TODO
+
+---
+
+## 📦 Requirements
+- [ ] TODO
+
+---
+
+## 📋 Subtasks
+- [ ] TODO
+
+---
+
+#Todo

--- a/docs/agile/tasks/build_data_structures_for_eidolon_field_codex_task.md
+++ b/docs/agile/tasks/build_data_structures_for_eidolon_field_codex_task.md
@@ -1,0 +1,22 @@
+## 🛠️ Task: Build data structures for Eidolon field #codex-task
+
+Generated from [../unique/2025.07.28.18.07.20.md](../unique/2025.07.28.18.07.20.md)
+
+---
+
+## 🎯 Goals
+- [ ] TODO
+
+---
+
+## 📦 Requirements
+- [ ] TODO
+
+---
+
+## 📋 Subtasks
+- [ ] TODO
+
+---
+
+#Todo

--- a/docs/agile/tasks/build_tiny_web_page_that_uses_promclient_in_the_br.md
+++ b/docs/agile/tasks/build_tiny_web_page_that_uses_promclient_in_the_br.md
@@ -1,0 +1,22 @@
+## 🛠️ Task: Build tiny web page that uses `PromClient` in the browser to show live `process.state` (optional)
+
+Generated from [../unique/2025.08.08.19.08.49.md](../unique/2025.08.08.19.08.49.md)
+
+---
+
+## 🎯 Goals
+- [ ] TODO
+
+---
+
+## 📦 Requirements
+- [ ] TODO
+
+---
+
+## 📋 Subtasks
+- [ ] TODO
+
+---
+
+#Todo

--- a/docs/agile/tasks/create_base_readme_md_templates_for_each_service.md
+++ b/docs/agile/tasks/create_base_readme_md_templates_for_each_service.md
@@ -1,0 +1,22 @@
+## 🛠️ Task: \[\[Create base `README.md` templates for each service]]
+
+Generated from [../unique/2025.07.28.18.07.20.md](../unique/2025.07.28.18.07.20.md)
+
+---
+
+## 🎯 Goals
+- [ ] TODO
+
+---
+
+## 📦 Requirements
+- [ ] TODO
+
+---
+
+## 📋 Subtasks
+- [ ] TODO
+
+---
+
+#Todo

--- a/docs/agile/tasks/create_permission_gating_layer_codex_task.md
+++ b/docs/agile/tasks/create_permission_gating_layer_codex_task.md
@@ -1,0 +1,22 @@
+## 🛠️ Task: Create permission gating layer #codex-task
+
+Generated from [../unique/2025.07.28.18.07.20.md](../unique/2025.07.28.18.07.20.md)
+
+---
+
+## 🎯 Goals
+- [ ] TODO
+
+---
+
+## 📦 Requirements
+- [ ] TODO
+
+---
+
+## 📋 Subtasks
+- [ ] TODO
+
+---
+
+#Todo

--- a/docs/agile/tasks/create_permission_gating_layer_framework_core.md
+++ b/docs/agile/tasks/create_permission_gating_layer_framework_core.md
@@ -1,0 +1,22 @@
+## 🛠️ Task: Create permission gating layer #framework-core
+
+Generated from [../unique/2025.07.28.18.07.20.md](../unique/2025.07.28.18.07.20.md)
+
+---
+
+## 🎯 Goals
+- [ ] TODO
+
+---
+
+## 📦 Requirements
+- [ ] TODO
+
+---
+
+## 📋 Subtasks
+- [ ] TODO
+
+---
+
+#Todo

--- a/docs/agile/tasks/define_default_scopes_publish_heartbeat_received_s.md
+++ b/docs/agile/tasks/define_default_scopes_publish_heartbeat_received_s.md
@@ -1,0 +1,22 @@
+## 🛠️ Task: Define default scopes: `publish:heartbeat.received`, `subscribe:process.state`
+
+Generated from [../unique/2025.08.08.19.08.49.md](../unique/2025.08.08.19.08.49.md)
+
+---
+
+## 🎯 Goals
+- [ ] TODO
+
+---
+
+## 📦 Requirements
+- [ ] TODO
+
+---
+
+## 📋 Subtasks
+- [ ] TODO
+
+---
+
+#Todo

--- a/docs/agile/tasks/deploy_changefeed_for_collections_you_want_mirrore.md
+++ b/docs/agile/tasks/deploy_changefeed_for_collections_you_want_mirrore.md
@@ -1,0 +1,22 @@
+## 🛠️ Task: Deploy **changefeed** for collections you want mirrored to topics
+
+Generated from [../unique/2025.08.08.20.08.52.md](../unique/2025.08.08.20.08.52.md)
+
+---
+
+## 🎯 Goals
+- [ ] TODO
+
+---
+
+## 📦 Requirements
+- [ ] TODO
+
+---
+
+## 📋 Subtasks
+- [ ] TODO
+
+---
+
+#Todo

--- a/docs/agile/tasks/detect_contradictions_in_memory_codex_task.md
+++ b/docs/agile/tasks/detect_contradictions_in_memory_codex_task.md
@@ -1,0 +1,22 @@
+## 🛠️ Task: Detect contradictions in memory #codex-task
+
+Generated from [../unique/2025.07.28.18.07.20.md](../unique/2025.07.28.18.07.20.md)
+
+---
+
+## 🎯 Goals
+- [ ] TODO
+
+---
+
+## 📦 Requirements
+- [ ] TODO
+
+---
+
+## 📋 Subtasks
+- [ ] TODO
+
+---
+
+#Todo

--- a/docs/agile/tasks/document_etag_semantics_and_cache_headers_for_snap.md
+++ b/docs/agile/tasks/document_etag_semantics_and_cache_headers_for_snap.md
@@ -1,0 +1,22 @@
+## 🛠️ Task: Document ETag semantics and cache headers for `/snap/:key`
+
+Generated from [../unique/2025.08.08.20.08.83.md](../unique/2025.08.08.20.08.83.md)
+
+---
+
+## 🎯 Goals
+- [ ] TODO
+
+---
+
+## 📦 Requirements
+- [ ] TODO
+
+---
+
+## 📋 Subtasks
+- [ ] TODO
+
+---
+
+#Todo

--- a/docs/agile/tasks/enable_compactor_for_process_state_process_state_s.md
+++ b/docs/agile/tasks/enable_compactor_for_process_state_process_state_s.md
@@ -1,0 +1,22 @@
+## 🛠️ Task: Enable compactor for `process.state` → `process.state.snapshot`
+
+Generated from [../unique/2025.08.08.15.08.47.md](../unique/2025.08.08.15.08.47.md)
+
+---
+
+## 🎯 Goals
+- [ ] TODO
+
+---
+
+## 📦 Requirements
+- [ ] TODO
+
+---
+
+## 📋 Subtasks
+- [ ] TODO
+
+---
+
+#Todo

--- a/docs/agile/tasks/enable_scripts_lint_topics_ts_in_ci.md
+++ b/docs/agile/tasks/enable_scripts_lint_topics_ts_in_ci.md
@@ -1,0 +1,22 @@
+## 🛠️ Task: Enable **scripts/lint-topics.ts** in CI
+
+Generated from [../unique/2025.08.08.20.08.52.md](../unique/2025.08.08.20.08.52.md)
+
+---
+
+## 🎯 Goals
+- [ ] TODO
+
+---
+
+## 📦 Requirements
+- [ ] TODO
+
+---
+
+## 📋 Subtasks
+- [ ] TODO
+
+---
+
+#Todo

--- a/docs/agile/tasks/ensure_github_compatible_markdown_settings_are_doc.md
+++ b/docs/agile/tasks/ensure_github_compatible_markdown_settings_are_doc.md
@@ -1,0 +1,22 @@
+## 🛠️ Task: Ensure GitHub-compatible markdown settings are documented *(no link yet)*
+
+Generated from [../unique/2025.07.28.18.07.20.md](../unique/2025.07.28.18.07.20.md)
+
+---
+
+## 🎯 Goals
+- [ ] TODO
+
+---
+
+## 📦 Requirements
+- [ ] TODO
+
+---
+
+## 📋 Subtasks
+- [ ] TODO
+
+---
+
+#Todo

--- a/docs/agile/tasks/ensure_mongo_indexes_key_1_unique_common_query_fie.md
+++ b/docs/agile/tasks/ensure_mongo_indexes_key_1_unique_common_query_fie.md
@@ -1,0 +1,22 @@
+## 🛠️ Task: Ensure Mongo indexes: `{ _key: 1 } unique` + common query fields
+
+Generated from [../unique/2025.08.08.20.08.56.md](../unique/2025.08.08.20.08.56.md)
+
+---
+
+## 🎯 Goals
+- [ ] TODO
+
+---
+
+## 📦 Requirements
+- [ ] TODO
+
+---
+
+## 📋 Subtasks
+- [ ] TODO
+
+---
+
+#Todo

--- a/docs/agile/tasks/evaluate_and_reward_flow_satisfaction_framework_co.md
+++ b/docs/agile/tasks/evaluate_and_reward_flow_satisfaction_framework_co.md
@@ -1,0 +1,22 @@
+## 🛠️ Task: Evaluate and reward flow satisfaction #framework-core
+
+Generated from [../unique/2025.07.28.18.07.20.md](../unique/2025.07.28.18.07.20.md)
+
+---
+
+## 🎯 Goals
+- [ ] TODO
+
+---
+
+## 📦 Requirements
+- [ ] TODO
+
+---
+
+## 📋 Subtasks
+- [ ] TODO
+
+---
+
+#Todo

--- a/docs/agile/tasks/expose_metrics_on_an_express_app_and_scrape_with_p.md
+++ b/docs/agile/tasks/expose_metrics_on_an_express_app_and_scrape_with_p.md
@@ -1,0 +1,22 @@
+## 🛠️ Task: Expose `/metrics` on an express app and scrape with Prom
+
+Generated from [../unique/2025.08.08.15.08.47.md](../unique/2025.08.08.15.08.47.md)
+
+---
+
+## 🎯 Goals
+- [ ] TODO
+
+---
+
+## 📦 Requirements
+- [ ] TODO
+
+---
+
+## 📋 Subtasks
+- [ ] TODO
+
+---
+
+#Todo

--- a/docs/agile/tasks/expose_snapshot_api_for_processes_collection_proce.md
+++ b/docs/agile/tasks/expose_snapshot_api_for_processes_collection_proce.md
@@ -1,0 +1,22 @@
+## 🛠️ Task: Expose **Snapshot API** for `processes` (collection `processes`)
+
+Generated from [../unique/2025.08.08.20.08.83.md](../unique/2025.08.08.20.08.83.md)
+
+---
+
+## 🎯 Goals
+- [ ] TODO
+
+---
+
+## 📦 Requirements
+- [ ] TODO
+
+---
+
+## 📋 Subtasks
+- [ ] TODO
+
+---
+
+#Todo

--- a/docs/agile/tasks/finalize_migration_plan_md.md
+++ b/docs/agile/tasks/finalize_migration_plan_md.md
@@ -1,0 +1,22 @@
+## 🛠️ Task: \[\[Finalize `MIGRATION_PLAN.md`]]
+
+Generated from [../unique/2025.07.28.18.07.20.md](../unique/2025.07.28.18.07.20.md)
+
+---
+
+## 🎯 Goals
+- [ ] TODO
+
+---
+
+## 📦 Requirements
+- [ ] TODO
+
+---
+
+## 📋 Subtasks
+- [ ] TODO
+
+---
+
+#Todo

--- a/docs/agile/tasks/identify_ancestral_resonance_patterns_framework_co.md
+++ b/docs/agile/tasks/identify_ancestral_resonance_patterns_framework_co.md
@@ -1,0 +1,22 @@
+## 🛠️ Task: Identify ancestral resonance patterns #framework-core
+
+Generated from [../unique/2025.07.28.18.07.20.md](../unique/2025.07.28.18.07.20.md)
+
+---
+
+## 🎯 Goals
+- [ ] TODO
+
+---
+
+## 📦 Requirements
+- [ ] TODO
+
+---
+
+## 📋 Subtasks
+- [ ] TODO
+
+---
+
+#Todo

--- a/docs/agile/tasks/implement_fragment_ingestion_with_activation_vecto.md
+++ b/docs/agile/tasks/implement_fragment_ingestion_with_activation_vecto.md
@@ -1,0 +1,22 @@
+## 🛠️ Task: Implement fragment ingestion with activation vectors #codex-task
+
+Generated from [../unique/2025.07.28.18.07.20.md](../unique/2025.07.28.18.07.20.md)
+
+---
+
+## 🎯 Goals
+- [ ] TODO
+
+---
+
+## 📦 Requirements
+- [ ] TODO
+
+---
+
+## 📋 Subtasks
+- [ ] TODO
+
+---
+
+#Todo

--- a/docs/agile/tasks/implement_pause_resume_ops_on_gateway.md
+++ b/docs/agile/tasks/implement_pause_resume_ops_on_gateway.md
@@ -1,0 +1,22 @@
+## 🛠️ Task: Implement `PAUSE/RESUME` ops on gateway
+
+Generated from [../unique/2025.08.08.19.08.25.md](../unique/2025.08.08.19.08.25.md)
+
+---
+
+## 🎯 Goals
+- [ ] TODO
+
+---
+
+## 📦 Requirements
+- [ ] TODO
+
+---
+
+## 📋 Subtasks
+- [ ] TODO
+
+---
+
+#Todo

--- a/docs/agile/tasks/implement_timetravel_processat_processid_t_in_a_sm.md
+++ b/docs/agile/tasks/implement_timetravel_processat_processid_t_in_a_sm.md
@@ -1,0 +1,22 @@
+## 🛠️ Task: Implement `timetravel.processAt(processId, T)` in a small CLI for debugging
+
+Generated from [../unique/2025.08.08.20.08.83.md](../unique/2025.08.08.20.08.83.md)
+
+---
+
+## 🎯 Goals
+- [ ] TODO
+
+---
+
+## 📦 Requirements
+- [ ] TODO
+
+---
+
+## 📋 Subtasks
+- [ ] TODO
+
+---
+
+#Todo

--- a/docs/agile/tasks/implement_transcendence_cascade_framework_core.md
+++ b/docs/agile/tasks/implement_transcendence_cascade_framework_core.md
@@ -1,0 +1,22 @@
+## 🛠️ Task: Implement transcendence cascade #framework-core
+
+Generated from [../unique/2025.07.28.18.07.20.md](../unique/2025.07.28.18.07.20.md)
+
+---
+
+## 🎯 Goals
+- [ ] TODO
+
+---
+
+## 📦 Requirements
+- [ ] TODO
+
+---
+
+## 📋 Subtasks
+- [ ] TODO
+
+---
+
+#Todo

--- a/docs/agile/tasks/launch_replayapi_on_8083_test_replay_and_export_nd.md
+++ b/docs/agile/tasks/launch_replayapi_on_8083_test_replay_and_export_nd.md
@@ -1,0 +1,22 @@
+## 🛠️ Task: Launch `ReplayAPI` on `:8083`; test `/replay` and `/export?ndjson=1`
+
+Generated from [../unique/2025.08.08.19.08.25.md](../unique/2025.08.08.19.08.25.md)
+
+---
+
+## 🎯 Goals
+- [ ] TODO
+
+---
+
+## 📦 Requirements
+- [ ] TODO
+
+---
+
+## 📋 Subtasks
+- [ ] TODO
+
+---
+
+#Todo

--- a/docs/agile/tasks/migrate_portfolio_client_code_to_promethean.md
+++ b/docs/agile/tasks/migrate_portfolio_client_code_to_promethean.md
@@ -1,0 +1,22 @@
+## 🛠️ Task: Migrate portfolio client code to Promethean
+
+Generated from [../unique/2025.07.28.18.07.20.md](../unique/2025.07.28.18.07.20.md)
+
+---
+
+## 🎯 Goals
+- [ ] TODO
+
+---
+
+## 📦 Requirements
+- [ ] TODO
+
+---
+
+## 📋 Subtasks
+- [ ] TODO
+
+---
+
+#Todo

--- a/docs/agile/tasks/migrate_server_side_sibilant_libs_to_promethean_ar.md
+++ b/docs/agile/tasks/migrate_server_side_sibilant_libs_to_promethean_ar.md
@@ -1,0 +1,22 @@
+## 🛠️ Task: Migrate server side sibilant libs to Promethean architecture.
+
+Generated from [../unique/2025.07.28.18.07.20.md](../unique/2025.07.28.18.07.20.md)
+
+---
+
+## 🎯 Goals
+- [ ] TODO
+
+---
+
+## 📦 Requirements
+- [ ] TODO
+
+---
+
+## 📋 Subtasks
+- [ ] TODO
+
+---
+
+#Todo

--- a/docs/agile/tasks/migrating_relevant_modules_from_riatzukiza_github_.md
+++ b/docs/agile/tasks/migrating_relevant_modules_from_riatzukiza_github_.md
@@ -1,0 +1,22 @@
+## 🛠️ Task: Migrating relevant modules from `riatzukiza.github.io` to `/site/` and `/docs/`
+
+Generated from [../unique/2025.07.28.18.07.20.md](../unique/2025.07.28.18.07.20.md)
+
+---
+
+## 🎯 Goals
+- [ ] TODO
+
+---
+
+## 📦 Requirements
+- [ ] TODO
+
+---
+
+## 📋 Subtasks
+- [ ] TODO
+
+---
+
+#Todo

--- a/docs/agile/tasks/obsidian_kanban_github_project_board_mirror_system.md
+++ b/docs/agile/tasks/obsidian_kanban_github_project_board_mirror_system.md
@@ -1,0 +1,22 @@
+## 🛠️ Task: Obsidian Kanban <-> GitHub Project Board Mirror system
+
+Generated from [../unique/2025.07.28.18.07.20.md](../unique/2025.07.28.18.07.20.md)
+
+---
+
+## 🎯 Goals
+- [ ] TODO
+
+---
+
+## 📦 Requirements
+- [ ] TODO
+
+---
+
+## 📋 Subtasks
+- [ ] TODO
+
+---
+
+#Todo

--- a/docs/agile/tasks/pin_versions_in_configs_promethean_codex.md
+++ b/docs/agile/tasks/pin_versions_in_configs_promethean_codex.md
@@ -1,0 +1,22 @@
+## 🛠️ Task: Pin versions in configs (Promethean + Codex)
+
+Generated from [../unique/2025.08.08.16.08.27.md](../unique/2025.08.08.16.08.27.md)
+
+---
+
+## 🎯 Goals
+- [ ] TODO
+
+---
+
+## 📦 Requirements
+- [ ] TODO
+
+---
+
+## 📋 Subtasks
+- [ ] TODO
+
+---
+
+#Todo

--- a/docs/agile/tasks/register_v_1_schema_for_any_evolving_topic_and_wri.md
+++ b/docs/agile/tasks/register_v_1_schema_for_any_evolving_topic_and_wri.md
@@ -1,0 +1,22 @@
+## 🛠️ Task: Register **v+1** schema for any evolving topic and write minimal **upcaster**
+
+Generated from [../unique/2025.08.08.20.08.52.md](../unique/2025.08.08.20.08.52.md)
+
+---
+
+## 🎯 Goals
+- [ ] TODO
+
+---
+
+## 📦 Requirements
+- [ ] TODO
+
+---
+
+## 📋 Subtasks
+- [ ] TODO
+
+---
+
+#Todo

--- a/docs/agile/tasks/run_bakeoff_see_below.md
+++ b/docs/agile/tasks/run_bakeoff_see_below.md
@@ -1,0 +1,22 @@
+## 🛠️ Task: Run bakeoff (see below)
+
+Generated from [../unique/2025.08.08.16.08.27.md](../unique/2025.08.08.16.08.27.md)
+
+---
+
+## 🎯 Goals
+- [ ] TODO
+
+---
+
+## 📦 Requirements
+- [ ] TODO
+
+---
+
+## 📋 Subtasks
+- [ ] TODO
+
+---
+
+#Todo

--- a/docs/agile/tasks/run_bench_subscribe_ts_with_mongo_bus_and_record_p.md
+++ b/docs/agile/tasks/run_bench_subscribe_ts_with_mongo_bus_and_record_p.md
@@ -1,0 +1,22 @@
+## 🛠️ Task: Run `bench/subscribe.ts` with Mongo bus and record p50/p99
+
+Generated from [../unique/2025.08.08.19.08.25.md](../unique/2025.08.08.19.08.25.md)
+
+---
+
+## 🎯 Goals
+- [ ] TODO
+
+---
+
+## 📦 Requirements
+- [ ] TODO
+
+---
+
+## 📋 Subtasks
+- [ ] TODO
+
+---
+
+#Todo

--- a/docs/agile/tasks/set_up_makefile_for_python_js_build_test_dev.md
+++ b/docs/agile/tasks/set_up_makefile_for_python_js_build_test_dev.md
@@ -1,0 +1,22 @@
+## 🛠️ Task: \[\[Set up `Makefile` for Python + JS build test dev]]
+
+Generated from [../unique/2025.07.28.18.07.20.md](../unique/2025.07.28.18.07.20.md)
+
+---
+
+## 🎯 Goals
+- [ ] TODO
+
+---
+
+## 📦 Requirements
+- [ ] TODO
+
+---
+
+## 📋 Subtasks
+- [ ] TODO
+
+---
+
+#Todo

--- a/docs/agile/tasks/smart_task_templater.md
+++ b/docs/agile/tasks/smart_task_templater.md
@@ -1,0 +1,22 @@
+## 🛠️ Task: Smart Task templater
+
+Generated from [../unique/2025.07.28.18.07.20.md](../unique/2025.07.28.18.07.20.md)
+
+---
+
+## 🎯 Goals
+- [ ] TODO
+
+---
+
+## 📦 Requirements
+- [ ] TODO
+
+---
+
+## 📋 Subtasks
+- [ ] TODO
+
+---
+
+#Todo

--- a/docs/agile/tasks/snapshot_prompts_specs_to_repo.md
+++ b/docs/agile/tasks/snapshot_prompts_specs_to_repo.md
@@ -1,0 +1,22 @@
+## 🛠️ Task: Snapshot prompts/specs to repo
+
+Generated from [../unique/2025.08.08.16.08.27.md](../unique/2025.08.08.16.08.27.md)
+
+---
+
+## 🎯 Goals
+- [ ] TODO
+
+---
+
+## 📦 Requirements
+- [ ] TODO
+
+---
+
+## 📋 Subtasks
+- [ ] TODO
+
+---
+
+#Todo

--- a/docs/agile/tasks/spin_up_ws_gateway_ws_port_8090_ws_token_devtoken_.md
+++ b/docs/agile/tasks/spin_up_ws_gateway_ws_port_8090_ws_token_devtoken_.md
@@ -1,0 +1,22 @@
+## 🛠️ Task: Spin up WS gateway (`WS_PORT=8090 WS_TOKEN=devtoken node index.js`)
+
+Generated from [../unique/2025.08.08.15.08.47.md](../unique/2025.08.08.15.08.47.md)
+
+---
+
+## 🎯 Goals
+- [ ] TODO
+
+---
+
+## 📦 Requirements
+- [ ] TODO
+
+---
+
+## 📋 Subtasks
+- [ ] TODO
+
+---
+
+#Todo

--- a/docs/agile/tasks/start_eidolon.md
+++ b/docs/agile/tasks/start_eidolon.md
@@ -1,0 +1,22 @@
+## 🛠️ Task: Start Eidolon
+
+Generated from [../unique/2025.07.28.18.07.20.md](../unique/2025.07.28.18.07.20.md)
+
+---
+
+## 🎯 Goals
+- [ ] TODO
+
+---
+
+## 📦 Requirements
+- [ ] TODO
+
+---
+
+## 📋 Subtasks
+- [ ] TODO
+
+---
+
+#Todo

--- a/docs/agile/tasks/structure_vault_to_mirror_services_agents_docs.md
+++ b/docs/agile/tasks/structure_vault_to_mirror_services_agents_docs.md
@@ -1,0 +1,22 @@
+## 🛠️ Task: Structure vault to mirror `services`, `agents`, `docs`
+
+Generated from [../unique/2025.07.28.18.07.20.md](../unique/2025.07.28.18.07.20.md)
+
+---
+
+## 🎯 Goals
+- [ ] TODO
+
+---
+
+## 📦 Requirements
+- [ ] TODO
+
+---
+
+## 📋 Subtasks
+- [ ] TODO
+
+---
+
+#Todo

--- a/docs/agile/tasks/suggest_metaprogramming_updates_codex_task.md
+++ b/docs/agile/tasks/suggest_metaprogramming_updates_codex_task.md
@@ -1,0 +1,22 @@
+## 🛠️ Task: Suggest metaprogramming updates #codex-task
+
+Generated from [../unique/2025.07.28.18.07.20.md](../unique/2025.07.28.18.07.20.md)
+
+---
+
+## 🎯 Goals
+- [ ] TODO
+
+---
+
+## 📦 Requirements
+- [ ] TODO
+
+---
+
+## 📋 Subtasks
+- [ ] TODO
+
+---
+
+#Todo

--- a/docs/agile/tasks/switch_critical_readers_to_subscribenormalized.md
+++ b/docs/agile/tasks/switch_critical_readers_to_subscribenormalized.md
@@ -1,0 +1,22 @@
+## 🛠️ Task: Switch critical readers to **subscribeNormalized**
+
+Generated from [../unique/2025.08.08.20.08.52.md](../unique/2025.08.08.20.08.52.md)
+
+---
+
+## 🎯 Goals
+- [ ] TODO
+
+---
+
+## 📦 Requirements
+- [ ] TODO
+
+---
+
+## 📋 Subtasks
+- [ ] TODO
+
+---
+
+#Todo

--- a/docs/agile/tasks/switch_gateway_auth_to_jwt_generate_temp_hs256_tok.md
+++ b/docs/agile/tasks/switch_gateway_auth_to_jwt_generate_temp_hs256_tok.md
@@ -1,0 +1,22 @@
+## 🛠️ Task: Switch gateway auth to JWT; generate temp HS256 token for dev
+
+Generated from [../unique/2025.08.08.19.08.49.md](../unique/2025.08.08.19.08.49.md)
+
+---
+
+## 🎯 Goals
+- [ ] TODO
+
+---
+
+## 📦 Requirements
+- [ ] TODO
+
+---
+
+## 📋 Subtasks
+- [ ] TODO
+
+---
+
+#Todo

--- a/docs/agile/tasks/use_subscribepartitioned_for_cpu_heavy_consumers_t.md
+++ b/docs/agile/tasks/use_subscribepartitioned_for_cpu_heavy_consumers_t.md
@@ -1,0 +1,22 @@
+## 🛠️ Task: Use **subscribePartitioned** for CPU-heavy consumers; tune `partitions` (power of 2 is fine)
+
+Generated from [../unique/2025.08.08.20.08.56.md](../unique/2025.08.08.20.08.56.md)
+
+---
+
+## 🎯 Goals
+- [ ] TODO
+
+---
+
+## 📦 Requirements
+- [ ] TODO
+
+---
+
+## 📋 Subtasks
+- [ ] TODO
+
+---
+
+#Todo

--- a/docs/agile/tasks/wire_mongoeventstore_mongocursorstore_in_place_of_.md
+++ b/docs/agile/tasks/wire_mongoeventstore_mongocursorstore_in_place_of_.md
@@ -1,0 +1,22 @@
+## 🛠️ Task: Wire MongoEventStore + MongoCursorStore in place of InMemory
+
+Generated from [../unique/2025.08.08.15.08.47.md](../unique/2025.08.08.15.08.47.md)
+
+---
+
+## 🎯 Goals
+- [ ] TODO
+
+---
+
+## 📦 Requirements
+- [ ] TODO
+
+---
+
+## 📋 Subtasks
+- [ ] TODO
+
+---
+
+#Todo

--- a/docs/agile/tasks/wire_runoutboxdrainer_in_event_hub.md
+++ b/docs/agile/tasks/wire_runoutboxdrainer_in_event_hub.md
@@ -1,0 +1,22 @@
+## 🛠️ Task: Wire `runOutboxDrainer` in event-hub
+
+Generated from [../unique/2025.08.08.19.08.49.md](../unique/2025.08.08.19.08.49.md)
+
+---
+
+## 🎯 Goals
+- [ ] TODO
+
+---
+
+## 📦 Requirements
+- [ ] TODO
+
+---
+
+## 📋 Subtasks
+- [ ] TODO
+
+---
+
+#Todo

--- a/docs/agile/tasks/wrap_event_hub_publish_path_with_withschemavalidat.md
+++ b/docs/agile/tasks/wrap_event_hub_publish_path_with_withschemavalidat.md
@@ -1,0 +1,22 @@
+## 🛠️ Task: Wrap `event-hub` publish path with **withSchemaValidation**; fail fast on bad payloads
+
+Generated from [../unique/2025.08.08.20.08.56.md](../unique/2025.08.08.20.08.56.md)
+
+---
+
+## 🎯 Goals
+- [ ] TODO
+
+---
+
+## 📦 Requirements
+- [ ] TODO
+
+---
+
+## 📋 Subtasks
+- [ ] TODO
+
+---
+
+#Todo

--- a/docs/agile/tasks/wrap_writers_with_withdualwrite.md
+++ b/docs/agile/tasks/wrap_writers_with_withdualwrite.md
@@ -1,0 +1,22 @@
+## 🛠️ Task: Wrap writers with **withDualWrite**
+
+Generated from [../unique/2025.08.08.20.08.52.md](../unique/2025.08.08.20.08.52.md)
+
+---
+
+## 🎯 Goals
+- [ ] TODO
+
+---
+
+## 📦 Requirements
+- [ ] TODO
+
+---
+
+## 📋 Subtasks
+- [ ] TODO
+
+---
+
+#Todo

--- a/docs/agile/tasks/write_a_replay_job_that_replays_process_state_snap.md
+++ b/docs/agile/tasks/write_a_replay_job_that_replays_process_state_snap.md
@@ -1,0 +1,22 @@
+## 🛠️ Task: Write a replay job that replays `process.state.snapshot` to warm the `processes` collection
+
+Generated from [../unique/2025.08.08.20.08.56.md](../unique/2025.08.08.20.08.56.md)
+
+---
+
+## 🎯 Goals
+- [ ] TODO
+
+---
+
+## 📦 Requirements
+- [ ] TODO
+
+---
+
+## 📋 Subtasks
+- [ ] TODO
+
+---
+
+#Todo

--- a/docs/agile/tasks/write_a_small_cutover_script_to_replay_historical_.md
+++ b/docs/agile/tasks/write_a_small_cutover_script_to_replay_historical_.md
@@ -1,0 +1,22 @@
+## 🛠️ Task: Write a small **cutover** script to replay historical events through upcasters into snapshots
+
+Generated from [../unique/2025.08.08.20.08.52.md](../unique/2025.08.08.20.08.52.md)
+
+---
+
+## 🎯 Goals
+- [ ] TODO
+
+---
+
+## 📦 Requirements
+- [ ] TODO
+
+---
+
+## 📋 Subtasks
+- [ ] TODO
+
+---
+
+#Todo

--- a/docs/agile/tasks/write_a_smoke_test_client_subscribes_publish_10_ms.md
+++ b/docs/agile/tasks/write_a_smoke_test_client_subscribes_publish_10_ms.md
@@ -1,0 +1,22 @@
+## 🛠️ Task: Write a smoke test: client subscribes, publish 10 msgs, assert all ACKed
+
+Generated from [../unique/2025.08.08.15.08.47.md](../unique/2025.08.08.15.08.47.md)
+
+---
+
+## 🎯 Goals
+- [ ] TODO
+
+---
+
+## 📦 Requirements
+- [ ] TODO
+
+---
+
+## 📋 Subtasks
+- [ ] TODO
+
+---
+
+#Todo

--- a/docs/agile/tasks/write_simple_ecosystem_declaration_library_for_new.md
+++ b/docs/agile/tasks/write_simple_ecosystem_declaration_library_for_new.md
@@ -1,0 +1,22 @@
+## 🛠️ Task: write simple ecosystem declaration library for new agents
+
+Generated from [../unique/2025.07.28.18.07.20.md](../unique/2025.07.28.18.07.20.md)
+
+---
+
+## 🎯 Goals
+- [ ] TODO
+
+---
+
+## 📦 Requirements
+- [ ] TODO
+
+---
+
+## 📋 Subtasks
+- [ ] TODO
+
+---
+
+#Todo

--- a/docs/agile/tasks/write_vault_config_readme_md_for_obsidian_vault_on.md
+++ b/docs/agile/tasks/write_vault_config_readme_md_for_obsidian_vault_on.md
@@ -1,0 +1,22 @@
+## 🛠️ Task: Write `vault-config/README.md` for Obsidian vault onboarding
+
+Generated from [../unique/2025.07.28.18.07.20.md](../unique/2025.07.28.18.07.20.md)
+
+---
+
+## 🎯 Goals
+- [ ] TODO
+
+---
+
+## 📦 Requirements
+- [ ] TODO
+
+---
+
+## 📋 Subtasks
+- [ ] TODO
+
+---
+
+#Todo

--- a/scripts/tasks_from_unique.py
+++ b/scripts/tasks_from_unique.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""Generate task stubs from TODO items in docs/unique."""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Iterable, Tuple
+
+UNIQUE_DIR = Path("docs/unique")
+TASKS_DIR = Path("docs/agile/tasks")
+
+PATTERN = re.compile(r"^[*-]\s\[ \]\s*(.+)")
+
+
+def slugify(text: str) -> str:
+    """Create a filesystem-friendly slug from text."""
+    text = text.lower()
+    text = re.sub(r"[^a-z0-9]+", "_", text).strip("_")
+    return text[:50] or "task"
+
+
+def extract_tasks() -> Iterable[Tuple[str, Path]]:
+    """Yield (task_title, source_path) for each TODO line."""
+    for path in UNIQUE_DIR.rglob("*.md"):
+        for line in path.read_text(encoding="utf-8").splitlines():
+            m = PATTERN.match(line)
+            if m:
+                yield m.group(1).strip(), path
+
+
+def task_stub(title: str, source: Path) -> str:
+    rel = Path("../unique") / source.name
+    return (
+        f"## 🛠️ Task: {title}\n\n"
+        f"Generated from [{rel}]({rel})\n\n"
+        "---\n\n"
+        "## 🎯 Goals\n"
+        "- [ ] TODO\n\n"
+        "---\n\n"
+        "## 📦 Requirements\n"
+        "- [ ] TODO\n\n"
+        "---\n\n"
+        "## 📋 Subtasks\n"
+        "- [ ] TODO\n\n"
+        "---\n\n"
+        "#Todo\n"
+    )
+
+
+def main() -> None:
+    TASKS_DIR.mkdir(parents=True, exist_ok=True)
+    for title, source in extract_tasks():
+        slug = slugify(title)
+        path = TASKS_DIR / f"{slug}.md"
+        if path.exists():
+            continue
+        path.write_text(task_stub(title, source), encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a script to scan docs/unique for unchecked TODOs and create task stubs in docs/agile/tasks
- populate docs/agile/tasks with stubs linking back to their originating notes

## Testing
- `make format-python`
- `make lint-python`
- `make test-python` *(fails: Makefile:131: test-python Error 1)*
- `make build-python`


------
https://chatgpt.com/codex/tasks/task_e_6897c322334083248044f8f419af8f49