### PR TITLE
Fix board-updater TypeScript typings

### DIFF
--- a/services/ts/board-updater/src/index.ts
+++ b/services/ts/board-updater/src/index.ts
@@ -10,8 +10,8 @@ const defaultRepoRoot = process.env.REPO_ROOT || "";
 function runPython(script: string, repoRoot: string): Promise<void> {
   return new Promise((resolve, reject) => {
     const proc = spawn("python", [script], { cwd: repoRoot });
-    proc.stderr.on("data", (c) => process.stderr.write(c));
-    proc.on("close", (code) => {
+    proc.stderr.on("data", (c: Buffer) => process.stderr.write(c));
+    proc.on("close", (code: number | null) => {
       if (code === 0) resolve();
       else reject(new Error(`Process exited with code ${code}`));
     });

--- a/services/ts/board-updater/tsconfig.json
+++ b/services/ts/board-updater/tsconfig.json
@@ -43,6 +43,7 @@
     // Language and Environment
     "experimentalDecorators": true,
     "lib": ["ESNext", "esnext.disposable"],
+    "types": ["node"],
     "target": "ESNext",
     "useDefineForClassFields": true,
 


### PR DESCRIPTION
## Summary
- annotate child process handlers in board-updater with explicit types
- include Node type definitions in board-updater tsconfig

## Testing
- `npm test` (in services/ts/board-updater)


------
https://chatgpt.com/codex/tasks/task_e_6898de3817c883248a0a196843e263b1