### PR TITLE
docs: refine breakdown tasks

### DIFF
--- a/docs/agile/tasks/File explorer.md
+++ b/docs/agile/tasks/File explorer.md
@@ -1,21 +1,52 @@
-# Description
+## 🛠️ Description
 
+Provide a lightweight file explorer for navigating repository contents through the agent interface.
 
-## Requirements/Definition of done
+---
 
-- If it doesn't have this, we can't accept it
+## 🎯 Goals
 
-## Tasks 
+- Browse directories and open file previews.
+- Search for files by name within allowed scope.
 
-- [ ] Step 1
-- [ ] Step 2
-- [ ] Step 3
-- [ ] Step 4
+---
 
-## Relevent resources
+## 📦 Requirements
 
-You might find [this] useful while working on this task
+- [ ] Read-only navigation respecting permission rules.
+- [ ] Search functionality with fuzzy matching.
+- [ ] Clear error messages for restricted paths.
 
-## Comments
+---
 
-Useful for agents to engage in append only conversations about this task.
+## 📋 Subtasks
+
+- [ ] Outline UX and permission constraints.
+- [ ] Implement backend API for listing and reading files.
+- [ ] Add UI component or chat command for navigation.
+- [ ] Include tests covering permission and search cases.
+- [ ] Document usage with examples.
+
+---
+
+## 🔗 Related Epics
+
+#framework-core
+
+---
+
+## ⛓️ Blocked By
+
+Nothing
+
+## ⛓️ Blocks
+
+Nothing
+
+---
+
+## 🔍 Relevant Links
+
+- [kanban](../boards/kanban.md)
+
+#accepted

--- a/docs/agile/tasks/Set up proper openai custom gpt compatable oauth login flow.md
+++ b/docs/agile/tasks/Set up proper openai custom gpt compatable oauth login flow.md
@@ -1,23 +1,53 @@
-# Description
+## 🛠️ Description
 
-We want to have a full oauth login flow with redirect urls and the whole 9 so we can get the best possible security when using the custom gpts
+Implement a secure OAuth flow for OpenAI custom GPT integrations, including redirect handling and token management.
 
+---
 
-## Requirements/Definition of done
+## 🎯 Goals
 
-- If it doesn't have this, we can't accept it
+- Allow users to authenticate with OpenAI via OAuth.
+- Ensure minimal scopes and safe token storage.
 
-## Tasks 
+---
 
-- [ ] Step 1
-- [ ] Step 2
-- [ ] Step 3
-- [ ] Step 4
+## 📦 Requirements
 
-## Relevent resources
+- [ ] OAuth client with configurable redirect URI.
+- [ ] Use PKCE or similar protection.
+- [ ] Persist and refresh tokens securely.
+- [ ] Document setup and environment variables.
 
-You might find [this] useful while working on this task
+---
 
-## Comments
+## 📋 Subtasks
 
-Useful for agents to engage in append only conversations about this task.
+- [ ] Research OpenAI OAuth endpoints and required scopes.
+- [ ] Implement authorization request and callback handler.
+- [ ] Store tokens in vault or encrypted config.
+- [ ] Validate flow end-to-end with a demo client.
+- [ ] Write README instructions for configuring the flow.
+
+---
+
+## 🔗 Related Epics
+
+#framework-core
+
+---
+
+## ⛓️ Blocked By
+
+Nothing
+
+## ⛓️ Blocks
+
+Nothing
+
+---
+
+## 🔍 Relevant Links
+
+- [kanban](../boards/kanban.md)
+
+#accepted

--- a/docs/agile/tasks/add_twitch_chat_integration_md_md.md
+++ b/docs/agile/tasks/add_twitch_chat_integration_md_md.md
@@ -1,24 +1,31 @@
 ## 🛠️ Description
 
-Placeholder task stub generated from kanban board.
+Integrate Twitch chat so agents can read and respond to messages during live streams.
 
 ---
 
 ## 🎯 Goals
 
-- What are we trying to accomplish?
+- Mirror Twitch channel messages into the system.
+- Allow agents to post replies or trigger actions from chat.
 
 ---
 
 ## 📦 Requirements
 
-- [ ] Detail requirements.
+- [ ] Connect using Twitch IRC or EventSub with OAuth.
+- [ ] Respect Twitch rate limits and moderation settings.
+- [ ] Map chat messages to internal event format.
 
 ---
 
 ## 📋 Subtasks
 
-- [ ] Outline steps to implement.
+- [ ] Register a Twitch application and obtain credentials.
+- [ ] Implement connection handler for subscribing to chat events.
+- [ ] Translate chat messages into broker events.
+- [ ] Enable optional agent responses back to Twitch.
+- [ ] Add tests for message flow and rate limit handling.
 
 ---
 
