### PR TITLE
feat: add portable worker pool and parallel ECS scheduler

### DIFF
--- a/services/js/workers/physics.job.ts
+++ b/services/js/workers/physics.job.ts
@@ -1,0 +1,32 @@
+import type { Patch } from "../../shared/js/prom-lib/ds/ecs.patches";
+
+export type PhysicsInput = {
+  eids: number[];
+  cols: Record<number, any[]>; // cid -> column values (arrays aligned with eids)
+  dt: number;
+  time: number;
+  writes: number[];
+  extra?: any;
+};
+
+export async function handle(input: PhysicsInput): Promise<Patch[]> {
+  // Suppose: cols[POS_CID] = [{x,y}...], cols[VEL_CID] = [{x,y}...]
+  const POS = input.extra.POS as number;
+  const VEL = input.extra.VEL as number;
+  const pos = input.cols[POS] as { x: number; y: number }[];
+  const vel = input.cols[VEL] as { x: number; y: number }[];
+  const patches: Patch[] = [];
+  for (let i = 0; i < input.eids.length; i++) {
+    const p = pos[i],
+      v = vel[i];
+    if (!p || !v) continue;
+    patches.push({
+      kind: "set",
+      eid: input.eids[i],
+      cid: POS,
+      value: { x: p.x + v.x * input.dt, y: p.y + v.y * input.dt },
+    });
+  }
+  return patches;
+}
+export default handle;

--- a/services/web/workers/physics.worker.ts
+++ b/services/web/workers/physics.worker.ts
@@ -1,0 +1,22 @@
+import type { Patch } from "../../shared/js/prom-lib/ds/ecs.patches";
+
+self.onmessage = (ev: MessageEvent) => {
+  const input = ev.data as any;
+  const POS = input.extra.POS as number;
+  const VEL = input.extra.VEL as number;
+  const pos = input.cols[POS] as { x: number; y: number }[];
+  const vel = input.cols[VEL] as { x: number; y: number }[];
+  const patches: Patch[] = [];
+  for (let i = 0; i < input.eids.length; i++) {
+    const p = pos[i],
+      v = vel[i];
+    if (!p || !v) continue;
+    patches.push({
+      kind: "set",
+      eid: input.eids[i],
+      cid: POS,
+      value: { x: p.x + v.x * input.dt, y: p.y + v.y * input.dt },
+    });
+  }
+  (self as any).postMessage(patches);
+};

--- a/shared/js/prom-lib/ds/ecs.patches.test.ts
+++ b/shared/js/prom-lib/ds/ecs.patches.test.ts
@@ -1,0 +1,27 @@
+import { World } from "./ecs";
+import { applyPatches, Patch } from "./ecs.patches";
+
+describe("applyPatches", () => {
+  test("applies add/set/remove/destroy", () => {
+    const w = new World();
+    const Pos = w.defineComponent<{ x: number }>({ name: "Pos" });
+    const eid = w.addEntity();
+
+    const patches: Patch[] = [
+      { kind: "add", eid, cid: Pos.id, value: { x: 1 } },
+      { kind: "set", eid, cid: Pos.id, value: { x: 2 } },
+      { kind: "remove", eid, cid: Pos.id },
+      { kind: "add", eid, cid: Pos.id, value: { x: 3 } },
+      { kind: "destroy", eid },
+    ];
+
+    applyPatches(w, patches.slice(0, 2));
+    expect(w.get(eid, Pos)).toEqual({ x: 2 });
+
+    applyPatches(w, patches.slice(2, 4));
+    expect(w.get(eid, Pos)).toEqual({ x: 3 });
+
+    applyPatches(w, [patches[4]]);
+    expect(w.get(eid, Pos)).toBeUndefined();
+  });
+});

