### PR TITLE
Extract tasks from unique notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Added
 
+- Extracted actionable tasks from unique notes into tasks/unique-notes.md
 - Policy-based access control with user and role management for SmartGPT Bridge.
 - Directory tree endpoint for SmartGPT Bridge file API.
 - v1 router exposing consolidated SmartGPT Bridge endpoints.

--- a/tasks/unique-notes.md
+++ b/tasks/unique-notes.md
@@ -1,0 +1,9 @@
+# Actionable Tasks from Unique Notes
+
+- [ ] Adjust window when `msg.type === 'FLOW'` (docs/unique/2025.08.08.15.08.23.md line 636)
+- [ ] Implement multi-partition fan-in per connection (docs/unique/2025.08.08.15.08.23.md line 650)
+- [ ] Implement placeholder function (docs/unique/2025.08.09.13.08.04.md line 142)
+- [ ] Build syntax-normalized hash if needed (docs/unique/2025.08.08.23.08.30.md line 176)
+- [ ] Decode and emit rather than pass through raw (docs/unique/2025.08.08.23.08.30.md line 224)
+- [ ] Map definition lists and task lists to TODO/DONE (docs/unique/2025.08.08.23.08.34.md line 292)
+- [ ] Finalize TODO-laden guides after adding context (docs/unique/2025.07.31.16.07.75.md line 119)


### PR DESCRIPTION
## Summary
- collect actionable items from unique notes into a new tasks/unique-notes.md file
- document task extraction in changelog

## Testing
- `make format` *(fails: Interrupt)*
- `make lint` *(fails: Interrupt)*
- `make test` *(fails: AttributeError: module 'main' has no attribute 'next_messages')*
- `make build` *(fails: Interrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68ad0efbb5d483249bba2a6a81eb2b46