### PR TITLE
Add service README template generator

### DIFF
--- a/scripts/generate_service_templates.py
+++ b/scripts/generate_service_templates.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+"""Generate README templates from existing service READMEs.
+
+Scans service directories under ``services/`` for ``README.md`` files and
+creates templated copies with the heading replaced by ``{{SERVICE_NAME}}``.
+Templates are written to ``services/templates``.
+"""
+from __future__ import annotations
+
+import pathlib
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+SERVICES_DIR = ROOT / "services"
+TEMPLATE_DIR = SERVICES_DIR / "templates"
+
+
+def generate_templates() -> None:
+    TEMPLATE_DIR.mkdir(exist_ok=True)
+    for readme in SERVICES_DIR.glob("*/*/README.md"):
+        service_dir = readme.parent
+        service_slug = service_dir.name
+        service_title = service_slug.replace("_", " ").title()
+
+        lines = readme.read_text().splitlines()
+        if lines and lines[0].startswith("#"):
+            lines[0] = "# {{SERVICE_NAME}} Service"
+        template_path = TEMPLATE_DIR / f"{service_slug}_README.template.md"
+        template_path.write_text("\n".join(lines) + "\n")
+
+
+if __name__ == "__main__":
+    generate_templates()

--- a/services/templates/README.md
+++ b/services/templates/README.md
@@ -1,3 +1,9 @@
 # Templates for services
 
 This folder contains markdown templates for services.
+
+Regenerate the templates based on the current service READMEs with:
+
+```
+python scripts/generate_service_templates.py
+```

--- a/services/templates/board-updater_README.template.md
+++ b/services/templates/board-updater_README.template.md
@@ -1,0 +1,4 @@
+# {{SERVICE_NAME}} Service
+
+Regenerates the kanban board in response to task changes.
+

--- a/services/templates/broker_README.template.md
+++ b/services/templates/broker_README.template.md
@@ -1,0 +1,46 @@
+# {{SERVICE_NAME}} Service
+
+Simple WebSocket-based pub/sub broker. Services connect and exchange messages through
+topics instead of direct links. Messages are normalized into a common event format and
+routed to subscribers by topic.
+
+## Protocol
+
+Clients send JSON messages:
+
+- `{"action":"subscribe","topic":"example.topic"}`
+- `{"action":"unsubscribe","topic":"example.topic"}`
+- `{"action":"publish","message":{...}}`
+
+Published messages are normalized to:
+
+```json
+{
+  "type": "example.topic",
+  "source": "publisher-id",
+  "payload": { "key": "value" },
+  "timestamp": "2025-08-06T01:23:45Z",
+  "correlationId": "optional",
+  "replyTo": "optional.topic"
+}
+```
+
+Subscribers receive `{ "event": <normalized message> }` envelopes.
+
+## Task Queues
+
+The broker also provides simple task queue semantics. Clients may enqueue work items and workers may dequeue them one at a time.
+
+### Actions
+
+- `{"action":"enqueue","queue":"jobs","task":{...}}`
+- `{"action":"dequeue","queue":"jobs"}` → server responds with `{ "task": { ... } }` or `{ "task": null }` if empty
+
+If a Redis server is available (configured via `REDIS_URL` or default `redis://127.0.0.1:6379`), queues are persisted in Redis. Otherwise, an in-memory queue is used.
+
+## Development
+
+```
+npm install
+npm test
+```

--- a/services/templates/discord-embedder_README.template.md
+++ b/services/templates/discord-embedder_README.template.md
@@ -1,0 +1,20 @@
+# {{SERVICE_NAME}} Service
+
+Enriches Discord messages by generating embeddings and storing them in ChromaDB.
+Built with Node.js and TypeScript.
+
+## Setup
+
+```bash
+npm install
+```
+
+## Usage
+
+Run in development mode:
+
+```bash
+npm run start:dev
+```
+
+#hashtags: #discord #service #promethean

--- a/services/templates/discord_attachment_embedder_README.template.md
+++ b/services/templates/discord_attachment_embedder_README.template.md
@@ -1,0 +1,20 @@
+# {{SERVICE_NAME}} Service
+
+Generates a ChromaDB collection of embeddings for Discord message text and image attachments.
+Uses the shared embedding service so that related images and descriptions map to similar vectors.
+
+## Setup
+
+```bash
+pipenv install
+```
+
+## Usage
+
+Process indexed messages and build the collection:
+
+```bash
+pipenv run python main.py
+```
+
+#hashtags: #discord #chromadb #embeddings #service

