### PR TITLE
Use DualStore inserts in markdown-graph

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - STT and TTS services now use shared audio utilities for encoding and decoding.
 - Kanban processor now persists via shared DualStore and ContextStore.
 - Markdown Graph service now uses shared DualStore and ContextStore for persistence.
+- Markdown Graph service uses DualStore insert API instead of direct Mongo writes.
 - DualStoreManager introduces `insert` API (with `addEntry` alias); Cephalon uses DualStore and ContextStore directly.
 - MCP server now creates a dedicated bridge connection per session and exposes tool schemas via `inputSchema`.
 - Proxy service now serves frontend files directly, removing the need for a separate static server.

--- a/docs/agile/tasks/Agent Tasks Persistence Migration to DualStore.md
+++ b/docs/agile/tasks/Agent Tasks Persistence Migration to DualStore.md
@@ -63,7 +63,7 @@
 
 ### Markdown Graph
 
-* [ ] Replace raw `MongoClient` with `DualStore`.
+* [x] Replace raw `MongoClient` with `DualStore`.
 * [ ] Add optional embedding for graph queries if needed.
 
 ✅ Output: All services use `DualStore` instead of local clients.

--- a/docs/services/discord-embedder/AGENTS.md
+++ b/docs/services/discord-embedder/AGENTS.md
@@ -11,3 +11,7 @@ TODO: Add service description.
 ## Tags
 
 #service #ts
+
+## Persistence
+
+Persistence is handled via shared module: @shared/ts/persistence/DualStore

--- a/docs/services/kanban-processor/AGENTS.md
+++ b/docs/services/kanban-processor/AGENTS.md
@@ -11,3 +11,7 @@ Keeps the kanban board and task files in sync by reacting to file watcher events
 ## Tags
 
 #service #ts
+
+## Persistence
+
+Persistence is handled via shared module: @shared/ts/persistence/DualStore

--- a/docs/services/markdown-graph/AGENTS.md
+++ b/docs/services/markdown-graph/AGENTS.md
@@ -11,3 +11,7 @@ TODO: Add service description.
 ## Tags
 
 #service #ts
+
+## Persistence
+
+Persistence is handled via shared module: @shared/ts/persistence/DualStore

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
         "zod": "^3.25.76"
     },
     "devDependencies": {
+        "@biomejs/biome": "^2.2.2",
         "@types/jest": "^30.0.0",
         "@types/mongodb": "^4.0.6",
         "@typescript-eslint/eslint-plugin": "^8.39.0",

--- a/services/ts/markdown-graph/src/graph.ts
+++ b/services/ts/markdown-graph/src/graph.ts
@@ -59,24 +59,26 @@ export class GraphDB {
     async updateFile(filePath: string, content: string): Promise<void> {
         const rel = this.rel(filePath);
         await this.links.mongoCollection.deleteMany({ 'metadata.src': rel } as any);
-        await this.hashtags.mongoCollection.deleteMany({ 'metadata.path': rel } as any);
+        await this.hashtags.mongoCollection.deleteMany({
+            'metadata.path': rel,
+        } as any);
 
         const dir = path.dirname(rel);
         for (const link of this.parseLinks(content)) {
             const target = path.normalize(path.join(dir, link));
             const dst = this.rel(target);
-            await this.links.mongoCollection.insertOne({
+            await this.links.insert({
                 text: dst,
                 timestamp: Date.now(),
                 metadata: { src: rel, dst },
-            } as any);
+            });
         }
         for (const tag of this.parseTags(content)) {
-            await this.hashtags.mongoCollection.insertOne({
+            await this.hashtags.insert({
                 text: tag,
                 timestamp: Date.now(),
                 metadata: { path: rel, tag },
-            } as any);
+            });
         }
     }
 


### PR DESCRIPTION
## Summary
- insert markdown links and tags via DualStore API with timestamps
- document shared persistence usage for markdown-graph, discord-embedder, and kanban-processor services
- mark markdown-graph migration step complete

## Testing
- `pnpm run build` (markdown-graph)
- `pnpm test` (markdown-graph) *(fails: spawn chroma ENOENT)*
- `pnpm run lint` (markdown-graph) *(fails: formatting issues in existing files)*
- `make format-ts SERVICE=markdown-graph` *(fails: Command "@biomejs/biome" not found)*

------
https://chatgpt.com/codex/tasks/task_e_68add996f8448324a32db98999756095