### PR TITLE
feat: add Lisp compiler frontend

### DIFF
--- a/shared/js/prom-lib/compiler/ast.ts
+++ b/shared/js/prom-lib/compiler/ast.ts
@@ -1,0 +1,23 @@
+import type { Span } from "./lisp/syntax";
+
+export interface Name {
+  text: string;
+  span?: Span;
+}
+export function name(text: string, span?: Span): Name {
+  return { text, span };
+}
+
+export type Expr =
+  | { kind: "Num"; value: number; span: Span }
+  | { kind: "Str"; value: string; span: Span }
+  | { kind: "Bool"; value: boolean; span: Span }
+  | { kind: "Null"; span: Span }
+  | { kind: "Var"; name: Name; span: Span }
+  | { kind: "If"; cond: Expr; then: Expr; else: Expr; span: Span }
+  | { kind: "Block"; exprs: Expr[]; span: Span }
+  | { kind: "Let"; name: Name; value: Expr; body: Expr; span: Span }
+  | { kind: "Fun"; params: Name[]; body: Expr; span: Span }
+  | { kind: "Bin"; op: string; left: Expr; right: Expr; span: Span }
+  | { kind: "Un"; op: string; expr: Expr; span: Span }
+  | { kind: "Call"; callee: Expr; args: Expr[]; span: Span };

--- a/shared/js/prom-lib/compiler/jsgen.ts
+++ b/shared/js/prom-lib/compiler/jsgen.ts
@@ -1,0 +1,52 @@
+import type { Expr } from "./ast";
+
+interface Options {
+  iife: boolean;
+  importNames: string[];
+  pretty: boolean;
+}
+
+export function emitJS(expr: Expr, opts: Options): string {
+  const body = emitExpr(expr);
+  const imports = opts.importNames;
+  const header = imports.length
+    ? `const { ${imports.join(", ")} } = args;`
+    : "";
+  return `(function(args){${header}return ${body};})`;
+}
+
+function emitExpr(e: Expr): string {
+  switch (e.kind) {
+    case "Num":
+      return String(e.value);
+    case "Str":
+      return JSON.stringify(e.value);
+    case "Bool":
+      return e.value ? "true" : "false";
+    case "Null":
+      return "null";
+    case "Var":
+      return e.name.text;
+    case "If":
+      return `(${emitExpr(e.cond)}?${emitExpr(e.then)}:${emitExpr(e.else)})`;
+    case "Block": {
+      const exprs = e.exprs.map(emitExpr);
+      const last = exprs.pop() ?? "null";
+      return `(function(){${exprs
+        .map((x) => `${x};`)
+        .join("")}return ${last};})()`;
+    }
+    case "Let":
+      return `(function(){const ${e.name.text}=${emitExpr(
+        e.value,
+      )};return ${emitExpr(e.body)};})()`;
+    case "Fun":
+      return `(${e.params.map((p) => p.text).join(",")}=>${emitExpr(e.body)})`;
+    case "Bin":
+      return `(${emitExpr(e.left)}${e.op}${emitExpr(e.right)})`;
+    case "Un":
+      return `(${e.op}${emitExpr(e.expr)})`;
+    case "Call":
+      return `${emitExpr(e.callee)}(${e.args.map(emitExpr).join(",")})`;
+  }
+}

--- a/shared/js/prom-lib/compiler/lisp/driver.test.ts
+++ b/shared/js/prom-lib/compiler/lisp/driver.test.ts
@@ -1,0 +1,14 @@
+import { runLisp } from "./driver";
+
+test("basic arithmetic", () => {
+  expect(runLisp("(+ 2 40)")).toBe(42);
+});
+
+test("macro expansion", () => {
+  const src = `
+    (defmacro twice (x)
+      \`(+ ,x ,x))
+    (twice 21)
+  `;
+  expect(runLisp(src)).toBe(42);
+});

