### PR TITLE
feat: policy-based access control for SmartGPT Bridge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - Placeholder example entry to demonstrate format. Replace/remove in future releases.
 
+## [Unreleased]
+
+### Added
+- Policy-based access control with user and role management for SmartGPT Bridge.
+
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]

--- a/services/ts/smartgpt-bridge/src/models/Policy.js
+++ b/services/ts/smartgpt-bridge/src/models/Policy.js
@@ -1,0 +1,10 @@
+import { Schema, model } from 'mongoose';
+
+const PolicySchema = new Schema({
+    role: { type: String, required: true },
+    action: { type: String, required: true },
+    resource: { type: String, required: true },
+    effect: { type: String, enum: ['allow', 'deny'], default: 'allow' },
+});
+
+export const Policy = model('Policy', PolicySchema, 'policies');

--- a/services/ts/smartgpt-bridge/src/models/User.js
+++ b/services/ts/smartgpt-bridge/src/models/User.js
@@ -1,0 +1,10 @@
+import { Schema, model } from 'mongoose';
+
+const UserSchema = new Schema({
+    username: { type: String, unique: true, required: true },
+    apiKey: { type: String, unique: true, required: true },
+    roles: { type: [String], default: ['user'] },
+    createdAt: { type: Date, default: Date.now },
+});
+
+export const User = model('User', UserSchema, 'users');

--- a/services/ts/smartgpt-bridge/src/rbac.js
+++ b/services/ts/smartgpt-bridge/src/rbac.js
@@ -1,0 +1,25 @@
+import { User } from './models/User.js';
+import { checkAccess } from './utils/policyEngine.js';
+import { initMongo } from './mongo.js';
+
+export function registerRbac(app) {
+    app.decorate('authUser', async (req, reply) => {
+        await initMongo();
+        const token = req.headers['x-pi-token'];
+        if (!token) throw new Error('Missing API token');
+        const user = await User.findOne({ apiKey: token });
+        if (!user) throw new Error('Invalid token');
+        req.user = user;
+        return user;
+    });
+
+    app.decorate('requirePolicy', (action, resource) => {
+        return async (req, reply) => {
+            const resName = typeof resource === 'function' ? resource(req) : resource;
+            const allowed = await checkAccess(req.user, action, resName);
+            if (!allowed) {
+                reply.code(403).send({ ok: false, error: 'Forbidden' });
+            }
+        };
+    });
+}

--- a/services/ts/smartgpt-bridge/src/routes/bootstrap.js
+++ b/services/ts/smartgpt-bridge/src/routes/bootstrap.js
@@ -1,0 +1,49 @@
+import crypto from 'crypto';
+import { User } from '../models/User.js';
+
+function requireLocal(req, reply, done) {
+    const ip = req.ip;
+    if (ip === '127.0.0.1' || ip === '::1' || ip === '::ffff:127.0.0.1') {
+        return done();
+    }
+    reply.code(403).send({ ok: false, error: 'Bootstrap must be run locally' });
+}
+
+export function registerBootstrapRoutes(app) {
+    app.post('/bootstrap/admin', {
+        preHandler: [requireLocal],
+        schema: {
+            summary: 'Bootstrap first admin (one-time, local only)',
+            operationId: 'bootstrapAdmin',
+            tags: ['Admin'],
+            response: {
+                200: {
+                    type: 'object',
+                    properties: {
+                        ok: { type: 'boolean' },
+                        username: { type: 'string' },
+                        apiKey: { type: 'string' },
+                    },
+                    required: ['ok', 'username', 'apiKey'],
+                },
+                400: {
+                    type: 'object',
+                    properties: { ok: { type: 'boolean' }, error: { type: 'string' } },
+                },
+                403: {
+                    type: 'object',
+                    properties: { ok: { type: 'boolean' }, error: { type: 'string' } },
+                },
+            },
+        },
+        handler: async () => {
+            const count = await User.countDocuments();
+            if (count > 0) {
+                return { ok: false, error: 'Already initialized' };
+            }
+            const apiKey = crypto.randomBytes(32).toString('hex');
+            const user = await User.create({ username: 'admin', apiKey, roles: ['admin'] });
+            return { ok: true, username: user.username, apiKey };
+        },
+    });
+}