--- a/services/templates/discord_attachment_indexer_README.template.md
+++ b/services/templates/discord_attachment_indexer_README.template.md
@@ -1,0 +1,20 @@
+# {{SERVICE_NAME}} Service
+
+Scans Discord messages for file attachments and stores their metadata in MongoDB.
+Implemented in Python.
+
+## Setup
+
+```bash
+pipenv install
+```
+
+## Usage
+
+Run the crawler:
+
+```bash
+pipenv run python main.py
+```
+
+#hashtags: #discord #service #attachments #promethean

--- a/services/templates/discord_indexer_README.template.md
+++ b/services/templates/discord_indexer_README.template.md
@@ -1,0 +1,20 @@
+# {{SERVICE_NAME}} Service
+
+Archives Discord messages for later processing using the Discord API.
+Implemented in Python.
+
+## Setup
+
+```bash
+pipenv install
+```
+
+## Usage
+
+Run the crawler:
+
+```bash
+pipenv run python main.py
+```
+
+#hashtags: #discord #service #promethean

--- a/services/templates/eidolon-field_README.template.md
+++ b/services/templates/eidolon-field_README.template.md
@@ -1,0 +1,5 @@
+# {{SERVICE_NAME}} Service
+
+Runs an 8-dimensional vector field on a constant tick and persists each
+tick's field snapshot to MongoDB. Configure the connection with
+`MONGO_URL`, `DB_NAME`, and `COLLECTION` environment variables.

--- a/services/templates/file-watcher_README.template.md
+++ b/services/templates/file-watcher_README.template.md
@@ -1,0 +1,13 @@
+# {{SERVICE_NAME}} Service
+
+This service monitors the local kanban board and task files.
+
+- When `docs/agile/boards/kanban.md` changes it runs `kanban_to_hashtags.py` to
+  update the task files.
+- When any document under `docs/agile/tasks/` changes it runs
+  `hashtags_to_kanban.py` and writes the output back to the board.
+- When a new task is created the service calls the LLM HTTP endpoint to
+  generate a starter task stub.
+
+`npm start` will compile the TypeScript source before launching.
+Use `npm run start:dev` while developing to watch TypeScript files.

--- a/services/templates/health_README.template.md
+++ b/services/templates/health_README.template.md
@@ -1,0 +1,7 @@
+# {{SERVICE_NAME}} Service
+
+**Path**: `services/js/health/index.js`
+
+Listens for heartbeat events from the message broker and exposes a `/health`
+endpoint with aggregated CPU and memory utilization. Other services can poll
+this endpoint to decide when to throttle their workloads.

--- a/services/templates/heartbeat_README.template.md
+++ b/services/templates/heartbeat_README.template.md
@@ -1,0 +1,32 @@
+# {{SERVICE_NAME}} Service
+
+Tracks process heartbeats published on the message broker and terminates those that fail to report within a timeout.
+Backed by MongoDB for storage. Intended for detecting and cleaning up hung or orphaned worker processes.
+Also enforces the instance limits defined in a PM2 ecosystem file, rejecting registrations that exceed the configured count for a given app name.
+Each heartbeat updates CPU, memory, and network byte counts for the process based on its PID.
+Heartbeats are tagged with a service-instance session ID so that restarts do not conflict with stale database entries.
+On shutdown the service marks all heartbeats from its current session as killed to allow clean restarts.
+
+## API
+
+- Broker topic `heartbeat`
+  - Services publish `{ pid: number, name: string }` messages to this topic.
+  - Heartbeats exceeding instance limits are ignored.
+
+## Environment
+
+- `MONGO_URL` (default `mongodb://127.0.0.1:27017`)
+- `DB_NAME` (default `heartbeat_db`)
+- `HEARTBEAT_TIMEOUT` milliseconds before a process is considered stale (default `10000`)
+- `CHECK_INTERVAL` monitor interval in milliseconds (default `5000`)
+- `ECOSYSTEM_CONFIG` path to a PM2 ecosystem config file; defaults to `../../../ecosystem.config.js`
+- `BROKER_URL` WebSocket URL of the message broker (default `ws://127.0.0.1:7000`)
+
+## Development
+
+```
+npm install
+npm test
+```
+
+⚠️ Killing processes requires appropriate permissions. Use with care.