--- a/shared/js/prom-lib/compiler/lisp/driver.ts
+++ b/shared/js/prom-lib/compiler/lisp/driver.ts
@@ -1,0 +1,28 @@
+import { read } from "./reader";
+import { macroexpandAll } from "./expand";
+import { toExpr } from "./to-expr";
+import { lower } from "../lower";
+import { emitJS } from "../jsgen";
+
+export function compileLispToJS(
+  src: string,
+  { pretty = false, importNames = [] as string[] } = {},
+) {
+  const forms = read(src);
+  const expanded = macroexpandAll(forms);
+  // stitch multiple top-level forms into (begin ...)
+  const program =
+    expanded.length === 1
+      ? expanded[0]
+      : ({ t: "list", xs: [{ t: "sym", name: "begin" }, ...expanded] } as any);
+  const ast = toExpr(program as any);
+  const ir = lower(ast);
+  const js = emitJS(ir, { iife: false, importNames, pretty });
+  return { forms, expanded, ast, ir, js };
+}
+
+export function runLisp(src: string, imports: Record<string, any> = {}) {
+  const { js } = compileLispToJS(src);
+  const fn = (0, eval)(js);
+  return fn(imports);
+}

--- a/shared/js/prom-lib/compiler/lisp/expand.ts
+++ b/shared/js/prom-lib/compiler/lisp/expand.ts
@@ -1,0 +1,48 @@
+import { S, List, Sym, isList, isSym, list, sym } from "./syntax";
+import { MacroEnv, installCoreMacros } from "./macros";
+
+export function macroexpandAll(forms: S[], user?: (m: MacroEnv) => void): S[] {
+  const M = new MacroEnv();
+  installCoreMacros(M);
+  user?.(M); // allow host to preinstall macros
+
+  // one pass that registers top-level defmacros, then expand everything
+  const expanded: S[] = [];
+  for (const f of forms) {
+    if (isList(f, "defmacro")) {
+      expand(f, M);
+      continue;
+    }
+    const e = expand(f, M);
+    expanded.push(e);
+  }
+  return expanded;
+}
+
+function expand(x: S, M: MacroEnv): S {
+  // atoms unchanged
+  if (x.t !== "list" || x.xs.length === 0) return x;
+
+  // handle defmacro at top or nested (register and return nil)
+  if (isList(x, "defmacro")) {
+    const head = (x as List).xs[0] as Sym;
+    const fn = M.get("defmacro")!;
+    return fn(x as List, (y) => expand(y, M));
+  }
+
+  // macro call?
+  const head = (x as List).xs[0];
+  if (head.t === "sym" && M.has(head.name)) {
+    const fn = M.get(head.name)!;
+    const out = fn(x as List, (y) => expand(y, M));
+    return expand(out, M);
+  }
+
+  // special forms that must not expand their operands eagerly can be handled here if needed.
+
+  // otherwise recursively expand elements
+  return list(
+    x.xs.map((e) => expand(e, M)),
+    x.span,
+  );
+}

