### PR TITLE
Add permissions for Discord interactions

### DIFF
--- a/shared/permissions.yaml
+++ b/shared/permissions.yaml
@@ -9,6 +9,42 @@ default:
       features:
         access_level: 0.0
         trust_level: 0.0
+    join_voice_channel:
+      features:
+        access_level: 0.0
+        trust_level: 0.0
+    leave_voice_channel:
+      features:
+        access_level: 0.0
+        trust_level: 0.0
+    set_capture_channel:
+      features:
+        access_level: 0.0
+        trust_level: 0.0
+    set_desktop_channel:
+      features:
+        access_level: 0.0
+        trust_level: 0.0
+    begin_recording_user:
+      features:
+        access_level: 0.0
+        trust_level: 0.0
+    stop_recording_user:
+      features:
+        access_level: 0.0
+        trust_level: 0.0
+    begin_transcribing_user:
+      features:
+        access_level: 0.0
+        trust_level: 0.0
+    tts:
+      features:
+        access_level: 0.0
+        trust_level: 0.0
+    start_dialog:
+      features:
+        access_level: 0.0
+        trust_level: 0.0
 agents:
   alice:
     actions:


### PR DESCRIPTION
## Summary
- document discord slash commands in shared permissions

## Testing
- `make setup-ts-service-cephalon`
- `make format`
- `make lint-ts-service-cephalon`
- `make build-ts`
- `make test-ts-service-cephalon`

------
https://chatgpt.com/codex/tasks/task_e_6897f2fc4abc8324b42b3a6b8f6a854b