### PR TITLE
docs: add local development setup guide

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -13,6 +13,7 @@ This `docs` directory houses internal documentation for the **Promethean Framewo
     - [MIGRATION_PLAN](MIGRATION_PLAN.md) – a living checklist of steps to migrate code from legacy repositories into this structure.
     - [site README](../site/README.md) – instructions for building and serving the portfolio site.
     - [pre-commit](pre-commit.md) – how to install and run repository hooks before committing changes.
+    - [local-development-setup](local-development-setup.md) – service-specific install and validation steps.
         
 - **Agile process and tasks**
     

--- a/docs/local-development-setup.md
+++ b/docs/local-development-setup.md
@@ -1,0 +1,36 @@
+# Local Development Setup
+
+This guide explains how to install dependencies and validate changes when working on the Promethean Framework.
+
+## Install only the services you need
+
+Each service is independent. Install dependencies for a single service instead of running the global setup:
+
+```bash
+make setup-quick SERVICE=stt
+make setup-quick SERVICE=tts
+make setup-quick SERVICE=cephalon
+```
+
+You can also invoke the lower level targets directly if you prefer:
+
+```bash
+make setup-python-service-stt
+make setup-hy-service-eidolon
+make setup-js-service-io
+```
+
+Avoid using `make setup-quick` without a service name; it installs every service and takes much longer.
+
+## Validate your work
+
+Before opening a pull request run the relevant `make` targets for the services you touched:
+
+```bash
+make test
+make build
+make lint
+make format
+```
+
+Run these commands only for the services affected by your changes. Skipping unrelated services keeps development fast and mirrors the expectations in [../AGENTS.md](../AGENTS.md).


### PR DESCRIPTION
## Summary
- document service-scoped setup and validation steps for contributors
- link the new setup guide from the docs index

## Testing
- `pre-commit run --files docs/local-development-setup.md docs/README.md`


------
https://chatgpt.com/codex/tasks/task_e_6898e0cac6bc8324979d7488690241c0