### PR TITLE
feat: add agent ECS scaffold

### DIFF
--- a/shared/js/agent-ecs/adapters/example-hooks.ts
+++ b/shared/js/agent-ecs/adapters/example-hooks.ts
@@ -1,0 +1,40 @@
+import { enqueueUtterance } from "../helpers/enqueueUtterance";
+
+export function wireAdapters(
+  world: ReturnType<typeof import("../agent-ecs/world").createAgentWorld>,
+  deps: {
+    tts: { synth: (text: string) => Promise<any> }; // returns AudioResource-compatible stream
+  },
+) {
+  const { w, agent, C } = world;
+
+  return {
+    onRawLevel(level: number) {
+      const vad = w.get(agent, C.RawVAD)!; // ensure RawVAD is added if you want per-agent source
+      if (!vad) {
+        const cmd = w.beginTick();
+        cmd.add(agent, C.RawVAD, { level, ts: Date.now() });
+        cmd.flush();
+        w.endTick();
+      } else {
+        vad.level = level;
+        vad.ts = Date.now();
+        w.set(agent, C.RawVAD, vad);
+      }
+    },
+    onFinalTranscript(text: string) {
+      const cmd = w.beginTick();
+      cmd.add(agent, C.TranscriptFinal, { text, ts: Date.now() });
+      cmd.flush();
+      w.endTick();
+    },
+    speak(text: string) {
+      enqueueUtterance(w, agent, {
+        group: "agent-speech",
+        priority: 1,
+        bargeIn: "pause",
+        factory: async () => deps.tts.synth(text),
+      });
+    },
+  };
+}

--- a/shared/js/agent-ecs/components.ts
+++ b/shared/js/agent-ecs/components.ts
@@ -1,0 +1,114 @@
+import type { World } from "../prom-lib/ds/ecs";
+
+export type BargeIn = "none" | "duck" | "pause" | "stop";
+
+export const defineAgentComponents = (w: World) => {
+  const Turn = w.defineComponent<{ id: number }>({
+    name: "Turn",
+    defaults: () => ({ id: 0 }),
+  });
+
+  const RawVAD = w.defineComponent<{ level: number; ts: number }>({
+    name: "RawVAD",
+    defaults: () => ({ level: 0, ts: 0 }),
+  });
+
+  const VAD = w.defineComponent<{
+    active: boolean;
+    lastTrueAt: number;
+    lastFalseAt: number;
+    attackMs: number;
+    releaseMs: number;
+    hangMs: number;
+    threshold: number;
+    _prevActive?: boolean; // local prev flag (not persisted across restarts)
+  }>({
+    name: "VAD",
+    defaults: () => ({
+      active: false,
+      lastTrueAt: 0,
+      lastFalseAt: 0,
+      attackMs: 120,
+      releaseMs: 250,
+      hangMs: 800,
+      threshold: 0.5,
+      _prevActive: false,
+    }),
+  });
+
+  const PlaybackQ = w.defineComponent<{ items: number[] }>({
+    name: "PlaybackQ",
+    defaults: () => ({ items: [] }),
+  });
+
+  const AudioRef = w.defineComponent<{
+    player: {
+      play: (res: any) => void;
+      stop: (force?: boolean) => void;
+      pause: (force?: boolean) => void;
+      unpause: () => void;
+      isPlaying: () => boolean;
+    };
+  }>({
+    name: "AudioRef",
+    defaults: () => ({
+      player: {
+        play() {},
+        stop() {},
+        pause() {},
+        unpause() {},
+        isPlaying: () => false,
+      },
+    }),
+  });
+
+  const Utterance = w.defineComponent<{
+    id: string;
+    turnId: number;
+    priority: number;
+    group?: string;
+    bargeIn: BargeIn;
+    status: "queued" | "playing" | "done" | "cancelled";
+    token: number; // race-cancel token
+  }>({
+    name: "Utterance",
+    defaults: () => ({
+      id: "",
+      turnId: 0,
+      priority: 1,
+      bargeIn: "pause",
+      status: "queued",
+      token: 0,
+    }),
+  });
+
+  const AudioRes = w.defineComponent<{
+    factory: () => Promise<any>;
+    durationMs?: number;
+  }>({
+    name: "AudioRes",
+    defaults: () => ({ factory: async () => null }),
+  });
+
+  const TranscriptFinal = w.defineComponent<{ text: string; ts: number }>({
+    name: "TranscriptFinal",
+    defaults: () => ({ text: "", ts: 0 }),
+  });
+
+  const Policy = w.defineComponent<{ defaultBargeIn: BargeIn }>({
+    name: "Policy",
+    defaults: () => ({ defaultBargeIn: "pause" }),
+  });
+
+  return {
+    Turn,
+    RawVAD,
+    VAD,
+    PlaybackQ,
+    AudioRef,
+    Utterance,
+    AudioRes,
+    TranscriptFinal,
+    Policy,
+  };
+};

