### PR TITLE
Fix test import path

### DIFF
--- a/tests/test_permission_gate.py
+++ b/tests/test_permission_gate.py
@@ -1,4 +1,9 @@
 import importlib
+import os
+import sys
+
+# Ensure repository root is on the path so `shared` can be imported
+sys.path.append(os.getcwd())
 
 permission_gate = importlib.import_module("shared.py.permission_gate")
 


### PR DESCRIPTION
## Summary
- add repo root to path in permission gate test

## Testing
- `pytest tests/test_permission_gate.py tests/test_util.py`
- `make build` (no build step message)
- `make setup-shared-python` (failed: KeyboardInterrupt during pipenv install)
- `make setup-js`
- `make lint` (failed: biome configuration requiring migration)
- `make test` (interrupted during JS tests)


------
https://chatgpt.com/codex/tasks/task_e_6899224f036c832489420764ae567177