### PR TITLE
Fix path setup in split_sentences tests

### DIFF
--- a/shared/py/tests/test_split_sentences.py
+++ b/shared/py/tests/test_split_sentences.py
@@ -1,12 +1,12 @@
 import os
 import sys
-from shared.py.utils.split_sentences import split_sentences
-
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "shared", "py"))
 
 sys.path.insert(
     0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../"))
 )
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "shared", "py"))
+
+from shared.py.utils.split_sentences import split_sentences
 
 
 def test_split_basic():


### PR DESCRIPTION
## Summary
- Ensure test for split_sentences adjusts `sys.path` before importing module to avoid `ModuleNotFoundError`

## Testing
- `python -m pytest shared/py/tests/test_split_sentences.py`
- `python -m pytest shared/py/tests/test_numbers.py`
- `make lint-python`
- `make build-python`


------
https://chatgpt.com/codex/tasks/task_e_6899224f036c832489420764ae567177