### PR TITLE
test: cover shared settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Proxy route `/bridge` through the shared proxy service for SmartGPT Bridge.
 - Tool calling support for Codex Context service.
 - Template for building Discord bots in TypeScript based on the Cephalon service.
+- Tests for `shared.py.settings` confirming environment defaults and overrides.
 
 ### Changed
 

--- a/shared/py/tests/test_settings.py
+++ b/shared/py/tests/test_settings.py
@@ -1,0 +1,38 @@
+import importlib
+
+
+def reload_settings():
+    """Import and reload the settings module to apply environment changes."""
+    import shared.py.settings as settings
+
+    return importlib.reload(settings)
+
+
+def test_defaults(monkeypatch):
+    """Defaults apply when environment variables are absent."""
+    monkeypatch.delenv("AGENT_NAME", raising=False)
+    monkeypatch.delenv("MIN_TEMP", raising=False)
+    monkeypatch.setenv("DISCORD_TOKEN", "token")
+    monkeypatch.setenv("DEFAULT_CHANNEL", "123")
+    monkeypatch.setenv("DEFAULT_CHANNEL_NAME", "general")
+
+    reloaded = reload_settings()
+
+    assert reloaded.AGENT_NAME == "duck"
+    assert reloaded.MIN_TEMP == 0.7
+    assert reloaded.DEFAULT_CHANNEL == "123"
+
+
+def test_overrides(monkeypatch):
+    """Environment variables override default settings."""
+    monkeypatch.setenv("AGENT_NAME", "eagle")
+    monkeypatch.setenv("MIN_TEMP", "0.5")
+    monkeypatch.setenv("DISCORD_TOKEN", "token")
+    monkeypatch.setenv("DEFAULT_CHANNEL", "456")
+    monkeypatch.setenv("DEFAULT_CHANNEL_NAME", "chat")
+
+    reloaded = reload_settings()
+
+    assert reloaded.AGENT_NAME == "eagle"
+    assert reloaded.MIN_TEMP == 0.5
+    assert reloaded.DEFAULT_CHANNEL == "456"


### PR DESCRIPTION
## Summary
- add tests for shared settings verifying defaults and environment overrides
- document settings tests in changelog

## Testing
- `make format-python`
- `make build-python`
- `make lint-python` *(fails: RecursionError in flake8's sympy plugin)*
- `make test-shared-python` *(fails: missing dependencies requests, websockets, inflect, numpy)*
- `flake8 shared/py/tests/test_settings.py`
- `pytest shared/py/tests/test_settings.py`


------
https://chatgpt.com/codex/tasks/task_e_68ad185b3db08324a7dd454ae81af7db