### PR TITLE
test: enable system python testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - OpenAPI docs obey `OPENAPI_PUBLIC`, staying private when auth is enabled unless explicitly exposed.
 - Grep endpoint requires a regex pattern and returns validation errors for missing fields.
 - SSE agent log streaming cleans up listeners on disconnect to avoid leaks.
+- Python tests run without pipenv isolation.
+- Added missing `next_messages` helper for discord indexer tests.
 
 ### Removed
 

--- a/Makefile.hy
+++ b/Makefile.hy
@@ -241,13 +241,16 @@
 
 (defn-cmd test-python-service [service]
   (print (.format "Running tests for Python service: {}" service))
-  (sh "python -m pipenv run pytest tests/" :cwd (join "services/py" service) :shell True))
+  ;; run tests directly with the system Python environment
+  (sh "if [ -d tests ]; then python -m pytest tests/; else echo 'no tests'; fi" :cwd (join "services/py" service) :shell True))
 
 (defn-cmd test-python-services []
-  (run-dirs SERVICES_PY "echo 'Running tests in $PWD...' && python -m pipenv run pytest tests/" :shell True))
+  ;; execute each service's tests without relying on pipenv
+  (run-dirs SERVICES_PY "echo 'Running tests in $PWD...' && if [ -d tests ]; then python -m pytest tests/; else echo 'no tests'; fi" :shell True))
 
 (defn-cmd test-shared-python []
-  (sh "python -m pipenv run pytest tests/" :cwd "shared/py" :shell True))
+  ;; shared python tests use the same direct invocation
+  (sh "python -m pytest tests/" :cwd "shared/py" :shell True))
 
 (defn-cmd test-python []
   (test-python-services)

--- a/services/py/discord_indexer/main.py
+++ b/services/py/discord_indexer/main.py
@@ -88,6 +88,17 @@ async def index_channel(channel: discord.TextChannel) -> None:
     return print(f"Newest message: {newest_message}")
 
 
+async def next_messages(channel: discord.TextChannel) -> List[discord.Message]:
+    """Return messages after the stored cursor for a channel."""
+    doc = discord_channel_collection.find_one({"id": channel.id})
+    after = None
+    if doc:
+        cursor = doc.get("cursor")
+        if cursor is not None:
+            after = channel.get_partial_message(cursor)
+    return [m async for m in channel.history(limit=200, oldest_first=True, after=after)]
+
+
 @client.event
 async def on_ready():
     global _hb_started, _hb_ctx

--- a/services/py/embedding_service/main.py
+++ b/services/py/embedding_service/main.py
@@ -4,7 +4,7 @@ from functools import lru_cache
 from typing import List
 
 from shared.py.service_template import start_service
-from drivers import get_driver
+from .drivers import get_driver
 
 
 @lru_cache(maxsize=1)

--- a/services/py/stt/service.py
+++ b/services/py/stt/service.py
@@ -6,7 +6,6 @@ import asyncio
 import base64
 
 from shared.py.service_template import start_service
-from shared.py.speech.wisper_stt import transcribe_pcm
 
 
 async def process_task(client, task):
@@ -18,7 +17,9 @@ async def process_task(client, task):
         print("[stt] task missing 'pcm' field")
         return
     pcm_bytes = base64.b64decode(pcm_b64)
-    text = transcribe_pcm(bytearray(pcm_bytes), sample_rate)
+    from shared.py.speech import wisper_stt as _wisper
+
+    text = _wisper.transcribe_pcm(bytearray(pcm_bytes), sample_rate)
     await client.publish("stt.transcribed", {"text": text}, correlationId=task["id"])
 
 


### PR DESCRIPTION
## Summary
- run Python service tests without pipenv isolation
- add helper to fetch channel messages after stored cursor
- support relative driver imports in embedding service
- allow STT service monkeypatching by importing module inside function

## Testing
- `pnpm test`
- `make test-python`
- `make build`
- `make lint` *(fails: A config object is using the "extends" key)*
- `make format` *(fails: Invalid string length reading libtorch_cuda.so)*

------
https://chatgpt.com/codex/tasks/task_e_68ad25a32f8c8324a9a20ba254484652