### PR TITLE
feat: add discord bot template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - `sites/` directory consolidating all frontend code.
 - Proxy route `/bridge` through the shared proxy service for SmartGPT Bridge.
 - Tool calling support for Codex Context service.
+- Template for building Discord bots in TypeScript based on the Cephalon service.
 
 ### Changed
 

--- a/templates/ts/discord-bot/README.md
+++ b/templates/ts/discord-bot/README.md
@@ -1,0 +1,11 @@
+# Discord Bot Template
+
+Use this template as a starting point for new Discord bots built with TypeScript.
+
+## Usage
+
+```bash
+cp -r templates/ts/discord-bot services/ts/my-bot
+```
+
+Then update `package.json`, configure your Discord token in `.env`, and implement your bot logic under `src/`.

--- a/templates/ts/discord-bot/biome.json
+++ b/templates/ts/discord-bot/biome.json
@@ -1,0 +1,11 @@
+{
+    "$schema": "https://biomejs.dev/schemas/2.1.3/schema.json",
+    "files": {
+        "includes": ["src/**", "tests/**"]
+    },
+    "linter": {
+        "rules": {
+            "recommended": false
+        }
+    }
+}

--- a/templates/ts/discord-bot/ecosystem.config.js
+++ b/templates/ts/discord-bot/ecosystem.config.js
@@ -1,0 +1,24 @@
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { defineApp } from '../../../dev/pm2Helpers.js';
+import deps from './ecosystem.dependencies.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const root = path.join(__dirname, '../../..');
+
+if (!process.env.PROMETHEAN_ROOT_ECOSYSTEM) {
+    defineApp.PYTHONPATH = root;
+    defineApp.HEARTBEAT_PORT = 5005;
+}
+
+const apps = [
+    defineApp('discord-bot', 'dist/index.js', [], {
+        cwd: __dirname,
+        watch: [__dirname],
+    }),
+];
+
+const allApps = !process.env.PROMETHEAN_ROOT_ECOSYSTEM ? [...apps, ...(deps?.apps || [])] : apps;
+
+export default { apps: allApps };

--- a/templates/ts/discord-bot/ecosystem.dependencies.js
+++ b/templates/ts/discord-bot/ecosystem.dependencies.js
@@ -1,0 +1,3 @@
+export default {
+    apps: [],
+};

--- a/templates/ts/discord-bot/package.json
+++ b/templates/ts/discord-bot/package.json
@@ -1,0 +1,37 @@
+{
+    "name": "discord-bot-template",
+    "version": "0.0.0",
+    "private": true,
+    "type": "module",
+    "main": "dist/index.js",
+    "scripts": {
+        "build": "tsc -p .",
+        "start": "node dist/index.js",
+        "start:dev": "node --loader ts-node/esm src/index.ts",
+        "test": "pnpm run build && ava",
+        "coverage": "pnpm run build && c8 ava",
+        "lint": "pnpm exec biome lint . || true",
+        "format": "pnpm exec biome format --write ."
+    },
+    "dependencies": {
+        "discord.js": "^14.17.3",
+        "dotenv": "^17.2.0"
+    },
+    "devDependencies": {
+        "@biomejs/biome": "^2.1.4",
+        "@types/node": "^22.17.0",
+        "ava": "^6.4.1",
+        "c8": "^9.1.0",
+        "ts-node": "^10.9.2",
+        "typescript": "5.7.3"
+    },
+    "ava": {
+        "files": [
+            "dist/tests/**/*.js"
+        ],
+        "nodeArguments": [
+            "--enable-source-maps"
+        ]
+    },
+    "packageManager": "pnpm@9.0.0"
+}

