### PR TITLE
refactor: use DualStore in cephalon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Discord embedder migrated to shared DualStore and ContextStore for unified persistence.
 - Kanban processor now persists via shared DualStore and ContextStore.
 - Markdown Graph service now uses shared DualStore and ContextStore for persistence.
+- DualStoreManager introduces `insert` API (with `addEntry` alias); Cephalon uses DualStore and ContextStore directly.
 - MCP server now creates a dedicated bridge connection per session and exposes tool schemas via `inputSchema`.
 
 - Proxy service now serves frontend files directly, removing the need for a separate static server.

--- a/docs/agile/tasks/Agent Tasks Persistence Migration to DualStore.md
+++ b/docs/agile/tasks/Agent Tasks Persistence Migration to DualStore.md
@@ -37,9 +37,9 @@
 
 ### Cephalon
 
-* [ ] Replace all imports of `CollectionManager` with `DualStore`.
-* [ ] Replace `ContextManager` with `ContextStore` from shared.
-* [ ] Adjust methods:
+* [x] Replace all imports of `CollectionManager` with `DualStore`.
+* [x] Replace `ContextManager` with `ContextStore` from shared.
+* [x] Adjust methods:
 
   * `addEntry` → `insert`
   * `getMostRecent` → `getMostRecent`

--- a/docs/reports/persistence-migration-checklist.md
+++ b/docs/reports/persistence-migration-checklist.md
@@ -2,7 +2,7 @@
 
 Track services adopting the shared DualStore persistence layer.
 
-- [ ] Cephalon uses DualStore
+- [x] Cephalon uses DualStore
 - [ ] SmartGPT Bridge uses DualStore
 - [ ] Discord-embedder uses DualStore
 - [ ] Kanban Processor uses DualStore

--- a/docs/services/cephalon/AGENTS.md
+++ b/docs/services/cephalon/AGENTS.md
@@ -34,3 +34,7 @@ Use `@shared/js/brokerClient.js` (or `AgentBus` wrapping it) for all broker comm
 - `begin-recording speaker:@user` / `stop-recording speaker:@user`
 - `begin-transcribing speaker:@user [log:true|false]`
 - `set-capture-channel #channel` / `set-desktop-channel #channel`
+
+## Persistence
+
+Persistence is handled via shared module: @shared/ts/persistence/DualStore

--- a/services/ts/cephalon/src/actions/join-voice.scope.ts
+++ b/services/ts/cephalon/src/actions/join-voice.scope.ts
@@ -3,7 +3,7 @@ import type { Bot } from '../bot.js';
 import { VoiceSession } from '../voice-session.js';
 import { makeLogger, type Logger } from '../factories/logger.js';
 import { makePolicy, type PolicyChecker } from '../factories/policy.js';