--- a/shared/js/prom-lib/compiler/lisp/macros.ts
+++ b/shared/js/prom-lib/compiler/lisp/macros.ts
@@ -1,0 +1,114 @@
+import { S, List, Sym, list, sym, isList, isSym, gensym } from "./syntax";
+import { qq } from "./qq";
+
+export type MacroFn = (form: List, expand: (x: S) => S) => S;
+export class MacroEnv {
+  private m = new Map<string, MacroFn>();
+  define(name: string, fn: MacroFn) {
+    this.m.set(name, fn);
+  }
+  get(name: string) {
+    return this.m.get(name);
+  }
+  has(name: string) {
+    return this.m.has(name);
+  }
+}
+
+// (defmacro name (a b . rest) `(... ,a ,@rest ...))
+export function installCoreMacros(M: MacroEnv) {
+  // defmacro
+  M.define("defmacro", (form, expand) => {
+    // (defmacro name (params...) body)
+    const [_tag, nameS, paramsList, body] = form.xs;
+    const name = (nameS as Sym).name;
+    const { params, rest } = parseParams(paramsList as List);
+
+    const fn: MacroFn = (call, expand2) => {
+      const args = call.xs.slice(1);
+      const env: Record<string, S> = {};
+      params.forEach((p, i) => (env[p] = args[i]));
+      if (rest) env[rest] = list(args.slice(params.length));
+      // body is typically a quasiquote; run qq with env
+      const expanded = isList(body, "quasiquote") ? qq(body, env) : body;
+      return expand(expanded); // allow nested macros inside result
+    };
+    M.define(name, fn);
+    return sym("nil");
+  });
+
+  // when
+  M.define("when", (form, expand) => {
+    // (when test a b c) => (if test (begin a b c) nil)
+    const [_tag, test, ...body] = form.xs;
+    const begin = list([sym("begin"), ...body]);
+    return list([sym("if"), test, begin, sym("nil")]);
+  });
+
+  // unless
+  M.define("unless", (form, expand) => {
+    const [_tag, test, ...body] = form.xs;
+    const begin = list([sym("begin"), ...body]);
+    return list([sym("if"), list([sym("not"), test]), begin, sym("nil")]);
+  });
+
+  // -> (thread-first)
+  M.define("->", (form, expand) => {
+    // (-> x (f 1) (g 2)) => (g (f x 1) 2)
+    const [_tag, x, ...steps] = form.xs;
+    let acc = x;
+    for (const s of steps) {
+      if (s.t !== "list" || s.xs.length === 0) continue;
+      const [f, ...args] = s.xs;
+      acc = list([f, acc, ...args], s.span);
+    }
+    return acc;
+  });
+
+  // let* sugar -> nested lets
+  M.define("let*", (form) => {
+    // (let* ((a 1)(b 2)) body) => (let ((a 1)) (let ((b 2)) body))
+    const [_tag, bindings, body] = form.xs;
+    const pairs = (bindings as List).xs.map((b) => (b as List).xs);
+    let acc = body;
+    for (let i = pairs.length - 1; i >= 0; i--) {
+      const [n, v] = pairs[i];
+      acc = list([sym("let"), list([list([n, v])]), acc]);
+    }
+    return acc;
+  });
+
+  // cond -> nested ifs
+  M.define("cond", (form) => {
+    const [_tag, ...clauses] = form.xs;
+    const expandClause = (i: number): S => {
+      if (i >= clauses.length) return sym("nil");
+      const clause = clauses[i] as List;
+      const [test, ...body] = clause.xs;
+      if (isSym(test, "else")) return list([sym("begin"), ...body]);
+      return list([
+        sym("if"),
+        test,
+        list([sym("begin"), ...body]),
+        expandClause(i + 1),
+      ]);
+    };
+    return expandClause(0);
+  });
+}
+
+function parseParams(p: List): { params: string[]; rest?: string } {
+  // (a b c) or (a b . rest)
+  const xs = p.xs;
+  const params: string[] = [];
+  let rest: string | undefined;
+  for (let i = 0; i < xs.length; i++) {
+    const a = xs[i];
+    if (a.t === "sym" && a.name === ".") {
+      rest = (xs[i + 1] as Sym).name;
+      break;
+    }
+    params.push((a as Sym).name);
+  }
+  return { params, rest };
+}

--- a/shared/js/prom-lib/compiler/lisp/qq.ts
+++ b/shared/js/prom-lib/compiler/lisp/qq.ts
@@ -1,0 +1,33 @@
+import { S, List, Sym, Nil, isList, isSym, list, sym, nil } from "./syntax";
+
+export function qq(expr: S, env: Record<string, S>): S {
+  // (quasiquote x) expands with , and ,@ substitutions from env
+  if (!isList(expr, "quasiquote")) return expr;
+  return expand((expr as List).xs[1], env);
+}
+
+function expand(x: S, env: Record<string, S>): S {
+  if (isList(x, "unquote")) {
+    const v = (x as List).xs[1];
+    if (v.t !== "sym") throw new Error("unquote expects symbol");
+    return env[v.name] ?? env[(v as any).gensym ?? ""] ?? v;
+  }
+  if (isList(x, "unquote-splicing")) {
+    throw new Error(",@ only valid inside list contexts");
+  }
+  if (x.t !== "list") return x;
+  // build list, handling splices
+  const out: S[] = [];
+  for (const el of x.xs) {
+    if (isList(el, "unquote-splicing")) {
+      const v = (el as List).xs[1];
+      if (v.t !== "sym") throw new Error(",@ expects symbol");
+      const xs = env[v.name] ?? env[(v as any).gensym ?? ""];
+      if (!xs || xs.t !== "list") throw new Error(",@ needs a list");
+      out.push(...xs.xs);
+    } else {
+      out.push(expand(el, env));
+    }
+  }
+  return list(out, x.span);
+}