--- a/templates/ts/discord-bot/pnpm-lock.yaml
+++ b/templates/ts/discord-bot/pnpm-lock.yaml
@@ -1,0 +1,2659 @@
+lockfileVersion: '9.0'
+
+settings:
+    autoInstallPeers: true
+    excludeLinksFromLockfile: false
+
+importers:
+    .:
+        dependencies:
+            discord.js:
+                specifier: ^14.17.3
+                version: 14.22.1
+            dotenv:
+                specifier: ^17.2.0
+                version: 17.2.1
+        devDependencies:
+            '@biomejs/biome':
+                specifier: ^2.1.4
+                version: 2.2.2
+            '@types/node':
+                specifier: ^22.17.0
+                version: 22.18.0
+            ava:
+                specifier: ^6.4.1
+                version: 6.4.1
+            c8:
+                specifier: ^9.1.0
+                version: 9.1.0
+            ts-node:
+                specifier: ^10.9.2
+                version: 10.9.2(@types/node@22.18.0)(typescript@5.7.3)
+            typescript:
+                specifier: 5.7.3
+                version: 5.7.3
+
+packages:
+    '@bcoe/v8-coverage@0.2.3':
+        resolution:
+            {
+                integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==,
+            }
+
+    '@biomejs/biome@2.2.2':
+        resolution:
+            {
+                integrity: sha512-j1omAiQWCkhuLgwpMKisNKnsM6W8Xtt1l0WZmqY/dFj8QPNkIoTvk4tSsi40FaAAkBE1PU0AFG2RWFBWenAn+w==,
+            }
+        engines: { node: '>=14.21.3' }
+        hasBin: true
+
+    '@biomejs/cli-darwin-arm64@2.2.2':
+        resolution:
+            {
+                integrity: sha512-6ePfbCeCPryWu0CXlzsWNZgVz/kBEvHiPyNpmViSt6A2eoDf4kXs3YnwQPzGjy8oBgQulrHcLnJL0nkCh80mlQ==,
+            }
+        engines: { node: '>=14.21.3' }
+        cpu: [arm64]
+        os: [darwin]
+
+    '@biomejs/cli-darwin-x64@2.2.2':
+        resolution:
+            {
+                integrity: sha512-Tn4JmVO+rXsbRslml7FvKaNrlgUeJot++FkvYIhl1OkslVCofAtS35MPlBMhXgKWF9RNr9cwHanrPTUUXcYGag==,
+            }
+        engines: { node: '>=14.21.3' }
+        cpu: [x64]
+        os: [darwin]
+
+    '@biomejs/cli-linux-arm64-musl@2.2.2':
+        resolution:
+            {
+                integrity: sha512-/MhYg+Bd6renn6i1ylGFL5snYUn/Ct7zoGVKhxnro3bwekiZYE8Kl39BSb0MeuqM+72sThkQv4TnNubU9njQRw==,
+            }
+        engines: { node: '>=14.21.3' }
+        cpu: [arm64]
+        os: [linux]
+
+    '@biomejs/cli-linux-arm64@2.2.2':
+        resolution:
+            {
+                integrity: sha512-JfrK3gdmWWTh2J5tq/rcWCOsImVyzUnOS2fkjhiYKCQ+v8PqM+du5cfB7G1kXas+7KQeKSWALv18iQqdtIMvzw==,
+            }
+        engines: { node: '>=14.21.3' }
+        cpu: [arm64]
+        os: [linux]
+
+    '@biomejs/cli-linux-x64-musl@2.2.2':
+        resolution:
+            {
+                integrity: sha512-ZCLXcZvjZKSiRY/cFANKg+z6Fhsf9MHOzj+NrDQcM+LbqYRT97LyCLWy2AS+W2vP+i89RyRM+kbGpUzbRTYWig==,
+            }
+        engines: { node: '>=14.21.3' }
+        cpu: [x64]
+        os: [linux]
+
+    '@biomejs/cli-linux-x64@2.2.2':
+        resolution:
+            {
+                integrity: sha512-Ogb+77edO5LEP/xbNicACOWVLt8mgC+E1wmpUakr+O4nKwLt9vXe74YNuT3T1dUBxC/SnrVmlzZFC7kQJEfquQ==,
+            }
+        engines: { node: '>=14.21.3' }
+        cpu: [x64]
+        os: [linux]
+
+    '@biomejs/cli-win32-arm64@2.2.2':
+        resolution:
+            {
+                integrity: sha512-wBe2wItayw1zvtXysmHJQoQqXlTzHSpQRyPpJKiNIR21HzH/CrZRDFic1C1jDdp+zAPtqhNExa0owKMbNwW9cQ==,
+            }
+        engines: { node: '>=14.21.3' }
+        cpu: [arm64]
+        os: [win32]
+
+    '@biomejs/cli-win32-x64@2.2.2':
+        resolution:
+            {
+                integrity: sha512-DAuHhHekGfiGb6lCcsT4UyxQmVwQiBCBUMwVra/dcOSs9q8OhfaZgey51MlekT3p8UwRqtXQfFuEJBhJNdLZwg==,
+            }
+        engines: { node: '>=14.21.3' }
+        cpu: [x64]
+        os: [win32]
+
+    '@cspotcode/source-map-support@0.8.1':
+        resolution:
+            {
+                integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==,
+            }
+        engines: { node: '>=12' }
+
+    '@discordjs/builders@1.11.3':
+        resolution:
+            {
+                integrity: sha512-p3kf5eV49CJiRTfhtutUCeivSyQ/l2JlKodW1ZquRwwvlOWmG9+6jFShX6x8rUiYhnP6wKI96rgN/SXMy5e5aw==,
+            }
+        engines: { node: '>=16.11.0' }
+
+    '@discordjs/collection@1.5.3':
+        resolution:
+            {
+                integrity: sha512-SVb428OMd3WO1paV3rm6tSjM4wC+Kecaa1EUGX7vc6/fddvw/6lg90z4QtCqm21zvVe92vMMDt9+DkIvjXImQQ==,
+            }
+        engines: { node: '>=16.11.0' }
+
+    '@discordjs/collection@2.1.1':
+        resolution:
+            {
+                integrity: sha512-LiSusze9Tc7qF03sLCujF5iZp7K+vRNEDBZ86FT9aQAv3vxMLihUvKvpsCWiQ2DJq1tVckopKm1rxomgNUc9hg==,
+            }
+        engines: { node: '>=18' }
+
+    '@discordjs/formatters@0.6.1':
+        resolution:
+            {
+                integrity: sha512-5cnX+tASiPCqCWtFcFslxBVUaCetB0thvM/JyavhbXInP1HJIEU+Qv/zMrnuwSsX3yWH2lVXNJZeDK3EiP4HHg==,
+            }
+        engines: { node: '>=16.11.0' }
+
+    '@discordjs/rest@2.6.0':
+        resolution:
+            {
+                integrity: sha512-RDYrhmpB7mTvmCKcpj+pc5k7POKszS4E2O9TYc+U+Y4iaCP+r910QdO43qmpOja8LRr1RJ0b3U+CqVsnPqzf4w==,
+            }
+        engines: { node: '>=18' }
+
+    '@discordjs/util@1.1.1':
+        resolution:
+            {
+                integrity: sha512-eddz6UnOBEB1oITPinyrB2Pttej49M9FZQY8NxgEvc3tq6ZICZ19m70RsmzRdDHk80O9NoYN/25AqJl8vPVf/g==,
+            }
+        engines: { node: '>=18' }
+
+    '@discordjs/ws@1.2.3':
+        resolution:
+            {
+                integrity: sha512-wPlQDxEmlDg5IxhJPuxXr3Vy9AjYq5xCvFWGJyD7w7Np8ZGu+Mc+97LCoEc/+AYCo2IDpKioiH0/c/mj5ZR9Uw==,
+            }
+        engines: { node: '>=16.11.0' }
+
+    '@isaacs/cliui@8.0.2':
+        resolution:
+            {
+                integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==,
+            }
+        engines: { node: '>=12' }
+
+    '@isaacs/fs-minipass@4.0.1':
+        resolution:
+            {
+                integrity: sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==,
+            }
+        engines: { node: '>=18.0.0' }
+
+    '@istanbuljs/schema@0.1.3':
+        resolution:
+            {
+                integrity: sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==,
+            }
+        engines: { node: '>=8' }
+
+    '@jridgewell/resolve-uri@3.1.2':
+        resolution:
+            {
+                integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==,
+            }
+        engines: { node: '>=6.0.0' }
+
+    '@jridgewell/sourcemap-codec@1.5.5':
+        resolution:
+            {
+                integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==,
+            }
+
+    '@jridgewell/trace-mapping@0.3.30':
+        resolution:
+            {
+                integrity: sha512-GQ7Nw5G2lTu/BtHTKfXhKHok2WGetd4XYcVKGx00SjAk8GMwgJM3zr6zORiPGuOE+/vkc90KtTosSSvaCjKb2Q==,
+            }
+
+    '@jridgewell/trace-mapping@0.3.9':
+        resolution:
+            {
+                integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==,
+            }
+
+    '@mapbox/node-pre-gyp@2.0.0':
+        resolution:
+            {
+                integrity: sha512-llMXd39jtP0HpQLVI37Bf1m2ADlEb35GYSh1SDSLsBhR+5iCxiNGlT31yqbNtVHygHAtMy6dWFERpU2JgufhPg==,
+            }
+        engines: { node: '>=18' }
+        hasBin: true
+
+    '@nodelib/fs.scandir@2.1.5':
+        resolution:
+            {
+                integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==,
+            }
+        engines: { node: '>= 8' }
+
+    '@nodelib/fs.stat@2.0.5':
+        resolution:
+            {
+                integrity: sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==,
+            }
+        engines: { node: '>= 8' }
+
+    '@nodelib/fs.walk@1.2.8':
+        resolution:
+            {
+                integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==,
+            }
+        engines: { node: '>= 8' }
+
+    '@pkgjs/parseargs@0.11.0':
+        resolution:
+            {
+                integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==,
+            }
+        engines: { node: '>=14' }
+
+    '@rollup/pluginutils@5.2.0':
+        resolution:
+            {
+                integrity: sha512-qWJ2ZTbmumwiLFomfzTyt5Kng4hwPi9rwCYN4SHb6eaRU1KNO4ccxINHr/VhH4GgPlt1XfSTLX2LBTme8ne4Zw==,
+            }
+        engines: { node: '>=14.0.0' }
+        peerDependencies:
+            rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
+        peerDependenciesMeta:
+            rollup:
+                optional: true
+
+    '@sapphire/async-queue@1.5.5':
+        resolution:
+            {
+                integrity: sha512-cvGzxbba6sav2zZkH8GPf2oGk9yYoD5qrNWdu9fRehifgnFZJMV+nuy2nON2roRO4yQQ+v7MK/Pktl/HgfsUXg==,
+            }
+        engines: { node: '>=v14.0.0', npm: '>=7.0.0' }
+
+    '@sapphire/shapeshift@4.0.0':
+        resolution:
+            {
+                integrity: sha512-d9dUmWVA7MMiKobL3VpLF8P2aeanRTu6ypG2OIaEv/ZHH/SUQ2iHOVyi5wAPjQ+HmnMuL0whK9ez8I/raWbtIg==,
+            }
+        engines: { node: '>=v16' }
+
+    '@sapphire/snowflake@3.5.3':
+        resolution:
+            {
+                integrity: sha512-jjmJywLAFoWeBi1W7994zZyiNWPIiqRRNAmSERxyg93xRGzNYvGjlZ0gR6x0F4gPRi2+0O6S71kOZYyr3cxaIQ==,
+            }
+        engines: { node: '>=v14.0.0', npm: '>=7.0.0' }
+
+    '@sindresorhus/merge-streams@2.3.0':
+        resolution:
+            {
+                integrity: sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg==,
+            }
+        engines: { node: '>=18' }
+
+    '@tsconfig/node10@1.0.11':
+        resolution:
+            {
+                integrity: sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==,
+            }
+
+    '@tsconfig/node12@1.0.11':
+        resolution:
+            {
+                integrity: sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==,
+            }
+
+    '@tsconfig/node14@1.0.3':
+        resolution:
+            {
+                integrity: sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==,
+            }
+
+    '@tsconfig/node16@1.0.4':
+        resolution:
+            {
+                integrity: sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==,
+            }
+
+    '@types/estree@1.0.8':
+        resolution:
+            {
+                integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==,
+            }
+
+    '@types/istanbul-lib-coverage@2.0.6':
+        resolution:
+            {
+                integrity: sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==,
+            }
+
+    '@types/node@22.18.0':
+        resolution:
+            {
+                integrity: sha512-m5ObIqwsUp6BZzyiy4RdZpzWGub9bqLJMvZDD0QMXhxjqMHMENlj+SqF5QxoUwaQNFe+8kz8XM8ZQhqkQPTgMQ==,
+            }
+
+    '@types/ws@8.18.1':
+        resolution:
+            {
+                integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==,
+            }
+
+    '@vercel/nft@0.29.4':
+        resolution:
+            {
+                integrity: sha512-6lLqMNX3TuycBPABycx7A9F1bHQR7kiQln6abjFbPrf5C/05qHM9M5E4PeTE59c7z8g6vHnx1Ioihb2AQl7BTA==,
+            }
+        engines: { node: '>=18' }
+        hasBin: true
+
+    '@vladfrangu/async_event_emitter@2.4.6':
+        resolution:
+            {
+                integrity: sha512-RaI5qZo6D2CVS6sTHFKg1v5Ohq/+Bo2LZ5gzUEwZ/WkHhwtGTCB/sVLw8ijOkAUxasZ+WshN/Rzj4ywsABJ5ZA==,
+            }
+        engines: { node: '>=v14.0.0', npm: '>=7.0.0' }
+
+    abbrev@3.0.1:
+        resolution:
+            {
+                integrity: sha512-AO2ac6pjRB3SJmGJo+v5/aK6Omggp6fsLrs6wN9bd35ulu4cCwaAU9+7ZhXjeqHVkaHThLuzH0nZr0YpCDhygg==,
+            }
+        engines: { node: ^18.17.0 || >=20.5.0 }
+
+    acorn-import-attributes@1.9.5:
+        resolution:
+            {
+                integrity: sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==,
+            }
+        peerDependencies:
+            acorn: ^8
+
+    acorn-walk@8.3.4:
+        resolution:
+            {
+                integrity: sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==,
+            }
+        engines: { node: '>=0.4.0' }
+
+    acorn@8.15.0:
+        resolution:
+            {
+                integrity: sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==,
+            }
+        engines: { node: '>=0.4.0' }
+        hasBin: true
+
+    agent-base@7.1.4:
+        resolution:
+            {
+                integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==,
+            }
+        engines: { node: '>= 14' }
+
+    ansi-regex@5.0.1:
+        resolution:
+            {
+                integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==,
+            }
+        engines: { node: '>=8' }
+
+    ansi-regex@6.2.0:
+        resolution:
+            {
+                integrity: sha512-TKY5pyBkHyADOPYlRT9Lx6F544mPl0vS5Ew7BJ45hA08Q+t3GjbueLliBWN3sMICk6+y7HdyxSzC4bWS8baBdg==,
+            }
+        engines: { node: '>=12' }
+
+    ansi-styles@4.3.0:
+        resolution:
+            {
+                integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==,
+            }
+        engines: { node: '>=8' }
+
+    ansi-styles@6.2.1:
+        resolution:
+            {
+                integrity: sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==,
+            }
+        engines: { node: '>=12' }
+
+    arg@4.1.3:
+        resolution:
+            {
+                integrity: sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==,
+            }
+
+    argparse@1.0.10:
+        resolution:
+            {
+                integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==,
+            }
+
+    array-find-index@1.0.2:
+        resolution:
+            {
+                integrity: sha512-M1HQyIXcBGtVywBt8WVdim+lrNaK7VHp99Qt5pSNziXznKHViIBbXWtfRTpEFpF/c4FdfxNAsCCwPp5phBYJtw==,
+            }
+        engines: { node: '>=0.10.0' }
+
+    arrgv@1.0.2:
+        resolution:
+            {
+                integrity: sha512-a4eg4yhp7mmruZDQFqVMlxNRFGi/i1r87pt8SDHy0/I8PqSXoUTlWZRdAZo0VXgvEARcujbtTk8kiZRi1uDGRw==,
+            }
+        engines: { node: '>=8.0.0' }
+
+    arrify@3.0.0:
+        resolution:
+            {
+                integrity: sha512-tLkvA81vQG/XqE2mjDkGQHoOINtMHtysSnemrmoGe6PydDPMRbVugqyk4A6V/WDWEfm3l+0d8anA9r8cv/5Jaw==,
+            }
+        engines: { node: '>=12' }
+
+    async-sema@3.1.1:
+        resolution:
+            {
+                integrity: sha512-tLRNUXati5MFePdAk8dw7Qt7DpxPB60ofAgn8WRhW6a2rcimZnYBP9oxHiv0OHy+Wz7kPMG+t4LGdt31+4EmGg==,
+            }
+
+    ava@6.4.1:
+        resolution:
+            {
+                integrity: sha512-vxmPbi1gZx9zhAjHBgw81w/iEDKcrokeRk/fqDTyA2DQygZ0o+dUGRHFOtX8RA5N0heGJTTsIk7+xYxitDb61Q==,
+            }
+        engines: { node: ^18.18 || ^20.8 || ^22 || ^23 || >=24 }
+        hasBin: true
+        peerDependencies:
+            '@ava/typescript': '*'
+        peerDependenciesMeta:
+            '@ava/typescript':
+                optional: true
+
+    balanced-match@1.0.2:
+        resolution:
+            {
+                integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==,
+            }
+
+    bindings@1.5.0:
+        resolution:
+            {
+                integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==,
+            }
+
+    blueimp-md5@2.19.0:
+        resolution:
+            {
+                integrity: sha512-DRQrD6gJyy8FbiE4s+bDoXS9hiW3Vbx5uCdwvcCf3zLHL+Iv7LtGHLpr+GZV8rHG8tK766FGYBwRbu8pELTt+w==,
+            }
+
+    brace-expansion@1.1.12:
+        resolution:
+            {
+                integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==,
+            }
+
+    brace-expansion@2.0.2:
+        resolution:
+            {
+                integrity: sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==,
+            }
+
+    braces@3.0.3:
+        resolution:
+            {
+                integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==,
+            }
+        engines: { node: '>=8' }
+
+    c8@9.1.0:
+        resolution:
+            {
+                integrity: sha512-mBWcT5iqNir1zIkzSPyI3NCR9EZCVI3WUD+AVO17MVWTSFNyUueXE82qTeampNtTr+ilN/5Ua3j24LgbCKjDVg==,
+            }
+        engines: { node: '>=14.14.0' }
+        hasBin: true
+
+    callsites@4.2.0:
+        resolution:
+            {
+                integrity: sha512-kfzR4zzQtAE9PC7CzZsjl3aBNbXWuXiSeOCdLcPpBfGW8YuCqQHcRPFDbr/BPVmd3EEPVpuFzLyuT/cUhPr4OQ==,
+            }
+        engines: { node: '>=12.20' }
+
+    cbor@10.0.10:
+        resolution:
+            {
+                integrity: sha512-EirvzAg0G4okCsdTfTjLWHU+tToQ2V2ptO3577Vyy2GOTeVJad99uCIuDqdK7ppFRRcEuigyJY6TJ59wv5JpSg==,
+            }
+        engines: { node: '>=20' }
+
+    chalk@5.6.0:
+        resolution:
+            {
+                integrity: sha512-46QrSQFyVSEyYAgQ22hQ+zDa60YHA4fBstHmtSApj1Y5vKtG27fWowW03jCk5KcbXEWPZUIR894aARCA/G1kfQ==,
+            }
+        engines: { node: ^12.17.0 || ^14.13 || >=16.0.0 }
+
+    chownr@3.0.0:
+        resolution:
+            {
+                integrity: sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==,
+            }
+        engines: { node: '>=18' }
+
+    chunkd@2.0.1:
+        resolution:
+            {
+                integrity: sha512-7d58XsFmOq0j6el67Ug9mHf9ELUXsQXYJBkyxhH/k+6Ke0qXRnv0kbemx+Twc6fRJ07C49lcbdgm9FL1Ei/6SQ==,
+            }
+
+    ci-info@4.3.0:
+        resolution:
+            {
+                integrity: sha512-l+2bNRMiQgcfILUi33labAZYIWlH1kWDp+ecNo5iisRKrbm0xcRyCww71/YU0Fkw0mAFpz9bJayXPjey6vkmaQ==,
+            }
+        engines: { node: '>=8' }
+
+    ci-parallel-vars@1.0.1:
+        resolution:
+            {
+                integrity: sha512-uvzpYrpmidaoxvIQHM+rKSrigjOe9feHYbw4uOI2gdfe1C3xIlxO+kVXq83WQWNniTf8bAxVpy+cQeFQsMERKg==,
+            }
+
+    cli-truncate@4.0.0:
+        resolution:
+            {
+                integrity: sha512-nPdaFdQ0h/GEigbPClz11D0v/ZJEwxmeVZGeMo3Z5StPtUTkA9o1lD6QwoirYiSDzbcwn2XcjwmCp68W1IS4TA==,
+            }
+        engines: { node: '>=18' }
+
+    cliui@8.0.1:
+        resolution:
+            {
+                integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==,
+            }
+        engines: { node: '>=12' }
+
+    code-excerpt@4.0.0:
+        resolution:
+            {
+                integrity: sha512-xxodCmBen3iy2i0WtAK8FlFNrRzjUqjRsMfho58xT/wvZU1YTM3fCnRjcy1gJPMepaRlgm/0e6w8SpWHpn3/cA==,
+            }
+        engines: { node: ^12.20.0 || ^14.13.1 || >=16.0.0 }
+
+    color-convert@2.0.1:
+        resolution:
+            {
+                integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==,
+            }
+        engines: { node: '>=7.0.0' }
+
+    color-name@1.1.4:
+        resolution:
+            {
+                integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==,
+            }
+
+    common-path-prefix@3.0.0:
+        resolution:
+            {
+                integrity: sha512-QE33hToZseCH3jS0qN96O/bSh3kaw/h+Tq7ngyY9eWDUnTlTNUyqfqvCXioLe5Na5jFsL78ra/wuBU4iuEgd4w==,
+            }
+
+    concat-map@0.0.1:
+        resolution:
+            {
+                integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==,
+            }
+
+    concordance@5.0.4:
+        resolution:
+            {
+                integrity: sha512-OAcsnTEYu1ARJqWVGwf4zh4JDfHZEaSNlNccFmt8YjB2l/n19/PF2viLINHc57vO4FKIAFl2FWASIGZZWZ2Kxw==,
+            }
+        engines: { node: '>=10.18.0 <11 || >=12.14.0 <13 || >=14' }
+
+    consola@3.4.2:
+        resolution:
+            {
+                integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==,
+            }
+        engines: { node: ^14.18.0 || >=16.10.0 }
+
+    convert-source-map@2.0.0:
+        resolution:
+            {
+                integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==,
+            }
+
+    convert-to-spaces@2.0.1:
+        resolution:
+            {
+                integrity: sha512-rcQ1bsQO9799wq24uE5AM2tAILy4gXGIK/njFWcVQkGNZ96edlpY+A7bjwvzjYvLDyzmG1MmMLZhpcsb+klNMQ==,
+            }
+        engines: { node: ^12.20.0 || ^14.13.1 || >=16.0.0 }
+
+    create-require@1.1.1:
+        resolution:
+            {
+                integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==,
+            }
+
+    cross-spawn@7.0.6:
+        resolution:
+            {
+                integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==,
+            }
+        engines: { node: '>= 8' }
+
+    currently-unhandled@0.4.1:
+        resolution:
+            {
+                integrity: sha512-/fITjgjGU50vjQ4FH6eUoYu+iUoUKIXws2hL15JJpIR+BbTxaXQsMuuyjtNh2WqsSBS5nsaZHFsFecyw5CCAng==,
+            }
+        engines: { node: '>=0.10.0' }
+
+    date-time@3.1.0:
+        resolution:
+            {
+                integrity: sha512-uqCUKXE5q1PNBXjPqvwhwJf9SwMoAHBgWJ6DcrnS5o+W2JOiIILl0JEdVD8SGujrNS02GGxgwAg2PN2zONgtjg==,
+            }
+        engines: { node: '>=6' }
+
+    debug@4.4.1:
+        resolution:
+            {
+                integrity: sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==,
+            }
+        engines: { node: '>=6.0' }
+        peerDependencies:
+            supports-color: '*'
+        peerDependenciesMeta:
+            supports-color:
+                optional: true
+
+    detect-libc@2.0.4:
+        resolution:
+            {
+                integrity: sha512-3UDv+G9CsCKO1WKMGw9fwq/SWJYbI0c5Y7LU1AXYoDdbhE2AHQ6N6Nb34sG8Fj7T5APy8qXDCKuuIHd1BR0tVA==,
+            }
+        engines: { node: '>=8' }
+
+    diff@4.0.2:
+        resolution:
+            {
+                integrity: sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==,
+            }
+        engines: { node: '>=0.3.1' }
+
+    discord-api-types@0.38.21:
+        resolution:
+            {
+                integrity: sha512-E6KtXUNjZVIYP1GMjmeRdAC1xRql9xtSahRwJYpP74/hJ6Q2i2oTp6ZbFG/FUN0WqtdW2igHDsJyF2u9hV8pHQ==,
+            }
+
+    discord.js@14.22.1:
+        resolution:
+            {
+                integrity: sha512-3k+Kisd/v570Jr68A1kNs7qVhNehDwDJAPe4DZ2Syt+/zobf9zEcuYFvsfIaAOgCa0BiHMfOOKQY4eYINl0z7w==,
+            }
+        engines: { node: '>=18' }
+
+    dotenv@17.2.1:
+        resolution:
+            {
+                integrity: sha512-kQhDYKZecqnM0fCnzI5eIv5L4cAe/iRI+HqMbO/hbRdTAeXDG+M9FjipUxNfbARuEg4iHIbhnhs78BCHNbSxEQ==,
+            }
+        engines: { node: '>=12' }
+
+    eastasianwidth@0.2.0:
+        resolution:
+            {
+                integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==,
+            }
+
+    emittery@1.2.0:
+        resolution:
+            {
+                integrity: sha512-KxdRyyFcS85pH3dnU8Y5yFUm2YJdaHwcBZWrfG8o89ZY9a13/f9itbN+YG3ELbBo9Pg5zvIozstmuV8bX13q6g==,
+            }
+        engines: { node: '>=14.16' }
+
+    emoji-regex@10.4.0:
+        resolution:
+            {
+                integrity: sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw==,
+            }
+
+    emoji-regex@8.0.0:
+        resolution:
+            {
+                integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==,
+            }
+
+    emoji-regex@9.2.2:
+        resolution:
+            {
+                integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==,
+            }
+
+    escalade@3.2.0:
+        resolution:
+            {
+                integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==,
+            }
+        engines: { node: '>=6' }
+
+    escape-string-regexp@2.0.0:
+        resolution:
+            {
+                integrity: sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==,
+            }
+        engines: { node: '>=8' }
+
+    escape-string-regexp@5.0.0:
+        resolution:
+            {
+                integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==,
+            }
+        engines: { node: '>=12' }
+
+    esprima@4.0.1:
+        resolution:
+            {
+                integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==,
+            }
+        engines: { node: '>=4' }
+        hasBin: true
+
+    estree-walker@2.0.2:
+        resolution:
+            {
+                integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==,
+            }
+
+    esutils@2.0.3:
+        resolution:
+            {
+                integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==,
+            }
+        engines: { node: '>=0.10.0' }
+
+    fast-deep-equal@3.1.3:
+        resolution:
+            {
+                integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==,
+            }
+
+    fast-diff@1.3.0:
+        resolution:
+            {
+                integrity: sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==,
+            }
+
+    fast-glob@3.3.3:
+        resolution:
+            {
+                integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==,
+            }
+        engines: { node: '>=8.6.0' }
+
+    fastq@1.19.1:
+        resolution:
+            {
+                integrity: sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==,
+            }
+
+    figures@6.1.0:
+        resolution:
+            {
+                integrity: sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==,
+            }
+        engines: { node: '>=18' }
+
+    file-uri-to-path@1.0.0:
+        resolution:
+            {
+                integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==,
+            }
+
+    fill-range@7.1.1:
+        resolution:
+            {
+                integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==,
+            }
+        engines: { node: '>=8' }
+
+    find-up-simple@1.0.1:
+        resolution:
+            {
+                integrity: sha512-afd4O7zpqHeRyg4PfDQsXmlDe2PfdHtJt6Akt8jOWaApLOZk5JXs6VMR29lz03pRe9mpykrRCYIYxaJYcfpncQ==,
+            }
+        engines: { node: '>=18' }
+
+    find-up@5.0.0:
+        resolution:
+            {
+                integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==,
+            }
+        engines: { node: '>=10' }
+
+    foreground-child@3.3.1:
+        resolution:
+            {
+                integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==,
+            }
+        engines: { node: '>=14' }
+
+    fs.realpath@1.0.0:
+        resolution:
+            {
+                integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==,
+            }
+
+    get-caller-file@2.0.5:
+        resolution:
+            {
+                integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==,
+            }
+        engines: { node: 6.* || 8.* || >= 10.* }
+
+    get-east-asian-width@1.3.0:
+        resolution:
+            {
+                integrity: sha512-vpeMIQKxczTD/0s2CdEWHcb0eeJe6TFjxb+J5xgX7hScxqrGuyjmv4c1D4A/gelKfyox0gJJwIHF+fLjeaM8kQ==,
+            }
+        engines: { node: '>=18' }
+
+    glob-parent@5.1.2:
+        resolution:
+            {
+                integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==,
+            }
+        engines: { node: '>= 6' }
+
+    glob@10.4.5:
+        resolution:
+            {
+                integrity: sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==,
+            }
+        hasBin: true
+
+    glob@7.2.3:
+        resolution:
+            {
+                integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==,
+            }
+        deprecated: Glob versions prior to v9 are no longer supported
+
+    globby@14.1.0:
+        resolution:
+            {
+                integrity: sha512-0Ia46fDOaT7k4og1PDW4YbodWWr3scS2vAr2lTbsplOt2WkKp0vQbkI9wKis/T5LV/dqPjO3bpS/z6GTJB82LA==,
+            }
+        engines: { node: '>=18' }
+
+    graceful-fs@4.2.11:
+        resolution:
+            {
+                integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==,
+            }
+
+    has-flag@4.0.0:
+        resolution:
+            {
+                integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==,
+            }
+        engines: { node: '>=8' }
+
+    html-escaper@2.0.2:
+        resolution:
+            {
+                integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==,
+            }
+
+    https-proxy-agent@7.0.6:
+        resolution:
+            {
+                integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==,
+            }
+        engines: { node: '>= 14' }
+
+    ignore-by-default@2.1.0:
+        resolution:
+            {
+                integrity: sha512-yiWd4GVmJp0Q6ghmM2B/V3oZGRmjrKLXvHR3TE1nfoXsmoggllfZUQe74EN0fJdPFZu2NIvNdrMMLm3OsV7Ohw==,
+            }
+        engines: { node: '>=10 <11 || >=12 <13 || >=14' }
+
+    ignore@7.0.5:
+        resolution:
+            {
+                integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==,
+            }
+        engines: { node: '>= 4' }
+
+    imurmurhash@0.1.4:
+        resolution:
+            {
+                integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==,
+            }
+        engines: { node: '>=0.8.19' }
+
+    indent-string@5.0.0:
+        resolution:
+            {
+                integrity: sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==,
+            }
+        engines: { node: '>=12' }
+
+    inflight@1.0.6:
+        resolution:
+            {
+                integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==,
+            }
+        deprecated: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
+
+    inherits@2.0.4:
+        resolution:
+            {
+                integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==,
+            }
+
+    irregular-plurals@3.5.0:
+        resolution:
+            {
+                integrity: sha512-1ANGLZ+Nkv1ptFb2pa8oG8Lem4krflKuX/gINiHJHjJUKaJHk/SXk5x6K3J+39/p0h1RQ2saROclJJ+QLvETCQ==,
+            }
+        engines: { node: '>=8' }
+
+    is-extglob@2.1.1:
+        resolution:
+            {
+                integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==,
+            }
+        engines: { node: '>=0.10.0' }
+
+    is-fullwidth-code-point@3.0.0:
+        resolution:
+            {
+                integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==,
+            }
+        engines: { node: '>=8' }
+
+    is-fullwidth-code-point@4.0.0:
+        resolution:
+            {
+                integrity: sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ==,
+            }
+        engines: { node: '>=12' }
+
+    is-glob@4.0.3:
+        resolution:
+            {
+                integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==,
+            }
+        engines: { node: '>=0.10.0' }
+
+    is-number@7.0.0:
+        resolution:
+            {
+                integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==,
+            }
+        engines: { node: '>=0.12.0' }
+
+    is-plain-object@5.0.0:
+        resolution:
+            {
+                integrity: sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==,
+            }
+        engines: { node: '>=0.10.0' }
+
+    is-promise@4.0.0:
+        resolution:
+            {
+                integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==,
+            }
+
+    is-unicode-supported@2.1.0:
+        resolution:
+            {
+                integrity: sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==,
+            }
+        engines: { node: '>=18' }
+
+    isexe@2.0.0:
+        resolution:
+            {
+                integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==,
+            }
+
+    istanbul-lib-coverage@3.2.2:
+        resolution:
+            {
+                integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==,
+            }
+        engines: { node: '>=8' }
+
+    istanbul-lib-report@3.0.1:
+        resolution:
+            {
+                integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==,
+            }
+        engines: { node: '>=10' }
+
+    istanbul-reports@3.2.0:
+        resolution:
+            {
+                integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==,
+            }
+        engines: { node: '>=8' }
+
+    jackspeak@3.4.3:
+        resolution:
+            {
+                integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==,
+            }
+
+    js-string-escape@1.0.1:
+        resolution:
+            {
+                integrity: sha512-Smw4xcfIQ5LVjAOuJCvN/zIodzA/BBSsluuoSykP+lUvScIi4U6RJLfwHet5cxFnCswUjISV8oAXaqaJDY3chg==,
+            }
+        engines: { node: '>= 0.8' }
+
+    js-yaml@3.14.1:
+        resolution:
+            {
+                integrity: sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==,
+            }
+        hasBin: true
+
+    load-json-file@7.0.1:
+        resolution:
+            {
+                integrity: sha512-Gnxj3ev3mB5TkVBGad0JM6dmLiQL+o0t23JPBZ9sd+yvSLk05mFoqKBw5N8gbbkU4TNXyqCgIrl/VM17OgUIgQ==,
+            }
+        engines: { node: ^12.20.0 || ^14.13.1 || >=16.0.0 }
+
+    locate-path@6.0.0:
+        resolution:
+            {
+                integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==,
+            }
+        engines: { node: '>=10' }
+
+    lodash.snakecase@4.1.1:
+        resolution:
+            {
+                integrity: sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw==,
+            }
+
+    lodash@4.17.21:
+        resolution:
+            {
+                integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==,
+            }
+
+    lru-cache@10.4.3:
+        resolution:
+            {
+                integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==,
+            }
+
+    magic-bytes.js@1.12.1:
+        resolution:
+            {
+                integrity: sha512-ThQLOhN86ZkJ7qemtVRGYM+gRgR8GEXNli9H/PMvpnZsE44Xfh3wx9kGJaldg314v85m+bFW6WBMaVHJc/c3zA==,
+            }
+
+    make-dir@4.0.0:
+        resolution:
+            {
+                integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==,
+            }
+        engines: { node: '>=10' }
+
+    make-error@1.3.6:
+        resolution:
+            {
+                integrity: sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==,
+            }
+
+    matcher@5.0.0:
+        resolution:
+            {
+                integrity: sha512-s2EMBOWtXFc8dgqvoAzKJXxNHibcdJMV0gwqKUaw9E2JBJuGUK7DrNKrA6g/i+v72TT16+6sVm5mS3thaMLQUw==,
+            }
+        engines: { node: ^12.20.0 || ^14.13.1 || >=16.0.0 }
+
+    md5-hex@3.0.1:
+        resolution:
+            {
+                integrity: sha512-BUiRtTtV39LIJwinWBjqVsU9xhdnz7/i889V859IBFpuqGAj6LuOvHv5XLbgZ2R7ptJoJaEcxkv88/h25T7Ciw==,
+            }
+        engines: { node: '>=8' }
+
+    memoize@10.1.0:
+        resolution:
+            {
+                integrity: sha512-MMbFhJzh4Jlg/poq1si90XRlTZRDHVqdlz2mPyGJ6kqMpyHUyVpDd5gpFAvVehW64+RA1eKE9Yt8aSLY7w2Kgg==,
+            }
+        engines: { node: '>=18' }
+
+    merge2@1.4.1:
+        resolution:
+            {
+                integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==,
+            }
+        engines: { node: '>= 8' }
+
+    micromatch@4.0.8:
+        resolution:
+            {
+                integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==,
+            }
+        engines: { node: '>=8.6' }
+
+    mimic-function@5.0.1:
+        resolution:
+            {
+                integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==,
+            }
+        engines: { node: '>=18' }
+
+    minimatch@3.1.2:
+        resolution:
+            {
+                integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==,
+            }
+
+    minimatch@9.0.5:
+        resolution:
+            {
+                integrity: sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==,
+            }
+        engines: { node: '>=16 || 14 >=14.17' }
+
+    minipass@7.1.2:
+        resolution:
+            {
+                integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==,
+            }
+        engines: { node: '>=16 || 14 >=14.17' }
+
+    minizlib@3.0.2:
+        resolution:
+            {
+                integrity: sha512-oG62iEk+CYt5Xj2YqI5Xi9xWUeZhDI8jjQmC5oThVH5JGCTgIjr7ciJDzC7MBzYd//WvR1OTmP5Q38Q8ShQtVA==,
+            }
+        engines: { node: '>= 18' }
+
+    mkdirp@3.0.1:
+        resolution:
+            {
+                integrity: sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==,
+            }
+        engines: { node: '>=10' }
+        hasBin: true
+
+    ms@2.1.3:
+        resolution:
+            {
+                integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==,
+            }
+
+    node-fetch@2.7.0:
+        resolution:
+            {
+                integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==,
+            }
+        engines: { node: 4.x || >=6.0.0 }
+        peerDependencies:
+            encoding: ^0.1.0
+        peerDependenciesMeta:
+            encoding:
+                optional: true
+
+    node-gyp-build@4.8.4:
+        resolution:
+            {
+                integrity: sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==,
+            }
+        hasBin: true
+
+    nofilter@3.1.0:
+        resolution:
+            {
+                integrity: sha512-l2NNj07e9afPnhAhvgVrCD/oy2Ai1yfLpuo3EpiO1jFTsB4sFz6oIfAfSZyQzVpkZQ9xS8ZS5g1jCBgq4Hwo0g==,
+            }
+        engines: { node: '>=12.19' }
+
+    nopt@8.1.0:
+        resolution:
+            {
+                integrity: sha512-ieGu42u/Qsa4TFktmaKEwM6MQH0pOWnaB3htzh0JRtx84+Mebc0cbZYN5bC+6WTZ4+77xrL9Pn5m7CV6VIkV7A==,
+            }
+        engines: { node: ^18.17.0 || >=20.5.0 }
+        hasBin: true
+
+    once@1.4.0:
+        resolution:
+            {
+                integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==,
+            }
+
+    p-limit@3.1.0:
+        resolution:
+            {
+                integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==,
+            }
+        engines: { node: '>=10' }
+
+    p-locate@5.0.0:
+        resolution:
+            {
+                integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==,
+            }
+        engines: { node: '>=10' }
+
+    p-map@7.0.3:
+        resolution:
+            {
+                integrity: sha512-VkndIv2fIB99swvQoA65bm+fsmt6UNdGeIB0oxBs+WhAhdh08QA04JXpI7rbB9r08/nkbysKoya9rtDERYOYMA==,
+            }
+        engines: { node: '>=18' }
+
+    package-config@5.0.0:
+        resolution:
+            {
+                integrity: sha512-GYTTew2slBcYdvRHqjhwaaydVMvn/qrGC323+nKclYioNSLTDUM/lGgtGTgyHVtYcozb+XkE8CNhwcraOmZ9Mg==,
+            }
+        engines: { node: '>=18' }
+
+    package-json-from-dist@1.0.1:
+        resolution:
+            {
+                integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==,
+            }
+
+    parse-ms@4.0.0:
+        resolution:
+            {
+                integrity: sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==,
+            }
+        engines: { node: '>=18' }
+
+    path-exists@4.0.0:
+        resolution:
+            {
+                integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==,
+            }
+        engines: { node: '>=8' }
+
+    path-is-absolute@1.0.1:
+        resolution:
+            {
+                integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==,
+            }
+        engines: { node: '>=0.10.0' }
+
+    path-key@3.1.1:
+        resolution:
+            {
+                integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==,
+            }
+        engines: { node: '>=8' }
+
+    path-scurry@1.11.1:
+        resolution:
+            {
+                integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==,
+            }
+        engines: { node: '>=16 || 14 >=14.18' }
+
+    path-type@6.0.0:
+        resolution:
+            {
+                integrity: sha512-Vj7sf++t5pBD637NSfkxpHSMfWaeig5+DKWLhcqIYx6mWQz5hdJTGDVMQiJcw1ZYkhs7AazKDGpRVji1LJCZUQ==,
+            }
+        engines: { node: '>=18' }
+
+    picomatch@2.3.1:
+        resolution:
+            {
+                integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==,
+            }
+        engines: { node: '>=8.6' }
+
+    picomatch@4.0.3:
+        resolution:
+            {
+                integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==,
+            }
+        engines: { node: '>=12' }
+
+    plur@5.1.0:
+        resolution:
+            {
+                integrity: sha512-VP/72JeXqak2KiOzjgKtQen5y3IZHn+9GOuLDafPv0eXa47xq0At93XahYBs26MsifCQ4enGKwbjBTKgb9QJXg==,
+            }
+        engines: { node: ^12.20.0 || ^14.13.1 || >=16.0.0 }
+
+    pretty-ms@9.2.0:
+        resolution:
+            {
+                integrity: sha512-4yf0QO/sllf/1zbZWYnvWw3NxCQwLXKzIj0G849LSufP15BXKM0rbD2Z3wVnkMfjdn/CB0Dpp444gYAACdsplg==,
+            }
+        engines: { node: '>=18' }
+
+    queue-microtask@1.2.3:
+        resolution:
+            {
+                integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==,
+            }
+
+    require-directory@2.1.1:
+        resolution:
+            {
+                integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==,
+            }
+        engines: { node: '>=0.10.0' }
+
+    resolve-cwd@3.0.0:
+        resolution:
+            {
+                integrity: sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==,
+            }
+        engines: { node: '>=8' }
+
+    resolve-from@5.0.0:
+        resolution:
+            {
+                integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==,
+            }
+        engines: { node: '>=8' }
+
+    reusify@1.1.0:
+        resolution:
+            {
+                integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==,
+            }
+        engines: { iojs: '>=1.0.0', node: '>=0.10.0' }
+
+    run-parallel@1.2.0:
+        resolution:
+            {
+                integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==,
+            }
+
+    semver@7.7.2:
+        resolution:
+            {
+                integrity: sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==,
+            }
+        engines: { node: '>=10' }
+        hasBin: true
+
+    serialize-error@7.0.1:
+        resolution:
+            {
+                integrity: sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==,
+            }
+        engines: { node: '>=10' }
+
+    shebang-command@2.0.0:
+        resolution:
+            {
+                integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==,
+            }
+        engines: { node: '>=8' }
+
+    shebang-regex@3.0.0:
+        resolution:
+            {
+                integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==,
+            }
+        engines: { node: '>=8' }
+
+    signal-exit@4.1.0:
+        resolution:
+            {
+                integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==,
+            }
+        engines: { node: '>=14' }
+
+    slash@5.1.0:
+        resolution:
+            {
+                integrity: sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==,
+            }
+        engines: { node: '>=14.16' }
+
+    slice-ansi@5.0.0:
+        resolution:
+            {
+                integrity: sha512-FC+lgizVPfie0kkhqUScwRu1O/lF6NOgJmlCgK+/LYxDCTk8sGelYaHDhFcDN+Sn3Cv+3VSa4Byeo+IMCzpMgQ==,
+            }
+        engines: { node: '>=12' }
+
+    sprintf-js@1.0.3:
+        resolution:
+            {
+                integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==,
+            }
+
+    stack-utils@2.0.6:
+        resolution:
+            {
+                integrity: sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==,
+            }
+        engines: { node: '>=10' }
+
+    string-width@4.2.3:
+        resolution:
+            {
+                integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==,
+            }
+        engines: { node: '>=8' }
+
+    string-width@5.1.2:
+        resolution:
+            {
+                integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==,
+            }
+        engines: { node: '>=12' }
+
+    string-width@7.2.0:
+        resolution:
+            {
+                integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==,
+            }
+        engines: { node: '>=18' }
+
+    strip-ansi@6.0.1:
+        resolution:
+            {
+                integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==,
+            }
+        engines: { node: '>=8' }
+
+    strip-ansi@7.1.0:
+        resolution:
+            {
+                integrity: sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==,
+            }
+        engines: { node: '>=12' }
+
+    supertap@3.0.1:
+        resolution:
+            {
+                integrity: sha512-u1ZpIBCawJnO+0QePsEiOknOfCRq0yERxiAchT0i4li0WHNUJbf0evXXSXOcCAR4M8iMDoajXYmstm/qO81Isw==,
+            }
+        engines: { node: ^12.20.0 || ^14.13.1 || >=16.0.0 }
+
+    supports-color@7.2.0:
+        resolution:
+            {
+                integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==,
+            }
+        engines: { node: '>=8' }
+
+    tar@7.4.3:
+        resolution:
+            {
+                integrity: sha512-5S7Va8hKfV7W5U6g3aYxXmlPoZVAwUMy9AOKyF2fVuZa2UD3qZjg578OrLRt8PcNN1PleVaL/5/yYATNL0ICUw==,
+            }
+        engines: { node: '>=18' }
+
+    temp-dir@3.0.0:
+        resolution:
+            {
+                integrity: sha512-nHc6S/bwIilKHNRgK/3jlhDoIHcp45YgyiwcAk46Tr0LfEqGBVpmiAyuiuxeVE44m3mXnEeVhaipLOEWmH+Njw==,
+            }
+        engines: { node: '>=14.16' }
+
+    test-exclude@6.0.0:
+        resolution:
+            {
+                integrity: sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==,
+            }
+        engines: { node: '>=8' }
+
+    time-zone@1.0.0:
+        resolution:
+            {
+                integrity: sha512-TIsDdtKo6+XrPtiTm1ssmMngN1sAhyKnTO2kunQWqNPWIVvCm15Wmw4SWInwTVgJ5u/Tr04+8Ei9TNcw4x4ONA==,
+            }
+        engines: { node: '>=4' }
+
+    to-regex-range@5.0.1:
+        resolution:
+            {
+                integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==,
+            }
+        engines: { node: '>=8.0' }
+
+    tr46@0.0.3:
+        resolution:
+            {
+                integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==,
+            }
+
+    ts-mixer@6.0.4:
+        resolution:
+            {
+                integrity: sha512-ufKpbmrugz5Aou4wcr5Wc1UUFWOLhq+Fm6qa6P0w0K5Qw2yhaUoiWszhCVuNQyNwrlGiscHOmqYoAox1PtvgjA==,
+            }
+
+    ts-node@10.9.2:
+        resolution:
+            {
+                integrity: sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==,
+            }
+        hasBin: true
+        peerDependencies:
+            '@swc/core': '>=1.2.50'
+            '@swc/wasm': '>=1.2.50'
+            '@types/node': '*'
+            typescript: '>=2.7'
+        peerDependenciesMeta:
+            '@swc/core':
+                optional: true
+            '@swc/wasm':
+                optional: true
+
+    tslib@2.8.1:
+        resolution:
+            {
+                integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==,
+            }
+
+    type-fest@0.13.1:
+        resolution:
+            {
+                integrity: sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==,
+            }
+        engines: { node: '>=10' }
+
+    typescript@5.7.3:
+        resolution:
+            {
+                integrity: sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==,
+            }
+        engines: { node: '>=14.17' }
+        hasBin: true
+
+    undici-types@6.21.0:
+        resolution:
+            {
+                integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==,
+            }
+
+    undici@6.21.3:
+        resolution:
+            {
+                integrity: sha512-gBLkYIlEnSp8pFbT64yFgGE6UIB9tAkhukC23PmMDCe5Nd+cRqKxSjw5y54MK2AZMgZfJWMaNE4nYUHgi1XEOw==,
+            }
+        engines: { node: '>=18.17' }
+
+    unicorn-magic@0.3.0:
+        resolution:
+            {
+                integrity: sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==,
+            }
+        engines: { node: '>=18' }
+
+    v8-compile-cache-lib@3.0.1:
+        resolution:
+            {
+                integrity: sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==,
+            }
+
+    v8-to-istanbul@9.3.0:
+        resolution:
+            {
+                integrity: sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==,
+            }
+        engines: { node: '>=10.12.0' }
+
+    webidl-conversions@3.0.1:
+        resolution:
+            {
+                integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==,
+            }
+
+    well-known-symbols@2.0.0:
+        resolution:
+            {
+                integrity: sha512-ZMjC3ho+KXo0BfJb7JgtQ5IBuvnShdlACNkKkdsqBmYw3bPAaJfPeYUo6tLUaT5tG/Gkh7xkpBhKRQ9e7pyg9Q==,
+            }
+        engines: { node: '>=6' }
+
+    whatwg-url@5.0.0:
+        resolution:
+            {
+                integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==,
+            }
+
+    which@2.0.2:
+        resolution:
+            {
+                integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==,
+            }
+        engines: { node: '>= 8' }
+        hasBin: true
+
+    wrap-ansi@7.0.0:
+        resolution:
+            {
+                integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==,
+            }
+        engines: { node: '>=10' }
+
+    wrap-ansi@8.1.0:
+        resolution:
+            {
+                integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==,
+            }
+        engines: { node: '>=12' }
+
+    wrappy@1.0.2:
+        resolution:
+            {
+                integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==,
+            }
+
+    write-file-atomic@6.0.0:
+        resolution:
+            {
+                integrity: sha512-GmqrO8WJ1NuzJ2DrziEI2o57jKAVIQNf8a18W3nCYU3H7PNWqCCVTeH6/NQE93CIllIgQS98rrmVkYgTX9fFJQ==,
+            }
+        engines: { node: ^18.17.0 || >=20.5.0 }
+
+    ws@8.18.3:
+        resolution:
+            {
+                integrity: sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==,
+            }
+        engines: { node: '>=10.0.0' }
+        peerDependencies:
+            bufferutil: ^4.0.1
+            utf-8-validate: '>=5.0.2'
+        peerDependenciesMeta:
+            bufferutil:
+                optional: true
+            utf-8-validate:
+                optional: true
+
+    y18n@5.0.8:
+        resolution:
+            {
+                integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==,
+            }
+        engines: { node: '>=10' }
+
+    yallist@5.0.0:
+        resolution:
+            {
+                integrity: sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==,
+            }
+        engines: { node: '>=18' }
+
+    yargs-parser@21.1.1:
+        resolution:
+            {
+                integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==,
+            }
+        engines: { node: '>=12' }
+
+    yargs@17.7.2:
+        resolution:
+            {
+                integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==,
+            }
+        engines: { node: '>=12' }
+
+    yn@3.1.1:
+        resolution:
+            {
+                integrity: sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==,
+            }
+        engines: { node: '>=6' }
+
+    yocto-queue@0.1.0:
+        resolution:
+            {
+                integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==,
+            }
+        engines: { node: '>=10' }
+
+snapshots:
+    '@bcoe/v8-coverage@0.2.3': {}
+
+    '@biomejs/biome@2.2.2':
+        optionalDependencies:
+            '@biomejs/cli-darwin-arm64': 2.2.2
+            '@biomejs/cli-darwin-x64': 2.2.2
+            '@biomejs/cli-linux-arm64': 2.2.2
+            '@biomejs/cli-linux-arm64-musl': 2.2.2
+            '@biomejs/cli-linux-x64': 2.2.2
+            '@biomejs/cli-linux-x64-musl': 2.2.2
+            '@biomejs/cli-win32-arm64': 2.2.2
+            '@biomejs/cli-win32-x64': 2.2.2
+
+    '@biomejs/cli-darwin-arm64@2.2.2':
+        optional: true
+
+    '@biomejs/cli-darwin-x64@2.2.2':
+        optional: true
+
+    '@biomejs/cli-linux-arm64-musl@2.2.2':
+        optional: true
+
+    '@biomejs/cli-linux-arm64@2.2.2':
+        optional: true
+
+    '@biomejs/cli-linux-x64-musl@2.2.2':
+        optional: true
+
+    '@biomejs/cli-linux-x64@2.2.2':
+        optional: true
+
+    '@biomejs/cli-win32-arm64@2.2.2':
+        optional: true
+
+    '@biomejs/cli-win32-x64@2.2.2':
+        optional: true
+
+    '@cspotcode/source-map-support@0.8.1':
+        dependencies:
+            '@jridgewell/trace-mapping': 0.3.9
+
+    '@discordjs/builders@1.11.3':
+        dependencies:
+            '@discordjs/formatters': 0.6.1
+            '@discordjs/util': 1.1.1
+            '@sapphire/shapeshift': 4.0.0
+            discord-api-types: 0.38.21
+            fast-deep-equal: 3.1.3
+            ts-mixer: 6.0.4
+            tslib: 2.8.1
+
+    '@discordjs/collection@1.5.3': {}
+
+    '@discordjs/collection@2.1.1': {}
+
+    '@discordjs/formatters@0.6.1':
+        dependencies:
+            discord-api-types: 0.38.21
+
+    '@discordjs/rest@2.6.0':
+        dependencies:
+            '@discordjs/collection': 2.1.1
+            '@discordjs/util': 1.1.1
+            '@sapphire/async-queue': 1.5.5
+            '@sapphire/snowflake': 3.5.3
+            '@vladfrangu/async_event_emitter': 2.4.6
+            discord-api-types: 0.38.21
+            magic-bytes.js: 1.12.1
+            tslib: 2.8.1
+            undici: 6.21.3
+
+    '@discordjs/util@1.1.1': {}
+
+    '@discordjs/ws@1.2.3':
+        dependencies:
+            '@discordjs/collection': 2.1.1
+            '@discordjs/rest': 2.6.0
+            '@discordjs/util': 1.1.1
+            '@sapphire/async-queue': 1.5.5
+            '@types/ws': 8.18.1
+            '@vladfrangu/async_event_emitter': 2.4.6
+            discord-api-types: 0.38.21
+            tslib: 2.8.1
+            ws: 8.18.3
+        transitivePeerDependencies:
+            - bufferutil
+            - utf-8-validate
+
+    '@isaacs/cliui@8.0.2':
+        dependencies:
+            string-width: 5.1.2
+            string-width-cjs: string-width@4.2.3
+            strip-ansi: 7.1.0
+            strip-ansi-cjs: strip-ansi@6.0.1
+            wrap-ansi: 8.1.0
+            wrap-ansi-cjs: wrap-ansi@7.0.0
+
+    '@isaacs/fs-minipass@4.0.1':
+        dependencies:
+            minipass: 7.1.2
+
+    '@istanbuljs/schema@0.1.3': {}
+
+    '@jridgewell/resolve-uri@3.1.2': {}
+
+    '@jridgewell/sourcemap-codec@1.5.5': {}
+
+    '@jridgewell/trace-mapping@0.3.30':
+        dependencies:
+            '@jridgewell/resolve-uri': 3.1.2
+            '@jridgewell/sourcemap-codec': 1.5.5
+
+    '@jridgewell/trace-mapping@0.3.9':
+        dependencies:
+            '@jridgewell/resolve-uri': 3.1.2
+            '@jridgewell/sourcemap-codec': 1.5.5
+
+    '@mapbox/node-pre-gyp@2.0.0':
+        dependencies:
+            consola: 3.4.2
+            detect-libc: 2.0.4
+            https-proxy-agent: 7.0.6
+            node-fetch: 2.7.0
+            nopt: 8.1.0
+            semver: 7.7.2
+            tar: 7.4.3
+        transitivePeerDependencies:
+            - encoding
+            - supports-color
+
+    '@nodelib/fs.scandir@2.1.5':
+        dependencies:
+            '@nodelib/fs.stat': 2.0.5
+            run-parallel: 1.2.0
+
+    '@nodelib/fs.stat@2.0.5': {}
+
+    '@nodelib/fs.walk@1.2.8':
+        dependencies:
+            '@nodelib/fs.scandir': 2.1.5
+            fastq: 1.19.1
+
+    '@pkgjs/parseargs@0.11.0':
+        optional: true
+
+    '@rollup/pluginutils@5.2.0':
+        dependencies:
+            '@types/estree': 1.0.8
+            estree-walker: 2.0.2
+            picomatch: 4.0.3
+
+    '@sapphire/async-queue@1.5.5': {}
+
+    '@sapphire/shapeshift@4.0.0':
+        dependencies:
+            fast-deep-equal: 3.1.3
+            lodash: 4.17.21
+
+    '@sapphire/snowflake@3.5.3': {}
+
+    '@sindresorhus/merge-streams@2.3.0': {}
+
+    '@tsconfig/node10@1.0.11': {}
+
+    '@tsconfig/node12@1.0.11': {}
+
+    '@tsconfig/node14@1.0.3': {}
+
+    '@tsconfig/node16@1.0.4': {}
+
+    '@types/estree@1.0.8': {}
+
+    '@types/istanbul-lib-coverage@2.0.6': {}
+
+    '@types/node@22.18.0':
+        dependencies:
+            undici-types: 6.21.0
+
+    '@types/ws@8.18.1':
+        dependencies:
+            '@types/node': 22.18.0
+
+    '@vercel/nft@0.29.4':
+        dependencies:
+            '@mapbox/node-pre-gyp': 2.0.0
+            '@rollup/pluginutils': 5.2.0
+            acorn: 8.15.0
+            acorn-import-attributes: 1.9.5(acorn@8.15.0)
+            async-sema: 3.1.1
+            bindings: 1.5.0
+            estree-walker: 2.0.2
+            glob: 10.4.5
+            graceful-fs: 4.2.11
+            node-gyp-build: 4.8.4
+            picomatch: 4.0.3
+            resolve-from: 5.0.0
+        transitivePeerDependencies:
+            - encoding
+            - rollup
+            - supports-color
+
+    '@vladfrangu/async_event_emitter@2.4.6': {}
+
+    abbrev@3.0.1: {}
+
+    acorn-import-attributes@1.9.5(acorn@8.15.0):
+        dependencies:
+            acorn: 8.15.0
+
+    acorn-walk@8.3.4:
+        dependencies:
+            acorn: 8.15.0
+
+    acorn@8.15.0: {}
+
+    agent-base@7.1.4: {}
+
+    ansi-regex@5.0.1: {}
+
+    ansi-regex@6.2.0: {}
+
+    ansi-styles@4.3.0:
+        dependencies:
+            color-convert: 2.0.1
+
+    ansi-styles@6.2.1: {}
+
+    arg@4.1.3: {}
+
+    argparse@1.0.10:
+        dependencies:
+            sprintf-js: 1.0.3
+
+    array-find-index@1.0.2: {}
+
+    arrgv@1.0.2: {}
+
+    arrify@3.0.0: {}
+
+    async-sema@3.1.1: {}
+
+    ava@6.4.1:
+        dependencies:
+            '@vercel/nft': 0.29.4
+            acorn: 8.15.0
+            acorn-walk: 8.3.4
+            ansi-styles: 6.2.1
+            arrgv: 1.0.2
+            arrify: 3.0.0
+            callsites: 4.2.0
+            cbor: 10.0.10
+            chalk: 5.6.0
+            chunkd: 2.0.1
+            ci-info: 4.3.0
+            ci-parallel-vars: 1.0.1
+            cli-truncate: 4.0.0
+            code-excerpt: 4.0.0
+            common-path-prefix: 3.0.0
+            concordance: 5.0.4
+            currently-unhandled: 0.4.1
+            debug: 4.4.1
+            emittery: 1.2.0
+            figures: 6.1.0
+            globby: 14.1.0
+            ignore-by-default: 2.1.0
+            indent-string: 5.0.0
+            is-plain-object: 5.0.0
+            is-promise: 4.0.0
+            matcher: 5.0.0
+            memoize: 10.1.0
+            ms: 2.1.3
+            p-map: 7.0.3
+            package-config: 5.0.0
+            picomatch: 4.0.3
+            plur: 5.1.0
+            pretty-ms: 9.2.0
+            resolve-cwd: 3.0.0
+            stack-utils: 2.0.6
+            strip-ansi: 7.1.0
+            supertap: 3.0.1
+            temp-dir: 3.0.0
+            write-file-atomic: 6.0.0
+            yargs: 17.7.2
+        transitivePeerDependencies:
+            - encoding
+            - rollup
+            - supports-color
+
+    balanced-match@1.0.2: {}
+
+    bindings@1.5.0:
+        dependencies:
+            file-uri-to-path: 1.0.0
+
+    blueimp-md5@2.19.0: {}
+
+    brace-expansion@1.1.12:
+        dependencies:
+            balanced-match: 1.0.2
+            concat-map: 0.0.1
+
+    brace-expansion@2.0.2:
+        dependencies:
+            balanced-match: 1.0.2
+
+    braces@3.0.3:
+        dependencies:
+            fill-range: 7.1.1
+
+    c8@9.1.0:
+        dependencies:
+            '@bcoe/v8-coverage': 0.2.3
+            '@istanbuljs/schema': 0.1.3
+            find-up: 5.0.0
+            foreground-child: 3.3.1
+            istanbul-lib-coverage: 3.2.2
+            istanbul-lib-report: 3.0.1
+            istanbul-reports: 3.2.0
+            test-exclude: 6.0.0
+            v8-to-istanbul: 9.3.0
+            yargs: 17.7.2
+            yargs-parser: 21.1.1
+
+    callsites@4.2.0: {}
+
+    cbor@10.0.10:
+        dependencies:
+            nofilter: 3.1.0
+
+    chalk@5.6.0: {}
+
+    chownr@3.0.0: {}
+
+    chunkd@2.0.1: {}
+
+    ci-info@4.3.0: {}
+
+    ci-parallel-vars@1.0.1: {}
+
+    cli-truncate@4.0.0:
+        dependencies:
+            slice-ansi: 5.0.0
+            string-width: 7.2.0
+
+    cliui@8.0.1:
+        dependencies:
+            string-width: 4.2.3
+            strip-ansi: 6.0.1
+            wrap-ansi: 7.0.0
+
+    code-excerpt@4.0.0:
+        dependencies:
+            convert-to-spaces: 2.0.1
+
+    color-convert@2.0.1:
+        dependencies:
+            color-name: 1.1.4
+
+    color-name@1.1.4: {}
+
+    common-path-prefix@3.0.0: {}
+
+    concat-map@0.0.1: {}
+
+    concordance@5.0.4:
+        dependencies:
+            date-time: 3.1.0
+            esutils: 2.0.3
+            fast-diff: 1.3.0
+            js-string-escape: 1.0.1
+            lodash: 4.17.21
+            md5-hex: 3.0.1
+            semver: 7.7.2
+            well-known-symbols: 2.0.0
+
+    consola@3.4.2: {}
+
+    convert-source-map@2.0.0: {}
+
+    convert-to-spaces@2.0.1: {}
+
+    create-require@1.1.1: {}
+
+    cross-spawn@7.0.6:
+        dependencies:
+            path-key: 3.1.1
+            shebang-command: 2.0.0
+            which: 2.0.2
+
+    currently-unhandled@0.4.1:
+        dependencies:
+            array-find-index: 1.0.2
+
+    date-time@3.1.0:
+        dependencies:
+            time-zone: 1.0.0
+
+    debug@4.4.1:
+        dependencies:
+            ms: 2.1.3
+
+    detect-libc@2.0.4: {}
+
+    diff@4.0.2: {}
+
+    discord-api-types@0.38.21: {}
+
+    discord.js@14.22.1:
+        dependencies:
+            '@discordjs/builders': 1.11.3
+            '@discordjs/collection': 1.5.3
+            '@discordjs/formatters': 0.6.1
+            '@discordjs/rest': 2.6.0
+            '@discordjs/util': 1.1.1
+            '@discordjs/ws': 1.2.3
+            '@sapphire/snowflake': 3.5.3
+            discord-api-types: 0.38.21
+            fast-deep-equal: 3.1.3
+            lodash.snakecase: 4.1.1
+            magic-bytes.js: 1.12.1
+            tslib: 2.8.1
+            undici: 6.21.3
+        transitivePeerDependencies:
+            - bufferutil
+            - utf-8-validate
+
+    dotenv@17.2.1: {}
+
+    eastasianwidth@0.2.0: {}
+
+    emittery@1.2.0: {}
+
+    emoji-regex@10.4.0: {}
+
+    emoji-regex@8.0.0: {}
+
+    emoji-regex@9.2.2: {}
+
+    escalade@3.2.0: {}
+
+    escape-string-regexp@2.0.0: {}
+
+    escape-string-regexp@5.0.0: {}
+
+    esprima@4.0.1: {}
+
+    estree-walker@2.0.2: {}
+
+    esutils@2.0.3: {}
+
+    fast-deep-equal@3.1.3: {}
+
+    fast-diff@1.3.0: {}
+
+    fast-glob@3.3.3:
+        dependencies:
+            '@nodelib/fs.stat': 2.0.5
+            '@nodelib/fs.walk': 1.2.8
+            glob-parent: 5.1.2
+            merge2: 1.4.1
+            micromatch: 4.0.8
+
+    fastq@1.19.1:
+        dependencies:
+            reusify: 1.1.0
+
+    figures@6.1.0:
+        dependencies:
+            is-unicode-supported: 2.1.0
+
+    file-uri-to-path@1.0.0: {}
+
+    fill-range@7.1.1:
+        dependencies:
+            to-regex-range: 5.0.1
+
+    find-up-simple@1.0.1: {}
+
+    find-up@5.0.0:
+        dependencies:
+            locate-path: 6.0.0
+            path-exists: 4.0.0
+
+    foreground-child@3.3.1:
+        dependencies:
+            cross-spawn: 7.0.6
+            signal-exit: 4.1.0
+
+    fs.realpath@1.0.0: {}
+
+    get-caller-file@2.0.5: {}
+
+    get-east-asian-width@1.3.0: {}
+
+    glob-parent@5.1.2:
+        dependencies:
+            is-glob: 4.0.3
+
+    glob@10.4.5:
+        dependencies:
+            foreground-child: 3.3.1
+            jackspeak: 3.4.3
+            minimatch: 9.0.5
+            minipass: 7.1.2
+            package-json-from-dist: 1.0.1
+            path-scurry: 1.11.1
+
+    glob@7.2.3:
+        dependencies:
+            fs.realpath: 1.0.0
+            inflight: 1.0.6
+            inherits: 2.0.4
+            minimatch: 3.1.2
+            once: 1.4.0
+            path-is-absolute: 1.0.1
+
+    globby@14.1.0:
+        dependencies:
+            '@sindresorhus/merge-streams': 2.3.0
+            fast-glob: 3.3.3
+            ignore: 7.0.5
+            path-type: 6.0.0
+            slash: 5.1.0
+            unicorn-magic: 0.3.0
+
+    graceful-fs@4.2.11: {}
+
+    has-flag@4.0.0: {}
+
+    html-escaper@2.0.2: {}
+
+    https-proxy-agent@7.0.6:
+        dependencies:
+            agent-base: 7.1.4
+            debug: 4.4.1
+        transitivePeerDependencies:
+            - supports-color
+
+    ignore-by-default@2.1.0: {}
+
+    ignore@7.0.5: {}
+
+    imurmurhash@0.1.4: {}
+
+    indent-string@5.0.0: {}
+
+    inflight@1.0.6:
+        dependencies:
+            once: 1.4.0
+            wrappy: 1.0.2
+
+    inherits@2.0.4: {}
+
+    irregular-plurals@3.5.0: {}
+
+    is-extglob@2.1.1: {}
+
+    is-fullwidth-code-point@3.0.0: {}
+
+    is-fullwidth-code-point@4.0.0: {}
+
+    is-glob@4.0.3:
+        dependencies:
+            is-extglob: 2.1.1
+
+    is-number@7.0.0: {}
+
+    is-plain-object@5.0.0: {}
+
+    is-promise@4.0.0: {}
+
+    is-unicode-supported@2.1.0: {}
+
+    isexe@2.0.0: {}
+
+    istanbul-lib-coverage@3.2.2: {}
+
+    istanbul-lib-report@3.0.1:
+        dependencies:
+            istanbul-lib-coverage: 3.2.2
+            make-dir: 4.0.0
+            supports-color: 7.2.0
+
+    istanbul-reports@3.2.0:
+        dependencies:
+            html-escaper: 2.0.2
+            istanbul-lib-report: 3.0.1
+
+    jackspeak@3.4.3:
+        dependencies:
+            '@isaacs/cliui': 8.0.2
+        optionalDependencies:
+            '@pkgjs/parseargs': 0.11.0
+
+    js-string-escape@1.0.1: {}
+
+    js-yaml@3.14.1:
+        dependencies:
+            argparse: 1.0.10
+            esprima: 4.0.1
+
+    load-json-file@7.0.1: {}
+
+    locate-path@6.0.0:
+        dependencies:
+            p-locate: 5.0.0
+
+    lodash.snakecase@4.1.1: {}
+
+    lodash@4.17.21: {}
+
+    lru-cache@10.4.3: {}
+
+    magic-bytes.js@1.12.1: {}
+
+    make-dir@4.0.0:
+        dependencies:
+            semver: 7.7.2
+
+    make-error@1.3.6: {}
+
+    matcher@5.0.0:
+        dependencies:
+            escape-string-regexp: 5.0.0
+
+    md5-hex@3.0.1:
+        dependencies:
+            blueimp-md5: 2.19.0
+
+    memoize@10.1.0:
+        dependencies:
+            mimic-function: 5.0.1
+
+    merge2@1.4.1: {}
+
+    micromatch@4.0.8:
+        dependencies:
+            braces: 3.0.3
+            picomatch: 2.3.1
+
+    mimic-function@5.0.1: {}
+
+    minimatch@3.1.2:
+        dependencies:
+            brace-expansion: 1.1.12
+
+    minimatch@9.0.5:
+        dependencies:
+            brace-expansion: 2.0.2
+
+    minipass@7.1.2: {}
+
+    minizlib@3.0.2:
+        dependencies:
+            minipass: 7.1.2
+
+    mkdirp@3.0.1: {}
+
+    ms@2.1.3: {}
+
+    node-fetch@2.7.0:
+        dependencies:
+            whatwg-url: 5.0.0
+
+    node-gyp-build@4.8.4: {}
+
+    nofilter@3.1.0: {}
+
+    nopt@8.1.0:
+        dependencies:
+            abbrev: 3.0.1
+
+    once@1.4.0:
+        dependencies:
+            wrappy: 1.0.2
+
+    p-limit@3.1.0:
+        dependencies:
+            yocto-queue: 0.1.0
+
+    p-locate@5.0.0:
+        dependencies:
+            p-limit: 3.1.0
+
+    p-map@7.0.3: {}
+
+    package-config@5.0.0:
+        dependencies:
+            find-up-simple: 1.0.1
+            load-json-file: 7.0.1
+
+    package-json-from-dist@1.0.1: {}
+
+    parse-ms@4.0.0: {}
+
+    path-exists@4.0.0: {}
+
+    path-is-absolute@1.0.1: {}
+
+    path-key@3.1.1: {}
+
+    path-scurry@1.11.1:
+        dependencies:
+            lru-cache: 10.4.3
+            minipass: 7.1.2
+
+    path-type@6.0.0: {}
+
+    picomatch@2.3.1: {}
+
+    picomatch@4.0.3: {}
+
+    plur@5.1.0:
+        dependencies:
+            irregular-plurals: 3.5.0
+
+    pretty-ms@9.2.0:
+        dependencies:
+            parse-ms: 4.0.0
+
+    queue-microtask@1.2.3: {}
+
+    require-directory@2.1.1: {}
+
+    resolve-cwd@3.0.0:
+        dependencies:
+            resolve-from: 5.0.0
+
+    resolve-from@5.0.0: {}
+
+    reusify@1.1.0: {}
+
+    run-parallel@1.2.0:
+        dependencies:
+            queue-microtask: 1.2.3
+
+    semver@7.7.2: {}
+
+    serialize-error@7.0.1:
+        dependencies:
+            type-fest: 0.13.1
+
+    shebang-command@2.0.0:
+        dependencies:
+            shebang-regex: 3.0.0
+
+    shebang-regex@3.0.0: {}
+
+    signal-exit@4.1.0: {}
+
+    slash@5.1.0: {}
+
+    slice-ansi@5.0.0:
+        dependencies:
+            ansi-styles: 6.2.1
+            is-fullwidth-code-point: 4.0.0
+
+    sprintf-js@1.0.3: {}
+
+    stack-utils@2.0.6:
+        dependencies:
+            escape-string-regexp: 2.0.0
+
+    string-width@4.2.3:
+        dependencies:
+            emoji-regex: 8.0.0
+            is-fullwidth-code-point: 3.0.0
+            strip-ansi: 6.0.1
+
+    string-width@5.1.2:
+        dependencies:
+            eastasianwidth: 0.2.0
+            emoji-regex: 9.2.2
+            strip-ansi: 7.1.0
+
+    string-width@7.2.0:
+        dependencies:
+            emoji-regex: 10.4.0
+            get-east-asian-width: 1.3.0
+            strip-ansi: 7.1.0
+
+    strip-ansi@6.0.1:
+        dependencies:
+            ansi-regex: 5.0.1
+
+    strip-ansi@7.1.0:
+        dependencies:
+            ansi-regex: 6.2.0
+
+    supertap@3.0.1:
+        dependencies:
+            indent-string: 5.0.0
+            js-yaml: 3.14.1
+            serialize-error: 7.0.1
+            strip-ansi: 7.1.0
+
+    supports-color@7.2.0:
+        dependencies:
+            has-flag: 4.0.0
+
+    tar@7.4.3:
+        dependencies:
+            '@isaacs/fs-minipass': 4.0.1
+            chownr: 3.0.0
+            minipass: 7.1.2
+            minizlib: 3.0.2
+            mkdirp: 3.0.1
+            yallist: 5.0.0
+
+    temp-dir@3.0.0: {}
+
+    test-exclude@6.0.0:
+        dependencies:
+            '@istanbuljs/schema': 0.1.3
+            glob: 7.2.3
+            minimatch: 3.1.2
+
+    time-zone@1.0.0: {}
+
+    to-regex-range@5.0.1:
+        dependencies:
+            is-number: 7.0.0
+
+    tr46@0.0.3: {}
+
+    ts-mixer@6.0.4: {}
+
+    ts-node@10.9.2(@types/node@22.18.0)(typescript@5.7.3):
+        dependencies:
+            '@cspotcode/source-map-support': 0.8.1
+            '@tsconfig/node10': 1.0.11
+            '@tsconfig/node12': 1.0.11
+            '@tsconfig/node14': 1.0.3
+            '@tsconfig/node16': 1.0.4
+            '@types/node': 22.18.0
+            acorn: 8.15.0
+            acorn-walk: 8.3.4
+            arg: 4.1.3
+            create-require: 1.1.1
+            diff: 4.0.2
+            make-error: 1.3.6
+            typescript: 5.7.3
+            v8-compile-cache-lib: 3.0.1
+            yn: 3.1.1
+
+    tslib@2.8.1: {}
+
+    type-fest@0.13.1: {}
+
+    typescript@5.7.3: {}
+
+    undici-types@6.21.0: {}
+
+    undici@6.21.3: {}
+
+    unicorn-magic@0.3.0: {}
+
+    v8-compile-cache-lib@3.0.1: {}
+
+    v8-to-istanbul@9.3.0:
+        dependencies:
+            '@jridgewell/trace-mapping': 0.3.30
+            '@types/istanbul-lib-coverage': 2.0.6
+            convert-source-map: 2.0.0
+
+    webidl-conversions@3.0.1: {}
+
+    well-known-symbols@2.0.0: {}
+
+    whatwg-url@5.0.0:
+        dependencies:
+            tr46: 0.0.3
+            webidl-conversions: 3.0.1
+
+    which@2.0.2:
+        dependencies:
+            isexe: 2.0.0
+
+    wrap-ansi@7.0.0:
+        dependencies:
+            ansi-styles: 4.3.0
+            string-width: 4.2.3
+            strip-ansi: 6.0.1
+
+    wrap-ansi@8.1.0:
+        dependencies:
+            ansi-styles: 6.2.1
+            string-width: 5.1.2
+            strip-ansi: 7.1.0
+
+    wrappy@1.0.2: {}
+
+    write-file-atomic@6.0.0:
+        dependencies:
+            imurmurhash: 0.1.4
+            signal-exit: 4.1.0
+
+    ws@8.18.3: {}
+
+    y18n@5.0.8: {}
+
+    yallist@5.0.0: {}
+
+    yargs-parser@21.1.1: {}
+
+    yargs@17.7.2:
+        dependencies:
+            cliui: 8.0.1
+            escalade: 3.2.0
+            get-caller-file: 2.0.5
+            require-directory: 2.1.1
+            string-width: 4.2.3
+            y18n: 5.0.8
+            yargs-parser: 21.1.1
+
+    yn@3.1.1: {}
+
+    yocto-queue@0.1.0: {}