--- a/shared/js/prom-lib/ds/ecs.patches.ts
+++ b/shared/js/prom-lib/ds/ecs.patches.ts
@@ -1,0 +1,16 @@
+export type Patch =
+  | { kind: "set"; eid: number; cid: number; value: any }
+  | { kind: "destroy"; eid: number }
+  | { kind: "add"; eid: number; cid: number; value?: any }
+  | { kind: "remove"; eid: number; cid: number };
+
+export function applyPatches(world: any, patches: Patch[]) {
+  for (const p of patches) {
+    if (p.kind === "set") world.set(p.eid, world["comps"][p.cid]!, p.value);
+    else if (p.kind === "destroy") world.destroyEntity(p.eid);
+    else if (p.kind === "add")
+      world.addComponent(p.eid, world["comps"][p.cid]!, p.value);
+    else if (p.kind === "remove")
+      world.removeComponent(p.eid, world["comps"][p.cid]!);
+  }
+}

--- a/shared/js/prom-lib/ds/ecs.scheduler.parallel.ts
+++ b/shared/js/prom-lib/ds/ecs.scheduler.parallel.ts
@@ -1,0 +1,111 @@
+import { Scheduler, SystemSpec, SystemContext } from "./ecs.scheduler";
+import { applyPatches, Patch } from "./ecs.patches";
+import { createPortablePool, WorkerPool } from "../worker/pool";
+import type { World, ComponentType } from "./ecs";
+
+export type OffloadSpec = {
+  // Node: ESM module path (e.g. file:// or dist path). Module must export `handle(input)`.
+  nodeModule?: string;
+  // Browser: name to resolve via BrowserWorkerPool factories
+  browserJobName?: string;
+  // Which components to snapshot and allow writes for
+  reads: ComponentType<any>[];
+  writes?: ComponentType<any>[];
+  // Optional extra payload per frame
+  extra?: (ctx: SystemContext) => any;
+};
+
+export interface OffloadableSystem extends SystemSpec {
+  offload: OffloadSpec;
+}
+
+export class ParallelScheduler extends Scheduler {
+  private pool!: WorkerPool;
+  private ready = false;
+
+  async initPool(opts?: {
+    size?: number;
+    browserWorkers?: Record<string, () => Worker>;
+  }) {
+    this.pool = await createPortablePool(opts);
+    this.ready = true;
+  }
+
+  // override tiny bit: when running batches, offload systems with .offload
+  protected async runSystem(sys: SystemSpec, ctx: SystemContext) {
+    const as = sys as OffloadableSystem;
+    if (!("offload" in as)) return sys.run(ctx);
+
+    if (!this.ready) await this.initPool();
+
+    // Build snapshot from query (if any)
+    const q = sys.query
+      ? this.world.makeQuery(sys.query(this.world))
+      : undefined;
+    const eids: number[] = [];
+    const cols: Record<number, any[]> = {};
+    for (const c of as.offload.reads.concat(as.offload.writes ?? []))
+      cols[c.id] = [];
+
+    if (q) {
+      for (const [e] of this.world.iter(q)) {
+        eids.push(e);
+        for (const c of as.offload.reads.concat(as.offload.writes ?? []))
+          cols[c.id].push(this.world.get(e, c));
+      }
+    }
+
+    const payload = {
+      eids,
+      cols,
+      dt: ctx.dt,
+      time: ctx.time,
+      writes: (as.offload.writes ?? []).map((c) => c.id),
+      extra: as.offload.extra?.(ctx),
+    };
+
+    // choose job id
+    const jobId =
+      typeof window !== "undefined"
+        ? as.offload.browserJobName ?? as.name
+        : as.offload.nodeModule ?? as.name;
+
+    const patches = (await this.pool.run(jobId, payload)) as Patch[];
+    if (patches && patches.length) applyPatches(this.world, patches);
+  }
+
+  async runFrame(dt: number, time: number, opts: { parallel?: boolean } = {}) {
+    // call parent’s logic but route per-system execution through runSystem()
+    // small override → copy of parent with one change:
+    if (!this["plan"]) this.compile();
+    const cmd = this["world"].beginTick();
+    const plan = this["plan"]!;
+
+    const call = (s: SystemSpec) =>
+      this.runSystem(s, {
+        world: this["world"],
+        dt,
+        time,
+        resources: this["resources"],
+        cmd,
+        stage: s.stage ?? "update",
+      });
+
+    try {
+      for (const stage of plan.stages) {
+        const batches = plan.batchesByStage.get(stage)!;
+        for (const batch of batches) {
+          if (opts.parallel ?? true) await Promise.all(batch.systems.map(call));
+          else for (const s of batch.systems) await call(s);
+        }
+      }
+    } finally {
+      cmd.flush();
+      this["world"].endTick();
+    }
+  }
+
+  async close() {
+    if (this.ready) await this.pool.close();
+  }
+}

