### PR TITLE
feat(site): add tool calls to llm chat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Smoke test script for MCP server and basic stdio wrapper test harness.
 - Frontend visualization for the markdown link graph using ForceGraph.
 - Simple web chat interface for the LLM service with HTTP and WebSocket endpoints.
+- Basic tool call support in the LLM chat frontend via SmartGPT Bridge.
+- Tests for tool call parsing and invocation in the LLM chat frontend.
 - File explorer UI for SmartGPT Bridge dashboard using file endpoints.
 - `sites/` directory consolidating all frontend code.
 - Proxy route `/bridge` through the shared proxy service for SmartGPT Bridge.

--- a/sites/README.md
+++ b/sites/README.md
@@ -5,7 +5,7 @@ This directory collects all frontend code for Promethean. Each subfolder contain
 Current frontends:
 
 - `smartgpt-dashboard` – OpenAPI-driven dashboard for SmartGPT Bridge.
-- `llm-chat` – Minimal chat interface for the LLM service.
+- `llm-chat` – Minimal chat interface for the LLM service with simple tool calls via SmartGPT Bridge.
 - `markdown-graph` – Force-directed visualization of markdown link graphs.
 
 Run `pnpm serve:sites` from the repo root and visit `http://localhost:4500/<site>/` to view a frontend. Future agents should place any web UI or dashboard code here.
@@ -14,4 +14,3 @@ All network requests from these frontends are routed through the proxy service a
 
 - LLM Chat calls `/llm/*` which the proxy forwards to the LLM service.
 - SmartGPT Dashboard calls `/bridge/*` which the proxy forwards to the SmartGPT Bridge service.
-

--- a/sites/llm-chat/index.html
+++ b/sites/llm-chat/index.html
@@ -6,6 +6,7 @@
     </head>
     <body>
         <div id="chat"></div>
+        <p>Tools: <code>codeSearch</code>, <code>semanticSearch</code></p>
         <form id="form">
             <input id="message" autocomplete="off" placeholder="Type your message..." />
             <button type="submit">Send</button>

--- a/sites/llm-chat/tools.js
+++ b/sites/llm-chat/tools.js
@@ -1,0 +1,23 @@
+export const tools = {
+    codeSearch: { method: 'POST', url: '/bridge/v1/search/code' },
+    semanticSearch: { method: 'POST', url: '/bridge/v1/search/semantic' },
+};
+
+export function parseToolCall(reply) {
+    try {
+        const j = JSON.parse(reply);
+        if (j.tool && j.args) return j;
+    } catch {}
+    return null;
+}
+
+export async function callTool(name, args) {
+    const spec = tools[name];
+    if (!spec) return { error: `Unknown tool ${name}` };
+    const res = await fetch(spec.url, {
+        method: spec.method,
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(args),
+    });
+    return await res.json();
+}

--- a/tests/llmChat.test.js
+++ b/tests/llmChat.test.js
@@ -1,0 +1,33 @@
+import test from 'ava';
+import { parseToolCall, callTool } from '../sites/llm-chat/tools.js';
+
+test('parseToolCall returns tool object for valid JSON', (t) => {
+    const tool = parseToolCall('{"tool":"codeSearch","args":{"q":"test"}}');
+    t.deepEqual(tool, { tool: 'codeSearch', args: { q: 'test' } });
+});
+
+test('parseToolCall returns null for invalid JSON', (t) => {
+    t.is(parseToolCall('not json'), null);
+    t.is(parseToolCall('{"tool":"x"}'), null);
+});
+
+test('callTool invokes fetch with correct spec', async (t) => {
+    const originalFetch = global.fetch;
+    let called = {};
+    global.fetch = async (url, options) => {
+        called = { url, options };
+        return { json: async () => ({ result: 1 }) };
+    };
+    const res = await callTool('codeSearch', { q: 'abc' });
+    t.deepEqual(res, { result: 1 });
+    t.is(called.url, '/bridge/v1/search/code');
+    t.is(called.options.method, 'POST');
+    t.is(called.options.headers['Content-Type'], 'application/json');
+    t.deepEqual(JSON.parse(called.options.body), { q: 'abc' });
+    global.fetch = originalFetch;
+});
+
+test('callTool returns error for unknown tool', async (t) => {
+    const res = await callTool('unknown', {});
+    t.deepEqual(res, { error: 'Unknown tool unknown' });
+});


### PR DESCRIPTION
## Summary
- add basic tool-call parsing to llm chat and forward to SmartGPT Bridge
- document tool availability and update sites overview
- note tool-call support in changelog
- extract tool-call helpers to module and add ava tests

## Testing
- `make format` *(aborted: repository-wide changes; formatted touched files with Prettier)*
- `make lint` *(fails: A config object is using the "extends" key, which is not supported in flat config system)*
- `make build` *(interrupted during execution)*
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68add9b89cac8324875c8f149435b2da