### PR TITLE
Use logger and refine broker_client error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,8 +41,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Kanban processor now persists via shared DualStore and ContextStore.
 - Markdown Graph service now uses shared DualStore and ContextStore for persistence.
 - MCP server now creates a dedicated bridge connection per session and exposes tool schemas via `inputSchema`.
-
 - Proxy service now serves frontend files directly, removing the need for a separate static server.
+- Broker client now uses structured logging and narrower exception handling.
 
 ### Fixed
 


### PR DESCRIPTION
## Summary
- add module-level logger for `BrokerClient`
- replace `print` calls with structured logging and narrow exception handling
- document `_listen` responsibilities

## Testing
- `make format-python`
- `flake8 shared/py/broker_client.py`
- `make build-python`
- `PYTHONPATH=. pytest shared/py/tests/test_service_template.py`


------
https://chatgpt.com/codex/tasks/task_e_68ad122514288324be582db4e8dc2e2f