### PR TITLE
feat: add portable worker pool and ecs patches

### DIFF
--- a/services/js/workers/physics.job.ts
+++ b/services/js/workers/physics.job.ts
@@ -1,0 +1,31 @@
+import type { Patch } from "../../shared/js/prom-lib/ds/ecs.patches";
+
+export type PhysicsInput = {
+  eids: number[];
+  cols: Record<number, any[]>;
+  dt: number;
+  time: number;
+  writes: number[];
+  extra?: any;
+};
+
+export async function handle(input: PhysicsInput): Promise<Patch[]> {
+  const POS = input.extra.POS as number;
+  const VEL = input.extra.VEL as number;
+  const pos = input.cols[POS] as { x: number; y: number }[];
+  const vel = input.cols[VEL] as { x: number; y: number }[];
+  const patches: Patch[] = [];
+  for (let i = 0; i < input.eids.length; i++) {
+    const p = pos[i],
+      v = vel[i];
+    if (!p || !v) continue;
+    patches.push({
+      kind: "set",
+      eid: input.eids[i],
+      cid: POS,
+      value: { x: p.x + v.x * input.dt, y: p.y + v.y * input.dt },
+    });
+  }
+  return patches;
+}
+export default handle;

--- a/services/web/workers/physics.worker.ts
+++ b/services/web/workers/physics.worker.ts
@@ -1,0 +1,22 @@
+import type { Patch } from "../../shared/js/prom-lib/ds/ecs.patches";
+
+self.onmessage = (ev: MessageEvent) => {
+  const input = ev.data as any;
+  const POS = input.extra.POS as number;
+  const VEL = input.extra.VEL as number;
+  const pos = input.cols[POS] as { x: number; y: number }[];
+  const vel = input.cols[VEL] as { x: number; y: number }[];
+  const patches: Patch[] = [];
+  for (let i = 0; i < input.eids.length; i++) {
+    const p = pos[i],
+      v = vel[i];
+    if (!p || !v) continue;
+    patches.push({
+      kind: "set",
+      eid: input.eids[i],
+      cid: POS,
+      value: { x: p.x + v.x * input.dt, y: p.y + v.y * input.dt },
+    });
+  }
+  (self as any).postMessage(patches);
+};