--- a/shared/js/prom-lib/ds/ecs.scheduler.ts
+++ b/shared/js/prom-lib/ds/ecs.scheduler.ts
@@ -1,0 +1,80 @@
+import type { World } from "./ecs";
+
+export interface SystemContext {
+  world: World;
+  dt: number;
+  time: number;
+  resources?: Record<string, any>;
+  cmd: any;
+  stage: string;
+}
+
+export interface SystemSpec {
+  name: string;
+  stage?: string;
+  query?: (world: World) => any;
+  run(ctx: SystemContext): any;
+}
+
+export class Scheduler {
+  protected world: World;
+  protected systems: SystemSpec[] = [];
+  protected resources: Record<string, any> = {};
+  protected plan?: {
+    stages: string[];
+    batchesByStage: Map<string, { systems: SystemSpec[] }[]>;
+  };
+
+  constructor(world: World) {
+    this.world = world;
+  }
+
+  register(spec: SystemSpec) {
+    this.systems.push(spec);
+  }
+
+  compile() {
+    const stages: string[] = [];
+    const batchesByStage = new Map<string, { systems: SystemSpec[] }[]>();
+    for (const sys of this.systems) {
+      const stage = sys.stage ?? "update";
+      if (!stages.includes(stage)) stages.push(stage);
+      let batches = batchesByStage.get(stage);
+      if (!batches) {
+        batches = [{ systems: [] }];
+        batchesByStage.set(stage, batches);
+      }
+      batches[0].systems.push(sys);
+    }
+    this.plan = { stages, batchesByStage };
+  }
+
+  protected async runSystem(sys: SystemSpec, ctx: SystemContext) {
+    await sys.run(ctx);
+  }
+
+  async runFrame(dt: number, time: number) {
+    if (!this.plan) this.compile();
+    const cmd = this.world.beginTick();
+    try {
+      for (const stage of this.plan!.stages) {
+        const batches = this.plan!.batchesByStage.get(stage)!;
+        for (const batch of batches) {
+          for (const sys of batch.systems) {
+            await this.runSystem(sys, {
+              world: this.world,
+              dt,
+              time,
+              resources: this.resources,
+              cmd,
+              stage,
+            });
+          }
+        }
+      }
+    } finally {
+      cmd.flush();
+      this.world.endTick();
+    }
+  }
+}

