### PR TITLE
feat: introduce speech arbiter

### DIFF
--- a/services/ts/cephalon/src/agent/speechCoordinator.ts
+++ b/services/ts/cephalon/src/agent/speechCoordinator.ts
@@ -1,0 +1,132 @@
+import { AudioPlayer, AudioResource } from '@discordjs/voice';
+import EventEmitter from 'events';
+
+export type Priority = 0 | 1 | 2;
+export type BargeInPolicy = 'none' | 'duck' | 'pause' | 'stop';
+
+export interface Utterance {
+	id: string;
+	turnId: number;
+	priority: Priority;
+	bargeIn: BargeInPolicy;
+	group?: string;
+	makeResource: () => Promise<AudioResource>;
+	onStart?: () => void;
+	onEnd?: (reason: 'finished' | 'cancelled') => void;
+}
+
+export class SpeechArbiter extends EventEmitter {
+	private player: AudioPlayer;
+	private queue: Utterance[] = [];
+	private playing: Utterance | null = null;
+	private playingToken = 0;
+	private currentTurnId = 0;
+
+	constructor(player: AudioPlayer) {
+		super();
+		this.player = player;
+
+		this.player.on('error', () => {
+			this.cancelCurrent('cancelled');
+		});
+		this.player.on('stateChange', (oldS: any, newS: any) => {
+			if (oldS.status !== 'playing' && newS.status === 'playing') {
+				this.emit('play-start', this.playing);
+			}
+			if (oldS.status === 'playing' && newS.status === 'idle') {
+				const done = this.playing;
+				this.playing = null;
+				done?.onEnd?.('finished');
+				this.emit('play-end', done);
+				this.kick();
+			}
+		});
+	}
+
+	get audioPlayer() {
+		return this.player;
+	}
+
+	setTurnId(turnId: number) {
+		if (turnId <= this.currentTurnId) return;
+		this.currentTurnId = turnId;
+		this.queue = this.queue.filter((u) => u.turnId >= this.currentTurnId);
+		if (this.playing && this.playing.turnId < this.currentTurnId) {
+			this.cancelCurrent('cancelled');
+		}
+	}
+
+	setUserSpeaking(active: boolean) {
+		if (!this.playing) return;
+		const policy = this.playing.bargeIn ?? 'pause';
+		if (active) {
+			if (policy === 'duck') this.emit('duck-on');
+			if (policy === 'pause') this.player.pause(true);
+			if (policy === 'stop') this.cancelCurrent('cancelled');
+		} else {
+			if (policy === 'duck') this.emit('duck-off');
+			if (policy === 'pause') this.player.unpause();
+		}
+	}
+
+	enqueue(u: Utterance) {
+		if (u.turnId < this.currentTurnId) return;
+		if (u.group) {
+			this.queue = this.queue.filter((q) => !(q.group === u.group && q.priority <= u.priority));
+			if (this.playing && this.playing.group === u.group && this.playing.priority <= u.priority) {
+				this.cancelCurrent('cancelled');
+			}
+		}
+		this.queue.push(u);
+		this.queue.sort((a, b) => b.priority - a.priority);
+		this.kick();
+	}
+
+	private async kick() {
+		if (this.playing) return;
+		while (this.queue.length) {
+			const next = this.queue.shift()!;
+			if (next.turnId < this.currentTurnId) continue;
+			this.playing = next;
+			const token = ++this.playingToken;
+			try {
+				const res = await next.makeResource();
+				if (token !== this.playingToken) {
+					next.onEnd?.('cancelled');
+					continue;
+				}
+				next.onStart?.();
+				this.player.play(res);
+				return;
+			} catch {
+				next.onEnd?.('cancelled');
+				this.playing = null;
+				continue;
+			}
+		}
+	}
+
+	private cancelCurrent(reason: 'cancelled') {
+		if (!this.playing) return;
+		const doomed = this.playing;
+		this.playing = null;
+		this.playingToken++;
+		try {
+			this.player.stop(true);
+		} catch {}
+		doomed.onEnd?.(reason);
+		this.emit('play-end', doomed);
+		this.kick();
+	}
+}
+
+export class TurnManager extends EventEmitter {
+	private _turnId = 0;
+	get turnId() {
+		return this._turnId;
+	}
+	bump(reason: string) {
+		this._turnId++;
+		this.emit('turn', this._turnId, reason);
+	}
+}

--- a/services/ts/cephalon/tests/speechCoordinator.test.ts
+++ b/services/ts/cephalon/tests/speechCoordinator.test.ts
@@ -1,0 +1,69 @@
+import test from 'ava';
+import EventEmitter from 'events';
+import { SpeechArbiter, TurnManager, Utterance } from '../src/agent/speechCoordinator';
+
+class FakePlayer extends EventEmitter {
+	play() {
+		this.emit('stateChange', { status: 'idle' }, { status: 'playing' });
+		this.emit('stateChange', { status: 'playing' }, { status: 'idle' });
+	}
+	pause() {}
+	unpause() {}
+	stop() {}
+}
+
+test('arbiter drops stale utterances', async (t) => {
+	const player = new FakePlayer() as any;
+	const arb = new SpeechArbiter(player);
+	const turn = new TurnManager();
+	turn.on('turn', (id) => arb.setTurnId(id));
+	turn.bump('start');
+	const played: string[] = [];
+	arb.on('play-start', (u) => played.push(u!.id));
+	const oldU: Utterance = {
+		id: 'old',
+		turnId: 0,
+		priority: 1,
+		bargeIn: 'pause',
+		makeResource: async () => ({}) as any,
+	};
+	const newU: Utterance = {
+		id: 'new',
+		turnId: 1,
+		priority: 1,
+		bargeIn: 'pause',
+		makeResource: async () => ({}) as any,
+	};
+	arb.enqueue(oldU);
+	arb.enqueue(newU);
+	await new Promise((r) => setTimeout(r, 10));
+	t.deepEqual(played, ['new']);
+});
+
+test('arbiter prioritizes higher priority', async (t) => {
+	const player = new FakePlayer() as any;
+	const arb = new SpeechArbiter(player);
+	arb.setTurnId(1);
+	const played: string[] = [];
+	arb.on('play-start', (u) => played.push(u!.id));
+	const low: Utterance = {
+		id: 'low',
+		turnId: 1,
+		priority: 0,
+		bargeIn: 'pause',
+		group: 'g',
+		makeResource: async () => ({}) as any,
+	};
+	const high: Utterance = {
+		id: 'high',
+		turnId: 1,
+		priority: 2,
+		bargeIn: 'pause',
+		group: 'g',
+		makeResource: async () => ({}) as any,
+	};
+	arb.enqueue(low);
+	arb.enqueue(high);
+	await new Promise((r) => setTimeout(r, 10));
+	t.deepEqual(played, ['high']);
+});


### PR DESCRIPTION
## Summary
- add SpeechArbiter and TurnManager to manage voice playback
- route AIAgent speech through arbiter
- cover arbiter behavior with unit tests

## Testing
- `make setup-ts-service-cephalon`
- `make lint-ts-service-cephalon`
- `make test-ts-service-cephalon`
- `make build-ts`


------
https://chatgpt.com/codex/tasks/task_e_6898e0867790832480540edf191dfdbc