### PR TITLE
package shared modules and centralize test path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - OpenAPI spec for `/v1` served at `/v1/openapi.json` with consolidated operations.
 - `distclean` target to remove ignored files via `git clean -fdX`.
 - MCP server and stdio wrapper exposing `search.query` over WebSocket and CLI.
+- Packaging for `shared` modules to enable standard imports.
+- Central `tests/conftest.py` to configure the test environment.
 - Smoke test script for MCP server and basic stdio wrapper test harness.
 - Frontend visualization for the markdown link graph using ForceGraph.
 - Simple web chat interface for the LLM service with HTTP and WebSocket endpoints.
@@ -56,6 +58,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Removed
 
 - Deprecated `scripts/serve-sites.js` static file server.
+- Per-file `sys.path.append` hacks in tests in favor of centralized setup.
 
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,14 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "promethean"
+version = "0.0.1"
+description = "Promethean shared modules"
+readme = "readme.md"
+authors = [{name="Promethean"}]
+requires-python = ">=3.8"
+
+[tool.setuptools.packages.find]
+include = ["shared*"]

--- a/services/hy/stt/tests/stt_unit_test.py
+++ b/services/hy/stt/tests/stt_unit_test.py
@@ -6,8 +6,6 @@ from unittest.mock import patch
 
 # Ensure service directory is importable
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-# Ensure shared modules are importable
-sys.path.append("../../../")
 
 
 @pytest.fixture(autouse=True)

--- a/services/py/stt/service.py
+++ b/services/py/stt/service.py
@@ -1,7 +1,4 @@
 import sys
-
-sys.path.append("../../../")
-
 import asyncio
 import base64
 

--- a/services/py/stt/tests/test_wisper_stt_config.py
+++ b/services/py/stt/tests/test_wisper_stt_config.py
@@ -1,10 +1,6 @@
 import importlib
 import sys
 import types
-from pathlib import Path
-
-# Ensure repository root is on sys.path so ``shared`` modules are importable
-sys.path.append(str(Path(__file__).resolve().parents[4]))
 
 
 def test_generation_config(monkeypatch):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,8 @@
+"""Test configuration for shared modules."""
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/e2e/test_discord_dialog.py
+++ b/tests/e2e/test_discord_dialog.py
@@ -19,8 +19,6 @@ pytest.skip(
     allow_module_level=True,
 )
 
-sys.path.append(os.path.join(os.path.dirname(__file__), "..", ".."))
-
 
 async def start_server(app, port):
     config = uvicorn.Config(app, host="127.0.0.1", port=port, log_level="warning")

--- a/tests/integration/test_markdown_graph_embedding.py
+++ b/tests/integration/test_markdown_graph_embedding.py
@@ -1,13 +1,10 @@
 import os