--- a/services/templates/kanban-processor_README.template.md
+++ b/services/templates/kanban-processor_README.template.md
@@ -1,0 +1,4 @@
+# {{SERVICE_NAME}} Service
+
+Subscribes to file watcher events and processes the kanban board.
+

--- a/services/templates/llm_README.template.md
+++ b/services/templates/llm_README.template.md
@@ -1,0 +1,16 @@
+# {{SERVICE_NAME}} Service
+
+This service exposes a simple HTTP endpoint that proxies requests to the local LLM via the `ollama` library.
+
+Start the service:
+
+```bash
+npm start
+```
+
+POST `/generate` with JSON containing `prompt`, `context` and optional `format` to receive the generated reply.
+
+Set the `LLM_MODEL` environment variable to choose which model Ollama uses. If
+not provided, it defaults to `gemma3`.
+
+#hashtags: #llm #service #promethean

--- a/services/templates/proxy_README.template.md
+++ b/services/templates/proxy_README.template.md
@@ -1,0 +1,21 @@
+# {{SERVICE_NAME}} Service
+
+Routes HTTP requests for multiple Promethean services through a single entry point.
+
+Also hosts a Socket.IO WebSocket hub for real-time event routing between clients.
+
+## Routes
+
+Requests with the following prefixes are proxied by default:
+
+- `/tts` -> `http://localhost:5001`
+- `/stt` -> `http://localhost:5002`
+- `/vision` -> `http://localhost:9999`
+- `/llm` -> `http://localhost:8888`
+
+## Development
+
+```
+npm install
+npm test
+```

--- a/services/templates/stt_README.template.md
+++ b/services/templates/stt_README.template.md
@@ -1,0 +1,16 @@
+# {{SERVICE_NAME}} Service
+
+This service handles speech-to-text using Whisper models.
+It now runs as a broker-connected worker using the shared Python service template.
+Tasks from the `stt.transcribe` queue are processed and results are published to
+`stt.transcribed`.
+
+## Usage
+
+Run the service via pm2 or execute `run.sh` directly:
+
+```bash
+./run.sh
+```
+
+#hashtags: #stt #service #promethean

--- a/services/templates/tts_README.template.md
+++ b/services/templates/tts_README.template.md
@@ -1,0 +1,18 @@
+# {{SERVICE_NAME}} Service
+
+This service converts text to speech using Tacotron and WaveRNN models.
+It exposes both an HTTP endpoint (`/synth_voice_pcm`) and a WebSocket
+endpoint (`/ws/tts`) on the same server. On startup the service also uses
+`shared.py.service_template` to connect to the message broker, consuming
+text tasks from the `tts.speak` queue and publishing synthesized audio as
+`tts-output` events.
+
+## Usage
+
+Run via pm2 or execute `run.sh` directly:
+
+```bash
+./run.sh
+```
+
+#hashtags: #tts #service #promethean

--- a/services/templates/vision_README.template.md
+++ b/services/templates/vision_README.template.md
@@ -1,0 +1,19 @@
+# {{SERVICE_NAME}} Service
+
+Express-based service for capturing screenshots. It exposes a `/capture` HTTP
+endpoint and a WebSocket at `/capture` for streaming images.
+
+The service also connects to the message broker via the shared
+`serviceTemplate.js`, listening on the `vision-capture` task queue and
+publishing `vision-capture` events with a base64-encoded image payload.
+
+## Usage
+
+Install dependencies and start the service:
+
+```bash
+npm install
+npm start
+```
+
+#hashtags: #vision #service #promethean

--- a/services/templates/voice_README.template.md
+++ b/services/templates/voice_README.template.md
@@ -1,0 +1,7 @@
+# {{SERVICE_NAME}} Service
+
+Handles Discord voice connections, recording/transcription via the STT service and playback through the TTS service.
+
+Run via pm2 or execute `npm start` after installing dependencies.
+
+#hashtags: #voice #service #promethean


### PR DESCRIPTION
## Summary
- script to convert existing service READMEs into reusable templates
- document template regeneration command
- add generated README templates for each service

## Testing
- `make lint` *(fails: Expected 2.1.4 Found: 2.1.3)*
- `make format` *(fails: interrupted after biome format runs)*
- `make test` *(fails: Exiting due to SIGINT)*
- `make build`


------
https://chatgpt.com/codex/tasks/task_e_6897c58a08ac83249a02ac2bbb367ebf