@@ -41,4 +48,5 @@ Nothing
 ## 🔍 Relevant Links
 
 - [kanban](../boards/kanban.md)
+
 #accepted

--- a/docs/agile/tasks/breakdown Makefile.hy.md
+++ b/docs/agile/tasks/breakdown Makefile.hy.md
@@ -1,24 +1,52 @@
-# Description
+## 🛠️ Description
 
-Makefile.hy is kind of a disaster. We should move away from it, pull out all of it's existing behavior into ./dev/tools.py
+Analyze the existing `Makefile.hy` and break it into clearer, maintainable components.
 
-## Requirements/Definition of done
+---
 
-- All documentation is updated to reflect new build, test, formatting, and so on procedures
-- Make file is no more
-- All behavior previously excuted by Makefile and Makefil.hy are now modularized and accessable from `./dev/tools.hy`
+## 🎯 Goals
 
-## Tasks 
+- Understand responsibilities of each target in `Makefile.hy`.
+- Propose a structure for modularization or documentation.
 
-- [ ] Step 1
-- [ ] Step 2
-- [ ] Step 3
-- [ ] Step 4
+---
 
-## Relevent resources
+## 📦 Requirements
 
-You might find [this] useful while working on this task
+- [ ] Inventory all current targets and dependencies.
+- [ ] Identify redundant or legacy code.
+- [ ] Provide recommendations for splitting or refactoring.
 
-## Comments
+---
 
-Useful for agents to engage in append only conversations about this task.
+## 📋 Subtasks
+
+- [ ] Read through `Makefile.hy` and annotate major sections.
+- [ ] Create a diagram or list of target dependencies.
+- [ ] Suggest modular layout or separate files per language.
+- [ ] Highlight areas needing tests or docs.
+- [ ] Compile findings into a summary document.
+
+---
+
+## 🔗 Related Epics
+
+#framework-core
+
+---
+
+## ⛓️ Blocked By
+
+Nothing
+
+## ⛓️ Blocks
+
+Nothing
+
+---
+
+## 🔍 Relevant Links
+
+- [kanban](../boards/kanban.md)
+
+#accepted

--- a/docs/agile/tasks/full_agent_mode_text_chat_selectively_join_channels_etc_md.md
+++ b/docs/agile/tasks/full_agent_mode_text_chat_selectively_join_channels_etc_md.md
@@ -1,26 +1,31 @@
 ## 🛠️ Description
 
-I want for discord agents to be able to join channels, leave channels, send messages (In channels and in DMs), etc all automaticly in a sort of "full  agent mode"
-
-I don't want him spamming messages or tts, I want him to be doing things in the background (curating context, guiding other simpler agent flows like the webcrawler )
+Enable "full agent mode" in Discord where agents can join or leave channels, send messages, and run tasks in the background without spamming users.
 
 ---
 
 ## 🎯 Goals
 
-- What are we trying to accomplish?
+- Allow agents to manage channel presence programmatically.
+- Keep interactions context-aware while minimizing noise.
 
 ---
 
 ## 📦 Requirements
 
-- [ ] Detail requirements.
+- [ ] Commands for join/leave/channel switch.
+- [ ] Rate limiting and anti-spam safeguards.
+- [ ] Background context curation and task orchestration.
 
 ---
 
 ## 📋 Subtasks
 
-- [ ] Outline steps to implement.
+- [ ] Define permissions and safety constraints for autonomous actions.
+- [ ] Implement Discord gateway handlers for channel management.
+- [ ] Add message queueing to prevent floods.
+- [ ] Provide hooks for launching auxiliary flows (e.g., webcrawler).
+- [ ] Test end-to-end with a mock guild.
 
 ---
 
@@ -43,4 +48,5 @@ Nothing
 ## 🔍 Relevant Links
 
 - [kanban](../boards/kanban.md)
+
 #accepted

--- a/docs/agile/tasks/gpt bridge fuzzy lookup should return multiple matches when it is used..md
+++ b/docs/agile/tasks/gpt bridge fuzzy lookup should return multiple matches when it is used..md
@@ -1,22 +1,53 @@
-# Description
+## 🛠️ Description
 
-Describe your task
+Update the GPT bridge fuzzy lookup so it returns multiple potential matches instead of only the first result.
 
-## Requirements/Definition of done
+---
 
-- If it doesn't have this, we can't accept it
+## 🎯 Goals
 
-## Tasks 
+- Provide a ranked list of candidates for fuzzy searches.
+- Allow users to select from the list when ambiguity exists.
 
-- [ ] Step 1
-- [ ] Step 2
-- [ ] Step 3
-- [ ] Step 4
+---
 
-## Relevent resources
+## 📦 Requirements
 
-You might find [this] useful while working on this task
+- [ ] Search endpoint returns top N matches with relevance scores.
+- [ ] Client can display and choose among suggestions.
+- [ ] Unit tests cover multi-match scenarios.
 
