### PR TITLE
test: add token bucket coverage

### DIFF
--- a/shared/ts/src/rate/limiter.test.ts
+++ b/shared/ts/src/rate/limiter.test.ts
@@ -1,0 +1,20 @@
+import test from 'ava';
+import { TokenBucket } from './limiter.js';
+
+// ensure TokenBucket enforces capacity and returns deficit
+test('TokenBucket enforces capacity', (t) => {
+    const bucket = new TokenBucket({ capacity: 5, refillPerSec: 1 });
+    t.true(bucket.tryConsume(3));
+    t.false(bucket.tryConsume(3));
+    t.is(bucket.deficit(3), 1);
+});
+
+// ensure tokens refill over time
+test('TokenBucket refills over time', async (t) => {
+    t.timeout?.(5000);
+    const bucket = new TokenBucket({ capacity: 1, refillPerSec: 1 });
+    t.true(bucket.tryConsume());
+    t.false(bucket.tryConsume());
+    await new Promise((r) => setTimeout(r, 1100));
+    t.true(bucket.tryConsume());
+});


### PR DESCRIPTION
## Summary
- add TokenBucket unit tests covering capacity enforcement and refills

## Testing
- `pnpm run coverage`
- `pnpm exec biome lint .` *(fails: Command "@biomejs/biome" not found / lint errors)*
- `pnpm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a4d44323a88324a5ee7b3467be66f2