--- a/shared/js/agent-ecs/helpers/enqueueUtterance.ts
+++ b/shared/js/agent-ecs/helpers/enqueueUtterance.ts
@@ -1,0 +1,51 @@
+import type { World, Entity } from "../../prom-lib/ds/ecs";
+import { defineAgentComponents } from "../components";
+
+export function enqueueUtterance(
+  w: World,
+  agent: Entity,
+  opts: {
+    id?: string;
+    priority?: number;
+    group?: string;
+    bargeIn?: "none" | "duck" | "pause" | "stop";
+    factory: () => Promise<any>;
+  },
+) {
+  const { Turn, PlaybackQ, Utterance, AudioRes, Policy } =
+    defineAgentComponents(w);
+  const turnId = w.get(agent, Turn)!.id;
+  const pq = w.get(agent, PlaybackQ)!;
+  const defaultBarge = w.get(agent, Policy)!.defaultBargeIn;
+
+  if (opts.group) {
+    for (const uEid of pq.items) {
+      const u = w.get(uEid, Utterance)!;
+      if (
+        u.group === opts.group &&
+        u.status === "queued" &&
+        u.priority <= (opts.priority ?? 1)
+      ) {
+        u.status = "cancelled";
+        w.set(uEid, Utterance, u);
+      }
+    }
+  }
+
+  const cmd = w.beginTick();
+  const e = cmd.createEntity();
+  cmd.add(e, Utterance, {
+    id: opts.id ?? globalThis.crypto?.randomUUID?.() ?? String(Math.random()),
+    turnId,
+    priority: opts.priority ?? 1,
+    group: opts.group,
+    bargeIn: opts.bargeIn ?? defaultBarge,
+    status: "queued",
+    token: Math.floor(Math.random() * 1e9),
+  });
+  cmd.add(e, AudioRes, { factory: opts.factory });
+  cmd.flush();
+  w.endTick();
+
+  pq.items.push(e);
+}

--- a/shared/js/agent-ecs/systems/speechArbiter.ts
+++ b/shared/js/agent-ecs/systems/speechArbiter.ts
@@ -1,0 +1,89 @@
+import type { World, Entity } from "../../prom-lib/ds/ecs";
+import { defineAgentComponents } from "../components";
+
+export function SpeechArbiterSystem(w: World) {
+  const { Turn, PlaybackQ, AudioRef, Utterance, AudioRes, VAD, Policy } =
+    defineAgentComponents(w);
+  const qAgent = w.makeQuery({ all: [Turn, PlaybackQ, AudioRef, Policy] });
+  const qVAD = w.makeQuery({ all: [VAD] });
+
+  function userSpeaking(): boolean {
+    for (const [, get] of w.iter(qVAD)) if (get(VAD).active) return true;
+    return false;
+  }
+
+  return async function run(_dt: number) {
+    for (const [agent, get] of w.iter(qAgent)) {
+      const turnId = get(Turn).id;
+      const queue = get(PlaybackQ);
+      const player = get(AudioRef).player;
+      const policy = get(Policy);
+
+      // purge stale/cancelled
+      queue.items = queue.items.filter((uEid: Entity) => {
+        const u = w.get(uEid, Utterance);
+        return (
+          u &&
+          u.turnId >= turnId &&
+          (u.status === "queued" || u.status === "playing")
+        );
+      });
+
+      // if currently playing, enforce barge-in
+      const current = queue.items.find(
+        (uEid) => w.get(uEid, Utterance)?.status === "playing",
+      );
+      if (current) {
+        const u = w.get(current, Utterance)!;
+        const active = userSpeaking();
+        const bi = u.bargeIn ?? policy.defaultBargeIn;
+        if (active) {
+          if (bi === "pause") player.pause(true);
+          else if (bi === "stop") {
+            u.status = "cancelled";
+            w.set(current, Utterance, u);
+            try {
+              player.stop(true);
+            } catch {}
+          } // duck handled externally if you implement a mixer
+        } else {
+          if (bi === "pause") player.unpause();
+        }
+        continue;
+      }
+
+      if (!player.isPlaying() && queue.items.length) {
+        queue.items.sort(
+          (a, b) =>
+            w.get(b, Utterance)!.priority - w.get(a, Utterance)!.priority,
+        );
+        let pickedIdx = -1,
+          picked: Entity | null = null;
+        for (let i = 0; i < queue.items.length; i++) {
+          const uEid = queue.items[i];
+          const u = w.get(uEid, Utterance)!;
+          if (u.turnId < turnId || u.status !== "queued") continue;
+          pickedIdx = i;
+          picked = uEid;
+          break;
+        }
+        if (picked != null) {
+          if (pickedIdx >= 0) queue.items.splice(pickedIdx, 1);
+          const utt = w.get(picked, Utterance)!;
+          const res = await w
+            .get(picked, AudioRes)!
+            .factory()
+            .catch(() => null);
+
+          // race cancel guard
+          const latest = w.get(picked, Utterance);
+          if (!latest || latest.token !== utt.token || !res) continue;
+
+          utt.status = "playing";
+          w.set(picked, Utterance, utt);
+          player.play(res);
+        }
+      }
+    }
+  };
+}