--- a/templates/ts/discord-bot/scripts/patch-imports.js
+++ b/templates/ts/discord-bot/scripts/patch-imports.js
@@ -1,0 +1,43 @@
+import fs from 'fs/promises';
+import path from 'path';
+
+const DIST_DIR = path.resolve('./dist');
+
+async function patchFile(filePath) {
+    let content = await fs.readFile(filePath, 'utf8');
+
+    // Match import/export statements with relative paths (./ or ../)
+    const result = content.replace(
+        /(from\s+['"])(\.{1,2}\/[^'"]+?)(['"])/g,
+        (_, prefix, importPath, suffix) => {
+            // Add .js unless it already ends with .js or .mjs or contains query params
+            if (
+                importPath.endsWith('.js') ||
+                importPath.endsWith('.mjs') ||
+                importPath.includes('?')
+            ) {
+                return `${prefix}${importPath}${suffix}`;
+            }
+            return `${prefix}${importPath}.js${suffix}`;
+        },
+    );
+
+    await fs.writeFile(filePath, result);
+}
+
+async function walk(dir) {
+    const files = await fs.readdir(dir, { withFileTypes: true });
+    await Promise.all(
+        files.map(async (entry) => {
+            const fullPath = path.join(dir, entry.name);
+            if (entry.isDirectory()) {
+                await walk(fullPath);
+            } else if (entry.name.endsWith('.js')) {
+                await patchFile(fullPath);
+            }
+        }),
+    );
+}
+
+await walk(DIST_DIR);
+console.log('✅ All relative imports patched to use .js');