-import sys
 import types
 
 import httpx
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
-
-sys.path.append(os.path.join(os.path.dirname(__file__), "..", ".."))
 
 
 markdown_graph = pytest.importorskip(

--- a/tests/integration/test_markdown_graph_embeddings.py
+++ b/tests/integration/test_markdown_graph_embeddings.py
@@ -5,8 +5,6 @@ import asyncio
 import httpx
 from fastapi.testclient import TestClient
 
-sys.path.append(os.path.join(os.path.dirname(__file__), "..", ".."))
-
 graph_module = importlib.import_module("services.py.markdown_graph.graph")
 sys.modules["graph"] = graph_module
 from services.py.markdown_graph.main import create_app

--- a/tests/integration/test_stt_llm_tts.py
+++ b/tests/integration/test_stt_llm_tts.py
@@ -7,8 +7,6 @@ import numpy as np
 import pytest
 from fastapi.testclient import TestClient
 
-sys.path.append(os.path.join(os.path.dirname(__file__), "..", ".."))
-
 
 def fake_llm(text: str) -> str:
     return f"LLM:{text}"

--- a/tests/scripts/test_agile_statuses.py
+++ b/tests/scripts/test_agile_statuses.py
@@ -1,8 +1,4 @@
-from pathlib import Path
-import sys
-
-sys.path.append(str(Path(__file__).resolve().parent))
-from utils import load_script_module
+from tests.scripts.utils import load_script_module
 
 agile = load_script_module("agile_statuses")
 

--- a/tests/scripts/test_convert_wikilinks.py
+++ b/tests/scripts/test_convert_wikilinks.py
@@ -1,8 +1,4 @@
-from pathlib import Path
-import sys
-
-sys.path.append(str(Path(__file__).resolve().parent))
-from utils import load_script_module
+from tests.scripts.utils import load_script_module
 
 cw = load_script_module("convert_wikilinks")
 

--- a/tests/scripts/test_hashtags_to_kanban.py
+++ b/tests/scripts/test_hashtags_to_kanban.py
@@ -1,8 +1,4 @@
-from pathlib import Path
-import sys
-
-sys.path.append(str(Path(__file__).resolve().parent))
-from utils import load_script_module
+from tests.scripts.utils import load_script_module
 
 hk = load_script_module("hashtags_to_kanban")
 

--- a/tests/scripts/test_index_project_files.py
+++ b/tests/scripts/test_index_project_files.py
@@ -4,9 +4,6 @@ from pathlib import Path
 import sys
 import types
 
-# Ensure the repository root is on sys.path so "scripts" can be imported
-sys.path.append(str(Path(__file__).resolve().parents[2]))
-
 # Provide a lightweight stub for chromadb if it's not installed. This allows
 # the tests to run without pulling in heavy optional dependencies.
 try:  # pragma: no cover - exercised when chromadb is available

--- a/tests/scripts/test_kanban_to_hashtags.py
+++ b/tests/scripts/test_kanban_to_hashtags.py
@@ -1,8 +1,6 @@
 from pathlib import Path
-import sys
 
-sys.path.append(str(Path(__file__).resolve().parent))
-from utils import load_script_module
+from tests.scripts.utils import load_script_module
 
 kh = load_script_module("kanban_to_hashtags")
 

--- a/tests/scripts/test_lowercase_links.py
+++ b/tests/scripts/test_lowercase_links.py
@@ -1,8 +1,4 @@
-from pathlib import Path
-import sys
-
-sys.path.append(str(Path(__file__).resolve().parent))
-from utils import load_script_module
+from tests.scripts.utils import load_script_module
 
 ll = load_script_module("lowercase_links")
 

--- a/tests/scripts/test_simulate_ci.py
+++ b/tests/scripts/test_simulate_ci.py
@@ -1,8 +1,6 @@
 from pathlib import Path
-import sys
 
-sys.path.append(str(Path(__file__).resolve().parent))
-from utils import load_script_module
+from tests.scripts.utils import load_script_module
 
 sc = load_script_module("simulate_ci")
 

--- a/tests/test_permission_gate.py
+++ b/tests/test_permission_gate.py
@@ -1,15 +1,6 @@
-import os
-import sys
 import importlib
-import os
-import sys
-
-# Ensure repository root is on the path so `shared` can be imported
-sys.path.append(os.getcwd())
-
 import pytest
 
-sys.path.append(os.getcwd())
 permission_gate = importlib.import_module("shared.py.permission_gate")
 
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,9 +1,4 @@
-import os
-import sys
-
 import hy  # noqa: F401
-
-sys.path.append(os.getcwd())
 
 import util
 from unittest.mock import patch


### PR DESCRIPTION
## Summary
- package shared modules via pyproject.toml for standard imports
- add tests/conftest.py to configure import path
- drop ad-hoc sys.path tweaks across tests and stt service

## Testing
- `pip install -e .`
- `pytest tests/test_permission_gate.py tests/test_util.py`
- `flake8 tests/conftest.py tests/integration/test_markdown_graph_embeddings.py tests/integration/test_stt_llm_tts.py tests/integration/test_markdown_graph_embedding.py tests/e2e/test_discord_dialog.py tests/scripts/test_convert_wikilinks.py tests/scripts/test_lowercase_links.py tests/scripts/test_agile_statuses.py tests/scripts/test_hashtags_to_kanban.py tests/scripts/test_kanban_to_hashtags.py tests/scripts/test_simulate_ci.py tests/scripts/test_index_project_files.py tests/test_util.py tests/test_permission_gate.py services/py/stt/service.py services/py/stt/tests/test_wisper_stt_config.py services/hy/stt/tests/stt_unit_test.py`


------
https://chatgpt.com/codex/tasks/task_e_68ad12160c2483248bd000affe4eae20