### PR TITLE
feat: add bus event modules

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,11 +9,13 @@
         "dotenv": "^17.2.1",
         "mongodb": "^6.18.0",
         "pm2": "^6.0.8",
-        "ws": "^8.18.3"
+        "ws": "^8.18.3",
+        "zod": "^3.23.8"
       },
       "devDependencies": {
         "@types/jest": "^30.0.0",
         "@types/mongodb": "^4.0.6",
+        "@types/ws": "^8.5.10",
         "@typescript-eslint/eslint-plugin": "^8.39.0",
         "@typescript-eslint/parser": "^8.39.0",
         "ava": "^6.4.1",
@@ -2388,6 +2390,16 @@
       "license": "MIT",
       "dependencies": {
         "@types/webidl-conversions": "*"
+      }
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/yargs": {
@@ -10065,7 +10077,6 @@
       "version": "3.25.76",
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -9,11 +9,13 @@
     "dotenv": "^17.2.1",
     "mongodb": "^6.18.0",
     "pm2": "^6.0.8",
-    "ws": "^8.18.3"
+    "ws": "^8.18.3",
+    "zod": "^3.23.8"
   },
   "devDependencies": {
     "@types/jest": "^30.0.0",
     "@types/mongodb": "^4.0.6",
+    "@types/ws": "^8.5.10",
     "@typescript-eslint/eslint-plugin": "^8.39.0",
     "@typescript-eslint/parser": "^8.39.0",
     "ava": "^6.4.1",

--- a/shared/js/prom-lib/bus/acls.ts
+++ b/shared/js/prom-lib/bus/acls.ts
@@ -1,0 +1,6 @@
+export type ACLCtx = { agent?: string; scopes?: string[] };
+export type ACLChecker = (
+  topic: string,
+  action: "publish" | "subscribe",
+  ctx: ACLCtx,
+) => boolean | Promise<boolean>;

--- a/shared/js/prom-lib/bus/client.ts
+++ b/shared/js/prom-lib/bus/client.ts
@@ -1,0 +1,73 @@
+import WebSocket from "ws";
+import { Ack, IMessageFrame, PublishRequest, SubscribeRequest } from "./types";
+
+export class BusClient {
+  private ws?: WebSocket;
+  private url: string;
+  private backoff = 500;
+  private max = 10_000;
+  private pending: any[] = [];
+  constructor(url = process.env.BUS_URL || "ws://127.0.0.1:7070") {
+    this.url = url;
+    this.connect();
+  }
+
+  private connect() {
+    this.ws = new WebSocket(this.url);
+    this.ws.on("open", () => {
+      this.backoff = 500;
+      for (const m of this.pending.splice(0)) this.ws!.send(JSON.stringify(m));
+    });
+    this.ws.on("message", (buf: WebSocket.RawData) =>
+      this.onMessage(JSON.parse(buf.toString())),
+    );
+    this.ws.on("close", () =>
+      setTimeout(
+        () => this.connect(),
+        (this.backoff = Math.min(this.max, this.backoff * 2)),
+      ),
+    );
+    this.ws.on("error", () => {});
+  }
+
+  private send(obj: any) {
+    const s = JSON.stringify(obj);
+    if (this.ws && this.ws.readyState === WebSocket.OPEN) this.ws.send(s);
+    else this.pending.push(obj);
+  }
+
+  publish<T>(
+    topic: string,
+    payload: T,
+    key?: string,
+    headers?: Record<string, string>,
+  ) {
+    const msg: PublishRequest<T> = {
+      type: "PUBLISH",
+      topic,
+      key,
+      headers,
+      payload,
+    };
+    this.send(msg);
+  }
+
+  subscribe(
+    req: Omit<SubscribeRequest, "type">,
+    onMessage: (m: IMessageFrame) => void,
+    onError?: (e: any) => void,
+  ) {
+    this.onMessage = (m) => {
+      if (m.type === "MESSAGE" && m.topic === req.topic)
+        onMessage(m as IMessageFrame);
+    };
+    this.send({ type: "SUBSCRIBE", ...req });
+  }
+
+  ack(ack: Ack) {
+    this.send(ack);
+  }
+
+  // overrideable hook
+  protected onMessage(_m: any) {}
+}

--- a/shared/js/prom-lib/bus/metrics.ts
+++ b/shared/js/prom-lib/bus/metrics.ts
@@ -1,0 +1,30 @@
+export interface BrokerMetrics {
+  published: number;
+  delivered: number;
+  acks: number;
+  redeliveries: number;
+  inflight: number;
+  byTopic: Record<string, { pub: number; del: number }>;
+}
+export class Metrics {
+  s: BrokerMetrics = {
+    published: 0,
+    delivered: 0,
+    acks: 0,
+    redeliveries: 0,
+    inflight: 0,
+    byTopic: {},
+  };
+  inc(t: keyof BrokerMetrics, topic?: string) {
+    (this.s as any)[t]++;
+    if (topic) {
+      const bt =
+        this.s.byTopic[topic] ?? (this.s.byTopic[topic] = { pub: 0, del: 0 });
+      if (t === "published") bt.pub++;
+      if (t === "delivered") bt.del++;
+    }
+  }
+  snapshot() {
+    return JSON.parse(JSON.stringify(this.s));
+  }
+}

--- a/shared/js/prom-lib/bus/schema.ts
+++ b/shared/js/prom-lib/bus/schema.ts
@@ -1,0 +1,52 @@
+import { z } from "zod";
+
+export const EnvelopeZ = z.object({
+  id: z.string(),
+  ts: z.number(),
+  topic: z.string(),
+  key: z.string().optional(),
+  partition: z.number().optional(),
+  headers: z.record(z.string()).optional(),
+  payload_sha256: z.string().optional(),
+  payload: z.unknown(),
+});
+
+export const EventRowZ = EnvelopeZ.extend({
+  offset: z.number(),
+  attempts: z.number().optional(),
+});
+
+export const SubscribeZ = z.object({
+  type: z.literal("SUBSCRIBE"),
+  topic: z.string(),
+  group: z.string(),
+  from: z
+    .object({
+      kind: z.enum(["latest", "offset", "timestamp"]),
+      value: z.number().optional(),
+    })
+    .optional(),
+  max_inflight: z.number().default(32),
+  filter: z
+    .object({
+      key: z.string().optional(),
+      header: z.tuple([z.string(), z.string()]).optional(),
+    })
+    .optional(),
+});
+
+export const PublishZ = z.object({
+  type: z.literal("PUBLISH"),
+  topic: z.string(),
+  key: z.string().optional(),
+  headers: z.record(z.string()).optional(),
+  payload: z.unknown(),
+});
+export const AckZ = z.object({
+  type: z.enum(["ACK", "NACK"]),
+  topic: z.string(),
+  partition: z.number(),
+  group: z.string(),
+  offset: z.number(),
+  reason: z.string().optional(),
+});

--- a/shared/js/prom-lib/bus/server.ts
+++ b/shared/js/prom-lib/bus/server.ts
@@ -1,0 +1,158 @@
+import WebSocket, { WebSocketServer } from "ws";
+import { MongoStorage } from "./storage/mongo";
+import { PublishRequest, SubscribeRequest, Ack, EventRow } from "./types";
+import { assignPartition } from "./util";
+
+export class BrokerServer {
+  private subs = new Map<string, Map<number, Map<string, Set<WebSocket>>>>();
+  private inflight = new Map<string, { deadline: number; ws: WebSocket }>();
+  private ACK_TIMEOUT_MS = 30_000;
+
+  constructor(
+    private store: MongoStorage,
+    private wss: WebSocketServer,
+  ) {
+    wss.on("connection", (ws: WebSocket) => this.onConn(ws));
+    setInterval(() => this.redeliverySweep(), 1000);
+  }
+
+  private subset(topic: string, p: number, group: string) {
+    if (!this.subs.has(topic)) this.subs.set(topic, new Map());
+    const parts = this.subs.get(topic)!;
+    if (!parts.has(p)) parts.set(p, new Map());
+    const groups = parts.get(p)!;
+    if (!groups.has(group)) groups.set(group, new Set());
+    return groups.get(group)!;
+  }
+
+  private onConn(ws: WebSocket) {
+    ws.on("message", (buf: WebSocket.RawData) => this.onMessage(ws, buf));
+  }
+
+  private async onMessage(ws: WebSocket, buf: WebSocket.RawData) {
+    const msg = JSON.parse(buf.toString());
+    if (msg.type === "PUBLISH")
+      return this.handlePublish(ws, msg as PublishRequest);
+    if (msg.type === "SUBSCRIBE")
+      return this.handleSubscribe(ws, msg as SubscribeRequest);
+    if (msg.type === "ACK" || msg.type === "NACK")
+      return this.handleAck(ws, msg as Ack);
+    if (msg.type === "FLOW") {
+      /* TODO: adjust window */ return;
+    }
+  }
+
+  private async handlePublish(ws: WebSocket, req: PublishRequest) {
+    const cfg = await this.store.getConfig(req.topic);
+    const p = assignPartition(req.key, cfg.partitions);
+    const offset = await this.store.nextOffset(req.topic, p);
+    const row: EventRow = {
+      id: crypto.randomUUID(),
+      ts: Date.now(),
+      topic: req.topic,
+      key: req.key,
+      partition: p,
+      headers: req.headers,
+      payload: req.payload,
+      offset,
+    };
+    await this.store.insertEvent(row);
+    this.notify(req.topic, p);
+    ws.send(
+      JSON.stringify({
+        type: "PUBLISHED",
+        topic: req.topic,
+        partition: p,
+        offset,
+      }),
+    );
+  }
+
+  private async handleSubscribe(ws: WebSocket, req: SubscribeRequest) {
+    const p = 0; // TODO: multi-partition fan-in per connection
+    this.subset(req.topic, p, req.group).add(ws);
+    await this.deliver(
+      req.topic,
+      p,
+      req.group,
+      ws,
+      req.max_inflight ?? 32,
+      req.from,
+    );
+  }
+
+  private inflightKey(topic: string, p: number, g: string, off: number) {
+    return `${topic}:${p}:${g}:${off}`;
+  }
+
+  private async deliver(
+    topic: string,
+    p: number,
+    g: string,
+    ws: WebSocket,
+    window: number,
+    from?: SubscribeRequest["from"],
+  ) {
+    const start =
+      from?.kind === "offset"
+        ? from.value ?? 0
+        : (await this.store.committed(topic, p, g)) + 1;
+    const rows = await this.store.readFrom(topic, p, start, window);
+    for (const row of rows) {
+      const frame = {
+        type: "MESSAGE",
+        topic,
+        partition: p,
+        group: g,
+        offset: row.offset,
+        envelope: row,
+      };
+      ws.send(JSON.stringify(frame));
+      this.inflight.set(this.inflightKey(topic, p, g, row.offset), {
+        deadline: Date.now() + this.ACK_TIMEOUT_MS,
+        ws,
+      });
+    }
+  }
+
+  private async handleAck(_ws: WebSocket, ack: Ack) {
+    if (ack.type === "ACK")
+      await this.store.commit(ack.topic, ack.partition, ack.group, ack.offset);
+    this.inflight.delete(
+      this.inflightKey(ack.topic, ack.partition, ack.group, ack.offset),
+    );
+  }
+
+  private async redeliverySweep() {
+    const now = Date.now();
+    for (const [k, lease] of this.inflight) {
+      if (lease.deadline <= now) {
+        const [topic, pStr, g, offStr] = k.split(":");
+        const p = Number(pStr),
+          off = Number(offStr);
+        try {
+          const [row] = await this.store.readFrom(topic, p, off, 1);
+          if (row)
+            lease.ws.send(
+              JSON.stringify({
+                type: "MESSAGE",
+                topic,
+                partition: p,
+                group: g,
+                offset: row.offset,
+                envelope: row,
+              }),
+            );
+          lease.deadline = now + this.ACK_TIMEOUT_MS;
+        } catch {}
+      }
+    }
+  }
+
+  private async notify(topic: string, p: number) {
+    const groups = this.subs.get(topic)?.get(p);
+    if (!groups) return;
+    for (const [g, set] of groups)
+      for (const ws of set) this.deliver(topic, p, g, ws, 32);
+  }
+}

--- a/shared/js/prom-lib/bus/storage/memory.ts
+++ b/shared/js/prom-lib/bus/storage/memory.ts
@@ -1,0 +1,40 @@
+import { EventRow } from "../types";
+
+export class MemoryStorage {
+  private rows = new Map<string, EventRow[]>();
+  private commits = new Map<string, number>();
+  private counters = new Map<string, number>();
+
+  key(topic: string, p: number) {
+    return `${topic}:${p}`;
+  }
+
+  async nextOffset(topic: string, p: number) {
+    const k = this.key(topic, p);
+    const n = (this.counters.get(k) ?? 0) + 1;
+    this.counters.set(k, n);
+    return n;
+  }
+
+  async insertEvent(row: EventRow) {
+    const k = this.key(row.topic, row.partition!);
+    const arr = this.rows.get(k) ?? [];
+    arr.push(row);
+    this.rows.set(k, arr);
+  }
+
+  async readFrom(topic: string, p: number, offset: number, limit: number) {
+    const arr = this.rows.get(this.key(topic, p)) ?? [];
+    return arr.filter((r) => r.offset >= offset).slice(0, limit);
+  }
+
+  async committed(topic: string, p: number, g: string) {
+    return this.commits.get(`${topic}:${p}:${g}`) ?? 0;
+  }
+  async commit(topic: string, p: number, g: string, off: number) {
+    this.commits.set(
+      `${topic}:${p}:${g}`,
+      Math.max(off, await this.committed(topic, p, g)),
+    );
+  }
+}

--- a/shared/js/prom-lib/bus/storage/mongo.ts
+++ b/shared/js/prom-lib/bus/storage/mongo.ts
@@ -1,0 +1,91 @@
+import { Collection, Db, MongoClient } from "mongodb";
+import { EventRow, GroupOffset, TopicConfig } from "../types";
+
+export class MongoStorage {
+  private events!: Collection<EventRow>;
+  private counters!: Collection<{ _id: string; nextOffset: number }>;
+  private offsets!: Collection<GroupOffset>;
+  private topicConfigs!: Collection<TopicConfig>;
+
+  constructor(private db: Db) {}
+
+  static async connect(url: string, dbName: string) {
+    const client = new MongoClient(url);
+    await client.connect();
+    const db = client.db(dbName);
+    const store = new MongoStorage(db);
+    await store.init();
+    return store;
+  }
+
+  async init() {
+    this.events = this.db.collection("events");
+    this.counters = this.db.collection("counters");
+    this.offsets = this.db.collection("group_offsets");
+    this.topicConfigs = this.db.collection("topic_configs");
+    await this.events.createIndex(
+      { topic: 1, partition: 1, offset: 1 },
+      { unique: true },
+    );
+    await this.events.createIndex({ topic: 1, partition: 1, ts: 1 });
+    await this.offsets.createIndex(
+      { topic: 1, partition: 1, group: 1 },
+      { unique: true },
+    );
+  }
+
+  async getConfig(topic: string): Promise<TopicConfig> {
+    return (
+      (await this.topicConfigs.findOne({ topic })) || { topic, partitions: 1 }
+    );
+  }
+
+  async nextOffset(topic: string, partition: number): Promise<number> {
+    const id = `${topic}:${partition}`;
+    const res = await this.counters.findOneAndUpdate(
+      { _id: id },
+      { $inc: { nextOffset: 1 } },
+      { upsert: true, returnDocument: "after" },
+    );
+    return (res as any)?.value?.nextOffset ?? (res as any)?.nextOffset ?? 0;
+  }
+
+  async insertEvent(row: EventRow) {
+    await this.events.insertOne(row);
+  }
+
+  async readFrom(
+    topic: string,
+    partition: number,
+    offset: number,
+    limit: number,
+  ) {
+    return await this.events
+      .find({ topic, partition, offset: { $gte: offset } })
+      .sort({ offset: 1 })
+      .limit(limit)
+      .toArray();
+  }
+
+  async committed(
+    topic: string,
+    partition: number,
+    group: string,
+  ): Promise<number> {
+    const g = await this.offsets.findOne({ topic, partition, group });
+    return g?.lastCommitted ?? 0;
+  }
+
+  async commit(
+    topic: string,
+    partition: number,
+    group: string,
+    offset: number,
+  ) {
+    await this.offsets.updateOne(
+      { topic, partition, group },
+      { $max: { lastCommitted: offset }, $set: { updatedTs: Date.now() } },
+      { upsert: true },
+    );
+  }
+}

--- a/shared/js/prom-lib/bus/types.ts
+++ b/shared/js/prom-lib/bus/types.ts
@@ -1,0 +1,91 @@
+export type UUID = string;
+export type Millis = number;
+export type Partition = number;
+
+export type Vec8 = [
+  number,
+  number,
+  number,
+  number,
+  number,
+  number,
+  number,
+  number,
+];
+
+export interface BrokerEnvelope<T = unknown> {
+  id: UUID;
+  ts: Millis;
+  topic: string;
+  key?: string;
+  partition?: Partition;
+  headers?: Record<string, string>;
+  payload_sha256?: string;
+  payload: T;
+}
+
+export interface EventRow<T = unknown> extends BrokerEnvelope<T> {
+  offset: number;
+  attempts?: number;
+}
+
+export interface TopicConfig {
+  topic: string;
+  partitions: number;
+  retentionMs?: number;
+  maxAttempts?: number;
+  publishACL?: string[];
+  subscribeACL?: string[];
+}
+
+export interface GroupOffset {
+  topic: string;
+  partition: number;
+  group: string;
+  lastCommitted: number;
+  updatedTs: number;
+}
+
+export type FromSpec = {
+  kind: "latest" | "offset" | "timestamp";
+  value?: number;
+};
+
+export interface SubscribeRequest {
+  type: "SUBSCRIBE";
+  topic: string;
+  group: string;
+  from?: FromSpec;
+  max_inflight?: number;
+  filter?: { key?: string; header?: [string, string] };
+}
+
+export interface PublishRequest<T = unknown> {
+  type: "PUBLISH";
+  topic: string;
+  key?: string;
+  headers?: Record<string, string>;
+  payload: T;
+}
+export interface Ack {
+  type: "ACK" | "NACK";
+  topic: string;
+  partition: number;
+  group: string;
+  offset: number;
+  reason?: string;
+}
+
+export interface IMessageFrame<T = unknown> {
+  type: "MESSAGE";
+  topic: string;
+  partition: number;
+  group: string;
+  offset: number;
+  envelope: BrokerEnvelope<T> & { offset?: number };
+}
+
+export interface Flow {
+  type: "FLOW";
+  credits: number;
+}

--- a/shared/js/prom-lib/bus/util.ts
+++ b/shared/js/prom-lib/bus/util.ts
@@ -1,0 +1,16 @@
+export function uuidv7(): string {
+  /* pluggable impl; use @lukeed/uuid or your own */ return crypto.randomUUID();
+}
+export function now(): number {
+  return Date.now();
+}
+export function assignPartition(
+  key: string | undefined,
+  partitions = 1,
+): number {
+  if (!partitions || partitions <= 1) return 0;
+  const k = key ?? `${Math.random()}`;
+  let h = 0;
+  for (let i = 0; i < k.length; i++) h = ((h << 5) - h + k.charCodeAt(i)) | 0;
+  return Math.abs(h) % partitions;
+}

--- a/shared/js/prom-lib/outbox/mongo_outbox.ts
+++ b/shared/js/prom-lib/outbox/mongo_outbox.ts
@@ -1,0 +1,37 @@
+import { Collection } from "mongodb";
+import { BusClient } from "../bus/client";
+
+export interface OutboxRow {
+  _id: string;
+  topic: string;
+  key?: string;
+  headers?: Record<string, string>;
+  payload: any;
+  createdTs: number;
+  sentTs?: number;
+  attempts?: number;
+}
+
+export async function drainOutbox(
+  col: Collection<OutboxRow>,
+  bus: BusClient,
+  { batch = 100, maxAttempts = 10 } = {},
+) {
+  const rows = await col
+    .find({
+      $or: [{ sentTs: { $exists: false } }, { attempts: { $lt: maxAttempts } }],
+    })
+    .limit(batch)
+    .toArray();
+  for (const r of rows) {
+    try {
+      bus.publish(r.topic, r.payload, r.key, r.headers);
+      await col.updateOne(
+        { _id: r._id },
+        { $set: { sentTs: Date.now() }, $inc: { attempts: 1 } },
+      );
+    } catch {
+      await col.updateOne({ _id: r._id }, { $inc: { attempts: 1 } });
+    }
+  }
+}

--- a/shared/js/prom-lib/task/queue.ts
+++ b/shared/js/prom-lib/task/queue.ts
@@ -1,0 +1,52 @@
+import { BusClient } from "../bus/client";
+import { IMessageFrame } from "../bus/types";
+import { Task } from "./types";
+
+export class TaskQueue {
+  constructor(
+    private bus: BusClient,
+    private topic: string,
+    private group = "workers",
+  ) {}
+
+  enqueue<T>(payload: T, key?: string) {
+    this.bus.publish(this.topic, { payload }, key);
+  }
+
+  start(handler: (task: Task) => Promise<void>) {
+    this.bus.subscribe(
+      {
+        topic: this.topic,
+        group: this.group,
+        from: { kind: "latest" },
+        max_inflight: 16,
+      },
+      async (m: IMessageFrame) => {
+        const task: Task = {
+          id: m.envelope.id,
+          topic: m.topic,
+          payload: (m.envelope as any).payload,
+        };
+        try {
+          await handler(task);
+          this.bus.ack({
+            type: "ACK",
+            topic: m.topic,
+            partition: m.partition,
+            group: m.group,
+            offset: m.offset,
+          });
+        } catch (e) {
+          this.bus.ack({
+            type: "NACK",
+            topic: m.topic,
+            partition: m.partition,
+            group: m.group,
+            offset: m.offset,
+            reason: String(e),
+          });
+        }
+      },
+    );
+  }
+}

--- a/shared/js/prom-lib/task/types.ts
+++ b/shared/js/prom-lib/task/types.ts
@@ -1,0 +1,6 @@
+export type Task<T = any> = {
+  id: string;
+  topic: string;
+  payload: T;
+  priority?: number;
+};

--- a/shared/js/prom-lib/tsconfig.json
+++ b/shared/js/prom-lib/tsconfig.json
@@ -15,6 +15,9 @@
     "event/**/*.ts",
     "ds/**/*.ts",
     "worker/**/*.ts",
-    "intention/**/*.ts"
+    "intention/**/*.ts",
+    "bus/**/*.ts",
+    "outbox/**/*.ts",
+    "task/**/*.ts"
   ]
 }


### PR DESCRIPTION
## Summary
- implement WebSocket broker server with durable Mongo-backed offsets
- add reconnecting client, task queue helper, and Mongo outbox drainer
- wire TypeScript config and package dependencies for new bus modules

## Testing
- `npm test`
- `npx tsc -p shared/js/prom-lib/tsconfig.json`
- `npx eslint shared/js/prom-lib/bus/**/*.ts shared/js/prom-lib/outbox/**/*.ts shared/js/prom-lib/task/**/*.ts`
- `npx prettier -w shared/js/prom-lib/bus/*.ts shared/js/prom-lib/bus/storage/*.ts shared/js/prom-lib/outbox/*.ts shared/js/prom-lib/task/*.ts`


------
https://chatgpt.com/codex/tasks/task_e_6897c3c1f4788324b7d721daa058f811