--- a/shared/js/prom-lib/ds/ecs.ts
+++ b/shared/js/prom-lib/ds/ecs.ts
@@ -1,0 +1,76 @@
+export type ComponentType<T = any> = {
+  id: number;
+  name?: string;
+  defaults?: () => T;
+};
+
+export class World {
+  comps: ComponentType<any>[] = [];
+  private nextEntityId = 1;
+  private entities = new Map<number, Record<number, any>>();
+
+  defineComponent<T>(spec: {
+    name?: string;
+    defaults?: () => T;
+  }): ComponentType<T> {
+    const id = this.comps.length;
+    const comp: ComponentType<T> = { id, ...spec };
+    this.comps.push(comp);
+    return comp;
+  }
+
+  addEntity(): number {
+    const id = this.nextEntityId++;
+    this.entities.set(id, {});
+    return id;
+  }
+
+  set<T>(eid: number, comp: ComponentType<T>, value: T) {
+    const e = this.entities.get(eid);
+    if (e) e[comp.id] = value;
+  }
+
+  addComponent<T>(eid: number, comp: ComponentType<T>, value?: T) {
+    const e = this.entities.get(eid);
+    if (e) e[comp.id] = value ?? comp.defaults?.();
+  }
+
+  removeComponent(eid: number, comp: ComponentType<any>) {
+    const e = this.entities.get(eid);
+    if (e) delete e[comp.id];
+  }
+
+  destroyEntity(eid: number) {
+    this.entities.delete(eid);
+  }
+
+  get<T>(eid: number, comp: ComponentType<T>): T | undefined {
+    return this.entities.get(eid)?.[comp.id];
+  }
+
+  makeQuery(spec: any) {
+    return spec;
+  }
+
+  *iter(q: any, ...comps: ComponentType<any>[]): IterableIterator<any[]> {
+    for (const [eid, data] of this.entities) {
+      let ok = true;
+      for (const c of q?.all ?? []) {
+        if (!(c.id in data)) {
+          ok = false;
+          break;
+        }
+      }
+      if (!ok) continue;
+      const row: any[] = [eid];
+      for (const c of comps) row.push(data[c.id]);
+      yield row;
+    }
+  }
+
+  beginTick() {
+    return { flush() {} };
+  }
+
+  endTick() {}
+}

--- a/shared/js/prom-lib/worker/pool.browser.ts
+++ b/shared/js/prom-lib/worker/pool.browser.ts
@@ -1,0 +1,25 @@
+export class BrowserWorkerPool {
+  private factories: Record<string, () => Worker>;
+  constructor(factories: Record<string, () => Worker>) {
+    this.factories = factories;
+  }
+  run(name: string, input: any) {
+    return new Promise((resolve, reject) => {
+      const w = this.factories[name]();
+      const onMsg = (ev: MessageEvent) => {
+        w.removeEventListener("message", onMsg);
+        w.terminate();
+        resolve(ev.data);
+      };
+      const onErr = (e: ErrorEvent) => {
+        w.removeEventListener("error", onErr);
+        w.terminate();
+        reject(e.error || new Error(e.message));
+      };
+      w.addEventListener("message", onMsg);
+      w.addEventListener("error", onErr);
+      w.postMessage(input);
+    });
+  }
+  async close() {}
+}

--- a/shared/js/prom-lib/worker/pool.local.ts
+++ b/shared/js/prom-lib/worker/pool.local.ts
@@ -1,0 +1,11 @@
+export class LocalPool {
+  async run(modOrName: string, input: any) {
+    // Synchronous fallback: dynamic import & call handle()
+    const m = await import(/* @vite-ignore */ modOrName).catch(() => ({
+      default: (x: any) => x,
+    }));
+    const fn = (m.handle ?? m.default) as any;
+    return fn ? fn(input) : input;
+  }
+  async close() {}
+}