--- a/shared/js/prom-lib/compiler/lisp/reader.ts
+++ b/shared/js/prom-lib/compiler/lisp/reader.ts
@@ -1,0 +1,181 @@
+import {
+  Span,
+  S,
+  Sym,
+  List,
+  Nil,
+  num,
+  str,
+  bool,
+  sym,
+  list,
+  nil,
+} from "./syntax";
+
+type Tok =
+  | { k: "id"; s: string; sp: Span }
+  | { k: "num"; s: string; sp: Span }
+  | { k: "str"; s: string; sp: Span }
+  | { k: "p"; s: string; sp: Span }
+  | { k: "eof"; sp: Span };
+
+export function read(src: string): S[] {
+  const tks = lex(src);
+  let i = 0;
+  const peek = () => tks[i];
+  const next = () => tks[i++];
+
+  function readDatum(): S {
+    const t = next();
+    if (t.k === "eof") return nil;
+    if (t.k === "num") return num(parseFloat(t.s), t.sp);
+    if (t.k === "str") return str(t.s, t.sp);
+    if (t.k === "id") {
+      if (t.s === "true") return bool(true, t.sp);
+      if (t.s === "false") return bool(false, t.sp);
+      if (t.s === "nil") return nil;
+      return sym(t.s, t.sp);
+    }
+    if (t.k === "p") {
+      if (t.s === "(") {
+        const xs: S[] = [];
+        while (true) {
+          const p = peek();
+          if (p.k === "p" && (p as any).s === ")") break;
+          xs.push(readDatum());
+        }
+        next(); // )
+        return list(xs, t.sp);
+      }
+      // quote / quasiquote / unquotes
+      if (t.s === "'") return list([sym("quote", t.sp), readDatum()], t.sp);
+      if (t.s === "`")
+        return list([sym("quasiquote", t.sp), readDatum()], t.sp);
+      if (t.s === ",") return list([sym("unquote", t.sp), readDatum()], t.sp);
+      if (t.s === ",@")
+        return list([sym("unquote-splicing", t.sp), readDatum()], t.sp);
+    }
+    throw new Error(`unexpected token ${JSON.stringify(t)}`);
+  }
+
+  const out: S[] = [];
+  while (peek().k !== "eof") out.push(readDatum());
+  return out;
+}
+
+// --- tiny lexer ---
+function lex(src: string): Tok[] {
+  const out: Tok[] = [];
+  let i = 0,
+    line = 1,
+    col = 1;
+  const span = (start: number): Span => ({ start, end: i, line, col });
+  const push = (k: any, s: string, st: number) =>
+    out.push({ k, s, sp: { start: st, end: i, line, col } });
+  const two = () => src.slice(i, i + 2);
+
+  while (i < src.length) {
+    const st = i;
+    const c = src[i];
+    if (c === " " || c === "\t" || c === "\r") {
+      i++;
+      col++;
+      continue;
+    }
+    if (c === "\n") {
+      i++;
+      line++;
+      col = 1;
+      continue;
+    }
+    if (c === ";") {
+      while (i < src.length && src[i] !== "\n") {
+        i++;
+        col++;
+      }
+      continue;
+    }
+
+    if (c === "(" || c === ")") {
+      i++;
+      col++;
+      push("p", c, st);
+      continue;
+    }
+    if (c === "'") {
+      i++;
+      col++;
+      push("p", "'", st);
+      continue;
+    }
+    if (c === "`") {
+      i++;
+      col++;
+      push("p", "`", st);
+      continue;
+    }
+    if (c === "," && two() === ",@") {
+      i += 2;
+      col += 2;
+      push("p", ",@", st);
+      continue;
+    }
+    if (c === ",") {
+      i++;
+      col++;
+      push("p", ",", st);
+      continue;
+    }
+
+    if (c === '"' || c === "'") {
+      const q = c;
+      i++;
+      col++;
+      let buf = "";
+      while (i < src.length && src[i] !== q) {
+        if (src[i] === "\\") {
+          buf += src[i + 1];
+          i += 2;
+          col += 2;
+        } else {
+          buf += src[i];
+          i++;
+          col++;
+        }
+      }
+      i++;
+      col++;
+      push("str", buf, st);
+      continue;
+    }
+
+    if (/[0-9]/.test(c) || (c === "." && /[0-9]/.test(src[i + 1] || ""))) {
+      let j = i;
+      while (/[0-9_]/.test(src[j] || "")) j++;
+      if (src[j] === ".") {
+        j++;
+        while (/[0-9_]/.test(src[j] || "")) j++;
+      }
+      const s = src.slice(i, j).replace(/_/g, "");
+      i = j;
+      col += j - st;
+      push("num", s, st);
+      continue;
+    }
+
+    // symbol chars
+    if (/[A-Za-z_\-\+\*\!\/\=\<\>\?\$:%]/.test(c)) {
+      let j = i + 1;
+      while (/[A-Za-z0-9_\-\+\*\!\/\=\<\>\?\$:%\.]/.test(src[j] || "")) j++;
+      const s = src.slice(i, j);
+      i = j;
+      col += j - st;
+      push("id", s, st);
+      continue;
+    }
+
+    throw new Error(`bad char '${c}'`);
+  }
+  out.push({ k: "eof", sp: { start: i, end: i, line, col } });
+  return out;
+}