--- a/services/ts/smartgpt-bridge/src/routes/policies.js
+++ b/services/ts/smartgpt-bridge/src/routes/policies.js
@@ -1,0 +1,58 @@
+import { Policy } from '../models/Policy.js';
+
+export function registerPolicyRoutes(app) {
+    app.get('/policies/list', {
+        preHandler: [app.authUser, app.requirePolicy('read', 'policies')],
+        schema: { operationId: 'listPolicies', tags: ['Admin'] },
+        handler: async () => {
+            const policies = await Policy.find().lean();
+            return { policies };
+        },
+    });
+
+    app.post('/policies/create', {
+        preHandler: [app.authUser, app.requirePolicy('write', 'policies')],
+        schema: {
+            operationId: 'createPolicy',
+            tags: ['Admin'],
+            body: {
+                type: 'object',
+                required: ['role', 'action', 'resource'],
+                properties: {
+                    role: { type: 'string' },
+                    action: { type: 'string' },
+                    resource: { type: 'string' },
+                    effect: { type: 'string', enum: ['allow', 'deny'], default: 'allow' },
+                },
+            },
+        },
+        handler: async (req) => {
+            const { role, action, resource, effect } = req.body || {};
+            const policy = await Policy.create({
+                role,
+                action,
+                resource,
+                effect: effect || 'allow',
+            });
+            return { ok: true, policy };
+        },
+    });
+
+    app.post('/policies/delete', {
+        preHandler: [app.authUser, app.requirePolicy('write', 'policies')],
+        schema: {
+            operationId: 'deletePolicy',
+            tags: ['Admin'],
+            body: {
+                type: 'object',
+                required: ['id'],
+                properties: { id: { type: 'string' } },
+            },
+        },
+        handler: async (req) => {
+            const { id } = req.body || {};
+            await Policy.findByIdAndDelete(id);
+            return { ok: true };
+        },
+    });
+}

