### PR TITLE
feat: support structured embedding items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Changed
 
 - Organized SmartGPT Bridge routes into versioned directories.
+- Embedding clients and related utilities now accept structured `{type, data}`
+  items instead of using the `img:` prefix.
 - Moved SmartGPT dashboard and LLM chat frontends into `sites/`.
 - Frontends now served from a central static file server instead of individual services.
 - Frontends communicate with backend services via the central proxy.

--- a/docs/dev/ts-remote-embedding.md
+++ b/docs/dev/ts-remote-embedding.md
@@ -9,17 +9,16 @@ Usage
 import { RemoteEmbeddingFunction } from '@shared/ts/dist/embeddings/remote.js';
 
 const embeddingFunction = RemoteEmbeddingFunction.fromConfig({
-  driver: process.env.EMBEDDING_DRIVER || 'ollama',
-  fn: process.env.EMBEDDING_FUNCTION || 'nomic-embed-text',
-  // optional:
-  brokerUrl: process.env.BROKER_URL,
-  clientIdPrefix: 'cephalon-embed',
+    driver: process.env.EMBEDDING_DRIVER || 'ollama',
+    fn: process.env.EMBEDDING_FUNCTION || 'nomic-embed-text',
+    // optional:
+    brokerUrl: process.env.BROKER_URL,
+    clientIdPrefix: 'cephalon-embed',
 });
 ```
 
 Notes
 
 - Replaces duplicated per-service implementations in Cephalon and Discord Embedder.
-- Accepts image URLs by prefixing texts with `img:` which map to `{ type: 'image_url', data }` items.
+- Items may be either strings (treated as `{ type: 'text', data }`) or explicit `{ type, data }` objects, e.g. `{ type: 'image_url', data: 'https://example.com' }`.
 - Default distance space: `l2` (also supports `cosine`).
-

--- a/services/ts/attachment-embedder/src/index.ts
+++ b/services/ts/attachment-embedder/src/index.ts
@@ -19,7 +19,9 @@ export async function embedAttachments(evt) {
     const embedder = makeDeterministicEmbedder({ modelId: model, dim });
     const results: string[] = [];
     for (const a of evt.attachments) {
-        const signal = a.content_type?.startsWith('image/') ? `img:${a.url}` : a.url;
+        const signal = a.content_type?.startsWith('image/')
+            ? { type: 'image_url', data: a.url }
+            : { type: 'text', data: a.url };
         const embedding = await embedder.embedOne(signal);
         const id = `${evt.provider}:${evt.tenant}:attachment:${a.urn}`;
         await chroma.upsert([

--- a/services/ts/smartgpt-bridge/tests/unit/remoteEmbedding.more.test.js
+++ b/services/ts/smartgpt-bridge/tests/unit/remoteEmbedding.more.test.js
@@ -8,7 +8,7 @@ test('RemoteEmbeddingFunction: image url item mapping', async (t) => {
         process.env.SHARED_IMPORT = 'file://' + abs;
         const { RemoteEmbeddingFunction } = await import('../../src/remoteEmbedding.ts');
         const ref = new RemoteEmbeddingFunction(undefined, 'driverX', 'fnY');
-        const out = await ref.generate(['img:https://example.com/i.png']);
+        const out = await ref.generate([{ type: 'image_url', data: 'https://example.com/i.png' }]);
         t.true(Array.isArray(out));
         t.is(out.length, 1);
         t.true(Array.isArray(out[0]));

--- a/shared/py/embedding_client.py
+++ b/shared/py/embedding_client.py
@@ -1,14 +1,24 @@
 from __future__ import annotations
 
 import os
-from typing import List
+from typing import Dict, List, Union
 
 import requests
 from chromadb.utils.embedding_functions import EmbeddingFunction
 
 
 class EmbeddingServiceClient(EmbeddingFunction):
-    """Chromadb embedding function that forwards to the embedding service."""
+    """Chromadb embedding function that forwards requests to the embedding service.
+
+    Items passed to this client may be either plain strings, which are treated as
+    text, or dictionaries containing explicit ``{"type", "data"}`` pairs. The
+    following formats are supported:
+
+    - ``"some text"`` → ``{"type": "text", "data": "some text"}``
+    - ``{"type": "image_url", "data": "https://example.com"}``
+
+    Additional item types may be forwarded to the service as-is.
+    """
 
     def __init__(
         self,
@@ -24,14 +34,15 @@ class EmbeddingServiceClient(EmbeddingFunction):
         self.driver = driver or os.environ.get("EMBEDDING_DRIVER")
         self.function = function or os.environ.get("EMBEDDING_FUNCTION")
 
-    def __call__(self, texts: List[str]) -> List[List[float]]:
+    def __call__(self, texts: List[Union[str, Dict[str, str]]]) -> List[List[float]]:
+        """Generate embeddings for the provided items.
+
+        Each item may be a plain string or a dictionary with ``{"type", "data"}``
+        keys. Plain strings are normalised to ``{"type": "text", "data": s}``.
+        """
+
         items = [
-            (
-                {"type": "image_url", "data": t[4:]}
-                if t.startswith("img:")
-                else {"type": "text", "data": t}
-            )
-            for t in texts
+            t if isinstance(t, dict) else {"type": "text", "data": t} for t in texts
         ]
         payload: dict = {"items": items}
         if self.driver:

--- a/shared/py/tests/test_embedding_client.py
+++ b/shared/py/tests/test_embedding_client.py
@@ -43,7 +43,7 @@ def test_embedding_client_builds_payload(monkeypatch):
         function="fn",
     )
 
-    result = client(["hello", "img:https://image"])
+    result = client(["hello", {"type": "image_url", "data": "https://image"}])
 
     assert captured["url"] == "http://test"
     assert captured["json"] == {

--- a/shared/ts/embedding.ts
+++ b/shared/ts/embedding.ts
@@ -1,50 +1,46 @@
-import type { EmbeddingFunction, EmbeddingFunctionSpace } from "chromadb";
+import type { EmbeddingFunction, EmbeddingFunctionSpace } from 'chromadb';
 
 export class RemoteEmbeddingFunction implements EmbeddingFunction {
-  name = "remote";
-  url: string;
-  driver: string | undefined;
-  fn: string | undefined;
+    name = 'remote';
+    url: string;
+    driver: string | undefined;
+    fn: string | undefined;
 
-  constructor(
-    url = process.env.EMBEDDING_SERVICE_URL || "http://localhost:8000/embed",
-    driver = process.env.EMBEDDING_DRIVER,
-    fn = process.env.EMBEDDING_FUNCTION,
-  ) {
-    this.url = url;
-    this.driver = driver;
-    this.fn = fn;
-  }
+    constructor(
+        url = process.env.EMBEDDING_SERVICE_URL || 'http://localhost:8000/embed',
+        driver = process.env.EMBEDDING_DRIVER,
+        fn = process.env.EMBEDDING_FUNCTION,
+    ) {
+        this.url = url;
+        this.driver = driver;
+        this.fn = fn;
+    }
 
-  async generate(texts: string[]): Promise<number[][]> {
-    const items = texts.map((t) =>
-      t.startsWith("img:")
-        ? { type: "image_url", data: t.slice(4) }
-        : { type: "text", data: t },
-    );
-    const body: any = { items };
-    if (this.driver) body.driver = this.driver;
-    if (this.fn) body.function = this.fn;
-    const fetchFn = (globalThis as any).fetch;
-    const res = await fetchFn(this.url, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(body),
-    });
-    const json = await res.json();
-    return json.embeddings;
-  }
+    async generate(texts: Array<string | { type: string; data: string }>): Promise<number[][]> {
+        const items = texts.map((t) => (typeof t === 'string' ? { type: 'text', data: t } : t));
+        const body: any = { items };
+        if (this.driver) body.driver = this.driver;
+        if (this.fn) body.function = this.fn;
+        const fetchFn = (globalThis as any).fetch;
+        const res = await fetchFn(this.url, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(body),
+        });
+        const json = await res.json();
+        return json.embeddings;
+    }
 
-  defaultSpace(): EmbeddingFunctionSpace {
-    return "l2";
-  }
-  supportedSpaces(): EmbeddingFunctionSpace[] {
-    return ["l2", "cosine"];
-  }
-  static buildFromConfig(): RemoteEmbeddingFunction {
-    return new RemoteEmbeddingFunction();
-  }
-  getConfig() {
-    return {};
-  }
+    defaultSpace(): EmbeddingFunctionSpace {
+        return 'l2';
+    }
+    supportedSpaces(): EmbeddingFunctionSpace[] {
+        return ['l2', 'cosine'];
+    }
+    static buildFromConfig(): RemoteEmbeddingFunction {
+        return new RemoteEmbeddingFunction();
+    }
+    getConfig() {
+        return {};
+    }
 }

--- a/shared/ts/src/embeddings/remote.ts
+++ b/shared/ts/src/embeddings/remote.ts
@@ -60,10 +60,8 @@ export class RemoteEmbeddingFunction implements EmbeddingFunction {
         return new RemoteEmbeddingFunction(cfg.brokerUrl, cfg.driver, cfg.fn, undefined, cfg.clientIdPrefix);
     }
 
-    async generate(texts: string[]): Promise<number[][]> {
-        const items = texts.map((t) =>
-            t.startsWith('img:') ? { type: 'image_url', data: t.slice(4) } : { type: 'text', data: t },
-        );
+    async generate(texts: Array<string | { type: string; data: string }>): Promise<number[][]> {
+        const items = texts.map((t) => (typeof t === 'string' ? { type: 'text', data: t } : t));
         await this.#ready;
         return new Promise((resolve) => {
             this.#pending.push(resolve);


### PR DESCRIPTION
## Summary
- allow embedding client to accept structured `{type, data}` items and normalize plain strings
- update TS embedding utilities and deterministic embedder for structured inputs
- replace legacy `img:` prefix usage in services with explicit item objects and document the new format

## Testing
- `pytest shared/py/tests/test_embedding_client.py`
- `npx ava services/ts/smartgpt-bridge/tests/unit/remoteEmbedding.more.test.js` *(fails: Unknown file extension ".ts" for remoteEmbedding.ts)*
- `pnpm exec eslint shared/ts/embedding.ts shared/ts/src/embeddings/remote.ts shared/ts/src/migrations/embedder.ts services/ts/attachment-embedder/src/index.ts services/ts/smartgpt-bridge/tests/unit/remoteEmbedding.more.test.js` *(fails: A config object is using the "extends" key, which is not supported in flat config system.)*
- `make build`


------
https://chatgpt.com/codex/tasks/task_e_68add13fb78083248dd63abd33c72a82