--- a/shared/js/agent-ecs/systems/turn.ts
+++ b/shared/js/agent-ecs/systems/turn.ts
@@ -1,0 +1,31 @@
+import type { World } from "../../prom-lib/ds/ecs";
+import { defineAgentComponents } from "../components";
+
+export function TurnDetectionSystem(w: World) {
+  const { Turn, VAD, TranscriptFinal } = defineAgentComponents(w);
+  const qVad = w.makeQuery({ all: [Turn, VAD] });
+  const qFinal = w.makeQuery({
+    changed: [TranscriptFinal],
+    all: [Turn, TranscriptFinal],
+  });
+
+  return function run(_dt: number) {
+    for (const [e, get] of w.iter(qVad)) {
+      const turn = get(Turn);
+      const vad = get(VAD);
+      const prev = !!vad._prevActive;
+      if (!prev && vad.active) {
+        turn.id++;
+        w.set(e, Turn, turn);
+      }
+      vad._prevActive = vad.active;
+      w.set(e, VAD, vad);
+    }
+
+    for (const [e, get] of w.iter(qFinal)) {
+      const turn = get(Turn);
+      turn.id++;
+      w.set(e, Turn, turn);
+    }
+  };
+}

--- a/shared/js/agent-ecs/systems/vad.ts
+++ b/shared/js/agent-ecs/systems/vad.ts
@@ -1,0 +1,32 @@
+import type { World } from "../../prom-lib/ds/ecs";
+import { defineAgentComponents } from "../components";
+
+export function VADUpdateSystem(w: World) {
+  const { RawVAD, VAD } = defineAgentComponents(w);
+  const q = w.makeQuery({ all: [RawVAD, VAD] });
+
+  return function run(_dt: number) {
+    for (const [e, get] of w.iter(q)) {
+      const raw = get(RawVAD);
+      const vad = get(VAD);
+      const now = Date.now();
+
+      const rawActive = raw.level >= vad.threshold;
+      if (rawActive) {
+        if (!vad.active && now - vad.lastFalseAt >= vad.attackMs)
+          vad.active = true;
+        vad.lastTrueAt = now;
+      } else {
+        if (vad.active && now - vad.lastTrueAt >= vad.releaseMs)
+          vad.active = false;
+        vad.lastFalseAt = now;
+      }
+      if (vad.active && now - vad.lastTrueAt > vad.hangMs) {
+        vad.active = false;
+        vad.lastFalseAt = now;
+      }
+
+      w.set(e, VAD, vad);
+    }
+  };
+}

--- a/shared/js/agent-ecs/world.ts
+++ b/shared/js/agent-ecs/world.ts
@@ -1,0 +1,33 @@
+import { World } from "../prom-lib/ds/ecs";
+import { defineAgentComponents } from "./components";
+import { VADUpdateSystem } from "./systems/vad";
+import { TurnDetectionSystem } from "./systems/turn";
+import { SpeechArbiterSystem } from "./systems/speechArbiter";
+
+export function createAgentWorld(audioPlayer: any) {
+  const w = new World();
+  const C = defineAgentComponents(w);
+
+  // create agent entity
+  const cmd = w.beginTick();
+  const agent = cmd.createEntity();
+  cmd.add(agent, C.Turn);
+  cmd.add(agent, C.PlaybackQ);
+  cmd.add(agent, C.Policy, { defaultBargeIn: "pause" });
+  cmd.add(agent, C.AudioRef, { player: audioPlayer });
+  cmd.flush();
+  w.endTick();
+
+  const systems = [
+    VADUpdateSystem(w),
+    TurnDetectionSystem(w),
+    SpeechArbiterSystem(w),
+    // TODO: add ContextAssembler, LLMRequest, TTSRequest, PlaybackLifecycle
+  ];
+
+  function tick(dtMs = 50) {
+    systems.forEach((s) => s(dtMs));
+  }
+
+  return { w, agent, C, tick };
+}


### PR DESCRIPTION
## Summary
- add agent ECS component definitions and systems for VAD, turn detection, and speech arbitration
- provide helper for enqueuing speech and world bootstrap with example adapter hooks

## Testing
- `make setup-shared-js`
- `npx --yes prettier --write shared/js/agent-ecs`
- `npx --yes eslint shared/js/agent-ecs --ext .ts`
- `make lint-js`
- `make format-js`
- `make build`
- `make test-js` *(fails: Makefile:131: test-js Error 1)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6898ed07cf9483249e79ea4d64927460