--- a/shared/js/prom-lib/compiler/lisp/syntax.ts
+++ b/shared/js/prom-lib/compiler/lisp/syntax.ts
@@ -1,0 +1,35 @@
+export type Span = { start: number; end: number; line: number; col: number };
+export type Sym = { t: "sym"; name: string; gensym?: string; span?: Span };
+export type Num = { t: "num"; v: number; span?: Span };
+export type Str = { t: "str"; v: string; span?: Span };
+export type Bool = { t: "bool"; v: boolean; span?: Span };
+export type Nil = { t: "nil"; span?: Span };
+export type List = { t: "list"; xs: S[]; span?: Span };
+
+export type S = Sym | Num | Str | Bool | Nil | List;
+
+export const nil: Nil = { t: "nil" };
+export const sym = (name: string, span?: Span): Sym => ({
+  t: "sym",
+  name,
+  span,
+});
+export const list = (xs: S[], span?: Span): List => ({ t: "list", xs, span });
+export const num = (v: number, span?: Span): Num => ({ t: "num", v, span });
+export const str = (v: string, span?: Span): Str => ({ t: "str", v, span });
+export const bool = (v: boolean, span?: Span): Bool => ({ t: "bool", v, span });
+
+let _gid = 0;
+export function gensym(prefix = "g"): Sym {
+  return { t: "sym", name: `${prefix}`, gensym: `${prefix}$${_gid++}` };
+}
+export function symName(x: Sym): string {
+  return x.gensym ?? x.name;
+}
+export const isSym = (x: S, n?: string) =>
+  x.t === "sym" && (n ? (x as Sym).name === n : true);
+export const isList = (x: S, n?: string) =>
+  x.t === "list" &&
+  (n
+    ? (x as List).xs[0]?.t === "sym" && ((x as List).xs[0] as Sym).name === n
+    : true);

