### PR TITLE
feat: add zero-copy snapshot utilities

### DIFF
--- a/shared/js/prom-lib/ds/ecs.ts
+++ b/shared/js/prom-lib/ds/ecs.ts
@@ -1,0 +1,11 @@
+export interface ComponentType<T = any> {
+  id: number;
+}
+
+export interface World {
+  makeQuery(spec: any): any;
+  iter(query: any): Iterable<[number]>;
+  get(eid: number, type: ComponentType<any>): any;
+  set(eid: number, type: ComponentType<any>, value: any): void;
+  isAlive(eid: number): boolean;
+}

--- a/shared/js/prom-lib/worker/zero/layout.ts
+++ b/shared/js/prom-lib/worker/zero/layout.ts
@@ -1,0 +1,82 @@
+export type Scalar =
+  | "f32"
+  | "f64"
+  | "i32"
+  | "u32"
+  | "i16"
+  | "u16"
+  | "i8"
+  | "u8";
+export type FieldSpec = { [fieldName: string]: Scalar };
+export type CompLayout = { cid: number; fields: FieldSpec };
+
+const T = {
+  f32: Float32Array,
+  f64: Float64Array,
+  i32: Int32Array,
+  u32: Uint32Array,
+  i16: Int16Array,
+  u16: Uint16Array,
+  i8: Int8Array,
+  u8: Uint8Array,
+} as const;
+
+export type Columns = Record<
+  string,
+  | Float32Array
+  | Float64Array
+  | Int8Array
+  | Uint8Array
+  | Int16Array
+  | Uint16Array
+  | Int32Array
+  | Uint32Array
+>;
+export type CompColumns = { fields: Columns; changed: Uint8Array };
+
+export type Snap = {
+  shared: boolean;
+  rows: number;
+  eids: Int32Array;
+  comps: Record<number, CompColumns>;
+};
+
+export function canUseSAB(): boolean {
+  // Node always has SAB; browsers require crossOriginIsolated
+  if (typeof process !== "undefined" && (process as any).versions?.node) {
+    return typeof SharedArrayBuffer !== "undefined";
+  }
+  return (
+    typeof SharedArrayBuffer !== "undefined" &&
+    (globalThis as any).crossOriginIsolated === true
+  );
+}
+
+export function allocColumns(
+  rows: number,
+  layout: CompLayout,
+  shared: boolean,
+): CompColumns {
+  const fields: Columns = {};
+  for (const [k, ty] of Object.entries(layout.fields)) {
+    const Ctor = T[ty as Scalar];
+    const buf = shared
+      ? new SharedArrayBuffer(Ctor.BYTES_PER_ELEMENT * rows)
+      : new ArrayBuffer(Ctor.BYTES_PER_ELEMENT * rows);
+    // @ts-expect-error dynamic constructor
+    fields[k] = new Ctor(buf);
+  }
+  const chBuf = shared
+    ? new SharedArrayBuffer(Math.ceil(rows / 8))
+    : new ArrayBuffer(Math.ceil(rows / 8));
+  const changed = new Uint8Array(chBuf);
+  return { fields, changed };
+}
+
+export function markChanged(bitset: Uint8Array, i: number) {
+  bitset[i >> 3] |= 1 << (i & 7);
+}
+
+export function isChanged(bitset: Uint8Array, i: number) {
+  return (bitset[i >> 3] & (1 << (i & 7))) !== 0;
+}

--- a/shared/js/prom-lib/worker/zero/snapshot.test.ts
+++ b/shared/js/prom-lib/worker/zero/snapshot.test.ts
@@ -1,0 +1,59 @@
+import { buildSnapshot, commitSnapshot } from "./snapshot";
+import { markChanged } from "./layout";
+import type { World, ComponentType } from "../../ds/ecs";
+
+describe("snapshot build/commit", () => {
+  class MockWorld implements World {
+    comps = new Map<number, Map<number, any>>();
+    makeQuery(spec: any) {
+      return spec;
+    }
+    *iter(_query: any) {
+      for (const eid of this.comps.keys()) yield [eid] as [number];
+    }
+    get(eid: number, type: ComponentType<any>) {
+      return this.comps.get(eid)?.get(type.id);
+    }
+    set(eid: number, type: ComponentType<any>, value: any) {
+      let m = this.comps.get(eid);
+      if (!m) {
+        m = new Map();
+        this.comps.set(eid, m);
+      }
+      m.set(type.id, value);
+    }
+    isAlive(eid: number) {
+      return this.comps.has(eid);
+    }
+  }
+
+  const Pos: ComponentType<{ x: number; y: number }> = { id: 1 };
+  const Vel: ComponentType<{ x: number; y: number }> = { id: 2 };
+
+  const world = new MockWorld();
+  world.set(1, Pos, { x: 0, y: 0 });
+  world.set(1, Vel, { x: 1, y: 2 });
+
+  const spec = {
+    layouts: [
+      { cid: Pos.id, fields: { x: "f32", y: "f32" } as const },
+      { cid: Vel.id, fields: { x: "f32", y: "f32" } as const },
+    ],
+    types: { [Pos.id]: Pos, [Vel.id]: Vel },
+  };
+
+  test("build and commit snapshot", () => {
+    const q = world.makeQuery({ all: [Pos, Vel] });
+    const { snap } = buildSnapshot(world, spec, q);
+    expect(snap.rows).toBe(1);
+    expect(snap.eids[0]).toBe(1);
+    const px = snap.comps[Pos.id].fields["x"] as Float32Array;
+    expect(px[0]).toBe(0);
+    // simulate worker mutation
+    px[0] = 5;
+    markChanged(snap.comps[Pos.id].changed, 0);
+    commitSnapshot(world, spec, snap);
+    const pos = world.get(1, Pos);
+    expect(pos.x).toBe(5);
+  });
+});