--- a/services/ts/smartgpt-bridge/src/routes/search.js
+++ b/services/ts/smartgpt-bridge/src/routes/search.js
@@ -4,6 +4,7 @@ import { dualSinkRegistry } from '../utils/DualSinkRegistry.js';
 export function registerSearchRoutes(fastify) {
     const ROOT_PATH = fastify.ROOT_PATH;
     fastify.post('/search', {
+        preHandler: [fastify.authUser, fastify.requirePolicy('read', 'search')],
         schema: {
             summary: 'Semantic search via Chroma',
             operationId: 'semanticSearch',
@@ -41,6 +42,7 @@ export function registerSearchRoutes(fastify) {
     });
 
     fastify.post('/search/web', {
+        preHandler: [fastify.authUser, fastify.requirePolicy('search', 'bridge_searches')],
         schema: {
             operationId: 'webSearch',
             tags: ['Search'],

--- a/services/ts/smartgpt-bridge/src/routes/sinks.js
+++ b/services/ts/smartgpt-bridge/src/routes/sinks.js
@@ -2,11 +2,13 @@ import { dualSinkRegistry } from '../utils/DualSinkRegistry.js';
 
 export function registerSinkRoutes(app) {
     app.get('/sinks/list', {
+        preHandler: [app.authUser, app.requirePolicy('read', 'sinks')],
         schema: { operationId: 'listSinks', tags: ['Sinks'] },
         handler: async () => ({ sinks: dualSinkRegistry.list() }),
     });
 
     app.post('/sinks/:name/query', {
+        preHandler: [app.authUser, app.requirePolicy('read', (req) => req.params.name)],
         schema: {
             summary: 'Query sink in Mongo (structured filter)',
             operationId: 'querySink',
@@ -29,6 +31,7 @@ export function registerSinkRoutes(app) {
     });
 
     app.post('/sinks/:name/search', {
+        preHandler: [app.authUser, app.requirePolicy('read', (req) => req.params.name)],
         schema: {
             summary: 'Semantic search in sink (Chroma)',
             operationId: 'searchSink',

--- a/services/ts/smartgpt-bridge/src/routes/users.js
+++ b/services/ts/smartgpt-bridge/src/routes/users.js
@@ -1,0 +1,54 @@
+import crypto from 'crypto';
+import { User } from '../models/User.js';
+
+export function registerUserRoutes(app) {
+    app.post('/users/create', {
+        preHandler: [app.authUser, app.requirePolicy('write', 'users')],
+        schema: {
+            summary: 'Create user',
+            operationId: 'createUser',
+            tags: ['Admin'],
+            body: {
+                type: 'object',
+                required: ['username'],
+                properties: {
+                    username: { type: 'string' },
+                    roles: { type: 'array', items: { type: 'string' } },
+                },
+            },
+        },
+        handler: async (req) => {
+            const { username, roles } = req.body || {};
+            const apiKey = crypto.randomBytes(32).toString('hex');
+            const user = await User.create({ username, roles: roles || ['user'], apiKey });
+            return { ok: true, user: { username: user.username, apiKey, roles: user.roles } };
+        },
+    });
+
+    app.get('/users/list', {
+        preHandler: [app.authUser, app.requirePolicy('read', 'users')],
+        schema: { operationId: 'listUsers', tags: ['Admin'] },
+        handler: async () => {
+            const users = await User.find({}, { username: 1, roles: 1, createdAt: 1 }).lean();
+            return { users };
+        },
+    });
+
+    app.post('/users/delete', {
+        preHandler: [app.authUser, app.requirePolicy('write', 'users')],
+        schema: {
+            operationId: 'deleteUser',
+            tags: ['Admin'],
+            body: {
+                type: 'object',
+                required: ['username'],
+                properties: { username: { type: 'string' } },
+            },
+        },
+        handler: async (req) => {
+            const { username } = req.body || {};
+            await User.deleteOne({ username });
+            return { ok: true };
+        },
+    });
+}

--- a/services/ts/smartgpt-bridge/src/utils/policyEngine.js
+++ b/services/ts/smartgpt-bridge/src/utils/policyEngine.js
@@ -1,0 +1,28 @@
+import { Policy } from '../models/Policy.js';
+
+export async function checkAccess(user, action, resource) {
+    if (!user) return false;
+    const policies = await Policy.find({ role: { $in: user.roles } });
+
+    for (const p of policies) {
+        if (
+            (p.action === action || p.action === '*') &&
+            (p.resource === resource || p.resource === '*') &&
+            p.effect === 'deny'
+        ) {
+            return false;
+        }
+    }
+
+    for (const p of policies) {
+        if (
+            (p.action === action || p.action === '*') &&
+            (p.resource === resource || p.resource === '*') &&
+            p.effect === 'allow'
+        ) {
+            return true;
+        }
+    }
+
+    return false;
+}


### PR DESCRIPTION
## Summary
- add Mongo-backed User and Policy models
- enforce policy-based access with auth decorators
- secure bootstrap endpoint for initial admin creation

## Testing
- `make setup-ts-service-smartgpt-bridge`
- `make format` *(fails: SyntaxError in legacy sibilant modules)*
- `make lint-ts-service-smartgpt-bridge` *(fails: Missing script: lint)*
- `make build-ts` *(fails: Could not find a declaration file for module 'body-parser')*
- `make test-ts-service-smartgpt-bridge` *(fails: Cannot find module '../build/Debug/pty.node')*


------
https://chatgpt.com/codex/tasks/task_e_68a893b782a88324aa1adb43e1bf8772