-import { DualStoreManager as CollectionManager } from '@shared/ts/dist/persistence/dualStore.js';
+import { DualStoreManager } from '@shared/ts/dist/persistence/dualStore.js';
 import type { FinalTranscript } from '../transcriber.js';
 
 export type JoinVoiceScope = {
@@ -35,8 +35,8 @@ export function makeJoinAction(): JoinVoiceScope['join'] {
 
         bot.currentVoiceSession = new VoiceSession({ bot, guild, voiceChannelId });
         bot.currentVoiceSession.transcriber.on('transcriptEnd', async (transcript: FinalTranscript) => {
-            const transcripts = bot.context.getCollection('transcripts') as CollectionManager<'text', 'createdAt'>;
-            await transcripts.addEntry({
+            const transcripts = bot.context.getCollection('transcripts') as DualStoreManager<'text', 'createdAt'>;
+            await transcripts.insert({
                 text: transcript.transcript,
                 createdAt: transcript.startTime || Date.now(),
                 metadata: {

--- a/services/ts/cephalon/src/agent/index.ts
+++ b/services/ts/cephalon/src/agent/index.ts
@@ -15,7 +15,7 @@ import EventEmitter from 'events';
 import { DesktopCaptureManager, DesktopCaptureData } from '../desktop/desktopLoop.js';
 import { Bot } from '../bot.js';
 import { LLMService } from '../llm-service.js';
-import { ContextStore as ContextManager } from '@shared/ts/dist/persistence/contextStore.js';
+import { ContextStore } from '@shared/ts/dist/persistence/contextStore.js';
 import { AgentInnerState, AgentOptions, GenerateResponseOptions } from '../types.js';
 import { defaultPrompt, defaultState, generatePrompt } from '../prompts.js';
 import { sleep } from '../util.js';
@@ -78,7 +78,7 @@ export class AIAgent extends EventEmitter {
     audioPlayer: AudioPlayer;
     speechArbiter: SpeechArbiter;
     turnManager: TurnManager;
-    context: ContextManager;
+    context: ContextStore;
     llm: LLMService;
 
     // --- VAD smoothing / hysteresis ---
@@ -106,10 +106,6 @@ export class AIAgent extends EventEmitter {
         this.turnManager = new TurnManager();
         this.turnManager.on('turn', (id: number) => this.speechArbiter.setTurnId(id));
     }
-    get contextManager() {
-        return this.bot.context;
-    }
-
     speak = speakAction;
     storeAgentMessage = storeAgentMessageAction;
     generateVoiceResponse = generateVoiceResponseAction;

--- a/services/ts/cephalon/src/agent/innerState.ts
+++ b/services/ts/cephalon/src/agent/innerState.ts
@@ -4,7 +4,7 @@ try {
     ({ AGENT_NAME } = await import('@shared/js/env.js'));
 } catch {}
 import { choice } from '../util.js';
-import { DualStoreManager as CollectionManager } from '@shared/ts/dist/persistence/dualStore.js';
+import { DualStoreManager } from '@shared/ts/dist/persistence/dualStore.js';
 import { innerStateFormat } from '../prompts.js';
 import type { AgentInnerState } from '../types.js';
 import type { AIAgent } from './index.js';
@@ -49,9 +49,9 @@ export async function think(this: AIAgent): Promise<any> {
         ]),
     })) as string;
 
-    const thoughts = this.context.getCollection('agent_messages') as CollectionManager<'text', 'createdAt'>;
+    const thoughts = this.context.getCollection('agent_messages') as DualStoreManager<'text', 'createdAt'>;
 
-    await thoughts.addEntry({
+    await thoughts.insert({
         text: `You thought to yourself: ${newThought}`,
         createdAt: Date.now(),
         metadata: {

--- a/services/ts/cephalon/src/agent/speech.ts
+++ b/services/ts/cephalon/src/agent/speech.ts
@@ -3,7 +3,7 @@ try {
     ({ AGENT_NAME } = await import('../../../../../shared/js/env.js'));
 } catch {}
 import { splitSentances, seperateSpeechFromThought, classifyPause, estimatePauseDuration } from '../tokenizers.js';
-import { DualStoreManager as CollectionManager } from '@shared/ts/dist/persistence/dualStore.js';
+import { DualStoreManager } from '@shared/ts/dist/persistence/dualStore.js';
 import { sleep } from '../util.js';
 import type { AIAgent } from './index.js';
 import { createAudioResource, StreamType } from '@discordjs/voice';
@@ -43,8 +43,8 @@ export async function storeAgentMessage(
     startTime = Date.now(),
     endTime = Date.now(),
 ) {
-    const messages = this.contextManager.getCollection('agent_messages') as CollectionManager<'text', 'createdAt'>;
-    return messages.addEntry({
+    const messages = this.context.getCollection('agent_messages') as DualStoreManager<'text', 'createdAt'>;
+    return messages.insert({
         text,
         createdAt: Date.now(),
         metadata: {
@@ -79,7 +79,10 @@ export async function generateVoiceResponse(this: AIAgent) {
         const texts = seperateSpeechFromThought(content);
         const sentences: { type: string; text: string }[] = texts.flatMap(
             ({ text, type }: { text: string; type: string }) =>
-                splitSentances(text).map((sentance: string) => ({ text: sentance, type })),
+                splitSentances(text).map((sentance: string) => ({
+                    text: sentance,
+                    type,
+                })),
         );
         console.log({ sentences });
         const finishedSentences = [] as { type: string; text: string }[];

--- a/services/ts/cephalon/src/agent/voiceContent.ts
+++ b/services/ts/cephalon/src/agent/voiceContent.ts
@@ -1,4 +1,4 @@
-import { DualStoreManager as CollectionManager } from '@shared/ts/dist/persistence/dualStore.js';
+import { DualStoreManager } from '@shared/ts/dist/persistence/dualStore.js';
 import { formatMessage, GenericEntry } from '@shared/ts/dist/persistence/contextStore.js';
 import { generatePromptChoice, generateSpecialQuery } from '../util.js';
 import type { AIAgent } from './index.js';
@@ -26,7 +26,7 @@ ${text}
 export async function generateVoiceContentWithFormattedLatestmessage(this: AIAgent) {
     let content = '';
     let counter = 0;
-    const userCollection = this.contextManager.getCollection('transcripts') as CollectionManager<'text', 'createdAt'>;
+    const userCollection = this.context.getCollection('transcripts') as DualStoreManager<'text', 'createdAt'>;
     const latestUserMessage = (await userCollection.getMostRecent(1))[0] as GenericEntry;
     const context = (await this.context.compileContext([this.prompt], this.historyLimit)).filter(
         (m: { content: string }) => m.content !== latestUserMessage?.text,
@@ -65,7 +65,7 @@ export async function generateVoiceContentWithChoicePrompt(this: AIAgent) {
 export async function generateVoiceContentWithSpecialQuery(this: AIAgent) {
     let content = '';
     let counter = 0;
-    const userCollection = this.contextManager.getCollection('transcripts') as CollectionManager<'text', 'createdAt'>;
+    const userCollection = this.context.getCollection('transcripts') as DualStoreManager<'text', 'createdAt'>;
     const latestUserMessage = (await userCollection.getMostRecent(1))[0] as GenericEntry;
     const context = (await this.context.compileContext([this.prompt], this.historyLimit)).filter(
         (m: { content: string }) => m.content !== latestUserMessage?.text,

--- a/services/ts/cephalon/src/bot.ts
+++ b/services/ts/cephalon/src/bot.ts
@@ -9,7 +9,7 @@ import {
 } from 'discord.js';
 import { EventEmitter } from 'events';
 import { DESKTOP_CAPTURE_CHANNEL_ID } from '@shared/js/env.js';
-import { ContextStore as ContextManager } from '@shared/ts/dist/persistence/contextStore.js';
+import { ContextStore } from '@shared/ts/dist/persistence/contextStore.js';
 import { createAgentWorld } from '@shared/ts/dist/agent-ecs/world.js';
 import { enqueueUtterance } from '@shared/ts/dist/agent-ecs/helpers/enqueueUtterance.js';
 import { pushVisionFrame } from '@shared/ts/dist/agent-ecs/helpers/pushVision.js';
@@ -39,7 +39,7 @@ export class Bot extends EventEmitter {
     client: Client;
     token: string;
     applicationId: string;
-    context: ContextManager = new ContextManager();
+    context: ContextStore = new ContextStore();
     currentVoiceSession?: any;
     captureChannel?: discord.TextChannel;
     desktopChannel?: discord.TextChannel;

--- a/services/ts/cephalon/src/collections.ts
+++ b/services/ts/cephalon/src/collections.ts
@@ -1,10 +1,10 @@
-import { DualStoreManager as CollectionManager } from '@shared/ts/dist/persistence/dualStore.js';
+import { DualStoreManager } from '@shared/ts/dist/persistence/dualStore.js';
 import { AGENT_NAME } from '../../../../shared/js/env.js';
 
-export const discordMessages = await CollectionManager.create<'content', 'created_at'>(
+export const discordMessages = await DualStoreManager.create<'content', 'created_at'>(
     `${AGENT_NAME}_discord_messages`,
     'content',
     'created_at',
 );
-export const thoughts = await CollectionManager.create<'text', 'createdAt'>('thoughts', 'text', 'createdAt');
-export const transcripts = await CollectionManager.create<'text', 'createdAt'>('transcripts', 'text', 'createdAt');
+export const thoughts = await DualStoreManager.create<'text', 'createdAt'>('thoughts', 'text', 'createdAt');
+export const transcripts = await DualStoreManager.create<'text', 'createdAt'>('transcripts', 'text', 'createdAt');

--- a/services/ts/cephalon/src/tests/llm_forward.test.ts
+++ b/services/ts/cephalon/src/tests/llm_forward.test.ts
@@ -14,11 +14,11 @@ const { BrokerClient } = clientModule;
 
 const { AIAgent } = await import('../agent/index.js');
 const { LLMService } = await import('../llm-service.js');
-const { ContextStore: ContextManager } = await import('@shared/ts/dist/persistence/contextStore.js');
+const { ContextStore } = await import('@shared/ts/dist/persistence/contextStore.js');
 
 class StubBot extends EventEmitter {
     applicationId = 'app';
-    context = new ContextManager();
+    context = new ContextStore();
     currentVoiceSession = undefined;
 }
 
@@ -46,7 +46,7 @@ test('AIAgent forwards prompt to LLM service via broker', async (t) => {
     const llm = new LLMService({ brokerUrl: `ws://127.0.0.1:${port}` });
     const agent = new AIAgent({
         bot: new StubBot() as any,
-        context: new ContextManager(),
+        context: new ContextStore(),
         llm,
     });
 

--- a/services/ts/cephalon/src/tests/messageThrottler.test.ts
+++ b/services/ts/cephalon/src/tests/messageThrottler.test.ts
@@ -2,7 +2,7 @@ import test from 'ava';
 process.env.DISABLE_AUDIO = '1';
 import { AIAgent } from '../agent.js';
 import type { Bot } from '../bot.js';
-import type { ContextStore as ContextManager } from '@shared/ts/dist/persistence/contextStore.js';
+import type { ContextStore } from '@shared/ts/dist/persistence/contextStore.js';
 import { initMessageThrottler } from '../messageThrottler.js';
 import path from 'path';
 import { fileURLToPath } from 'url';
@@ -13,7 +13,7 @@ const brokerModule = await import(path.resolve(__dirname, '../../../../js/broker
 const { start: startBroker, stop: stopBroker } = brokerModule;
 
 test.skip('throttles tick interval based on messages', async (t) => {
-    const context = {} as unknown as ContextManager;
+    const context = {} as unknown as ContextStore;
     const bot = { context } as unknown as Bot;
     const agent = new AIAgent({ bot, context });
     const broker = await startBroker(0);

--- a/services/ts/cephalon/src/tests/tickrate.test.ts
+++ b/services/ts/cephalon/src/tests/tickrate.test.ts
@@ -2,10 +2,10 @@ import test from 'ava';
 process.env.DISABLE_AUDIO = '1';
 import { AIAgent } from '../agent.js';
 import type { Bot } from '../bot.js';
-import type { ContextStore as ContextManager } from '@shared/ts/dist/persistence/contextStore.js';
+import type { ContextStore } from '@shared/ts/dist/persistence/contextStore.js';
 
 test.skip('agent updates tick interval', (t) => {
-    const context = {} as unknown as ContextManager;
+    const context = {} as unknown as ContextStore;
     const bot = { context } as unknown as Bot;
     const agent = new AIAgent({ bot, context });
     t.is((agent as any).tickInterval, 100);

--- a/services/ts/cephalon/src/types.ts
+++ b/services/ts/cephalon/src/types.ts
@@ -1,6 +1,6 @@
 import { Message } from 'ollama';
 import { Bot } from './bot.js';
-import { ContextStore as ContextManager } from '@shared/ts/dist/persistence/contextStore.js';
+import { ContextStore } from '@shared/ts/dist/persistence/contextStore.js';
 import { LLMService } from './llm-service.js';
 
 export type FormatProperty = {
@@ -34,7 +34,7 @@ export interface AgentOptions {
     historyLimit?: number;
     prompt?: string;
     bot: Bot;
-    context: ContextManager;
+    context: ContextStore;
     llm?: LLMService;
 }
 

--- a/shared/ts/src/persistence/README.md
+++ b/shared/ts/src/persistence/README.md
@@ -10,7 +10,7 @@ This module centralizes MongoDB and ChromaDB persistence for Promethean services
 import { DualStoreManager } from '@shared/ts/persistence/dualStore.js';
 
 const store = await DualStoreManager.create('my_collection', 'text', 'createdAt');
-await store.addEntry({ text: 'hello', createdAt: Date.now(), metadata: { userName: 'Duck' } });
+await store.insert({ text: 'hello', createdAt: Date.now(), metadata: { userName: 'Duck' } });
 const recent = await store.getMostRecent(5);
 ```
 

--- a/shared/ts/src/persistence/dualStore.ts
+++ b/shared/ts/src/persistence/dualStore.ts
@@ -1,10 +1,10 @@
-import { Collection as ChromaCollection } from 'chromadb';
+import type { Collection as ChromaCollection } from 'chromadb';
 
 import { RemoteEmbeddingFunction } from '../embeddings/remote.js';
-import { Collection, OptionalUnlessRequiredId, WithId } from 'mongodb';
+import type { Collection, OptionalUnlessRequiredId, WithId } from 'mongodb';
 import { AGENT_NAME } from '@shared/js/env.js';
-import { randomUUID } from 'crypto';
-import { DualStoreEntry, AliasDoc } from './types.js';
+import { randomUUID } from 'node:crypto';
+import type { DualStoreEntry, AliasDoc } from './types.js';
 import { getChromaClient, getMongoClient } from './clients.js';
 
 export class DualStoreManager<TextKey extends string = 'text', TimeKey extends string = 'createdAt'> {
@@ -60,8 +60,7 @@ export class DualStoreManager<TextKey extends string = 'text', TimeKey extends s
         return new DualStoreManager(family, chromaCollection, mongoCollection, textKey, timeStampKey);
     }
 
-    // AddEntry method:
-    async addEntry(entry: DualStoreEntry<TextKey, TimeKey>) {
+    async insert(entry: DualStoreEntry<TextKey, TimeKey>) {
         const id = entry.id ?? randomUUID();
         entry.id = id;
 
@@ -86,6 +85,11 @@ export class DualStoreManager<TextKey extends string = 'text', TimeKey extends s
             [this.timeStampKey]: entry[this.timeStampKey],
             metadata: entry.metadata,
         } as OptionalUnlessRequiredId<DualStoreEntry<TextKey, TimeKey>>);
+    }
+
+    // TODO: remove in future – alias for backwards compatibility
+    async addEntry(entry: DualStoreEntry<TextKey, TimeKey>) {
+        return this.insert(entry);
     }
 
     async getMostRecent(


### PR DESCRIPTION
## Summary
- add insert() method to DualStoreManager with addEntry alias
- migrate Cephalon to DualStoreManager and ContextStore APIs
- document shared persistence usage and update migration checklist

## Testing
- `pnpm exec biome lint src/persistence/dualStore.ts` *(shared/ts)*
- `pnpm exec biome lint src/actions/join-voice.scope.ts src/actions/start-dialog.scope.ts src/agent/index.ts src/agent/innerState.ts src/agent/speech.ts src/agent/voiceContent.ts src/bot.ts src/collections.ts src/tests/llm_forward.test.ts src/tests/messageThrottler.test.ts src/tests/tickrate.test.ts src/types.ts` *(services/ts/cephalon)*
- `pnpm run build` *(shared/ts)*
- `pnpm run build` *(services/ts/cephalon)*
- `pnpm test` *(shared/ts, fail: 1 test failed)*
- `pnpm test` *(services/ts/cephalon)*

------
https://chatgpt.com/codex/tasks/task_e_68ad2478f9c88324973b86d6e4b0a830