### PR TITLE
fix: explicit whisper generation config

### DIFF
--- a/services/py/stt/tests/test_wisper_stt_config.py
+++ b/services/py/stt/tests/test_wisper_stt_config.py
@@ -1,0 +1,69 @@
+import importlib
+import sys
+import types
+from pathlib import Path
+
+# Ensure repository root is on sys.path so ``shared`` modules are importable
+sys.path.append(str(Path(__file__).resolve().parents[4]))
+
+
+def test_generation_config(monkeypatch):
+    class DummyModel:
+        def __init__(self):
+            self.generation_config = types.SimpleNamespace()
+
+        def to(self, device):
+            return self
+
+        def generate(self, *args, **kwargs):
+            return [[0]]
+
+    class DummyProcessor:
+        @classmethod
+        def from_pretrained(cls, *args, **kwargs):
+            processor = types.SimpleNamespace()
+            processor.__call__ = lambda *a, **k: {"input_features": None}
+            processor.batch_decode = lambda *a, **k: [""]
+            return processor
+
+    class DummyModelCls:
+        @classmethod
+        def from_pretrained(cls, *args, **kwargs):
+            return DummyModel()
+
+    dummy_transformers = types.SimpleNamespace(
+        WhisperProcessor=DummyProcessor,
+        WhisperForConditionalGeneration=DummyModelCls,
+    )
+    monkeypatch.setitem(sys.modules, "transformers", dummy_transformers)
+
+    class DummyResample:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def __call__(self, waveform):
+            return waveform
+
+    dummy_torchaudio = types.SimpleNamespace(
+        transforms=types.SimpleNamespace(Resample=DummyResample)
+    )
+    monkeypatch.setitem(sys.modules, "torchaudio", dummy_torchaudio)
+
+    dummy_torch = types.SimpleNamespace(
+        cuda=types.SimpleNamespace(is_available=lambda: False),
+        device=lambda *a, **k: "cpu",
+        Tensor=types.SimpleNamespace,
+    )
+    monkeypatch.setitem(sys.modules, "torch", dummy_torch)
+
+    dummy_numpy = types.SimpleNamespace()
+    dummy_numpy.ndarray = object
+    dummy_numpy.frombuffer = lambda *a, **k: []
+    dummy_numpy.int16 = "int16"
+    dummy_numpy.float32 = "float32"
+    dummy_numpy.clip = lambda arr, a, b: arr
+    monkeypatch.setitem(sys.modules, "numpy", dummy_numpy)
+
+    module = importlib.import_module("shared.py.speech.wisper_stt")
+    assert module.model.generation_config.task == "transcribe"
+    assert module.model.generation_config.language == "en"

--- a/shared/py/speech/wisper_stt.py
+++ b/shared/py/speech/wisper_stt.py
@@ -10,9 +10,14 @@ print("Using device:", device)
 
 # Load small model
 processor = WhisperProcessor.from_pretrained("openai/whisper-tiny")
+# The 2024 Transformers release deprecated relying on ``forced_decoder_ids``
+# defaults for Whisper.  Explicitly set the generation task and language to
+# avoid warnings and make behaviour deterministic.
 model = WhisperForConditionalGeneration.from_pretrained("openai/whisper-tiny").to(
     device
 )
+model.generation_config.task = "transcribe"
+model.generation_config.language = "en"
 
 
 def resample_waveform(


### PR DESCRIPTION
## Summary
- configure Whisper generation to use explicit task and language
- add unit test ensuring generation config is set

## Testing
- `make setup-quick-service-python-service-stt` *(fails: KeyboardInterrupt while installing nvidia packages)*
- `make test-quick-service-python-service-stt` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `make lint SERVICE=stt`
- `make format SERVICE=stt` *(fails: Command 'npx --yes @biomejs/biome format .' returned non-zero exit status 1)*
- `make build SERVICE=stt`
- `pytest services/py/stt/tests/test_wisper_stt_config.py`

------
https://chatgpt.com/codex/tasks/task_e_6899557720748324a2c6df1dc32bfd10