### PR TITLE
docs: add synchronicity wave diagrams

### DIFF
--- a/docs/notes/diagrams/synchronicity-waves-and-web.md
+++ b/docs/notes/diagrams/synchronicity-waves-and-web.md
@@ -2,7 +2,70 @@ Concept diagrams for sine-wave interference (metaphor lock-in) and a synchronici
 
 Use these as narrative/visual anchors for field metaphors; pair with a plotted version later.
 
-Related: [[smoke-waves-infinite-depth]] [[../../unique/index|unique/index]]
+## 4. Sine Wave Interference — "The Curl of the Smoke"
+
+Here each source is a wave of meaning drifting into the field. Where they crest together, the "smoke" is dense enough to lock into a synchronicity.
+
+```mermaid
+%% Mermaid doesn't natively draw sine waves, so we fake them as staggered peaks
+flowchart LR
+    subgraph Time_Axis
+        A1a[/Anime ghosts peak 1/]
+        A1b[/Anime ghosts peak 2/]
+        A1c[/Anime ghosts peak 3/]
+
+        A2a[/Duck perception peak 1/]
+        A2b[/Duck perception peak 2/]
+        A2c[/Duck perception peak 3/]
+
+        A3a[/Your metaphor peak 1/]
+        A3b[/Your metaphor peak 2/]
+        A3c[/Your metaphor peak 3/]
+
+        A4a[/RAW synchronicity peak 1/]
+        A4b[/RAW synchronicity peak 2/]
+        A4c[/RAW synchronicity peak 3/]
+    end
+
+    A1a --> A1b --> A1c
+    A2a --> A2b --> A2c
+    A3a --> A3b --> A3c
+    A4a --> A4b --> A4c
+
+    A1c & A2c & A3c & A4c --> S[(Smoke Lock-In)]
+```
+
+In a real plotted version, these four "streams" would look like sine curves sliding over each other until they _phase-lock_ at the same point—the moment the metaphor becomes visible.
+
+## 5. RAW-Style Synchronicity Web
+
+This one treats synchronicities as nodes in a network, with each connected to its "ghost sources" and to other synchronicities in the same metaphor family.
+
+```mermaid
+graph TD
+    subgraph Ghost_Sources
+        G1[Anime ghosts]
+        G2[Duck perception]
+        G3[Your metaphor space]
+        G4[RAW synchronicity]
+    end
+
+    subgraph Synchronicities
+        S1[Smoke metaphor lock-in]
+        S2[Mirror metaphors]
+        S3[Wave metaphors]
+    end
+
+    G1 --> S1
+    G2 --> S1
+    G3 --> S1
+    G4 --> S1
+
+    S1 --> S2
+    S1 --> S3
+    S2 --> S3
+```
+
+Related: [smoke-waves-infinite-depth](smoke-waves-infinite-depth.md) [unique/index](../../unique/index.md)
 
 #tags: #diagrams #metaphor #synchronicity
-


### PR DESCRIPTION
## Summary
- illustrate sine-wave interference leading to metaphor lock-in
- diagram RAW-style synchronicity web linking ghost sources

## Testing
- `make lint` *(fails: Code style issues in unrelated files)*
- `make test` *(fails: interrupted during service environment setup)*
- `make build`
- `npx --yes prettier docs/notes/diagrams/synchronicity-waves-and-web.md --write`

------
https://chatgpt.com/codex/tasks/task_e_6897c47c4ef08324808263c496473413