--- a/templates/ts/discord-bot/src/bot.ts
+++ b/templates/ts/discord-bot/src/bot.ts
@@ -1,0 +1,28 @@
+import { Client, GatewayIntentBits, Message } from 'discord.js';
+
+export class Bot {
+    private client: Client;
+    private token: string;
+
+    constructor(token: string) {
+        this.token = token;
+        this.client = new Client({
+            intents: [GatewayIntentBits.Guilds, GatewayIntentBits.GuildMessages],
+        });
+    }
+
+    async start() {
+        this.client.on('ready', () => {
+            console.log(`Logged in as ${this.client.user?.tag}!`);
+        });
+
+        this.client.on('messageCreate', async (message: Message) => {
+            if (message.author.bot) return;
+            if (message.content === '!ping') {
+                await message.reply('Pong!');
+            }
+        });
+
+        await this.client.login(this.token);
+    }
+}

--- a/templates/ts/discord-bot/src/index.ts
+++ b/templates/ts/discord-bot/src/index.ts
@@ -1,0 +1,16 @@
+import 'dotenv/config';
+import { Bot } from './bot.js';
+
+async function main() {
+    const token = process.env.DISCORD_TOKEN;
+    if (!token) {
+        throw new Error('DISCORD_TOKEN is not set');
+    }
+    const bot = new Bot(token);
+    await bot.start();
+}
+
+main().catch((err) => {
+    console.error(err);
+    process.exit(1);
+});