--- a/shared/js/prom-lib/worker/zero/snapshot.ts
+++ b/shared/js/prom-lib/worker/zero/snapshot.ts
@@ -1,0 +1,81 @@
+import type { World, ComponentType } from "../../ds/ecs";
+import { CompLayout, Snap, allocColumns, canUseSAB, isChanged } from "./layout";
+type Transferable = ArrayBuffer | SharedArrayBuffer;
+
+export type BuildSpec = {
+  layouts: CompLayout[];
+  types: Record<number, ComponentType<any>>;
+};
+
+export function buildSnapshot(
+  world: World,
+  spec: BuildSpec,
+  query: any,
+): { snap: Snap; transfer: Transferable[] } {
+  const shared = canUseSAB();
+  let rows = 0;
+  for (const _ of world.iter(query)) rows++;
+
+  const eids = (() => {
+    const buf = shared
+      ? new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT * rows)
+      : new ArrayBuffer(Int32Array.BYTES_PER_ELEMENT * rows);
+    return new Int32Array(buf);
+  })();
+
+  const comps: Snap["comps"] = {};
+  for (const L of spec.layouts) comps[L.cid] = allocColumns(rows, L, shared);
+
+  let i = 0;
+  for (const [e] of world.iter(query)) {
+    eids[i] = e as number;
+    for (const L of spec.layouts) {
+      const ctype = spec.types[L.cid];
+      const v = world.get(e as number, ctype);
+      if (v == null) continue;
+      for (const field of Object.keys(L.fields)) {
+        (comps[L.cid].fields[field] as any)[i] = (v as any)[field] ?? 0;
+      }
+    }
+    i++;
+  }
+
+  const snap: Snap = { shared, rows, eids, comps };
+  const transfer: Transferable[] = [];
+  if (!shared) {
+    transfer.push(snap.eids.buffer);
+    for (const L of spec.layouts) {
+      for (const arr of Object.values(snap.comps[L.cid].fields))
+        transfer.push((arr as any).buffer);
+      transfer.push(snap.comps[L.cid].changed.buffer);
+    }
+  }
+  return { snap, transfer };
+}
+
+export function commitSnapshot(world: World, spec: BuildSpec, snap: Snap) {
+  const rows = snap.rows;
+  for (const L of spec.layouts) {
+    const ctype = spec.types[L.cid];
+    const cols = snap.comps[L.cid];
+    const changed = cols.changed;
+    let any = false;
+    for (let b = 0; b < changed.length; b++)
+      if (changed[b]) {
+        any = true;
+        break;
+      }
+    if (!any) continue;
+
+    for (let i = 0; i < rows; i++) {
+      if (!isChanged(changed, i)) continue;
+      const eid = snap.eids[i];
+      if (!world.isAlive(eid)) continue;
+      const cur = world.get(eid, ctype) ?? {};
+      for (const [field, arr] of Object.entries(cols.fields)) {
+        (cur as any)[field] = (arr as any)[i];
+      }
+      world.set(eid, ctype, cur);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add ECS interfaces for world/component types
- implement zero-copy column layout helpers
- add snapshot build/commit logic with change tracking

## Testing
- `npm ci --prefix shared/js`
- `npx eslint shared/js/prom-lib/ds/ecs.ts shared/js/prom-lib/worker/zero/layout.ts shared/js/prom-lib/worker/zero/snapshot.ts shared/js/prom-lib/worker/zero/snapshot.test.ts`
- `npx tsc -p shared/js/prom-lib/tsconfig.json --noEmit`
- `npx jest -c shared/js/prom-lib/jest.config.ts`


------
https://chatgpt.com/codex/tasks/task_e_6897c481e3f48324b091f193cbada44f