### PR TITLE
Log chroma searches via dual sink

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated `capture_channel.test.ts` and `voice_session.test.ts` to inject stubbed transcriber.
 - Updated `messageThrottler.test.ts` to clean up broker, sockets, and audio players explicitly.
 - Fixed compile issues in `voice-session.ts` (optional `voiceSynth`, `renderWaveForm` args, `Float32Array` → `Buffer`).
+- Chroma search route now records queries using the `DualSink`.
 
 ### Removed
 

--- a/services/ts/smartgpt-bridge/src/routes/search.js
+++ b/services/ts/smartgpt-bridge/src/routes/search.js
@@ -34,6 +34,8 @@ export function registerSearchRoutes(fastify) {
                 const { q, n } = req.body || {};
                 if (!q) return reply.code(400).send({ ok: false, error: "Missing 'q'" });
                 const results = await search(ROOT_PATH, q, n ?? 8);
+                const sink = dualSinkRegistry.get('bridge_searches');
+                await sink.add({ query: q, results, service: 'chroma' });
                 reply.send({ ok: true, results });
             } catch (e) {
                 reply.code(500).send({ ok: false, error: String(e?.message || e) });


### PR DESCRIPTION
## Summary
- record query/results of repository Chroma search in `bridge_searches` dual sink
- document the change in the changelog

## Testing
- `make setup-ts-service-smartgpt-bridge`
- `make test-ts-service-smartgpt-bridge` *(fails: Cannot find module '/workspace/promethean/services/ts/smartgpt-bridge/node_modules/@shared/ts/dist/embeddings/remote.js')*
- `make build-ts`
- `make lint-ts-service-smartgpt-bridge` *(fails: Missing script: lint)*
- `make format`


------
https://chatgpt.com/codex/tasks/task_e_68a8bf0040d48324a2f40941ed13e563