### PR TITLE
refactor service doc generator

### DIFF
--- a/scripts/generate-service-docs.js
+++ b/scripts/generate-service-docs.js
@@ -1,76 +1,110 @@
-import { promises as fs } from "fs";
-import path from "path";
+import { promises as fs } from 'fs';
+import path from 'path';
 
+/**
+ * Convert a hyphenated service name into title case.
+ * @param {string} name Service identifier like "discord-indexer".
+ * @returns {string} Title-cased name such as "Discord Indexer".
+ */
 function titleize(name) {
-  return name
-    .split("-")
-    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
-    .join(" ");
+    return name
+        .split('-')
+        .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+        .join(' ');
 }
 
+/**
+ * Build a space-separated list of tags for service implementations.
+ * @param {{lang: string}[]} impls Implementations across languages.
+ * @returns {string} Example: "#service #js #py".
+ */
+function buildTags(impls) {
+    return ['#service', ...new Set(impls.map((i) => `#${i.lang}`))].join(' ');
+}
+
+/**
+ * Generate stub AGENTS.md files for each discovered service.
+ * @returns {Promise<void>} Resolves when files are written.
+ */
 async function main() {
-  const servicesRoot = path.join(process.cwd(), "services");
-  const docsRoot = path.join(process.cwd(), "docs", "services");
+    const servicesRoot = path.join(process.cwd(), 'services');
+    const docsRoot = path.join(process.cwd(), 'docs', 'services');
 
-  const entries = await fs.readdir(servicesRoot, { withFileTypes: true });
-  const exclude = new Set(["shared", "templates"]);
-  const serviceMap = new Map();
+    const entries = await fs.readdir(servicesRoot, { withFileTypes: true });
+    const exclude = new Set(['shared', 'templates']);
+    const serviceMap = new Map();
 
-  for (const langEntry of entries) {
-    if (!langEntry.isDirectory()) continue;
-    const lang = langEntry.name;
-    if (exclude.has(lang)) continue;
-    const langDir = path.join(servicesRoot, lang);
-    const services = await fs.readdir(langDir, { withFileTypes: true });
-    for (const svc of services) {
-      if (!svc.isDirectory()) continue;
-      const svcName = svc.name;
-      const key = svcName.replace(/_/g, "-");
-      const implPath = path.join("services", lang, svcName);
-      if (!serviceMap.has(key)) serviceMap.set(key, []);
-      serviceMap.get(key).push({ lang, implPath });
-    }
-  }
-
-  await fs.mkdir(docsRoot, { recursive: true });
-
-  for (const [service, impls] of serviceMap.entries()) {
-    const docDir = path.join(docsRoot, service);
-    await fs.mkdir(docDir, { recursive: true });
-    const agentFile = path.join(docDir, "AGENTS.md");
-    try {
-      await fs.access(agentFile);
-      continue; // Skip if already exists
-    } catch {
-      // File doesn't exist; create stub
+    for (const langEntry of entries) {
+        if (!langEntry.isDirectory()) continue;
+        const lang = langEntry.name;
+        if (exclude.has(lang)) continue;
+        const langDir = path.join(servicesRoot, lang);
+        const services = await fs.readdir(langDir, { withFileTypes: true });
+        for (const svc of services) {
+            if (!svc.isDirectory()) continue;
+            const svcName = svc.name;
+            const key = svcName.replace(/_/g, '-');
+            const implPath = path.join('services', lang, svcName);
+            if (!serviceMap.has(key)) serviceMap.set(key, []);
+            serviceMap.get(key).push({ lang, implPath });
+        }
     }
 
-    const tags = ["#service", ...new Set(impls.map((i) => `#${i.lang}`))].join(
-      " ",
-    );
-    const lines = [];
-    lines.push(`# ${titleize(service)} Service`);
-    lines.push("");
-    lines.push("## Overview");
-    lines.push("");
-    lines.push("TODO: Add service description.");
-    lines.push("");
-    lines.push("## Paths");
-    lines.push("");
-    for (const impl of impls) {
-      lines.push(`- [${impl.implPath}](../../../${impl.implPath})`);
-    }
-    lines.push("");
-    lines.push("## Tags");
-    lines.push("");
-    lines.push(tags);
-    lines.push("");
+    await fs.mkdir(docsRoot, { recursive: true });
 
-    await fs.writeFile(agentFile, lines.join("\n"));
-  }
+    for (const [service, impls] of serviceMap.entries()) {
+        const docDir = path.join(docsRoot, service);
+        await fs.mkdir(docDir, { recursive: true });
+        const agentFile = path.join(docDir, 'AGENTS.md');
+        try {
+            await fs.access(agentFile);
+            continue; // Skip if already exists
+        } catch {
+            // File doesn't exist; create stub
+        }
+
+        const content = `
+# ${titleize(service)} Service
+
+## Overview
+
+TODO: Add service description.
+
+## Paths
+
+${impls.map((impl) => `- [${impl.implPath}](../../../${impl.implPath})`).join('\n')}
+
+## Tags
+
+${buildTags(impls)}
+`
+            .trim()
+            .replace(/^ +/gm, '');
+
+        await fs.writeFile(agentFile, `${content}\n`);
+    }
 }
+
+/*
+Example output for a service with JS and Python implementations:
+
+# Stt Service
+
+## Overview
+
+TODO: Add service description.
+
+## Paths
+
+- [services/js/stt](../../../services/js/stt)
+- [services/py/stt](../../../services/py/stt)
+
+## Tags
+
+#service #js #py
+*/
 
 main().catch((err) => {
-  console.error(err);
-  process.exit(1);
+    console.error(err);
+    process.exit(1);
 });


### PR DESCRIPTION
## Summary
- simplify service doc generation using template strings and extracted tag helper
- document workflow and helper functions
- include example output for generated service docs

## Testing
- `pnpm exec eslint scripts/generate-service-docs.js` (fails: A config object is using the "extends" key, which is not supported in flat config system.)
- `pnpm dlx prettier scripts/generate-service-docs.js --write`
- `pnpm test`
- `pnpm run build:docs`


------
https://chatgpt.com/codex/tasks/task_e_68ad123136a8832498dfc3bc96f3e352