### PR TITLE
feat: add reusable graph data structure

### DIFF
--- a/shared/js/prom-lib/ds/graph.test.ts
+++ b/shared/js/prom-lib/ds/graph.test.ts
@@ -4,7 +4,8 @@ describe("Graph", () => {
   test("bfs traverses undirected graph", () => {
     const g = new Graph({ directed: false });
     g.addNode("A").addNode("B").addNode("C");
-    g.addEdge("A", "B").addEdge("B", "C");
+    g.addEdge("A", "B");
+    g.addEdge("B", "C");
     const { order } = g.bfs("A");
     expect(order).toEqual(["A", "B", "C"]);
   });
@@ -12,8 +13,13 @@ describe("Graph", () => {
   test("dijkstra finds shortest paths", () => {
     const g = new Graph({ directed: true });
     g.addNode("A").addNode("B").addNode("C");
-    g.addEdge("A", "B", 1).addEdge("A", "C", 5).addEdge("B", "C", 1);
-    const { distances } = g.dijkstra("A");
-    expect(distances["C"]).toBe(2);
+    g.addEdge("A", "B", { weight: 1 });
+    g.addEdge("A", "C", { weight: 5 });
+    g.addEdge("B", "C", { weight: 1 });
+    const res = g.shortestPathDijkstra("A", "C") as {
+      distance: number;
+      path: (string | number)[];
+    };
+    expect(res.distance).toBe(2);
   });
 });

--- a/shared/js/prom-lib/ds/graph.ts
+++ b/shared/js/prom-lib/ds/graph.ts
@@ -1,209 +1,401 @@
-export interface Node<T> {
-  id: string;
-  data?: T;
+// shared/js/prom-lib/ds/graph.ts
+// MIT. Zero deps. Node + browser safe.
+
+export type Id = string | number;
+
+export interface NodeRecord<ND = unknown> {
+  id: Id;
+  data?: ND;
 }
 
-export interface Edge<E> {
-  from: string;
-  to: string;
-  weight: number;
-  data?: E;
+export interface EdgeRecord<ED = unknown> {
+  u: Id;
+  v: Id;
+  weight?: number; // default = 1
+  data?: ED;
 }
 
-interface BFSResult {
-  order: string[];
-}
+type EdgeCell<ED> = { weight: number; data?: ED };
 
-interface DFSResult {
-  order: string[];
-}
-
-interface DijkstraResult {
-  distances: Record<string, number>;
-  previous: Record<string, string | null>;
-}
-
-export class Graph<N = unknown, E = unknown> {
+export class Graph<ND = unknown, ED = unknown> {
   readonly directed: boolean;
-  private nodes: Map<string, N> = new Map();
-  private edges: Map<string, Map<string, { weight: number; data?: E }>> =
-    new Map();
+  private nodesMap = new Map<Id, ND | undefined>();
+  // adjacency: u -> (v -> {weight,data})
+  private adj = new Map<Id, Map<Id, EdgeCell<ED>>>();
 
   constructor(opts: { directed?: boolean } = {}) {
-    this.directed = opts.directed ?? true;
+    this.directed = !!opts.directed;
   }
 
-  addNode(id: string, data?: N): this {
-    if (!this.nodes.has(id)) {
-      this.nodes.set(id, data as N);
-      this.edges.set(id, new Map());
-    }
+  //#region node ops
+  addNode(id: Id, data?: ND): this {
+    if (!this.nodesMap.has(id)) this.nodesMap.set(id, data);
+    else if (data !== undefined) this.nodesMap.set(id, data);
+    if (!this.adj.has(id)) this.adj.set(id, new Map());
     return this;
   }
+  hasNode(id: Id): boolean {
+    return this.nodesMap.has(id);
+  }
+  getNode(id: Id): ND | undefined {
+    return this.nodesMap.get(id);
+  }
+  setNodeData(id: Id, data: ND): void {
+    if (!this.nodesMap.has(id)) throw new Error(`node ${String(id)} not found`);
+    this.nodesMap.set(id, data);
+  }
+  removeNode(id: Id): void {
+    if (!this.nodes()) return;
+    // remove outgoing
+    this.adj.get(id)?.clear();
+    this.adj.delete(id);
+    // remove incoming
+    for (const [, m] of this.adj) m.delete(id);
+    this.nodesMap.delete(id);
+  }
+  countNodes(): number {
+    return this.nodesMap.size;
+  }
+  *nodes(): IterableIterator<NodeRecord<ND>> {
+    for (const [id, data] of this.nodesMap) yield { id, data };
+  }
+  //#endregion
 
-  addEdge(from: string, to: string, weight = 1, data?: E): this {
-    if (!this.nodes.has(from) || !this.nodes.has(to)) {
-      throw new Error("Both nodes must exist before adding an edge");
-    }
-    this.edges.get(from)!.set(to, { weight, data });
+  //#region edge ops
+  addEdge(
+    u: Id,
+    v: Id,
+    opts: { weight?: number; data?: ED; overwrite?: boolean } = {},
+  ): this {
+    const w = opts.weight ?? 1;
+    this.addNode(u);
+    this.addNode(v);
+    const row = this.adj.get(u)!;
+    if (!row.has(v) || opts.overwrite)
+      row.set(v, { weight: w, data: opts.data });
     if (!this.directed) {
-      this.edges.get(to)!.set(from, { weight, data });
+      const back = this.adj.get(v)!;
+      if (!back.has(u) || opts.overwrite)
+        back.set(u, { weight: w, data: opts.data });
     }
     return this;
   }
-
-  neighbors(id: string): string[] {
-    return Array.from(this.edges.get(id)?.keys() ?? []);
+  hasEdge(u: Id, v: Id): boolean {
+    return this.adj.get(u)?.has(v) ?? false;
   }
+  removeEdge(u: Id, v: Id): void {
+    this.adj.get(u)?.delete(v);
+    if (!this.directed) this.adj.get(v)?.delete(u);
+  }
+  getEdge(u: Id, v: Id): EdgeRecord<ED> | undefined {
+    const cell = this.adj.get(u)?.get(v);
+    if (!cell) return undefined;
+    return { u, v, weight: cell.weight, data: cell.data };
+  }
+  neighbors(u: Id): IterableIterator<[Id, EdgeCell<ED>]> {
+    return (this.adj.get(u) ?? new Map()).entries();
+  }
+  degree(u: Id): number {
+    return this.adj.get(u)?.size ?? 0;
+  }
+  *edges(): IterableIterator<EdgeRecord<ED>> {
+    for (const [u, row] of this.adj) {
+      for (const [v, cell] of row) {
+        if (!this.directed && String(u) > String(v)) continue; // avoid dup
+        yield { u, v, weight: cell.weight, data: cell.data };
+      }
+    }
+  }
+  //#endregion
 
-  bfs(start: string): BFSResult {
-    const visited = new Set<string>();
-    const queue: string[] = [start];
-    const order: string[] = [];
-    visited.add(start);
-    while (queue.length) {
-      const v = queue.shift()!;
-      order.push(v);
-      for (const n of this.neighbors(v)) {
-        if (!visited.has(n)) {
-          visited.add(n);
-          queue.push(n);
+  //#region traversals
+  bfs(
+    start: Id,
+    stop?: (id: Id) => boolean,
+  ): { parent: Map<Id, Id | null>; order: Id[] } {
+    if (!this.hasNode(start))
+      throw new Error(`start node ${String(start)} missing`);
+    const q: Id[] = [start];
+    const parent = new Map<Id, Id | null>([[start, null]]);
+    const order: Id[] = [];
+    while (q.length) {
+      const u = q.shift()!;
+      order.push(u);
+      if (stop && stop(u)) break;
+      for (const [v] of this.neighbors(u)) {
+        if (!parent.has(v)) {
+          parent.set(v, u);
+          q.push(v);
         }
       }
     }
-    return { order };
+    return { parent, order };
   }
 
-  dfs(start: string): DFSResult {
-    const visited = new Set<string>();
-    const order: string[] = [];
-    const visit = (v: string) => {
-      visited.add(v);
-      order.push(v);
-      for (const n of this.neighbors(v)) {
-        if (!visited.has(n)) visit(n);
+  dfs(
+    start: Id,
+    stop?: (id: Id) => boolean,
+  ): { parent: Map<Id, Id | null>; order: Id[] } {
+    if (!this.hasNode(start))
+      throw new Error(`start node ${String(start)} missing`);
+    const st: Id[] = [start];
+    const parent = new Map<Id, Id | null>([[start, null]]);
+    const order: Id[] = [];
+    while (st.length) {
+      const u = st.pop()!;
+      order.push(u);
+      if (stop && stop(u)) break;
+      for (const [v] of Array.from(this.neighbors(u)).reverse()) {
+        if (!parent.has(v)) {
+          parent.set(v, u);
+          st.push(v);
+        }
       }
+    }
+    return { parent, order };
+  }
+  //#endregion
+
+  //#region shortest paths
+  shortestPathDijkstra(
+    src: Id,
+    dst?: Id,
+    weightOf?: (u: Id, v: Id, w: number) => number,
+  ) {
+    const dist = new Map<Id, number>();
+    const prev = new Map<Id, Id | null>();
+    const pq = new MinHeap<[Id, number]>((a, b) => a[1] - b[1]);
+
+    for (const { id } of this.nodes()) {
+      dist.set(id, Infinity);
+      prev.set(id, null);
+    }
+    if (!this.hasNode(src)) throw new Error(`src ${String(src)} missing`);
+    dist.set(src, 0);
+    pq.push([src, 0]);
+
+    while (!pq.empty()) {
+      const [u, d] = pq.pop()!;
+      if (d !== dist.get(u)) continue; // stale
+      if (dst !== undefined && u === dst) break;
+      for (const [v, cell] of this.neighbors(u)) {
+        const w = weightOf ? weightOf(u, v, cell.weight) : cell.weight;
+        const nd = d + w;
+        if (nd < (dist.get(v) ?? Infinity)) {
+          dist.set(v, nd);
+          prev.set(v, u);
+          pq.push([v, nd]);
+        }
+      }
+    }
+
+    const pathTo = (target: Id) => {
+      if (!isFinite(dist.get(target) ?? Infinity))
+        return { distance: Infinity, path: [] as Id[] };
+      const path: Id[] = [];
+      for (
+        let cur: Id | null = target;
+        cur != null;
+        cur = prev.get(cur) ?? null
+      )
+        path.push(cur);
+      path.reverse();
+      return { distance: dist.get(target)!, path };
     };
-    visit(start);
-    return { order };
+
+    return dst !== undefined ? pathTo(dst) : { dist, prev, pathTo };
   }
 
-  dijkstra(start: string): DijkstraResult {
-    const distances: Record<string, number> = {};
-    const previous: Record<string, string | null> = {};
-    const pq = new Set<string>(this.nodes.keys());
-    for (const n of pq) {
-      distances[n] = n === start ? 0 : Infinity;
-      previous[n] = null;
+  aStar(
+    src: Id,
+    dst: Id,
+    h: (id: Id) => number,
+    weightOf?: (u: Id, v: Id, w: number) => number,
+  ) {
+    const g = new Map<Id, number>(); // cost so far
+    const prev = new Map<Id, Id | null>();
+    const open = new MinHeap<[Id, number]>((a, b) => a[1] - b[1]); // f = g + h
+    for (const { id } of this.nodes()) {
+      g.set(id, Infinity);
+      prev.set(id, null);
     }
-    while (pq.size) {
-      let u: string | null = null;
-      let min = Infinity;
-      for (const n of pq) {
-        if (distances[n] < min) {
-          min = distances[n];
-          u = n;
-        }
-      }
-      if (u === null) break;
-      pq.delete(u);
-      for (const [v, { weight }] of this.edges.get(u) ?? []) {
-        const alt = distances[u] + weight;
-        if (alt < distances[v]) {
-          distances[v] = alt;
-          previous[v] = u;
-        }
-      }
-    }
-    return { distances, previous };
-  }
+    g.set(src, 0);
+    open.push([src, h(src)]);
 
-  topoSort(): string[] {
+    while (!open.empty()) {
+      const [u] = open.pop()!;
+      if (u === dst) break;
+      const gu = g.get(u)!;
+      for (const [v, cell] of this.neighbors(u)) {
+        const w = weightOf ? weightOf(u, v, cell.weight) : cell.weight;
+        const cand = gu + w;
+        if (cand < (g.get(v) ?? Infinity)) {
+          g.set(v, cand);
+          prev.set(v, u);
+          open.push([v, cand + h(v)]);
+        }
+      }
+    }
+
+    const path: Id[] = [];
+    if (isFinite(g.get(dst) ?? Infinity)) {
+      for (let cur: Id | null = dst; cur != null; cur = prev.get(cur) ?? null)
+        path.push(cur);
+      path.reverse();
+    }
+    return { distance: g.get(dst) ?? Infinity, path };
+  }
+  //#endregion
+
+  //#region structure / analysis
+  topologicalSort(): Id[] {
     if (!this.directed)
-      throw new Error("Topological sort requires directed graph");
-    const visited = new Set<string>();
-    const temp = new Set<string>();
-    const result: string[] = [];
-    const visit = (n: string) => {
-      if (temp.has(n)) throw new Error("Graph has cycles");
-      if (!visited.has(n)) {
-        temp.add(n);
-        for (const m of this.neighbors(n)) visit(m);
-        temp.delete(n);
-        visited.add(n);
-        result.push(n);
+      throw new Error("topologicalSort requires directed graph");
+    const indeg = new Map<Id, number>();
+    for (const { id } of this.nodes()) indeg.set(id, 0);
+    for (const { u, v } of this.edges()) indeg.set(v, (indeg.get(v) ?? 0) + 1);
+    const q: Id[] = [];
+    for (const [id, d] of indeg) if (d === 0) q.push(id);
+    const out: Id[] = [];
+    while (q.length) {
+      const u = q.shift()!;
+      out.push(u);
+      for (const [v] of this.neighbors(u)) {
+        indeg.set(v, (indeg.get(v) ?? 0) - 1);
+        if ((indeg.get(v) ?? 0) === 0) q.push(v);
       }
-    };
-    for (const n of this.nodes.keys()) visit(n);
-    return result.reverse();
+    }
+    if (out.length !== this.countNodes())
+      throw new Error("graph has at least one cycle");
+    return out;
   }
 
-  connectedComponents(): string[][] {
+  connectedComponents(): Id[][] {
     if (this.directed)
-      throw new Error("Use stronglyConnectedComponents for directed graphs");
-    const visited = new Set<string>();
-    const comps: string[][] = [];
-    for (const n of this.nodes.keys()) {
-      if (!visited.has(n)) {
-        const { order } = this.bfs(n);
-        order.forEach((v) => visited.add(v));
-        comps.push(order);
-      }
+      throw new Error("connectedComponents expects undirected graph");
+    const seen = new Set<Id>();
+    const comps: Id[][] = [];
+    for (const { id } of this.nodes()) {
+      if (seen.has(id)) continue;
+      const { order } = this.bfs(id);
+      for (const v of order) seen.add(v);
+      comps.push(order);
     }
     return comps;
   }
 
-  stronglyConnectedComponents(): string[][] {
-    if (!this.directed) throw new Error("SCC only for directed graphs");
-    const visited = new Set<string>();
-    const stack: string[] = [];
-    const dfs1 = (v: string) => {
-      visited.add(v);
-      for (const n of this.neighbors(v)) if (!visited.has(n)) dfs1(n);
-      stack.push(v);
+  stronglyConnectedComponents(): Id[][] {
+    if (!this.directed) throw new Error("SCC expects directed graph");
+    // Kosaraju
+    const order: Id[] = [];
+    const seen = new Set<Id>();
+    const dfs1 = (u: Id) => {
+      seen.add(u);
+      for (const [v] of this.neighbors(u)) if (!seen.has(v)) dfs1(v);
+      order.push(u);
     };
-    for (const n of this.nodes.keys()) if (!visited.has(n)) dfs1(n);
-    // transpose graph
-    const gt = new Graph<N, E>({ directed: true });
-    for (const [id, data] of this.nodes) gt.addNode(id, data);
-    for (const [u, outs] of this.edges)
-      for (const [v, e] of outs) gt.addEdge(v, u, e.weight, e.data);
-    visited.clear();
-    const comps: string[][] = [];
-    const dfs2 = (v: string, comp: string[]) => {
-      visited.add(v);
-      comp.push(v);
-      for (const n of gt.neighbors(v)) if (!visited.has(n)) dfs2(n, comp);
+    for (const { id } of this.nodes()) if (!seen.has(id)) dfs1(id);
+
+    // transpose
+    const gt = new Graph<ND, ED>({ directed: true });
+    for (const { id, data } of this.nodes()) gt.addNode(id, data);
+    for (const { u, v, weight, data } of this.edges())
+      gt.addEdge(v, u, { weight, data });
+
+    const comps: Id[][] = [];
+    const seen2 = new Set<Id>();
+    const dfs2 = (g: Graph<ND, ED>, u: Id, acc: Id[]) => {
+      seen2.add(u);
+      acc.push(u);
+      for (const [v] of g.neighbors(u)) if (!seen2.has(v)) dfs2(g, v, acc);
     };
-    while (stack.length) {
-      const v = stack.pop()!;
-      if (!visited.has(v)) {
-        const comp: string[] = [];
-        dfs2(v, comp);
-        comps.push(comp);
+    for (let i = order.length - 1; i >= 0; i--) {
+      const u = order[i];
+      if (!seen2.has(u)) {
+        const acc: Id[] = [];
+        dfs2(gt, u, acc);
+        comps.push(acc);
       }
     }
     return comps;
   }
+  //#endregion
 
-  toJSON(): { directed: boolean; nodes: Node<N>[]; edges: Edge<E>[] } {
-    const nodes: Node<N>[] = [];
-    for (const [id, data] of this.nodes) nodes.push({ id, data });
-    const edges: Edge<E>[] = [];
-    for (const [u, outs] of this.edges)
-      for (const [v, e] of outs)
-        edges.push({ from: u, to: v, weight: e.weight, data: e.data });
-    return { directed: this.directed, nodes, edges };
-  }
-
-  static fromJSON<N = unknown, E = unknown>(json: {
+  //#region serialization / utils
+  toJSON(): {
     directed: boolean;
-    nodes: Node<N>[];
-    edges: Edge<E>[];
-  }): Graph<N, E> {
-    const g = new Graph<N, E>({ directed: json.directed });
-    for (const n of json.nodes) g.addNode(n.id, n.data);
-    for (const e of json.edges) g.addEdge(e.from, e.to, e.weight, e.data);
+    nodes: NodeRecord<ND>[];
+    edges: EdgeRecord<ED>[];
+  } {
+    return {
+      directed: this.directed,
+      nodes: Array.from(this.nodes()),
+      edges: Array.from(this.edges()),
+    };
+  }
+  static fromJSON<ND = unknown, ED = unknown>(j: {
+    directed: boolean;
+    nodes: NodeRecord<ND>[];
+    edges: EdgeRecord<ED>[];
+  }): Graph<ND, ED> {
+    const g = new Graph<ND, ED>({ directed: j.directed });
+    for (const n of j.nodes) g.addNode(n.id, n.data);
+    for (const e of j.edges)
+      g.addEdge(e.u, e.v, { weight: e.weight, data: e.data });
     return g;
+  }
+  clone(): Graph<ND, ED> {
+    return Graph.fromJSON(this.toJSON());
+  }
+  //#endregion
+}
+
+// Tiny binary heap for Dijkstra/A*
+class MinHeap<T> {
+  private a: T[] = [];
+  private cmp: (x: T, y: T) => number;
+  constructor(cmp: (x: T, y: T) => number) {
+    this.cmp = cmp;
+  }
+  size() {
+    return this.a.length;
+  }
+  empty() {
+    return this.a.length === 0;
+  }
+  push(v: T) {
+    this.a.push(v);
+    this.up(this.a.length - 1);
+  }
+  pop(): T | undefined {
+    if (!this.a.length) return undefined;
+    const top = this.a[0],
+      end = this.a.pop()!;
+    if (this.a.length) {
+      this.a[0] = end;
+      this.down(0);
+    }
+    return top;
+  }
+  private up(i: number) {
+    while (i) {
+      const p = (i - 1) >> 1;
+      if (this.cmp(this.a[i], this.a[p]) >= 0) break;
+      [this.a[i], this.a[p]] = [this.a[p], this.a[i]];
+      i = p;
+    }
+  }
+  private down(i: number) {
+    const n = this.a.length;
+    while (true) {
+      let l = (i << 1) + 1,
+        r = l + 1,
+        s = i;
+      if (l < n && this.cmp(this.a[l], this.a[s]) < 0) s = l;
+      if (r < n && this.cmp(this.a[r], this.a[s]) < 0) s = r;
+      if (s === i) break;
+      [this.a[i], this.a[s]] = [this.a[s], this.a[i]];
+      i = s;
+    }
   }
 }


### PR DESCRIPTION
## Summary
- replace existing graph module with generic, weight-aware graph supporting BFS/DFS, shortest paths, A*, and component analysis
- update tests for new graph API

## Testing
- `npx eslint shared/js/prom-lib/ds/graph.ts shared/js/prom-lib/ds/graph.test.ts`
- `npx prettier shared/js/prom-lib/ds/graph.ts shared/js/prom-lib/ds/graph.test.ts --write`
- `npx tsc -p shared/js/prom-lib/tsconfig.json --listEmittedFiles`
- `npx jest shared/js/prom-lib/ds/graph.test.ts --config shared/js/prom-lib/jest.config.ts`
- `npm test` (terminated after running 20 tests)


------
https://chatgpt.com/codex/tasks/task_e_6897c455d9848324a5af66db9c71ec30