--- a/shared/js/package-lock.json
+++ b/shared/js/package-lock.json
@@ -13,6 +13,7 @@
       },
       "devDependencies": {
         "@types/jest": "^30.0.0",
+        "@types/node": "^20.0.0",
         "eslint": "^8.57.0",
         "jest": "^29.7.0",
         "ts-jest": "^29.1.1",
@@ -1598,13 +1599,13 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "24.2.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.2.1.tgz",
-      "integrity": "sha512-DRh5K+ka5eJic8CjH7td8QpYEV6Zo10gfRkjHCO3weqZHWDtAaSTFtl4+VMqOJ4N5jcuhZ9/l+yy8rVgw7BQeQ==",
+      "version": "20.19.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.10.tgz",
+      "integrity": "sha512-iAFpG6DokED3roLSP0K+ybeDdIX6Bc0Vd3mLW5uDqThPWtNos3E+EqOM11mPQHKzfWHqEBuLjIlsBQQ8CsISmQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.10.0"
+        "undici-types": "~6.21.0"
       }
     },
     "node_modules/@types/stack-utils": {
@@ -5537,9 +5538,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.10.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.10.0.tgz",
-      "integrity": "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==",
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/shared/js/package.json
+++ b/shared/js/package.json
@@ -9,6 +9,7 @@
   },
   "devDependencies": {
     "@types/jest": "^30.0.0",
+    "@types/node": "^20.0.0",
     "eslint": "^8.57.0",
     "jest": "^29.7.0",
     "ts-jest": "^29.1.1",

--- a/shared/js/prom-lib/ds/ecs.patches.ts
+++ b/shared/js/prom-lib/ds/ecs.patches.ts
@@ -1,0 +1,18 @@
+import type { World } from "./ecs";
+
+export type Patch =
+  | { kind: "set"; eid: number; cid: number; value: any }
+  | { kind: "destroy"; eid: number }
+  | { kind: "add"; eid: number; cid: number; value?: any }
+  | { kind: "remove"; eid: number; cid: number };
+
+export function applyPatches(world: World, patches: Patch[]) {
+  for (const p of patches) {
+    if (p.kind === "set") world.set(p.eid, world["comps"][p.cid]!, p.value);
+    else if (p.kind === "destroy") world.destroyEntity(p.eid);
+    else if (p.kind === "add")
+      world.addComponent(p.eid, world["comps"][p.cid]!, p.value);
+    else if (p.kind === "remove")
+      world.removeComponent(p.eid, world["comps"][p.cid]!);
+  }
+}

--- a/shared/js/prom-lib/ds/ecs.scheduler.parallel.ts
+++ b/shared/js/prom-lib/ds/ecs.scheduler.parallel.ts
@@ -1,0 +1,102 @@
+import { Scheduler, SystemSpec, SystemContext } from "./ecs.scheduler";
+import { applyPatches, Patch } from "./ecs.patches";
+import { createPortablePool, WorkerPool } from "../worker/pool";
+import type { World, ComponentType } from "./ecs";
+
+export type OffloadSpec = {
+  nodeModule?: string;
+  browserJobName?: string;
+  reads: ComponentType<any>[];
+  writes?: ComponentType<any>[];
+  extra?: (ctx: SystemContext) => any;
+};
+
+export interface OffloadableSystem extends SystemSpec {
+  offload: OffloadSpec;
+}
+
+export class ParallelScheduler extends Scheduler {
+  private pool!: WorkerPool;
+  private ready = false;
+
+  async initPool(opts?: {
+    size?: number;
+    browserWorkers?: Record<string, () => Worker>;
+  }) {
+    this.pool = await createPortablePool(opts);
+    this.ready = true;
+  }
+
+  protected async runSystem(sys: SystemSpec, ctx: SystemContext) {
+    const as = sys as OffloadableSystem;
+    if (!("offload" in as)) return super.runSystem(sys, ctx);
+
+    if (!this.ready) await this.initPool();
+
+    const q = sys.query
+      ? this.world.makeQuery(sys.query(this.world))
+      : undefined;
+    const eids: number[] = [];
+    const cols: Record<number, any[]> = {};
+    for (const c of as.offload.reads.concat(as.offload.writes ?? []))
+      cols[c.id] = [];
+
+    if (q) {
+      for (const [e] of this.world.iter(q)) {
+        eids.push(e);
+        for (const c of as.offload.reads.concat(as.offload.writes ?? []))
+          cols[c.id].push(this.world.get(e, c));
+      }
+    }
+
+    const payload = {
+      eids,
+      cols,
+      dt: ctx.dt,
+      time: ctx.time,
+      writes: (as.offload.writes ?? []).map((c) => c.id),
+      extra: as.offload.extra?.(ctx),
+    };
+
+    const jobId =
+      typeof window !== "undefined"
+        ? as.offload.browserJobName ?? as.name
+        : as.offload.nodeModule ?? as.name;
+
+    const patches = (await this.pool.run(jobId, payload)) as Patch[];
+    if (patches && patches.length) applyPatches(this.world, patches);
+  }
+
+  async runFrame(dt: number, time: number, opts: { parallel?: boolean } = {}) {
+    if (!this["plan"]) this.compile();
+    const cmd = this["world"].beginTick();
+    const plan = this["plan"]!;
+
+    const call = (s: SystemSpec) =>
+      this.runSystem(s, {
+        world: this["world"],
+        dt,
+        time,
+        resources: this["resources"],
+        cmd,
+        stage: s.stage ?? "update",
+      });
+
+    try {
+      for (const stage of plan.stages) {
+        const batches = plan.batchesByStage.get(stage)!;
+        for (const batch of batches) {
+          if (opts.parallel ?? true) await Promise.all(batch.systems.map(call));
+          else for (const s of batch.systems) await call(s);
+        }
+      }
+    } finally {
+      cmd.flush();
+      this["world"].endTick();
+    }
+  }
+
+  async close() {
+    if (this.ready) await this.pool.close();
+  }
+}

--- a/shared/js/prom-lib/ds/ecs.scheduler.ts
+++ b/shared/js/prom-lib/ds/ecs.scheduler.ts
@@ -1,0 +1,75 @@
+import type { World } from "./ecs";
+
+export interface SystemContext {
+  world: World;
+  dt: number;
+  time: number;
+  resources: Record<string, any>;
+  cmd: { flush(): void };
+  stage: string;
+}
+
+export interface SystemSpec {
+  name: string;
+  stage?: string;
+  query?: (w: World) => { all: any[] };
+  run(ctx: SystemContext): void | Promise<void>;
+}
+
+export class Scheduler {
+  protected world: World;
+  protected systems: SystemSpec[] = [];
+  protected resources: Record<string, any> = {};
+  protected plan?: {
+    stages: string[];
+    batchesByStage: Map<string, { systems: SystemSpec[] }[]>;
+  };
+
+  constructor(world: World) {
+    this.world = world;
+  }
+
+  register(sys: SystemSpec) {
+    this.systems.push(sys);
+  }
+
+  compile() {
+    const stages = ["startup", "update", "late", "render", "cleanup"];
+    const batchesByStage = new Map<string, { systems: SystemSpec[] }[]>();
+    for (const stage of stages) batchesByStage.set(stage, [{ systems: [] }]);
+    for (const s of this.systems) {
+      const st = s.stage ?? "update";
+      const arr = batchesByStage.get(st);
+      if (!arr) batchesByStage.set(st, [{ systems: [s] }]);
+      else arr[0].systems.push(s);
+    }
+    const activeStages = stages.filter(
+      (st) => (batchesByStage.get(st)?.[0].systems.length ?? 0) > 0,
+    );
+    this.plan = { stages: activeStages, batchesByStage };
+  }
+
+  protected async runSystem(sys: SystemSpec, ctx: SystemContext) {
+    await sys.run(ctx);
+  }
+
+  async runFrame(dt: number, time: number) {
+    if (!this.plan) this.compile();
+    const cmd = { flush() {} };
+    for (const stage of this.plan!.stages) {
+      const batches = this.plan!.batchesByStage.get(stage)!;
+      for (const batch of batches) {
+        for (const s of batch.systems) {
+          await this.runSystem(s, {
+            world: this.world,
+            dt,
+            time,
+            resources: this.resources,
+            cmd,
+            stage: s.stage ?? "update",
+          });
+        }
+      }
+    }
+  }
+}

--- a/shared/js/prom-lib/ds/ecs.ts
+++ b/shared/js/prom-lib/ds/ecs.ts
@@ -1,0 +1,73 @@
+export interface ComponentType<T = any> {
+  id: number;
+  name: string;
+  defaults?: () => T;
+}
+
+export class World {
+  comps: ComponentType[] = [];
+  private store = new Map<number, Map<number, any>>();
+  private nextEid = 1;
+
+  defineComponent<T>(spec: {
+    name: string;
+    defaults?: () => T;
+  }): ComponentType<T> {
+    const comp: ComponentType<T> = {
+      id: this.comps.length,
+      name: spec.name,
+      defaults: spec.defaults,
+    };
+    this.comps.push(comp);
+    return comp;
+  }
+
+  createEntity(): number {
+    const eid = this.nextEid++;
+    this.store.set(eid, new Map());
+    return eid;
+  }
+
+  destroyEntity(eid: number) {
+    this.store.delete(eid);
+  }
+
+  addComponent<T>(eid: number, comp: ComponentType<T>, value?: T) {
+    const e = this.store.get(eid);
+    if (!e) return;
+    e.set(comp.id, value ?? comp.defaults?.());
+  }
+
+  removeComponent<T>(eid: number, comp: ComponentType<T>) {
+    const e = this.store.get(eid);
+    if (!e) return;
+    e.delete(comp.id);
+  }
+
+  set<T>(eid: number, comp: ComponentType<T>, value: T) {
+    const e = this.store.get(eid);
+    if (!e) return;
+    e.set(comp.id, value);
+  }
+
+  get<T>(eid: number, comp: ComponentType<T>): T | undefined {
+    const e = this.store.get(eid);
+    return e?.get(comp.id);
+  }
+
+  makeQuery(spec: { all: ComponentType<any>[] }) {
+    return spec.all.map((c) => c.id);
+  }
+
+  *iter(query: number[]) {
+    for (const [eid, comps] of this.store.entries()) {
+      if (query.every((cid) => comps.has(cid))) yield [eid];
+    }
+  }
+
+  beginTick() {
+    return { flush() {} };
+  }
+
+  endTick() {}
+}

--- a/shared/js/prom-lib/worker/pool.browser.ts
+++ b/shared/js/prom-lib/worker/pool.browser.ts
@@ -1,0 +1,25 @@
+export class BrowserWorkerPool {
+  private factories: Record<string, () => Worker>;
+  constructor(factories: Record<string, () => Worker>) {
+    this.factories = factories;
+  }
+  run(name: string, input: any) {
+    return new Promise((resolve, reject) => {
+      const w = this.factories[name]();
+      const onMsg = (ev: MessageEvent) => {
+        w.removeEventListener("message", onMsg);
+        w.terminate();
+        resolve(ev.data);
+      };
+      const onErr = (e: ErrorEvent) => {
+        w.removeEventListener("error", onErr);
+        w.terminate();
+        reject(e.error || new Error(e.message));
+      };
+      w.addEventListener("message", onMsg);
+      w.addEventListener("error", onErr);
+      w.postMessage(input);
+    });
+  }
+  async close() {}
+}

--- a/shared/js/prom-lib/worker/pool.local.ts
+++ b/shared/js/prom-lib/worker/pool.local.ts
@@ -1,0 +1,10 @@
+export class LocalPool {
+  async run(modOrName: string, input: any) {
+    const m = await import(/* @vite-ignore */ modOrName).catch(() => ({
+      default: (x: any) => x,
+    }));
+    const fn = (m.handle ?? m.default) as any;
+    return fn ? fn(input) : input;
+  }
+  async close() {}
+}

--- a/shared/js/prom-lib/worker/pool.node.ts
+++ b/shared/js/prom-lib/worker/pool.node.ts
@@ -1,0 +1,80 @@
+import { Worker } from "node:worker_threads";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+type Task = {
+  id: number;
+  mod: string;
+  input: any;
+  resolve: (v: any) => void;
+  reject: (e: any) => void;
+};
+
+export class NodeWorkerPool {
+  private size: number;
+  private workers: Worker[] = [];
+  private idle: Worker[] = [];
+  private q: Task[] = [];
+  private nextId = 1;
+  private runnerURL: string;
+  private _tasks = new Map<number, Task>();
+
+  constructor(size = Math.max(1, os.cpus().length - 1)) {
+    this.size = size;
+    const here = path.dirname(fileURLToPath(import.meta.url));
+    this.runnerURL = pathToFileURL(path.join(here, "runner.node.js")).href;
+    for (let i = 0; i < this.size; i++) this.spawn();
+  }
+
+  private spawn() {
+    const w = new Worker(this.runnerURL, { type: "module" });
+    w.on("message", (msg) => {
+      const task = this._tasks.get(msg.id);
+      if (!task) return;
+      this._tasks.delete(msg.id);
+      this.idle.push(w);
+      if (msg.ok) task.resolve(msg.out);
+      else task.reject(new Error(msg.err || "job failed"));
+      this._drain();
+    });
+    w.on("error", (err) => {
+      for (const [id, t] of this._tasks)
+        if ((t as any).worker === w) {
+          t.reject(err);
+          this._tasks.delete(id);
+        }
+      this.workers = this.workers.filter((x) => x !== w);
+      this.spawn();
+    });
+    (w as any)._busy = false;
+    this.workers.push(w);
+    this.idle.push(w);
+  }
+
+  private _drain() {
+    while (this.q.length && this.idle.length) {
+      const t = this.q.shift()!;
+      const w = this.idle.pop()!;
+      (t as any).worker = w;
+      this._tasks.set(t.id, t);
+      w.postMessage({ id: t.id, mod: t.mod, input: t.input });
+    }
+  }
+
+  run(mod: string, input: any) {
+    return new Promise((resolve, reject) => {
+      const id = this.nextId++;
+      this.q.push({ id, mod, input, resolve, reject });
+      this._drain();
+    });
+  }
+
+  async close() {
+    for (const w of this.workers) w.terminate();
+    this.workers.length = 0;
+    this.idle.length = 0;
+    this.q.length = 0;
+    this._tasks.clear();
+  }
+}

--- a/shared/js/prom-lib/worker/pool.ts
+++ b/shared/js/prom-lib/worker/pool.ts
@@ -1,0 +1,32 @@
+export type JobInput = any;
+export type JobOutput = any;
+export type JobModule = string;
+
+export interface WorkerPool {
+  run(moduleOrName: string, input: JobInput): Promise<JobOutput>;
+  close(): Promise<void>;
+}
+
+const isNode =
+  typeof process !== "undefined" && !!(process.versions as any)?.node;
+const isBrowser = typeof window !== "undefined";
+
+export async function createPortablePool(
+  opts: {
+    size?: number;
+    browserWorkers?: Record<string, () => Worker>;
+  } = {},
+): Promise<WorkerPool> {
+  if (isNode) {
+    const m = await import("./pool.node");
+    return new m.NodeWorkerPool(
+      opts.size ?? Math.max(1, require("os").cpus().length - 1),
+    );
+  }
+  if (isBrowser && typeof Worker !== "undefined" && opts.browserWorkers) {
+    const m = await import("./pool.browser");
+    return new m.BrowserWorkerPool(opts.browserWorkers);
+  }
+  const m = await import("./pool.local");
+  return new m.LocalPool();
+}

--- a/shared/js/prom-lib/worker/runner.node.ts
+++ b/shared/js/prom-lib/worker/runner.node.ts
@@ -1,0 +1,13 @@
+import { parentPort } from "node:worker_threads";
+
+parentPort!.on("message", async (msg) => {
+  const { id, mod, input } = msg;
+  try {
+    const m = await import(mod);
+    const fn = (m.handle ?? m.default) as (x: any) => any | Promise<any>;
+    const out = await fn(input);
+    parentPort!.postMessage({ id, ok: true, out });
+  } catch (e: any) {
+    parentPort!.postMessage({ id, ok: false, err: e?.message ?? String(e) });
+  }
+});


### PR DESCRIPTION
## Summary
- implement minimal ECS world and patch application utility
- add portable worker pool with Node, browser, and local implementations
- create parallel ECS scheduler with worker offloading and example physics jobs

## Testing
- `make setup-shared-js`
- `make format-js`
- `make lint-js`
- `make build-js`
- `make test-js-service-workers`
- `npx jest` *(fails: Jest encountered an unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_6897c4469ad88324a1efd85648d0fbd4