### PR TITLE
feat: add snapshot, projector, and timetravel utilities

### DIFF
--- a/shared/js/package-lock.json
+++ b/shared/js/package-lock.json
@@ -12,6 +12,7 @@
         "execa": "^9.6.0",
         "express": "^4.19.2",
         "fs-extra": "^11.3.0",
+        "mongodb": "^6.18.0",
         "prom-client": "^15.1.0",
         "ws": "^8.18.0",
         "yaml": "^2.7.0"
@@ -21,6 +22,7 @@
         "@types/express": "^4.17.21",
         "@types/jest": "^30.0.0",
         "@types/node": "^20.11.30",
+        "@types/ws": "^8.5.9",
         "eslint": "^8.57.0",
         "jest": "^29.7.0",
         "ts-jest": "^29.1.1",
@@ -1188,6 +1190,15 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@mongodb-js/saslprep": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.3.0.tgz",
+      "integrity": "sha512-zlayKCsIjYb7/IdfqxorK5+xUMyi4vOKcFy10wKJYc63NSdKI8mNME+uJqfatkPmOSMMUiojrL58IePKBm3gvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "sparse-bitfield": "^3.0.3"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -1729,6 +1740,31 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/webidl-conversions": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-7.0.3.tgz",
+      "integrity": "sha512-CiJJvcRtIgzadHCYXw7dqEnMNRjhGZlYK05Mj9OyktqV8uVT8fD2BFOB7S1uwBE3Kj2Z+4UyPmFw/Ixgw/LAlA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/whatwg-url": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-11.0.5.tgz",
+      "integrity": "sha512-coYR071JRaHa+xoEvvYqvnIHaVqaYrLPbsufM9BF63HkwI5Lgmy2QR8Q5K/lYDYo5AK82wOvSOS0UsLTpTG7uQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/webidl-conversions": "*"
+      }
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/yargs": {
       "version": "17.0.33",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.33.tgz",
@@ -2195,6 +2231,15 @@
       "license": "Apache-2.0",
       "dependencies": {
         "node-int64": "^0.4.0"
+      }
+    },
+    "node_modules/bson": {
+      "version": "6.10.4",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-6.10.4.tgz",
+      "integrity": "sha512-WIsKqkSC0ABoBJuT1LEX+2HEvNmNKKgnTAyd0fL8qzK4SH2i9NXg+t08YtdZp/V9IZ33cxe3iV4yM0qg8lMQng==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=16.20.1"
       }
     },
     "node_modules/buffer": {
@@ -4821,6 +4866,12 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/memory-pager": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
+      "integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==",
+      "license": "MIT"
+    },
     "node_modules/merge-descriptors": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
@@ -4942,6 +4993,62 @@
       "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
       "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
       "license": "MIT"
+    },
+    "node_modules/mongodb": {
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.18.0.tgz",
+      "integrity": "sha512-fO5ttN9VC8P0F5fqtQmclAkgXZxbIkYRTUi1j8JO6IYwvamkhtYDilJr35jOPELR49zqCJgXZWwCtW7B+TM8vQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@mongodb-js/saslprep": "^1.1.9",
+        "bson": "^6.10.4",
+        "mongodb-connection-string-url": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.20.1"
+      },
+      "peerDependencies": {
+        "@aws-sdk/credential-providers": "^3.188.0",
+        "@mongodb-js/zstd": "^1.1.0 || ^2.0.0",
+        "gcp-metadata": "^5.2.0",
+        "kerberos": "^2.0.1",
+        "mongodb-client-encryption": ">=6.0.0 <7",
+        "snappy": "^7.2.2",
+        "socks": "^2.7.1"
+      },
+      "peerDependenciesMeta": {
+        "@aws-sdk/credential-providers": {
+          "optional": true
+        },
+        "@mongodb-js/zstd": {
+          "optional": true
+        },
+        "gcp-metadata": {
+          "optional": true
+        },
+        "kerberos": {
+          "optional": true
+        },
+        "mongodb-client-encryption": {
+          "optional": true
+        },
+        "snappy": {
+          "optional": true
+        },
+        "socks": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/mongodb-connection-string-url": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-3.0.2.tgz",
+      "integrity": "sha512-rMO7CGo/9BFwyZABcKAWL8UJwH/Kc2x0g72uhDWzG48URRax5TCIcJ7Rc3RZqffZzO/Gwff/jyKwCU9TN8gehA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/whatwg-url": "^11.0.2",
+        "whatwg-url": "^14.1.0 || ^13.0.0"
+      }
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -5484,7 +5591,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -6024,6 +6130,15 @@
         "source-map": "^0.6.0"
       }
     },