--- a/shared/js/prom-lib/worker/pool.node.ts
+++ b/shared/js/prom-lib/worker/pool.node.ts
@@ -1,0 +1,84 @@
+import { Worker } from "node:worker_threads";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+type Task = {
+  id: number;
+  mod: string;
+  input: any;
+  resolve: (v: any) => void;
+  reject: (e: any) => void;
+};
+
+export class NodeWorkerPool {
+  private size: number;
+  private workers: Worker[] = [];
+  private idle: Worker[] = [];
+  private q: Task[] = [];
+  private nextId = 1;
+  private runnerURL: string;
+
+  constructor(size = Math.max(1, os.cpus().length - 1)) {
+    this.size = size;
+    // runner script (ESM)
+    const here = path.dirname(fileURLToPath(import.meta.url));
+    this.runnerURL = pathToFileURL(path.join(here, "runner.node.js")).href;
+    for (let i = 0; i < this.size; i++) this.spawn();
+  }
+
+  private spawn() {
+    const w = new Worker(this.runnerURL, { type: "module" });
+    w.on("message", (msg) => {
+      const task = this._tasks.get(msg.id);
+      if (!task) return;
+      this._tasks.delete(msg.id);
+      this.idle.push(w);
+      if (msg.ok) task.resolve(msg.out);
+      else task.reject(new Error(msg.err || "job failed"));
+      this._drain();
+    });
+    w.on("error", (err) => {
+      // fail any running task on this worker
+      for (const [id, t] of this._tasks)
+        if ((t as any).worker === w) {
+          t.reject(err);
+          this._tasks.delete(id);
+        }
+      // respawn
+      this.workers = this.workers.filter((x) => x !== w);
+      this.spawn();
+    });
+    (w as any)._busy = false;
+    this.workers.push(w);
+    this.idle.push(w);
+  }
+
+  private _tasks = new Map<number, Task>();
+
+  private _drain() {
+    while (this.q.length && this.idle.length) {
+      const t = this.q.shift()!;
+      const w = this.idle.pop()!;
+      (t as any).worker = w;
+      this._tasks.set(t.id, t);
+      w.postMessage({ id: t.id, mod: t.mod, input: t.input });
+    }
+  }
+
+  run(mod: string, input: any) {
+    return new Promise((resolve, reject) => {
+      const id = this.nextId++;
+      this.q.push({ id, mod, input, resolve, reject });
+      this._drain();
+    });
+  }
+
+  async close() {
+    for (const w of this.workers) w.terminate();
+    this.workers.length = 0;
+    this.idle.length = 0;
+    this.q.length = 0;
+    this._tasks.clear();
+  }
+}

--- a/shared/js/prom-lib/worker/pool.ts
+++ b/shared/js/prom-lib/worker/pool.ts
@@ -1,0 +1,35 @@
+export type JobInput = any;
+export type JobOutput = any;
+export type JobModule = string; // ESM path for Node worker to import
+
+export interface WorkerPool {
+  run(moduleOrName: string, input: JobInput): Promise<JobOutput>;
+  close(): Promise<void>;
+}
+
+const isNode =
+  typeof process !== "undefined" && !!(process.versions as any)?.node;
+const isBrowser = typeof window !== "undefined";
+
+export async function createPortablePool(
+  opts: {
+    size?: number;
+    // Node: pass absolute or importable ESM module paths when calling run()
+    // Browser: name→factory map (because bundlers need Worker(URL))
+    browserWorkers?: Record<string, () => Worker>;
+  } = {},
+): Promise<WorkerPool> {
+  if (isNode) {
+    const m = await import("./pool.node.js"); // compiled JS
+    return new m.NodeWorkerPool(
+      opts.size ?? Math.max(1, require("os").cpus().length - 1),
+    );
+  }
+  if (isBrowser && typeof Worker !== "undefined" && opts.browserWorkers) {
+    const m = await import("./pool.browser.js");
+    return new m.BrowserWorkerPool(opts.browserWorkers);
+  }
+  // Fallback (static page without workers)
+  const m = await import("./pool.local.js");
+  return new m.LocalPool();
+}

--- a/shared/js/prom-lib/worker/runner.node.ts
+++ b/shared/js/prom-lib/worker/runner.node.ts
@@ -1,0 +1,14 @@
+// A tiny generic Node worker: dynamic-import module and call handle(input)
+import { parentPort } from "node:worker_threads";
+
+parentPort!.on("message", async (msg) => {
+  const { id, mod, input } = msg;
+  try {
+    const m = await import(mod); // ESM module path
+    const fn = (m.handle ?? m.default) as (x: any) => any | Promise<any>;
+    const out = await fn(input);
+    parentPort!.postMessage({ id, ok: true, out });
+  } catch (e: any) {
+    parentPort!.postMessage({ id, ok: false, err: e?.message ?? String(e) });
+  }
+});


### PR DESCRIPTION
## Summary
- add minimal ECS patch format and applyPatches helper
- introduce portable worker pool supporting Node, browser, and local fallback
- extend scheduler with parallel offloading and add example physics worker

## Testing
- `npx jest`
- `make build`
- `npx eslint ds/ecs.patches.ts && echo ESLINT_OK`
- `make format`


------
https://chatgpt.com/codex/tasks/task_e_6897c43dc5488324ac0f0bd6a0fdcb4a