### PR TITLE
test: expand permission gate coverage

### DIFF
--- a/tests/test_permission_gate.py
+++ b/tests/test_permission_gate.py
@@ -1,5 +1,10 @@
+import os
+import sys
 import importlib
 
+import pytest
+
+sys.path.append(os.getcwd())
 permission_gate = importlib.import_module("shared.py.permission_gate")
 
 
@@ -9,3 +14,51 @@ def test_permission_granted():
 
 def test_permission_denied():
     assert not permission_gate.check_permission("alice", "delete")
+
+
+def test_sigmoid_midpoint():
+    """The sigmoid function should be centered at zero."""
+    assert permission_gate._sigmoid(0) == pytest.approx(0.5)
+
+
+def test_custom_config_path(tmp_path):
+    """A custom config path should influence permission decisions."""
+    # Config allowing the action
+    allow_cfg = tmp_path / "allow.yaml"
+    allow_cfg.write_text(
+        """
+beta: 1.0
+default:
+  threshold: 0
+  weights:
+    trust: 1
+  actions:
+    default:
+      features:
+        trust: 1
+"""
+    )
+
+    permission_gate._CONFIG_CACHE = None
+    assert permission_gate.check_permission("bob", "read", config_path=str(allow_cfg))
+
+    # Config denying the action
+    deny_cfg = tmp_path / "deny.yaml"
+    deny_cfg.write_text(
+        """
+beta: 1.0
+default:
+  threshold: 1
+  weights:
+    trust: 1
+  actions:
+    default:
+      features:
+        trust: 0
+"""
+    )
+
+    permission_gate._CONFIG_CACHE = None
+    assert not permission_gate.check_permission(
+        "bob", "read", config_path=str(deny_cfg)
+    )


### PR DESCRIPTION
## Summary
- expand permission gate tests to cover sigmoid midpoint behavior
- verify custom configuration files affect permission decisions

## Testing
- `make setup-shared-python` *(failed: KeyboardInterrupt during pipenv install)*
- `make format-python`
- `make lint-python`
- `make build-python`
- `make test-python` *(failed: ModuleNotFoundError for discord and others)*
- `pytest tests/test_permission_gate.py`

------
https://chatgpt.com/codex/tasks/task_e_6899224175e48324b93abbabc5d3ebd1