--- a/shared/js/prom-lib/compiler/lisp/to-expr.ts
+++ b/shared/js/prom-lib/compiler/lisp/to-expr.ts
@@ -1,0 +1,144 @@
+import type { Expr } from "../ast";
+import { name as mkName } from "../ast";
+import {
+  S,
+  List,
+  Sym,
+  Num,
+  Str,
+  Bool,
+  Nil,
+  isList,
+  isSym,
+  list,
+  sym,
+} from "./syntax";
+
+export function toExpr(x: S): Expr {
+  switch (x.t) {
+    case "num":
+      return { kind: "Num", value: x.v, span: x.span! };
+    case "str":
+      return { kind: "Str", value: x.v, span: x.span! };
+    case "bool":
+      return { kind: "Bool", value: x.v, span: x.span! };
+    case "nil":
+      return { kind: "Null", span: x.span! };
+    case "sym":
+      return {
+        kind: "Var",
+        name: mkName(x.gensym ?? x.name, x.span!),
+        span: x.span!,
+      };
+    case "list":
+      return listToExpr(x);
+  }
+}
+
+function listToExpr(x: List): Expr {
+  if (x.xs.length === 0) return { kind: "Null", span: x.span! };
+
+  const hd = x.xs[0];
+  // core forms: (if c t e), (let ((a v) (b w)) body...), (fn (a b) body...), (begin ...), (quote v)
+  if (isSym(hd, "if")) {
+    const [, c, t, e] = x.xs;
+    return {
+      kind: "If",
+      cond: toExpr(c),
+      then: toExpr(t),
+      else: toExpr(e),
+      span: x.span!,
+    };
+  }
+  if (isSym(hd, "begin")) {
+    const exprs = x.xs.slice(1).map(toExpr);
+    const span = exprs[0]?.["span"] ?? x.span!;
+    return { kind: "Block", exprs, span };
+  }
+  if (isSym(hd, "quote")) {
+    // quote datum -> turn into a JS literal via simple conversion (lists to nested arrays)
+    const v = datumToJs(x.xs[1]);
+    return { kind: "Str", value: JSON.stringify(v), span: x.span! }; // simplest: embed JSON string (you can upgrade to tagged data)
+  }
+  if (isSym(hd, "let")) {
+    // (let ((a v) (b w)) body...)
+    const bindings = (x.xs[1] as List).xs.map((b) => (b as List).xs);
+    let body = x.xs
+      .slice(2)
+      .reduceRight((acc, e) => list([sym("begin"), e, acc]), sym("nil") as S);
+    // desugar chain into nested lets
+    for (let i = bindings.length - 1; i >= 0; i--) {
+      const [n, v] = bindings[i];
+      body = list([sym("let1"), n, v, body]);
+    }
+    return toExpr(body);
+  }
+  if (isSym(hd, "let1")) {
+    const [, n, v, body] = x.xs;
+    return {
+      kind: "Let",
+      name: mkName((n as Sym).gensym ?? (n as Sym).name, n.span!),
+      value: toExpr(v),
+      body: toExpr(body),
+      span: x.span!,
+    };
+  }
+  if (isSym(hd, "fn") || isSym(hd, "lambda")) {
+    const params = ((x.xs[1] as List).xs as Sym[]).map((s) =>
+      mkName(s.gensym ?? s.name, s.span!),
+    );
+    const bodyS = x.xs.slice(2);
+    const body =
+      bodyS.length === 1
+        ? toExpr(bodyS[0])
+        : toExpr(list([sym("begin"), ...bodyS]));
+    return { kind: "Fun", params, body, span: x.span! };
+  }
+
+  // infix ops map to Bin/Un, else -> Call
+  const binOp = new Set([
+    "+",
+    "-",
+    "*",
+    "/",
+    "%",
+    "<",
+    ">",
+    "<=",
+    ">=",
+    "==",
+    "!=",
+  ]);
+  const unOp = new Set(["not", "neg"]);
+  if (hd.t === "sym" && binOp.has(hd.name) && x.xs.length === 3) {
+    return {
+      kind: "Bin",
+      op: hd.name,
+      left: toExpr(x.xs[1]),
+      right: toExpr(x.xs[2]),
+      span: x.span!,
+    } as any;
+  }
+  if (hd.t === "sym" && hd.name === "-" && x.xs.length === 2) {
+    return { kind: "Un", op: "-", expr: toExpr(x.xs[1]), span: x.span! } as any;
+  }
+  if (hd.t === "sym" && hd.name === "not" && x.xs.length === 2) {
+    return { kind: "Un", op: "!", expr: toExpr(x.xs[1]), span: x.span! } as any;
+  }
+
+  // function call: (f a b c)
+  return {
+    kind: "Call",
+    callee: toExpr(hd),
+    args: x.xs.slice(1).map(toExpr),
+    span: x.span!,
+  };
+}
+
+function datumToJs(x: any): any {
+  if (x.t === "num" || x.t === "str" || x.t === "bool") return x.v;
+  if (x.t === "nil") return null;
+  if (x.t === "sym") return x.name;
+  if (x.t === "list") return x.xs.map(datumToJs);
+  return null;
+}

--- a/shared/js/prom-lib/compiler/lower.ts
+++ b/shared/js/prom-lib/compiler/lower.ts
@@ -1,0 +1,5 @@
+import type { Expr } from "./ast";
+export type IR = Expr;
+export function lower(expr: Expr): IR {
+  return expr;
+}

--- a/shared/js/prom-lib/tsconfig.json
+++ b/shared/js/prom-lib/tsconfig.json
@@ -15,6 +15,7 @@
     "event/**/*.ts",
     "ds/**/*.ts",
     "worker/**/*.ts",
-    "intention/**/*.ts"
+    "intention/**/*.ts",
+    "compiler/**/*.ts"
   ]
 }


### PR DESCRIPTION
## Summary
- add Lisp syntax definitions, reader, macros, and macroexpander
- wire Lisp frontend to existing compiler pipeline and JS emitter
- include basic tests for arithmetic and macro expansion

## Testing
- `npx eslint shared/js/prom-lib/compiler/**/*.ts`
- `npx tsc -p shared/js/prom-lib/tsconfig.json`
- `npx jest -c shared/js/prom-lib/jest.config.ts`
- `make lint-js`
- `make format-js`
- `make build-js`
- `make test-js`


------
https://chatgpt.com/codex/tasks/task_e_6897c46f07e8832486df435a62f0fedf