### PR TITLE
chore: document shared persistence module

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -533,3 +533,8 @@ Follow the format:
 - Short description of the bug fix.
 ```
 
+
+## Shared Persistence
+
+Persistence is handled via shared module: @shared/ts/persistence/DualStore
+

--- a/docs/reports/persistence-dependency-graph.md
+++ b/docs/reports/persistence-dependency-graph.md
@@ -1,0 +1,23 @@
+# Persistence Dependency Graph
+
+## Before
+```mermaid
+graph TD
+    Cephalon --> CollectionManager
+    SmartGPTBridge --> DualSink
+    DiscordEmbedder --> MongoClient
+    KanbanProcessor --> MongoClient
+    MarkdownGraph --> MongoClient
+```
+
+## After
+```mermaid
+graph TD
+    Cephalon --> DualStore
+    SmartGPTBridge --> DualStore
+    DiscordEmbedder --> DualStore
+    KanbanProcessor --> DualStore
+    MarkdownGraph --> DualStore
+    DualStore --> MongoDB
+    DualStore --> ChromaDB
+```

--- a/docs/reports/persistence-migration-checklist.md
+++ b/docs/reports/persistence-migration-checklist.md
@@ -1,0 +1,11 @@
+# Persistence Migration Checklist
+
+Track services adopting the shared DualStore persistence layer.
+
+- [ ] Cephalon uses DualStore
+- [ ] SmartGPT Bridge uses DualStore
+- [ ] Discord-embedder uses DualStore
+- [ ] Kanban Processor uses DualStore
+- [ ] Markdown Graph uses DualStore
+
+Once all items are checked, legacy persistence code can be removed.

--- a/services/ts/cephalon/src/collectionManager.ts
+++ b/services/ts/cephalon/src/collectionManager.ts
@@ -1,3 +1,6 @@
+/**
+ * @deprecated Use DualStoreManager from @shared/ts/persistence/dualStore instead.
+ */
 import { Collection as ChromaCollection, ChromaClient } from 'chromadb';
 import { RemoteEmbeddingFunction } from '@shared/ts/dist/embeddings/remote.js';
 import { Collection, MongoClient, ObjectId, OptionalUnlessRequiredId, WithId } from 'mongodb';

--- a/services/ts/smartgpt-bridge/src/mongo.js
+++ b/services/ts/smartgpt-bridge/src/mongo.js
@@ -1,3 +1,6 @@
+/**
+ * @deprecated Persistence now uses @shared/ts/persistence/DualStore.
+ */
 import mongoose from 'mongoose';
 
 let connected = false;

--- a/services/ts/smartgpt-bridge/src/utils/DualSink.js
+++ b/services/ts/smartgpt-bridge/src/utils/DualSink.js
@@ -1,3 +1,6 @@
+/**
+ * @deprecated Use DualStoreManager from @shared/ts/persistence/dualStore instead.
+ */
 import mongoose from 'mongoose';
 import { getChroma } from '../indexer.js';
 import { initMongo } from '../mongo.js';

--- a/shared/ts/src/persistence/README.md
+++ b/shared/ts/src/persistence/README.md
@@ -1,0 +1,31 @@
+# Shared Persistence Module
+
+This module centralizes MongoDB and ChromaDB persistence for Promethean services.
+
+## DualStore
+
+`DualStoreManager` provides a unified API that writes documents to both MongoDB and ChromaDB. Each entry receives a UUID, timestamp, and optional metadata. Usage:
+
+```ts
+import { DualStoreManager } from '@shared/ts/persistence/dualStore.js';
+
+const store = await DualStoreManager.create('my_collection', 'text', 'createdAt');
+await store.addEntry({ text: 'hello', createdAt: Date.now(), metadata: { userName: 'Duck' } });
+const recent = await store.getMostRecent(5);
+```
+
+## ContextStore
+
+`ContextStore` manages multiple `DualStore` collections and can compile context for LLM prompts.
+
+```ts
+import { ContextStore } from '@shared/ts/persistence/contextStore.js';
+
+const ctx = new ContextStore();
+await ctx.createCollection('agent_messages', 'text', 'createdAt');
+const compiled = await ctx.compileContext(['hi']);
+```
+
+## Maintenance
+
+Background cleanup helpers live in `maintenance.ts` and can be reused by services for periodic trimming of large collections.

--- a/shared/ts/src/persistence/index.ts
+++ b/shared/ts/src/persistence/index.ts
@@ -1,0 +1,5 @@
+export * from './clients.js';
+export * from './types.js';
+export * from './dualStore.js';
+export * from './contextStore.js';
+export * from './maintenance.js';


### PR DESCRIPTION
## Summary
- expose shared persistence utilities via `shared/ts/src/persistence/index.ts`
- document DualStore and ContextStore usage
- deprecate legacy CollectionManager, DualSink, and mongo helpers
- add persistence migration checklist and dependency graph docs

## Testing
- `pnpm lint` *(fails: Command "@biomejs/biome" not found)*
- `pnpm test` *(fails: ENOENT fixture file)*
- `pnpm lint` in `services/ts/cephalon` *(fails: Command "@biomejs/biome" not found)*
- `pnpm test` in `services/ts/cephalon`
- `pnpm lint` in `services/ts/smartgpt-bridge` *(fails: Command "lint" not found)*
- `pnpm test` in `services/ts/smartgpt-bridge` *(fails: MongoMemoryServer UnableToUnlockLockfileError)*

------
https://chatgpt.com/codex/tasks/task_e_68ab8f07cfa48324909ae94680d9b1ac