### PR TITLE
feat: add retention and cleanup for SmartGPT Bridge logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Introduced `CHANGELOG.md` to track project changes.
 - Auto-generated OpenAPI spec for SmartGPT Bridge via Fastify swagger.
+- TTL log retention for SmartGPT Bridge with MongoDB and Chroma cleanup.
 
 ### Changed
 - Refactored `VoiceSession` to accept a stubbed `Transcriber` for testability.

--- a/services/ts/smartgpt-bridge/package.json
+++ b/services/ts/smartgpt-bridge/package.json
@@ -26,7 +26,9 @@
         "jsonwebtoken": "^9.0.2",
         "nanoid": "^5.0.7",
         "node-pty": "^1.0.0",
-        "typescript": "^5.6.2"
+        "typescript": "^5.6.2",
+        "mongoose": "^8.8.0",
+        "uuid": "^9.0.1"
     },
     "devDependencies": {
         "ava": "^6.1.3",

--- a/services/ts/smartgpt-bridge/src/fastifyApp.js
+++ b/services/ts/smartgpt-bridge/src/fastifyApp.js
@@ -17,10 +17,13 @@ import { registerGrepRoutes } from './routes/grep.js';
 import { registerSymbolsRoutes } from './routes/symbols.js';
 import { registerAgentRoutes } from './routes/agent.js';
 import { registerExecRoutes } from './routes/exec.js';
+import { registerLogRoutes } from './routes/logs.js';
+import { mongoChromaLogger } from './logging/index.js';
 
 export function buildFastifyApp(ROOT_PATH) {
     const app = Fastify({ logger: false, trustProxy: true });
     app.decorate('ROOT_PATH', ROOT_PATH);
+    app.register(mongoChromaLogger);
 
     const baseUrl = process.env.PUBLIC_BASE_URL || `http://localhost:${process.env.PORT || 3210}`;
     const authEnabled = String(process.env.AUTH_ENABLED || 'false').toLowerCase() === 'true';
@@ -80,6 +83,7 @@ export function buildFastifyApp(ROOT_PATH) {
         registerIndexerRoutes(f);
         registerAgentRoutes(f);
         registerExecRoutes(f);
+        registerLogRoutes(f);
     });
 
     // Initialize indexer bootstrap/incremental state unless in test

--- a/services/ts/smartgpt-bridge/src/fastifyServer.js
+++ b/services/ts/smartgpt-bridge/src/fastifyServer.js
@@ -1,5 +1,6 @@
 import { configDotenv } from 'dotenv';
 import { buildFastifyApp } from './fastifyApp.js';
+import { scheduleChromaCleanup } from './logging/chromaCleanup.js';
 
 try {
     configDotenv();
@@ -8,6 +9,7 @@ try {
 const PORT = Number(process.env.PORT || 3210);
 const ROOT_PATH = process.env.ROOT_PATH || process.cwd();
 const app = buildFastifyApp(ROOT_PATH);
+scheduleChromaCleanup();
 
 app.listen({ port: PORT, host: '0.0.0.0' })
     .then(() => {

--- a/services/ts/smartgpt-bridge/src/indexer.js
+++ b/services/ts/smartgpt-bridge/src/indexer.js
@@ -28,7 +28,7 @@ export function resetEmbeddingCache() {
     EMBEDDING_INSTANCE_KEY = null;
 }
 
-function getChroma() {
+export function getChroma() {
     if (!CHROMA) CHROMA = new ChromaClient();
     return CHROMA;
 }

--- a/services/ts/smartgpt-bridge/src/logModel.js
+++ b/services/ts/smartgpt-bridge/src/logModel.js
@@ -1,0 +1,39 @@
+import mongoose from 'mongoose';
+
+let connected = false;
+export async function initMongo() {
+    const uri = process.env.MONGODB_URI;
+    if (!uri) return null;
+    if (!connected) {
+        try {
+            await mongoose.connect(uri);
+            connected = true;
+        } catch {
+            return null;
+        }
+    }
+    return mongoose;
+}
+
+const LogSchema = new mongoose.Schema({
+    requestId: { type: String, required: true },
+    method: String,
+    path: String,
+    statusCode: Number,
+    request: Object,
+    response: Object,
+    error: String,
+    createdAt: { type: Date, default: Date.now, index: true },
+    latencyMs: Number,
+    service: String,
+    operationId: String,
+});
+
+LogSchema.index({ path: 1, createdAt: -1 });
+LogSchema.index({ statusCode: 1 });
+LogSchema.index({ operationId: 1 });
+
+const ttlDays = Number(process.env.LOG_TTL_DAYS || 30);
+LogSchema.index({ createdAt: 1 }, { expireAfterSeconds: ttlDays * 86400 });
+
+export const Log = mongoose.models.Log || mongoose.model('Log', LogSchema, 'bridge_logs');

--- a/services/ts/smartgpt-bridge/src/logging/chromaCleanup.js
+++ b/services/ts/smartgpt-bridge/src/logging/chromaCleanup.js
@@ -1,0 +1,47 @@
+import { getLogCollection } from './index.js';
+
+export async function cleanupChromaLogs(
+    days = Number(process.env.LOG_TTL_DAYS || 30),
+    max = Number(process.env.LOG_MAX_CHROMA || 100000),
+) {
+    const col = await getLogCollection();
+    if (!col) return { deleted: 0 };
+    let deleted = 0;
+    const cutoff = new Date(Date.now() - days * 86400 * 1000).toISOString();
+    try {
+        const old = await col.get({ where: { createdAt: { $lt: cutoff } }, include: ['ids'] });
+        if (old?.ids?.length) {
+            await col.delete({ ids: old.ids });
+            deleted += old.ids.length;
+        }
+    } catch {}
+
+    if (max > 0) {
+        try {
+            const count = await col.count();
+            if (count > max) {
+                const excess = count - max;
+                const all = await col.get({ include: ['ids', 'metadatas'] });
+                const pairs = (all.ids || []).map((id, i) => ({
+                    id,
+                    createdAt: all.metadatas?.[i]?.createdAt,
+                }));
+                pairs.sort((a, b) => new Date(a.createdAt) - new Date(b.createdAt));
+                const toDelete = pairs.slice(0, excess).map((p) => p.id);
+                if (toDelete.length) {
+                    await col.delete({ ids: toDelete });
+                    deleted += toDelete.length;
+                }
+            }
+        } catch {}
+    }
+    return { deleted };
+}
+
+export function scheduleChromaCleanup() {
+    const days = Number(process.env.LOG_TTL_DAYS || 30);
+    const max = Number(process.env.LOG_MAX_CHROMA || 100000);
+    const run = () => cleanupChromaLogs(days, max).catch(() => {});
+    run();
+    setInterval(run, 24 * 60 * 60 * 1000);
+}

--- a/services/ts/smartgpt-bridge/src/logging/index.js
+++ b/services/ts/smartgpt-bridge/src/logging/index.js
@@ -1,0 +1,116 @@
+import { v4 as uuidv4 } from 'uuid';
+import { initMongo, Log } from '../logModel.js';
+import { getChroma } from '../indexer.js';
+
+let CHROMA_COLLECTION = null;
+export async function getLogCollection() {
+    if (CHROMA_COLLECTION) return CHROMA_COLLECTION;
+    try {
+        const col = await getChroma().getOrCreateCollection({
+            name: 'bridge_logs',
+            metadata: { type: 'logs' },
+        });
+        CHROMA_COLLECTION = col;
+    } catch {
+        CHROMA_COLLECTION = null;
+    }
+    return CHROMA_COLLECTION;
+}
+
+export async function mongoChromaLogger(app) {
+    const collection = await getLogCollection().catch(() => null);
+
+    app.addHook('onRequest', async (req) => {
+        req.requestId = uuidv4();
+        req.startTime = Date.now();
+    });
+
+    app.addHook('onResponse', async (req, reply) => {
+        const latencyMs = Date.now() - (req.startTime || Date.now());
+        const entry = {
+            requestId: req.requestId,
+            method: req.method,
+            path: req.url,
+            statusCode: reply.statusCode,
+            request: { query: req.query, params: req.params, body: req.body },
+            response: safeParse(reply.payload),
+            createdAt: new Date(),
+            latencyMs,
+            service: 'smartgpt-bridge',
+            operationId: reply.context?.schema?.operationId,
+        };
+        try {
+            const mongo = await initMongo();
+            if (mongo) await Log.create(entry);
+        } catch {}
+        try {
+            const col = collection || (await getLogCollection());
+            await col?.add({
+                ids: [entry.requestId],
+                documents: [JSON.stringify(entry)],
+                metadatas: [
+                    {
+                        requestId: entry.requestId,
+                        path: entry.path,
+                        method: entry.method,
+                        statusCode: entry.statusCode,
+                        hasError: false,
+                        createdAt: entry.createdAt.toISOString(),
+                        latencyMs: entry.latencyMs,
+                        service: entry.service,
+                        operationId: entry.operationId,
+                    },
+                ],
+            });
+        } catch {}
+    });
+
+    app.addHook('onError', async (req, reply, error) => {
+        const latencyMs = Date.now() - (req.startTime || Date.now());
+        const entry = {
+            requestId: req.requestId || uuidv4(),
+            method: req.method,
+            path: req.url,
+            statusCode: reply.statusCode,
+            request: { query: req.query, params: req.params, body: req.body },
+            error: error.message,
+            createdAt: new Date(),
+            latencyMs,
+            service: 'smartgpt-bridge',
+            operationId: reply.context?.schema?.operationId,
+        };
+        try {
+            const mongo = await initMongo();
+            if (mongo) await Log.create(entry);
+        } catch {}
+        try {
+            const col = collection || (await getLogCollection());
+            await col?.add({
+                ids: [entry.requestId],
+                documents: [JSON.stringify(entry)],
+                metadatas: [
+                    {
+                        requestId: entry.requestId,
+                        path: entry.path,
+                        method: entry.method,
+                        statusCode: entry.statusCode,
+                        hasError: true,
+                        createdAt: entry.createdAt.toISOString(),
+                        latencyMs: entry.latencyMs,
+                        service: entry.service,
+                        operationId: entry.operationId,
+                    },
+                ],
+            });
+        } catch {}
+    });
+}
+
+function safeParse(payload) {
+    if (!payload) return undefined;
+    try {
+        return typeof payload === 'string' ? JSON.parse(payload) : payload;
+    } catch {
+        return { raw: String(payload) };
+    }
+}

--- a/services/ts/smartgpt-bridge/src/routes/logs.js
+++ b/services/ts/smartgpt-bridge/src/routes/logs.js
@@ -1,0 +1,61 @@
+import { Log } from '../logModel.js';
+import { getLogCollection } from '../logging/index.js';
+
+export function registerLogRoutes(app) {
+    app.post(
+        '/logs/query',
+        {
+            schema: {
+                summary: 'Query structured logs',
+                operationId: 'queryLogs',
+                tags: ['Logs'],
+                body: {
+                    type: 'object',
+                    properties: {
+                        path: { type: 'string' },
+                        method: { type: 'string' },
+                        statusCode: { type: 'integer' },
+                        since: { type: 'string' },
+                        until: { type: 'string' },
+                    },
+                },
+            },
+        },
+        async (req) => {
+            const { path, method, statusCode, since, until } = req.body || {};
+            const query = {};
+            if (path) query.path = path;
+            if (method) query.method = method.toUpperCase();
+            if (statusCode) query.statusCode = statusCode;
+            if (since || until) query.createdAt = {};
+            if (since) query.createdAt.$gte = new Date(since);
+            if (until) query.createdAt.$lte = new Date(until);
+            return Log.find(query).sort({ createdAt: -1 }).limit(100);
+        },
+    );
+
+    app.post(
+        '/logs/search',
+        {
+            schema: {
+                summary: 'Semantic + metadata-aware search logs',
+                operationId: 'semanticLogSearch',
+                tags: ['Logs'],
+                body: {
+                    type: 'object',
+                    required: ['q'],
+                    properties: {
+                        q: { type: 'string' },
+                        n: { type: 'integer', default: 10 },
+                        where: { type: 'object' },
+                    },
+                },
+            },
+        },
+        async (req) => {
+            const { q, n, where } = req.body;
+            const col = await getLogCollection();
+            return col.query({ queryTexts: [q], nResults: n || 10, where: where || {} });
+        },
+    );
+}


### PR DESCRIPTION
## Summary
- add MongoDB `Log` schema with TTL-based expiration
- prune Chroma log collection by age and size on a daily schedule
- wire logging plugin and log search endpoints with cleanup hooks

## Testing
- `pnpm --filter ./services/ts/smartgpt-bridge test` (fails: Cannot find module '@shared/ts/dist/embeddings/remote.js')
- `pnpm --filter ./services/ts/smartgpt-bridge run build` (fails: missing script)
- `pnpm --filter ./services/ts/smartgpt-bridge run lint` (fails: missing script)
- `pnpm --filter ./services/ts/smartgpt-bridge run format` (fails: missing script)


------
https://chatgpt.com/codex/tasks/task_e_68a888cc6440832493f3a5e174fe7b58