--- a/templates/ts/discord-bot/src/tests/bot.test.ts
+++ b/templates/ts/discord-bot/src/tests/bot.test.ts
@@ -1,0 +1,6 @@
+import test from 'ava';
+
+// This test is a placeholder to verify the template setup.
+test('placeholder', (t) => {
+    t.pass();
+});

--- a/templates/ts/discord-bot/tsconfig.eslint.json
+++ b/templates/ts/discord-bot/tsconfig.eslint.json
@@ -1,0 +1,3 @@
+{
+    "extends": "./tsconfig.json"
+}

--- a/templates/ts/discord-bot/tsconfig.json
+++ b/templates/ts/discord-bot/tsconfig.json
@@ -1,0 +1,19 @@
+{
+    "compilerOptions": {
+        "target": "ES2022",
+        "module": "NodeNext",
+        "moduleResolution": "NodeNext",
+        "outDir": "dist",
+        "rootDir": "src",
+        "strict": true,
+        "sourceMap": true,
+        "inlineSources": true,
+        "esModuleInterop": false,
+        "allowSyntheticDefaultImports": true,
+        "resolveJsonModule": true,
+        "types": ["node", "ava"],
+        "skipLibCheck": true
+    },
+    "include": ["src/**/*"],
+    "exclude": ["dist"]
+}


### PR DESCRIPTION
## Summary
- add TypeScript discord-bot template based on Cephalon
- document usage for creating new bots
- note new template in changelog

## Testing
- `pnpm run format`
- `pnpm run lint`
- `pnpm run build`
- `pnpm run test`
- `make format` (fails: Unable to read file services/py/discord_attachment_embedder/.venv/.../libtorch_cuda.so)
- `make lint` (fails: A config object is using the "extends" key)
- `make test` (fails: monitor kill ESRCH)

------
https://chatgpt.com/codex/tasks/task_e_68ace818e6f48324b7bfb9f1bce59b58