-## Comments
+---
 
-Useful for agents to engage in append only conversations about this task.
+## 📋 Subtasks
+
+- [ ] Audit current fuzzy lookup implementation.
+- [ ] Modify search logic to emit a list of matches.
+- [ ] Expose new response format through bridge API.
+- [ ] Add selection handling to consuming clients.
+- [ ] Write tests for ranking and selection.
+- [ ] Document the updated behaviour.
+
+---
+
+## 🔗 Related Epics
+
+#framework-core
+
+---
+
+## ⛓️ Blocked By
+
+Nothing
+
+## ⛓️ Blocks
+
+Nothing
+
+---
+
+## 🔍 Relevant Links
+
+- [kanban](../boards/kanban.md)
+
+#accepted

--- a/docs/agile/tasks/move discord scraper to ts.md
+++ b/docs/agile/tasks/move discord scraper to ts.md
@@ -1,22 +1,52 @@
-# Description
+## 🛠️ Description
 
-Describe your task
+Port the existing Discord scraper to TypeScript to align with the rest of the JS toolchain.
 
-## Requirements/Definition of done
+---
 
-- If it doesn't have this, we can't accept it
+## 🎯 Goals
 
-## Tasks 
+- Maintain current scraping capabilities in a TS implementation.
+- Simplify maintenance by using a single language stack.
 
-- [ ] Step 1
-- [ ] Step 2
-- [ ] Step 3
-- [ ] Step 4
+---
 
-## Relevent resources
+## 📦 Requirements
 
-You might find [this] useful while working on this task
+- [ ] Feature parity with current scraper.
+- [ ] Type-safe interfaces and error handling.
+- [ ] Automated tests verifying Discord interactions.
 
-## Comments
+---
 
-Useful for agents to engage in append only conversations about this task.
+## 📋 Subtasks
+
+- [ ] Review the current scraper and identify core features.
+- [ ] Scaffold a TypeScript project with required dependencies.
+- [ ] Re-implement scraping logic in TS.
+- [ ] Add unit tests for message and attachment collection.
+- [ ] Document how to run the new scraper and remove the old one.
+
+---
+
+## 🔗 Related Epics
+
+#framework-core
+
+---
+
+## ⛓️ Blocked By
+
+Nothing
+
+## ⛓️ Blocks
+
+Nothing
+
+---
+
+## 🔍 Relevant Links
+
+- [kanban](../boards/kanban.md)
+
+#accepted

--- a/docs/agile/tasks/setup new service generator.md
+++ b/docs/agile/tasks/setup new service generator.md
@@ -1,22 +1,52 @@
-# Description
+## 🛠️ Description
 
-Describe your task
+Create a generator that scaffolds new services with standard configuration, directory layout, and test stubs.
 
-## Requirements/Definition of done
+---
 
-- If it doesn't have this, we can't accept it
+## 🎯 Goals
 
-## Tasks 
+- Simplify adding services by automating boilerplate.
+- Ensure new services follow repository conventions.
 
-- [ ] Step 1
-- [ ] Step 2
-- [ ] Step 3
-- [ ] Step 4
+---
 
-## Relevent resources
+## 📦 Requirements
 
-You might find [this] useful while working on this task
+- [ ] CLI or Make target to generate a service skeleton.
+- [ ] Support Python, TypeScript, and Hy templates.
+- [ ] Include basic tests and README for the new service.
 
-## Comments
+---
 
-Useful for agents to engage in append only conversations about this task.
+## 📋 Subtasks
+
+- [ ] Identify common files needed for each service type.
+- [ ] Build template files and parameterize names.
+- [ ] Implement generator script and integrate with Makefile.
+- [ ] Add example usage and documentation.
+- [ ] Validate generator by creating a sample service.
+
+---
+
+## 🔗 Related Epics
+
+#framework-core
+
+---
+
+## ⛓️ Blocked By
+
+Nothing
+
+## ⛓️ Blocks
+
+Nothing
+
+---
+
+## 🔍 Relevant Links
+
+- [kanban](../boards/kanban.md)
+
+#accepted


### PR DESCRIPTION
## Summary
- flesh out tasks in kanban Breakdown column with clear goals, requirements, and subtasks
- add stubs for missing work like fuzzy lookup improvements, service generator, and Makefile.hy review
- expand existing placeholders for OAuth login flow, Twitch chat integration, and full agent mode

## Testing
- `make setup` *(fails: KeyboardInterrupt)*
- `make test` *(fails: KeyboardInterrupt)*
- `make build` *(fails: KeyboardInterrupt)*
- `make lint` *(fails: KeyboardInterrupt)*
- `make format`


------
https://chatgpt.com/codex/tasks/task_e_68add9d6f2108324a9ec9f118be1e41d