### PR TITLE
Parameterize naive embedding vector size and add tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Changed
 
+- Naive embedding driver now uses configurable `VECTOR_SIZE` constant.
 - Organized SmartGPT Bridge routes into versioned directories.
 - Moved SmartGPT dashboard and LLM chat frontends into `sites/`.
 - Frontends now served from a central static file server instead of individual services.

--- a/services/py/embedding_service/drivers/naive_driver.py
+++ b/services/py/embedding_service/drivers/naive_driver.py
@@ -4,6 +4,11 @@ from typing import List, Any
 from .base import EmbeddingDriver
 
 
+# 256 dimensions map neatly to byte values, offering a simple default size
+# for character-frequency embeddings while remaining lightweight for tests.
+VECTOR_SIZE = 256
+
+
 class NaiveDriver(EmbeddingDriver):
     """Very small embedding driver for testing."""
 
@@ -29,9 +34,15 @@ class NaiveDriver(EmbeddingDriver):
         raise ValueError(f"Unknown naive function {fn}")
 
     def _simple(self, text: str) -> List[float]:
-        vec = [0.0] * 256
+        """Return a normalized character-frequency vector.
+
+        Each character's Unicode code point maps to an index via
+        ``ord(ch) % VECTOR_SIZE``. Counts are accumulated and the vector is
+        L2-normalized to unit length.
+        """
+        vec = [0.0] * VECTOR_SIZE
         for ch in text:
-            vec[ord(ch) % 256] += 1.0
+            vec[ord(ch) % VECTOR_SIZE] += 1.0
         norm = sum(v * v for v in vec) ** 0.5
         return [(v / norm) if norm else 0.0 for v in vec]
 

--- a/services/py/embedding_service/tests/test_naive_driver.py
+++ b/services/py/embedding_service/tests/test_naive_driver.py
@@ -1,0 +1,23 @@
+import sys
+from pathlib import Path
+
+BASE_DIR = Path(__file__).resolve()
+sys.path.insert(0, str(BASE_DIR.parents[2]))
+sys.path.insert(0, str(BASE_DIR.parents[4]))
+
+from embedding_service.drivers import naive_driver
+
+
+def test_simple_embedding_uses_vector_size():
+    driver = naive_driver.NaiveDriver()
+    vec = driver._simple("abc")
+    assert len(vec) == naive_driver.VECTOR_SIZE
+
+
+def test_simple_embedding_respects_vector_size_change(monkeypatch):
+    monkeypatch.setattr(naive_driver, "VECTOR_SIZE", 512)
+    driver = naive_driver.NaiveDriver()
+    vec = driver._simple("a")
+    assert len(vec) == 512
+    idx = ord("a") % 512
+    assert vec[idx] == 1.0

--- a/services/py/embedding_service/tests/test_service.py
+++ b/services/py/embedding_service/tests/test_service.py
@@ -7,6 +7,7 @@ sys.path.insert(0, str(BASE_DIR.parents[2]))
 sys.path.insert(0, str(BASE_DIR.parents[4]))
 
 from embedding_service.main import handle_task
+from embedding_service.drivers.naive_driver import VECTOR_SIZE
 
 
 class DummyClient:
@@ -32,6 +33,6 @@ def test_handle_task_publishes_embeddings():
     assert client.published
     evt_type, payload, opts = client.published[0]
     assert evt_type == "embedding.result"
-    assert len(payload["embeddings"][0]) == 256
+    assert len(payload["embeddings"][0]) == VECTOR_SIZE
     assert opts["replyTo"] == "reply.queue"
     assert opts["correlationId"] == "1"


### PR DESCRIPTION
## Summary
- introduce `VECTOR_SIZE` constant for naive embedding driver and document character mapping
- reference `VECTOR_SIZE` in tests and add coverage for alternate sizes
- record change in changelog

## Testing
- `make setup-python-service-embedding_service`
- `make format-python`
- `flake8 services/py/embedding_service/drivers/naive_driver.py services/py/embedding_service/tests/test_service.py services/py/embedding_service/tests/test_naive_driver.py`
- `make build`

------
https://chatgpt.com/codex/tasks/task_e_68ad122f989083248240a8485de4d42c