### PR TITLE
Improve embedding service logging and validation

### DIFF
--- a/services/py/embedding_service/main.py
+++ b/services/py/embedding_service/main.py
@@ -1,10 +1,14 @@
 import asyncio
+import logging
 import os
 from functools import lru_cache
 from typing import List
 
 from shared.py.service_template import start_service
 from drivers import get_driver
+
+
+logger = logging.getLogger(__name__)
 
 
 @lru_cache(maxsize=1)
@@ -14,23 +18,83 @@ def _load(driver_name: str, function_name: str):
 
 
 def _embed(items, driver_name: str, function_name: str) -> List[List[float]]:
+    """Generate embeddings for ``items`` using ``driver_name`` and ``function_name``.
+
+    Parameters
+    ----------
+    items : list
+        A list of items (dicts or objects with ``data`` attributes) to embed.
+    driver_name : str
+        The driver backend to use.
+    function_name : str
+        The specific embedding function to invoke.
+
+    Returns
+    -------
+    List[List[float]]
+        A list of embedding vectors.
+    """
+
     driver = get_driver(driver_name)
     model = _load(driver_name, function_name)
     return driver.embed(items, function_name, model)
 
 
 async def handle_task(task, client):
-    print("embedding task recieved:")
-    payload = task.get("payload", {})
-    driver_name = payload.get("driver") or os.environ.get("EMBEDDING_DRIVER", "naive")
+    """Handle a single embedding task.
 
-    function_name = payload.get("function") or os.environ.get(
-        "EMBEDDING_FUNCTION", "simple"
-    )
-    items = payload.get("items", [])
-    embeddings = _embed(items, driver_name, function_name)
+    Parameters
+    ----------
+    task : dict
+        Task message containing a ``payload`` with ``items``, ``driver`` and
+        ``function`` fields and optional ``replyTo``.
+    client : Any
+        Broker client used to publish results.
+    """
+
+    logger.info("embedding task received")
+    payload = task.get("payload", {})
+
+    driver_name = payload.get("driver") or os.environ.get("EMBEDDING_DRIVER")
+    function_name = payload.get("function") or os.environ.get("EMBEDDING_FUNCTION")
+    items = payload.get("items")
+
     reply_to = payload.get("replyTo") or task.get("replyTo")
-    print(driver_name, function_name, reply_to)
+
+    missing = []
+    if items is None:
+        missing.append("items")
+    if not driver_name:
+        missing.append("driver")
+    if not function_name:
+        missing.append("function")
+
+    if missing:
+        error_msg = f"missing required fields: {', '.join(missing)}"
+        logger.error(error_msg)
+        if reply_to:
+            await client.publish(
+                "embedding.failed",
+                {"error": error_msg},
+                replyTo=reply_to,
+                correlationId=task.get("id"),
+            )
+        return
+
+    try:
+        embeddings = _embed(items, driver_name, function_name)
+    except Exception as exc:  # pylint: disable=broad-except
+        logger.exception("embedding failed: %s", exc)
+        if reply_to:
+            await client.publish(
+                "embedding.failed",
+                {"error": str(exc)},
+                replyTo=reply_to,
+                correlationId=task.get("id"),
+            )
+        return
+
+    logger.info("driver=%s function=%s reply=%s", driver_name, function_name, reply_to)
     if reply_to:
         await client.publish(
             "embedding.result",

--- a/services/py/embedding_service/tests/test_service.py
+++ b/services/py/embedding_service/tests/test_service.py
@@ -6,6 +6,8 @@ BASE_DIR = Path(__file__).resolve()
 sys.path.insert(0, str(BASE_DIR.parents[2]))
 sys.path.insert(0, str(BASE_DIR.parents[4]))
 
+import pytest
+
 from embedding_service.main import handle_task
 
 
@@ -35,3 +37,39 @@ def test_handle_task_publishes_embeddings():
     assert len(payload["embeddings"][0]) == 256
     assert opts["replyTo"] == "reply.queue"
     assert opts["correlationId"] == "1"
+
+
+def test_handle_task_missing_fields():
+    client = DummyClient()
+    task = {
+        "id": "2",
+        "payload": {"driver": "naive", "function": "simple", "replyTo": "r"},
+    }
+    asyncio.run(handle_task(task, client))
+    assert client.published
+    evt_type, payload, opts = client.published[0]
+    assert evt_type == "embedding.failed"
+    assert "items" in payload["error"]
+
+
+def test_handle_task_embed_failure(monkeypatch):
+    client = DummyClient()
+    task = {
+        "id": "3",
+        "payload": {
+            "items": [{"type": "text", "data": "hi"}],
+            "driver": "naive",
+            "function": "simple",
+            "replyTo": "reply.queue",
+        },
+    }
+
+    def boom(*args, **kwargs):  # noqa: D401,ANN001,ARG001
+        raise ValueError("boom")
+
+    monkeypatch.setattr("embedding_service.main._embed", boom)
+    asyncio.run(handle_task(task, client))
+    assert client.published
+    evt_type, payload, _ = client.published[0]
+    assert evt_type == "embedding.failed"
+    assert payload["error"] == "boom"


### PR DESCRIPTION
## Summary
- replace prints with structured logging and fix typo
- validate required payload fields and handle embedding failures gracefully
- add tests for missing fields and embed errors

## Testing
- `python3 -m pytest tests/test_service.py -q`
- `flake8 .`
- `black main.py tests/test_service.py`


------
https://chatgpt.com/codex/tasks/task_e_68ad122d0ac48324bc777dfa17dd8729