### PR TITLE
test: cover gui parameter defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Proxy route `/bridge` through the shared proxy service for SmartGPT Bridge.
 - Tool calling support for Codex Context service.
 - Template for building Discord bots in TypeScript based on the Cephalon service.
+- Test for GUI parameter defaults in `init_parameters_interactive`.
 
 ### Changed
 

--- a/shared/py/tests/test_gui.py
+++ b/shared/py/tests/test_gui.py
@@ -1,0 +1,78 @@
+import os
+import sys
+import types
+
+# Ensure project root is on sys.path for module imports
+sys.path.insert(
+    0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../"))
+)
+
+from shared.py.utils.gui import init_parameters_interactive
+
+
+def test_init_parameters_interactive_defaults(monkeypatch):
+    created = []
+
+    class DummyWidget:
+        def __init__(self, *args, **kwargs):
+            created.append(type(self).__name__)
+
+        def pack(self, *args, **kwargs):
+            pass
+
+    class DummyTk(DummyWidget):
+        def title(self, *_):
+            pass
+
+        def geometry(self, *_):
+            pass
+
+        def destroy(self):
+            pass
+
+    class DummyLabelFrame(DummyWidget):
+        pass
+
+    class DummyRadiobutton(DummyWidget):
+        pass
+
+    class DummyScale(DummyWidget):
+        pass
+
+    class DummyButton(DummyWidget):
+        pass
+
+    class DummyVar:
+        def __init__(self, value=None):
+            self.value = value
+
+        def get(self):
+            return self.value
+
+    class DummyIntVar(DummyVar):
+        pass
+
+    class DummyDoubleVar(DummyVar):
+        pass
+
+    fake_tk = types.SimpleNamespace(
+        Tk=DummyTk,
+        LabelFrame=DummyLabelFrame,
+        Radiobutton=DummyRadiobutton,
+        IntVar=DummyIntVar,
+        DoubleVar=DummyDoubleVar,
+        Scale=DummyScale,
+        Button=DummyButton,
+        W="w",
+        HORIZONTAL="horizontal",
+        mainloop=lambda: None,
+    )
+
+    monkeypatch.setitem(sys.modules, "tkinter", fake_tk)
+
+    args = types.SimpleNamespace(alpha=1.0)
+    result = init_parameters_interactive(args)
+
+    assert result == {"gender": "Male", "style": 1.0, "speed": 1.0}
+    assert "DummyTk" in created
+    assert "DummyRadiobutton" in created


### PR DESCRIPTION
## Summary
- add unit test for init_parameters_interactive with tkinter monkeypatch
- document addition in changelog

## Testing
- `make format-python`
- `flake8 shared/py/tests/test_gui.py`
- `make build-python`
- `make test-shared-python` (fails: 9 errors during collection)
- `pytest shared/py/tests/test_gui.py`


------
https://chatgpt.com/codex/tasks/task_e_68ad1204f50c83248715b9330d63aa67