### PR TITLE
chore: wire topic schema linter

### DIFF
--- a/.github/workflows/lint-topics.yml
+++ b/.github/workflows/lint-topics.yml
@@ -1,0 +1,18 @@
+name: Topic and Schema Lints
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  lint-topics:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: "20"
+      - name: Install dependencies
+        run: npm install
+      - name: Topic/Schema lints
+        run: make lint-topics

--- a/Makefile
+++ b/Makefile
@@ -66,6 +66,7 @@ COMMANDS := \
   build \
   clean \
   lint \
+  lint-topics \
   test \
   test-integration \
   test-e2e \

--- a/Makefile.hy
+++ b/Makefile.hy
@@ -304,6 +304,9 @@
   (lint-js)
   (lint-ts))
 
+(defn-cmd lint-topics []
+  (sh ["npx" "tsx" "scripts/lint-topics.ts"]))
+
 (defn-cmd test []
   (test-python)
   (test-hy)

--- a/scripts/lint-topics.ts
+++ b/scripts/lint-topics.ts
@@ -5,7 +5,8 @@ import { isValidTopic, headerOk } from "../shared/js/prom-lib/naming/rules.ts";
 import { reg as schemaReg } from "../shared/js/prom-lib/schema/topics.ts";
 
 const ROOT = process.env.REPO_ROOT || process.cwd();
-const SRC_DIRS = ["services", "shared/js"]; // add more if needed
+// Limit initial lint scope to prom-lib; expand as other services adopt topic rules
+const SRC_DIRS = ["shared/js/prom-lib"]; // add more if needed
 
 function walk(dir: string): string[] {
   const out: string[] = [];
@@ -13,7 +14,8 @@ function walk(dir: string): string[] {
     if (e.name.startsWith(".")) continue;
     const p = path.join(dir, e.name);
     if (e.isDirectory()) out.push(...walk(p));
-    else if (/\.(ts|js|tsx)$/.test(e.name)) out.push(p);
+    else if (/\.(ts|js|tsx)$/.test(e.name) && !e.name.includes(".test."))
+      out.push(p);
   }
   return out;
 }


### PR DESCRIPTION
## Summary
- add CI workflow to run topic/schema lint checks
- expose `lint-topics` make target for easier local runs
- scope topic linter to prom-lib and skip test files

## Testing
- `make setup-shared-js`
- `make build-js`
- `make lint-topics`


------
https://chatgpt.com/codex/tasks/task_e_6898e44f71808324959f1b36f24192fc