### PR TITLE
feat(codex-context): add tool calling support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Frontend visualization for the markdown link graph using ForceGraph.
 - Simple web chat interface for the LLM service with HTTP and WebSocket endpoints.
 - File explorer UI for SmartGPT Bridge dashboard using file endpoints.
+- Tool calling support for Codex Context service.
 
 ### Changed
 

--- a/services/ts/codex-context/src/save.ts
+++ b/services/ts/codex-context/src/save.ts
@@ -10,6 +10,7 @@ type SaveArgs = {
     augmentedSystem: string;
     citations: Array<{ path: string; startLine?: number; endLine?: number }>;
     responseText: string;
+    toolCalls?: any;
 };
 
 export async function persistArtifact(args: SaveArgs) {
@@ -37,6 +38,9 @@ function renderMarkdown(args: SaveArgs, ts: string) {
                 }`,
         )
         .join('\n');
+    const toolCalls = args.toolCalls
+        ? `\n## Tool Calls\n\n\`\`\`json\n${JSON.stringify(args.toolCalls, null, 2)}\n\`\`\`\n`
+        : '';
     return `# Codex Context Request ${ts}
 
 ## Request
@@ -54,7 +58,7 @@ ${args.augmentedSystem}
 ## Citations
 
 ${cites || '(none)'}
-
+${toolCalls}
 ## Response (excerpt)
 
 \`\`\`

--- a/services/ts/codex-context/src/tests/tool-calls.integration.test.ts
+++ b/services/ts/codex-context/src/tests/tool-calls.integration.test.ts
@@ -1,0 +1,23 @@
+import test from 'ava';
+import request from 'supertest';
+import { createApp } from '../index.js';
+
+test.skip('integration: logs tool_calls from real backend', async (t) => {
+    const app = createApp();
+    const tools = [
+        {
+            type: 'function',
+            function: { name: 'foo', parameters: { type: 'object', properties: {} } },
+        },
+    ];
+    const res = await request(app)
+        .post('/v1/chat/completions')
+        .send({
+            model: process.env.LLM_MODEL || 'llama3.1',
+            messages: [{ role: 'user', content: 'hi' }],
+            tools,
+        })
+        .expect(200);
+    t.log(res.body.choices?.[0]?.message?.tool_calls);
+    t.pass();
+});

--- a/services/ts/codex-context/src/tests/tool-calls.test.ts
+++ b/services/ts/codex-context/src/tests/tool-calls.test.ts
@@ -1,0 +1,58 @@
+import test from 'ava';
+import request from 'supertest';
+import { createApp } from '../index.js';
+
+class FakeRetriever {
+    async retrieve() {
+        return { search: [] } as any;
+    }
+}
+
+class CapturingBackend {
+    lastOpts: any = null;
+    async chat(_msgs: any[], _cfg: any, opts: any) {
+        this.lastOpts = opts;
+        return {
+            text: '',
+            raw: {
+                message: {
+                    tool_calls: [
+                        {
+                            id: '1',
+                            type: 'function',
+                            function: { name: 'foo', arguments: '{}' },
+                        },
+                    ],
+                },
+            },
+        };
+    }
+}
+
+test('forwards tools and returns tool_calls', async (t) => {
+    const backend = new CapturingBackend();
+    const app = createApp({
+        retriever: new FakeRetriever() as any,
+        backend: backend as any,
+        backendModel: 'fake',
+    });
+    const tools = [
+        {
+            type: 'function',
+            function: { name: 'foo', parameters: { type: 'object', properties: {} } },
+        },
+    ];
+    const res = await request(app)
+        .post('/v1/chat/completions')
+        .send({
+            model: 'fake',
+            messages: [{ role: 'user', content: 'hi' }],
+            tools,
+            tool_choice: 'auto',
+        })
+        .expect(200);
+    t.deepEqual(backend.lastOpts, { tools, tool_choice: 'auto' });
+    t.deepEqual(res.body.choices[0].message.tool_calls, [
+        { id: '1', type: 'function', function: { name: 'foo', arguments: '{}' } },
+    ]);
+});

--- a/services/ts/codex-context/src/types/openai.ts
+++ b/services/ts/codex-context/src/types/openai.ts
@@ -1,6 +1,6 @@
 export type ChatMessage = {
     role: 'system' | 'user' | 'assistant' | 'tool' | 'function';
-    content: string;
+    content: string | any;
     name?: string;
 };
 
@@ -13,6 +13,8 @@ export type ChatCompletionsRequest = {
     stream?: boolean;
     stop?: string | string[] | null;
     session_id?: string;
+    tools?: any[];
+    tool_choice?: any;
 };
 
 export type ChatChoice = {


### PR DESCRIPTION
## Summary
- allow BackendClient.chat to forward tool definitions and selections
- expose tool calls from backend responses through the API
- persist tool call data and add tests for tool support

## Testing
- `pnpm prettier --cache --write .`
- `pnpm eslint src --cache` *(fails: A config object is using the "extends" key, which is not supported in flat config system)*
- `pnpm run build`
- `pnpm run test`


------
https://chatgpt.com/codex/tasks/task_e_68aba520edf4832485b669adfe48a39d