### PR TITLE
feat: add directory tree endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Added
 - Policy-based access control with user and role management for SmartGPT Bridge.
+- Directory tree endpoint for SmartGPT Bridge file API.
 
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 

--- a/services/ts/smartgpt-bridge/tests/fixtures/subdir/nested.md
+++ b/services/ts/smartgpt-bridge/tests/fixtures/subdir/nested.md
@@ -1,0 +1,1 @@
+nested file

--- a/services/ts/smartgpt-bridge/tests/integration/server.files.tree.test.js
+++ b/services/ts/smartgpt-bridge/tests/integration/server.files.tree.test.js
@@ -1,0 +1,17 @@
+import test from 'ava';
+import path from 'path';
+import { withServer } from '../helpers/server.js';
+
+const ROOT = path.join(process.cwd(), 'tests', 'fixtures');
+
+test('GET /files/tree returns nested directory tree', async (t) => {
+    await withServer(ROOT, async (req) => {
+        const res = await req.get('/files/tree').query({ path: '.', depth: 2 }).expect(200);
+        t.true(res.body.ok);
+        t.is(res.body.base, '.');
+        const tree = res.body.tree;
+        const sub = tree.children.find((c) => c.name === 'subdir');
+        t.truthy(sub);
+        t.truthy(sub.children.find((c) => c.name === 'nested.md'));
+    });
+});


### PR DESCRIPTION
## Summary
- add recursive `treeDirectory` helper and fastify `/files/tree` route
- cover directory tree endpoint with integration test and fixture
- document new capability in changelog

## Testing
- `pnpm test` *(fails: No mongo URI provided)*
- `pnpm run build` *(fails: Missing script: build)*
- `pnpm run lint` *(fails: Missing script: lint)*
- `pnpm run format` *(fails: Missing script: format)*

------
https://chatgpt.com/codex/tasks/task_e_68a8b7451fa083248e02375edbf41bf9