### PR TITLE
docs: document markdown graph frontend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - v1 router exposing consolidated SmartGPT Bridge endpoints.
 - OpenAPI spec for `/v1` served at `/v1/openapi.json` with consolidated operations.
 - `distclean` target to remove ignored files via `git clean -fdX`.
+- Frontend visualization for the markdown link graph using ForceGraph.
 
 ### Changed
 - Organized SmartGPT Bridge routes into versioned directories.

--- a/site/graph.mjs
+++ b/site/graph.mjs
@@ -1,41 +1,39 @@
-export async function fetchGraph(baseUrl = "") {
-  const visited = new Set();
-  const nodes = [];
-  const links = [];
-  const queue = ["readme.md"];
-  while (queue.length) {
-    const path = queue.shift();
-    if (visited.has(path)) continue;
-    visited.add(path);
-    nodes.push({ id: path });
-    try {
-      const res = await fetch(`${baseUrl}/links/${encodeURIComponent(path)}`);
-      if (!res.ok) continue;
-      const data = await res.json();
-      for (const target of data.links || []) {
-        links.push({ source: path, target });
-        if (!visited.has(target)) queue.push(target);
-      }
-    } catch (err) {
-      // Swallow network errors to allow partial graphs
+// Fetch a transitive closure of markdown links starting at `readme.md`.
+// Returns a simple `{ nodes, links }` object ready for ForceGraph.
+export async function fetchGraph(baseUrl = '') {
+    const visited = new Set();
+    const nodes = [];
+    const links = [];
+    const queue = ['readme.md'];
+    while (queue.length) {
+        const path = queue.shift();
+        if (visited.has(path)) continue;
+        visited.add(path);
+        nodes.push({ id: path });
+        try {
+            const res = await fetch(`${baseUrl}/links/${encodeURIComponent(path)}`);
+            if (!res.ok) continue;
+            const data = await res.json();
+            for (const target of data.links || []) {
+                links.push({ source: path, target });
+                if (!visited.has(target)) queue.push(target);
+            }
+        } catch (err) {
+            // Swallow network errors to allow partial graphs
+        }
     }
-  }
-  return { nodes, links };
+    return { nodes, links };
 }
 
-export async function renderGraph(selector, baseUrl = "") {
-  const ForceGraph = (
-    await import("https://unpkg.com/force-graph@1.45.0/dist/force-graph.esm.js")
-  ).default;
-  const element =
-    typeof selector === "string" ? document.querySelector(selector) : selector;
-  const data = await fetchGraph(baseUrl);
-  const graph = ForceGraph()(element);
-  graph
-    .graphData(data)
-    .nodeId("id")
-    .nodeLabel("id")
-    .linkSource("source")
-    .linkTarget("target");
-  return graph;
+// Render the graph into a DOM element or CSS selector.
+// Uses the ForceGraph library loaded from a CDN at runtime.
+export async function renderGraph(selector, baseUrl = '') {
+    const ForceGraph = (
+        await import('https://unpkg.com/force-graph@1.45.0/dist/force-graph.esm.js')
+    ).default;
+    const element = typeof selector === 'string' ? document.querySelector(selector) : selector;
+    const data = await fetchGraph(baseUrl);
+    const graph = ForceGraph()(element);
+    graph.graphData(data).nodeId('id').nodeLabel('id').linkSource('source').linkTarget('target');
+    return graph;
 }


### PR DESCRIPTION
## Summary
- clarify markdown graph fetching and rendering APIs with comments
- log addition in changelog

## Testing
- `pnpm install`
- `make setup-js` *(fails: KeyboardInterrupt)*
- `make lint-js` *(fails: A config object is using the "extends" key, which is not supported in flat config system)*
- `make format-js` *(fails: KeyboardInterrupt)*
- `make build-js`
- `node tests/site/markdown_graph_frontend.test.mjs`


------
https://chatgpt.com/codex/tasks/task_e_68ab951b0e748324bafc5093c67ac912