### PR TITLE
feat: centralize audio base64 helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Proxy route `/bridge` through the shared proxy service for SmartGPT Bridge.
 - Tool calling support for Codex Context service.
 - Template for building Discord bots in TypeScript based on the Cephalon service.
+- Audio utility helpers for base64 PCM and WAV conversions.
 
 ### Changed
 
@@ -38,6 +39,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Frontends now served from a central static file server instead of individual services.
 - SmartGPT Bridge now uses shared DualStore and ContextStore for persistence.
 - Discord embedder migrated to shared DualStore and ContextStore for unified persistence.
+- STT and TTS services now use shared audio utilities for encoding and decoding.
 - Kanban processor now persists via shared DualStore and ContextStore.
 - Markdown Graph service now uses shared DualStore and ContextStore for persistence.
 - MCP server now creates a dedicated bridge connection per session and exposes tool schemas via `inputSchema`.

--- a/services/py/stt/service.py
+++ b/services/py/stt/service.py
@@ -3,9 +3,9 @@ import sys
 sys.path.append("../../../")
 
 import asyncio
-import base64
 
 from shared.py.service_template import start_service
+from shared.py.speech.audio_utils import pcm_from_base64
 from shared.py.speech.wisper_stt import transcribe_pcm
 
 
@@ -17,8 +17,8 @@ async def process_task(client, task):
     if pcm_b64 is None:
         print("[stt] task missing 'pcm' field")
         return
-    pcm_bytes = base64.b64decode(pcm_b64)
-    text = transcribe_pcm(bytearray(pcm_bytes), sample_rate)
+    pcm_bytes = pcm_from_base64(pcm_b64)
+    text = transcribe_pcm(pcm_bytes, sample_rate)
     await client.publish("stt.transcribed", {"text": text}, correlationId=task["id"])
 
 

--- a/services/py/tts/app.py
+++ b/services/py/tts/app.py
@@ -1,10 +1,10 @@
 from fastapi import FastAPI, Form, Response, WebSocket
-import base64
 import io
 import sys
 
 print(sys.path)
 from shared.py.service_template import start_service
+from shared.py.speech.audio_utils import wav_to_base64
 from shared.py.utils import websocket_endpoint
 
 import soundfile as sf
@@ -30,9 +30,7 @@ async def startup_event():
         if not text:
             return
         audio = synthesize(text)
-        buf = io.BytesIO()
-        sf.write(buf, audio, samplerate=22050, format="WAV")
-        audio_b64 = base64.b64encode(buf.getvalue()).decode("utf-8")
+        audio_b64 = wav_to_base64(audio, 22050)
         await broker.publish("tts-output", {"audio": audio_b64})
 
     try:

--- a/services/py/tts/tests/test_tts_websocket.py
+++ b/services/py/tts/tests/test_tts_websocket.py
@@ -94,6 +94,9 @@ def test_websocket_tts_returns_wav_bytes(monkeypatch):
             "speech.tts": dummy_module,
             "shared.py.speech": dummy_package,
             "shared.py.speech.tts": dummy_module,
+            "shared.py.speech.audio_utils": types.SimpleNamespace(
+                wav_to_base64=lambda audio, sr: ""
+            ),
             "shared.py.service_template": types.SimpleNamespace(
                 start_service=dummy_start_service
             ),

--- a/shared/py/speech/__init__.py
+++ b/shared/py/speech/__init__.py
@@ -1,0 +1,1 @@
+"""Speech utilities and service helpers."""

--- a/shared/py/speech/audio_utils.py
+++ b/shared/py/speech/audio_utils.py
@@ -1,0 +1,17 @@
+import base64
+import io
+from typing import Any
+
+
+def pcm_from_base64(data: str) -> bytearray:
+    """Decode a base64-encoded PCM string into raw bytes."""
+    return bytearray(base64.b64decode(data))
+
+
+def wav_to_base64(audio: Any, sample_rate: int) -> str:
+    """Encode audio samples as a base64 WAV string."""
+    import soundfile as sf
+
+    buffer = io.BytesIO()
+    sf.write(buffer, audio, samplerate=sample_rate, format="WAV")
+    return base64.b64encode(buffer.getvalue()).decode("utf-8")

--- a/shared/py/speech/tests/test_audio_utils.py
+++ b/shared/py/speech/tests/test_audio_utils.py
@@ -1,0 +1,32 @@
+import base64
+import io
+import os
+import sys
+
+import numpy as np
+import soundfile as sf
+
+sys.path.insert(
+    0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../.."))
+)
+
+from shared.py.speech.audio_utils import pcm_from_base64, wav_to_base64
+
+
+def test_pcm_from_base64_roundtrip():
+    original = b"\x01\x02\x03\x04"
+    encoded = base64.b64encode(original).decode("utf-8")
+    decoded = pcm_from_base64(encoded)
+    assert decoded == bytearray(original)
+
+
+def test_wav_to_base64_roundtrip():
+    sr = 22050
+    # generate 1 second of a sine wave
+    t = np.linspace(0, 1, sr, endpoint=False)
+    audio = np.sin(2 * np.pi * 440 * t).astype("float32")
+    encoded = wav_to_base64(audio, sr)
+    decoded = base64.b64decode(encoded)
+    recovered, read_sr = sf.read(io.BytesIO(decoded), dtype="float32")
+    assert read_sr == sr
+    np.testing.assert_allclose(recovered, audio, atol=1e-4)


### PR DESCRIPTION
## Summary
- add shared audio utilities for base64 PCM and WAV conversions
- use audio utils in STT service and TTS app
- expand unit and service tests for audio helpers and TTS

## Testing
- `make format-python`
- `flake8 services/py shared/py/`
- `make build-python`
- `pipenv run pytest speech/tests/test_audio_utils.py` *(in `shared/py`)*
- `make test-python-service-tts`
- `make test-python-service-stt` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_68ad1217765483249dcee35d7bdd3a21