+    "node_modules/sparse-bitfield": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
+      "integrity": "sha512-kvzhi7vqKTfkh0PZU+2D2PIllw2ymqJKujUcyPMd9Y75Nv4nPbGJZXNhxsgdQab2BmlDct1YnfQCguEvHr7VsQ==",
+      "license": "MIT",
+      "dependencies": {
+        "memory-pager": "^1.0.2"
+      }
+    },
     "node_modules/sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -6257,6 +6372,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.6"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/ts-jest": {
@@ -6590,6 +6717,28 @@
       "license": "Apache-2.0",
       "dependencies": {
         "makeerror": "1.0.12"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/which": {

--- a/shared/js/package.json
+++ b/shared/js/package.json
@@ -10,13 +10,15 @@
     "express": "^4.19.2",
     "body-parser": "^1.20.2",
     "prom-client": "^15.1.0",
-    "yaml": "^2.7.0"
+    "yaml": "^2.7.0",
+    "mongodb": "^6.18.0"
   },
   "devDependencies": {
     "@types/jest": "^30.0.0",
     "@types/node": "^20.11.30",
     "@types/express": "^4.17.21",
     "@types/body-parser": "^1.19.5",
+    "@types/ws": "^8.5.9",
     "eslint": "^8.57.0",
     "jest": "^29.7.0",
     "ts-jest": "^29.1.1",

--- a/shared/js/prom-lib/dev/harness.ts
+++ b/shared/js/prom-lib/dev/harness.ts
@@ -1,0 +1,29 @@
+import { InMemoryEventBus } from "../event/memory";
+import { startWSGateway } from "../ws/server";
+import { startHttpPublisher } from "../http/publish";
+import { startProcessProjector } from "../examples/process/projector";
+
+export interface Harness {
+  bus: InMemoryEventBus;
+  stop(): Promise<void>;
+}
+
+export async function startHarness({
+  wsPort = 9090,
+  httpPort = 9091,
+} = {}): Promise<Harness> {
+  const bus = new InMemoryEventBus();
+
+  const wss = startWSGateway(bus, wsPort, { auth: async () => ({ ok: true }) });
+  const http = startHttpPublisher(bus, httpPort);
+  const stopProj = await startProcessProjector(bus);
+
+  return {
+    bus,
+    async stop() {
+      await new Promise((r) => (http as any).close(r));
+      wss.close();
+      stopProj();
+    },
+  };
+}

--- a/shared/js/prom-lib/projectors/transactional.ts
+++ b/shared/js/prom-lib/projectors/transactional.ts
@@ -1,0 +1,45 @@
+import type { Db, ClientSession } from "mongodb";
+import type { EventBus, EventRecord } from "../event/types";
+
+export interface TxnProjectorOpts<E = any> {
+  topic: string;
+  group: string;
+  handler: (e: EventRecord<E>, db: Db, s: ClientSession) => Promise<void>;
+  from?: "earliest" | "latest";
+  retries?: number;
+}
+
+export async function startTransactionalProjector<E = any>(
+  bus: EventBus,
+  db: Db,
+  opts: TxnProjectorOpts<E>,
+) {
+  const from = opts.from ?? "earliest";
+  const retries = opts.retries ?? 3;
+
+  return bus.subscribe(
+    opts.topic,
+    opts.group,
+    async (e) => {
+      for (let i = 0; i <= retries; i++) {
+        const s = db.client.startSession();
+        try {
+          await s.withTransaction(
+            async () => {
+              await opts.handler(e, db, s);
+            },
+            { writeConcern: { w: "majority" } },
+          );
+          // success → exit retry loop
+          return;
+        } catch (err) {
+          if (i === retries) throw err;
+          await new Promise((r) => setTimeout(r, 100 * (i + 1)));
+        } finally {
+          await s.endSession();
+        }
+      }
+    },
+    { from, manualAck: false, batchSize: 200 },
+  );
+}

--- a/shared/js/prom-lib/snapshots/api.ts
+++ b/shared/js/prom-lib/snapshots/api.ts
@@ -1,0 +1,79 @@
+import express from "express";
+import type { Db } from "mongodb";
+import crypto from "crypto";
+
+export interface SnapshotApiOptions {
+  collection: string; // e.g., "processes.snapshot"
+  keyField?: string; // default "_key"
+  bodyLimit?: string; // default "200kb"
+  maxAgeSeconds?: number; // default 5 (client cache)
+}
+
+function etagOf(doc: any) {
+  const s = JSON.stringify(doc);
+  return '"' + crypto.createHash("sha1").update(s).digest("hex") + '"';
+}
+
+export function startSnapshotApi(
+  db: Db,
+  port = 8091,
+  opts: SnapshotApiOptions,
+) {
+  const app = express();
+  app.set("etag", false);
+  app.use(express.json({ limit: opts.bodyLimit ?? "200kb" }));
+
+  const coll = db.collection(opts.collection);
+  const keyField = opts.keyField ?? "_key";
+  const cacheCtl = `public, max-age=${opts.maxAgeSeconds ?? 5}`;
+
+  // GET /snap/:key
+  app.get("/snap/:key", async (req, res) => {
+    const key = req.params.key;
+    const doc = await coll.findOne({ [keyField]: key });
+    if (!doc) return res.status(404).json({ error: "not_found" });
+
+    const etag = etagOf({ ...doc, _id: undefined });
+    if (req.headers["if-none-match"] === etag) {
+      return res.status(304).end();
+    }
+    res.setHeader("ETag", etag);
+    res.setHeader("Cache-Control", cacheCtl);
+    res.json(doc);
+  });
+
+  // GET /list?offset=0&limit=100&status=alive
+  app.get("/list", async (req, res) => {
+    const limit = Math.min(Number(req.query.limit ?? 100), 1000);
+    const offset = Number(req.query.offset ?? 0);
+    const q: any = {};
+    // simple filters
+    for (const k of Object.keys(req.query)) {
+      if (["limit", "offset"].includes(k)) continue;
+      q[k] = req.query[k];
+    }
+    const cursor = coll.find(q).sort({ _ts: -1 }).skip(offset).limit(limit);
+    const items = await cursor.toArray();
+    res.setHeader("Cache-Control", "no-store");
+    res.json({ offset, limit, count: items.length, items });
+  });
+
+  // HEAD /snap/:key (for cheap freshness checks)
+  app.head("/snap/:key", async (req, res) => {
+    const key = req.params.key;
+    const doc = await coll.findOne(
+      { [keyField]: key },
+      { projection: { _id: 0, _ts: 1 } },
+    );
+    if (!doc) return res.status(404).end();
+    const etag = etagOf(doc);
+    if (req.headers["if-none-match"] === etag) return res.status(304).end();
+    res.setHeader("ETag", etag);
+    res.setHeader("Cache-Control", cacheCtl);
+    res.status(200).end();
+  });
+
+  return app.listen(port, () =>
+    console.log(`[snapshot-api] on :${port} (${opts.collection})`),
+  );
+}

--- a/shared/js/prom-lib/tests/dev.harness.int.test.ts
+++ b/shared/js/prom-lib/tests/dev.harness.int.test.ts
@@ -1,0 +1,23 @@
+import { startHarness } from "../dev/harness";
+
+test("harness end-to-end", async () => {
+  const h = await startHarness({ wsPort: 9190, httpPort: 9191 });
+
+  // publish a heartbeat and wait a tick
+  await h.bus.publish("heartbeat.received", {
+    pid: 1,
+    name: "stt",
+    host: "local",
+    cpu_pct: 1,
+    mem_mb: 2,
+  });
+  await new Promise((r) => setTimeout(r, 200));
+
+  // ensure projector emitted process.state
+  const events = await (h.bus as any).store.scan("process.state", { ts: 0 });
+  expect(events.length).toBe(1);
+  const cur = await h.bus.getCursor("heartbeat.received", "process-projector");
+  expect(cur).toBeTruthy();
+
+  await h.stop();
+}, 10_000);

--- a/shared/js/prom-lib/timetravel/examples.ts
+++ b/shared/js/prom-lib/timetravel/examples.ts
@@ -1,0 +1,15 @@
+import { reconstructAt } from "./reconstruct";
+import { MongoEventStore } from "../event/mongo";
+
+export async function processAt(
+  store: MongoEventStore,
+  processId: string,
+  atTs: number,
+) {
+  return reconstructAt(store, {
+    topic: "process.state",
+    key: processId,
+    atTs,
+    apply: (_prev, e) => e.payload as any,
+  });
+}

--- a/shared/js/prom-lib/timetravel/reconstruct.ts
+++ b/shared/js/prom-lib/timetravel/reconstruct.ts
@@ -1,0 +1,41 @@
+import type { MongoEventStore } from "../event/mongo";
+import type { EventRecord } from "../event/types";
+
+export interface ReconstructOpts<T = any> {
+  topic: string; // e.g., "process.state"
+  snapshotTopic?: string; // e.g., "process.state.snapshot" (optional)
+  key: string; // entity key
+  atTs: number; // target timestamp (epoch ms)
+  apply: (prev: T | null, e: EventRecord<T>) => T | null; // reducer: apply event->state
+  fetchSnapshot?: (
+    key: string,
+    upTo: number,
+  ) => Promise<{ state: T | null; ts: number } | null>;
+}
+
+export async function reconstructAt<T = any>(
+  store: MongoEventStore,
+  opts: ReconstructOpts<T>,
+) {
+  let baseState: T | null = null;
+  let baseTs = 0;
+
+  // optional snapshot as baseline
+  if (opts.fetchSnapshot) {
+    const snap = await opts.fetchSnapshot(opts.key, opts.atTs);
+    if (snap) {
+      baseState = snap.state;
+      baseTs = snap.ts;
+    }
+  }
+
+  // scan events after baseline up to atTs
+  const events = await store.scan(opts.topic, { ts: baseTs, limit: 1_000_000 });
+  for (const e of events) {
+    if (e.ts > opts.atTs) break;
+    if (e.key !== opts.key) continue;
+    baseState = opts.apply(baseState, e as EventRecord<T>);
+    baseTs = e.ts;
+  }
+  return { state: baseState, ts: baseTs };
+}

--- a/shared/js/prom-lib/tsconfig.json
+++ b/shared/js/prom-lib/tsconfig.json
@@ -19,12 +19,16 @@
     "naming/**/*.ts",
     "schema/**/*.ts",
     "dlq/**/*.ts",
-    "changefeed/**/*.ts"
-    "compiler/**/*.ts"
+    "changefeed/**/*.ts",
+    "compiler/**/*.ts",
     "ws/**/*.ts",
     "compaction/**/*.ts",
     "metrics/**/*.ts",
     "examples/**/*.ts",
-    "http/**/*.ts"
+    "http/**/*.ts",
+    "projectors/**/*.ts",
+    "snapshots/**/*.ts",
+    "timetravel/**/*.ts",
+    "dev/**/*.ts"
   ]
 }


### PR DESCRIPTION
## Summary
- add express-based snapshot API for reading state with ETag caching
- introduce transactional projector for multi-collection updates
- provide time-travel reconstruction helper and dev harness with test

## Testing
- `npm test` *(fails: Exiting due to SIGINT)*
- `npx eslint shared/js/prom-lib/snapshots/api.ts shared/js/prom-lib/projectors/transactional.ts shared/js/prom-lib/timetravel/reconstruct.ts shared/js/prom-lib/timetravel/examples.ts shared/js/prom-lib/dev/harness.ts shared/js/prom-lib/tests/dev.harness.int.test.ts`
- `npx tsc --noEmit shared/js/prom-lib/snapshots/api.ts shared/js/prom-lib/projectors/transactional.ts shared/js/prom-lib/timetravel/reconstruct.ts shared/js/prom-lib/timetravel/examples.ts shared/js/prom-lib/dev/harness.ts shared/js/prom-lib/tests/dev.harness.int.test.ts` *(fails: cannot find module or property errors)*
- `cd shared/js/prom-lib && npx jest tests/dev.harness.int.test.ts --config jest.config.ts`


------
https://chatgpt.com/codex/tasks/task_e_6898e4760410832495ff76ab1b2972f0