### PR TITLE
fix: treat leading slash as repo root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Policy-based access control with user and role management for SmartGPT Bridge.
 - Directory tree endpoint for SmartGPT Bridge file API.
 
+### Fixed
+- SmartGPT Bridge file actions now treat leading '/' as the repository root.
+
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]

--- a/services/ts/smartgpt-bridge/src/files.js
+++ b/services/ts/smartgpt-bridge/src/files.js
@@ -20,7 +20,19 @@ export function isInsideRoot(ROOT_PATH, abs) {
 }
 
 export function normalizeToRoot(ROOT_PATH, p = '.') {
-    const abs = path.resolve(path.isAbsolute(p) ? p : path.join(ROOT_PATH, p));
+    // Treat leading '/' as relative to the repository root rather than the filesystem root.
+    // Also treat empty string or '/' as the root directory itself.
+    if (!p || p === '/') p = '.';
+    let abs;
+    if (path.isAbsolute(p)) {
+        if (p.startsWith(ROOT_PATH)) {
+            abs = path.resolve(p);
+        } else {
+            abs = path.resolve(ROOT_PATH, p.slice(1));
+        }
+    } else {
+        abs = path.resolve(ROOT_PATH, p);
+    }
     if (!isInsideRoot(ROOT_PATH, abs)) throw new Error('path outside root');
     return abs;
 }

--- a/services/ts/smartgpt-bridge/tests/unit/files.more.test.js
+++ b/services/ts/smartgpt-bridge/tests/unit/files.more.test.js
@@ -1,6 +1,6 @@
 import test from 'ava';
 import path from 'path';
-import { locateStacktrace, resolvePath, viewFile } from '../../src/files.js';
+import { locateStacktrace, resolvePath, viewFile, normalizeToRoot } from '../../src/files.js';
 
 const ROOT = path.join(process.cwd(), 'tests', 'fixtures');
 
@@ -32,4 +32,15 @@ test('resolvePath returns null for non-existent', async (t) => {
 
 test('viewFile throws when file missing', async (t) => {
     await t.throwsAsync(() => viewFile(ROOT, 'nope.txt', 1, 1));
+});
+
+test('normalizeToRoot treats leading slash as repo root', (t) => {
+    const p1 = normalizeToRoot(process.cwd(), 'tests/fixtures/readme.md');
+    const p2 = normalizeToRoot(process.cwd(), '/tests/fixtures/readme.md');
+    t.is(p1, p2);
+});
+
+test('normalizeToRoot resolves "/" to repo root', (t) => {
+    const p = normalizeToRoot(process.cwd(), '/');
+    t.is(p, path.resolve(process.cwd()));
 });


### PR DESCRIPTION
## Summary
- ensure SmartGPT Bridge file actions treat leading `/` as repo root
- test path normalization for leading slashes
- document path behavior in changelog

## Testing
- `make format-ts`
- `make lint-ts-service-smartgpt-bridge` *(fails: Missing script: lint)*
- `make test-ts-service-smartgpt-bridge` *(fails: Expected 200 got 500)*
- `make build-ts`


------
https://chatgpt.com/codex/tasks/task_e_68a8bf73215c832488cdf9151aa7a1e2