### PR TITLE
refactor: flesh out kanban breakdown tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - v1 router exposing consolidated SmartGPT Bridge endpoints.
 - OpenAPI spec for `/v1` served at `/v1/openapi.json` with consolidated operations.
 - `distclean` target to remove ignored files via `git clean -fdX`.
+
+### Changed
+
+- Refined Kanban breakdown tasks with clear goals, requirements, and subtasks.
 - MCP server and stdio wrapper exposing `search.query` over WebSocket and CLI.
 - Packaging for `shared` modules to enable standard imports.
 - Central `tests/conftest.py` to configure the test environment.

--- a/docs/agile/tasks/LLM service must accept tool calls.md
+++ b/docs/agile/tasks/LLM service must accept tool calls.md
@@ -1,22 +1,53 @@
-# Description
+## 🛠️ Description
 
-Describe your task
+Extend the LLM service to support tool/function calls so agents can request structured actions.
 
-## Requirements/Definition of done
+---
 
-- If it doesn't have this, we can't accept it
+## 🎯 Goals
 
-## Tasks 
+- Allow clients to register callable tools with schema
+- Route tool invocation requests through broker to appropriate service
 
-- [ ] Step 1
-- [ ] Step 2
-- [ ] Step 3
-- [ ] Step 4
+---
 
-## Relevent resources
+## 📦 Requirements
 
-You might find [this] useful while working on this task
+- [ ] API accepts OpenAI-style tool definitions
+- [ ] Service returns tool call payloads when requested
+- [ ] Executed tool results fed back into conversation flow
+- [ ] Tests cover tool registration and invocation
 
-## Comments
+---
 
-Useful for agents to engage in append only conversations about this task.
+## 📋 Subtasks
+
+- [ ] Define tool-call schema in bridge and LLM service
+- [ ] Implement tool selection logic in LLM adapter
+- [ ] Integrate broker messaging for tool execution
+- [ ] Add end-to-end tests for sample tool
+
+---
+
+## 🔗 Related Epics
+
+#framework-core
+
+---
+
+## ⛓️ Blocked By
+
+Nothing
+
+## ⛓️ Blocks
+
+Nothing
+
+---
+
+## 🔍 Relevant Links
+
+- [kanban](../boards/kanban.md)
+
+#framework-core #accepted #breakdown
+

--- a/docs/agile/tasks/Phase out proxy in favor of bridge service.md
+++ b/docs/agile/tasks/Phase out proxy in favor of bridge service.md
@@ -1,30 +1,54 @@
-# Description
+## 🛠️ Description
 
-The bridge is the entry way into our system.
-it defines our outward facing API
+Retire the existing proxy layer and expose all external APIs through the broker-driven bridge service.
 
-[err-stealth-16-ai-studio-a1vgg.tailbe888a.ts.net/v1/openapi.json](https://err-stealth-16-ai-studio-a1vgg.tailbe888a.ts.net/v1/openapi.json)
+---
 
-## Requirements/Definition of done
+## 🎯 Goals
 
-- Frontends are exposed through the bridge
-- LLM is exposed through the bridge (by forwarding through the broker)
-	- This means the bridge must be OpenAI compliant
-- STT is exposed through the bridge
-- TTS is exposed through the bridge
-- Frontend access is policy controlled (no unauthorized access)
+- Consolidate public access points into the bridge
+- Ensure bridge speaks OpenAI-compatible API for LLM interactions
 
-## Tasks 
+---
 
-- [ ] Step 1
-- [ ] Step 2
-- [ ] Step 3
-- [ ] Step 4
+## 📦 Requirements
 
-## Relevent resources
+- [ ] Frontends route through bridge for API access
+- [ ] LLM requests forwarded through broker to backend models
+- [ ] STT and TTS endpoints available via bridge
+- [ ] Access controlled via policy rules
 
-You might find [this] useful while working on this task
+---
 
-## Comments
+## 📋 Subtasks
 
-Useful for agents to engage in append only conversations about this task.
+- [ ] Audit current proxy usage
+- [ ] Extend bridge with OpenAI-compatible endpoints
+- [ ] Migrate frontend/LLM/STT/TTS clients to bridge
+- [ ] Remove legacy proxy code
+
+---
+
+## 🔗 Related Epics
+
+#framework-core
+
+---
+
+## ⛓️ Blocked By
+
+Nothing
+
+## ⛓️ Blocks
+
+Nothing
+
+---
+
+## 🔍 Relevant Links
+
+- [API spec](https://err-stealth-16-ai-studio-a1vgg.tailbe888a.ts.net/v1/openapi.json)
+- [kanban](../boards/kanban.md)
+
+#framework-core #accepted #breakdown
+

--- a/docs/agile/tasks/audio processing service.md
+++ b/docs/agile/tasks/audio processing service.md
@@ -1,22 +1,52 @@
-# Description
+## 🛠️ Description
 
-Audio processing is not a stateful thing that needs to be bound up in the cephalon/duck/discord provider stuff
+Isolate audio manipulation (e.g., encoding, normalization, filtering) into a dedicated stateless service rather than embedding logic in agents or providers.
 
-## Requirements/Definition of done
+---
 
-- If it doesn't have this, we can't accept it
+## 🎯 Goals
 
-## Tasks 
+- Provide reusable audio processing pipeline for all agents
+- Simplify service composition by treating audio operations as standalone tasks
 
-- [ ] Step 1
-- [ ] Step 2
-- [ ] Step 3
-- [ ] Step 4
+---
 
-## Relevent resources
+## 📦 Requirements
 
-You might find [this] useful while working on this task
+- [ ] Service accepts raw/encoded audio and returns processed output
+- [ ] Exposes RPC or broker interface for other services
+- [ ] Includes tests covering common transforms
 
-## Comments
+---
 
-Useful for agents to engage in append only conversations about this task.
+## 📋 Subtasks
+
+- [ ] Design service API and message schema
+- [ ] Implement core transforms (normalize, denoise, resample)
+- [ ] Wire service into existing agent audio flow
+- [ ] Write unit tests and usage docs
+
+---
+
+## 🔗 Related Epics
+
+#framework-core
+
+---
+
+## ⛓️ Blocked By
+
+Nothing
+
+## ⛓️ Blocks
+
+Nothing
+
+---
+
+## 🔍 Relevant Links
+
+- [kanban](../boards/kanban.md)
+
+#framework-core #accepted #breakdown
+

--- a/docs/agile/tasks/clearly standardize data models.md
+++ b/docs/agile/tasks/clearly standardize data models.md
@@ -1,22 +1,52 @@
-# Description
+## 🛠️ Description
 
-We want data models like "User", "Policy", "File", "Directory" and so on to be shareable across services/packages etc
+Define shared data models (e.g., User, Policy, File, Directory) that can be imported across services and languages.
 
-## Requirements/Definition of done
+---
 
-- If it doesn't have this, we can't accept it
+## 🎯 Goals
 
-## Tasks 
+- Provide a single source of truth for core entities
+- Enable consistent serialization and validation
 
-- [ ] Step 1
-- [ ] Step 2
-- [ ] Step 3
-- [ ] Step 4
+---
 
-## Relevent resources
+## 📦 Requirements
 
-You might find [this] useful while working on this task
+- [ ] Canonical schemas published in a shared library
+- [ ] Language bindings for TypeScript and Python
+- [ ] Documentation for versioning and migration
 
-## Comments
+---
 
-Useful for agents to engage in append only conversations about this task.
+## 📋 Subtasks
+
+- [ ] Identify and document required entities
+- [ ] Design schema definitions (e.g., JSON Schema)
+- [ ] Implement library with generated types
+- [ ] Update services to consume shared models
+
+---
+
+## 🔗 Related Epics
+
+#framework-core
+
+---
+
+## ⛓️ Blocked By
+
+Nothing
+
+## ⛓️ Blocks
+
+Nothing
+
+---
+
+## 🔍 Relevant Links
+
+- [kanban](../boards/kanban.md)
+
+#framework-core #accepted #breakdown
+

--- a/docs/agile/tasks/convert current services to packages, then redefine the services using config files.md
+++ b/docs/agile/tasks/convert current services to packages, then redefine the services using config files.md
@@ -1,22 +1,52 @@
-# Description
+## 🛠️ Description
 
-Describe your task
+Transition existing services into reusable packages and instantiate concrete services via configuration files.
 
-## Requirements/Definition of done
+---
 
-- If it doesn't have this, we can't accept it
+## 🎯 Goals
 
-## Tasks 
+- Modularize service logic for reuse
+- Enable service composition through declarative configs
 
-- [ ] Step 1
-- [ ] Step 2
-- [ ] Step 3
-- [ ] Step 4
+---
 
-## Relevent resources
+## 📦 Requirements
 
-You might find [this] useful while working on this task
+- [ ] Extract core logic of each service into language-appropriate package
+- [ ] Provide config-driven bootstrap that loads desired modules
+- [ ] Document migration steps for existing services
 
-## Comments
+---
 
-Useful for agents to engage in append only conversations about this task.
+## 📋 Subtasks
+
+- [ ] Audit services and identify shared components
+- [ ] Publish packages for shared logic
+- [ ] Create template config for redefining services
+- [ ] Update build pipeline to consume packages
+
+---
+
+## 🔗 Related Epics
+
+#framework-core
+
+---
+
+## ⛓️ Blocked By
+
+Nothing
+
+## ⛓️ Blocks
+
+Nothing
+
+---
+
+## 🔍 Relevant Links
+
+- [kanban](../boards/kanban.md)
+
+#framework-core #accepted #breakdown
+

--- a/docs/agile/tasks/create a generic markdown helper module.md
+++ b/docs/agile/tasks/create a generic markdown helper module.md
@@ -1,22 +1,52 @@
-# Description
+## 🛠️ Description
 
-Describe your task
+Develop a shared module for reading, writing, and manipulating markdown files used across documentation scripts.
 
-## Requirements/Definition of done
+---
 
-- If it doesn't have this, we can't accept it
+## 🎯 Goals
 
-## Tasks 
+- Provide utilities for common markdown transformations
+- Reduce duplicated parsing logic in scripts
 
-- [ ] Step 1
-- [ ] Step 2
-- [ ] Step 3
-- [ ] Step 4
+---
 
-## Relevent resources
+## 📦 Requirements
 
-You might find [this] useful while working on this task
+- [ ] Module exposes parse and render helpers
+- [ ] Handles frontmatter, links, and task lists
+- [ ] Includes unit tests
 
-## Comments
+---
 
-Useful for agents to engage in append only conversations about this task.
+## 📋 Subtasks
+
+- [ ] Define helper API surface
+- [ ] Implement core parsing and formatting functions
+- [ ] Write tests covering typical file operations
+- [ ] Document usage in scripts README
+
+---
+
+## 🔗 Related Epics
+
+#framework-core
+
+---
+
+## ⛓️ Blocked By
+
+Nothing
+
+## ⛓️ Blocks
+
+Nothing
+
+---
+
+## 🔍 Relevant Links
+
+- [kanban](../boards/kanban.md)
+
+#framework-core #accepted #breakdown
+

--- a/docs/agile/tasks/dockerize the system.md
+++ b/docs/agile/tasks/dockerize the system.md
@@ -1,22 +1,52 @@
-# Description
+## 🛠️ Description
 
-We should have a dockerized environment for the tools to run in to make it easier to test and sanity check. Having docker images could make it easier to spin up for the codex online service once they add that feature in
+Provide Docker images and compose configuration so contributors can run the system and its services in containers for testing and deployment.
 
-## Requirements/Definition of done
+---
 
-- If it doesn't have this, we can't accept it
+## 🎯 Goals
 
-## Tasks 
+- Package core services into reproducible containers
+- Simplify local setup and pave way for hosted deployment
 
-- [ ] Step 1
-- [ ] Step 2
-- [ ] Step 3
-- [ ] Step 4
+---
 
-## Relevent resources
+## 📦 Requirements
 
-You might find [this] useful while working on this task
+- [ ] Dockerfiles for major services and dependencies
+- [ ] `docker-compose` (or similar) to orchestrate stack
+- [ ] Documentation for building and running images
 
-## Comments
+---
 
-Useful for agents to engage in append only conversations about this task.
+## 📋 Subtasks
+
+- [ ] Create base image with shared dependencies
+- [ ] Author service-specific Dockerfiles
+- [ ] Write compose file for local development
+- [ ] Test containerized workflow end-to-end
+
+---
+
+## 🔗 Related Epics
+
+#devops
+
+---
+
+## ⛓️ Blocked By
+
+Nothing
+
+## ⛓️ Blocks
+
+Nothing
+
+---
+
+## 🔍 Relevant Links
+
+- [kanban](../boards/kanban.md)
+
+#devops #accepted #breakdown
+

--- a/docs/agile/tasks/flatten services.md
+++ b/docs/agile/tasks/flatten services.md
@@ -1,22 +1,52 @@
-# Description
+## 🛠️ Description
 
-Describe your task
+Reorganize the repository so service directories are flattened, reducing unnecessary nesting and clarifying ownership.
 
-## Requirements/Definition of done
+---
 
-- If it doesn't have this, we can't accept it
+## 🎯 Goals
 
-## Tasks 
+- Simplify service discovery and navigation
+- Align service layout with package and deployment structure
 
-- [ ] Step 1
-- [ ] Step 2
-- [ ] Step 3
-- [ ] Step 4
+---
 
-## Relevent resources
+## 📦 Requirements
 
-You might find [this] useful while working on this task
+- [ ] Proposed flat structure documented
+- [ ] Imports and build scripts updated for new paths
+- [ ] Migration plan for moving existing code
 
-## Comments
+---
 
-Useful for agents to engage in append only conversations about this task.
+## 📋 Subtasks
+
+- [ ] Audit current service directory tree
+- [ ] Draft new flat layout with maintainers
+- [ ] Move or alias services accordingly
+- [ ] Update tooling references and docs
+
+---
+
+## 🔗 Related Epics
+
+#framework-core
+
+---
+
+## ⛓️ Blocked By
+
+Nothing
+
+## ⛓️ Blocks
+
+Nothing
+
+---
+
+## 🔍 Relevant Links
+
+- [kanban](../boards/kanban.md)
+
+#framework-core #accepted #breakdown
+

--- a/docs/agile/tasks/frontend build tool chain.md
+++ b/docs/agile/tasks/frontend build tool chain.md
@@ -1,24 +1,52 @@
-# Description
+## 🛠️ Description
 
-the frontend that lives in `./sites` should be able to import typescript files from shared. We need a frontend build pipeline
+Establish a repeatable build pipeline for the `sites/` frontend that shares TypeScript code with `shared/` and participates in CI.
 
-## Requirements/Definition of done
+---
 
-- A new module is created that encapsulates frontend dependencies, build, test, lint, etc pipelines.
-- There is a github action pipeline that runs this tool chain on the frontend as a part of prs
-- The frontend is included in the `make build`  command
+## 🎯 Goals
 
-## Tasks 
+- Bundle frontend assets with a modern toolchain
+- Integrate lint, test, and build steps into existing Makefile
 
-- [ ] Step 1
-- [ ] Step 2
-- [ ] Step 3
-- [ ] Step 4
+---
 
-## Relevent resources
+## 📦 Requirements
 
-You might find [this] useful while working on this task
+- [ ] Dedicated package manages frontend dependencies and scripts
+- [ ] GitHub Action runs lint/test/build for frontend on pull requests
+- [ ] `make build` triggers frontend build step
 
-## Comments
+---
 
-Useful for agents to engage in append only conversations about this task.
+## 📋 Subtasks
+
+- [ ] Scaffold frontend package (e.g., Vite or Next.js)
+- [ ] Wire shared TypeScript imports from `shared/`
+- [ ] Add lint and test tooling
+- [ ] Update Makefile and CI to invoke frontend pipeline
+
+---
+
+## 🔗 Related Epics
+
+#devops
+
+---
+
+## ⛓️ Blocked By
+
+Nothing
+
+## ⛓️ Blocks
+
+Nothing
+
+---
+
+## 🔍 Relevant Links
+
+- [kanban](../boards/kanban.md)
+
+#devops #accepted #breakdown
+

--- a/docs/agile/tasks/lisp package files.md
+++ b/docs/agile/tasks/lisp package files.md
@@ -1,22 +1,52 @@
-# Description
+## 🛠️ Description
 
-Describe your task
+Design a package file format for the Lisp components so modules can declare dependencies and be imported consistently.
 
-## Requirements/Definition of done
+---
 
-- If it doesn't have this, we can't accept it
+## 🎯 Goals
 
-## Tasks 
+- Enable reusable Lisp packages within the monorepo
+- Provide metadata for versioning and dependency resolution
 
-- [ ] Step 1
-- [ ] Step 2
-- [ ] Step 3
-- [ ] Step 4
+---
 
-## Relevent resources
+## 📦 Requirements
 
-You might find [this] useful while working on this task
+- [ ] Define package manifest schema
+- [ ] Loader resolves dependencies and loads modules
+- [ ] Unit tests verify package discovery and import
 
-## Comments
+---
 
-Useful for agents to engage in append only conversations about this task.
+## 📋 Subtasks
+
+- [ ] Draft manifest fields (name, version, deps)
+- [ ] Implement loader in Lisp compiler/runtime
+- [ ] Convert existing modules to new package format
+- [ ] Document package usage
+
+---
+
+## 🔗 Related Epics
+
+#framework-core
+
+---
+
+## ⛓️ Blocked By
+
+Nothing
+
+## ⛓️ Blocks
+
+Nothing
+
+---
+
+## 🔍 Relevant Links
+
+- [kanban](../boards/kanban.md)
+
+#framework-core #accepted #breakdown
+

--- a/docs/agile/tasks/redefine all existing lambdas with high order functions incoming.md
+++ b/docs/agile/tasks/redefine all existing lambdas with high order functions incoming.md
@@ -1,26 +1,29 @@
 ## 🛠️ Description
 
-Too many lambda functions used in a code base is a smelll. You're describing isolated reused logic without naming it, the deeper a closure tree goes the less clear what variables are coming from where. 
-
-The simplest way to fix this is to pull them all out, rename them Then  identify the variables it was using from it's surrounding scope. Then write a high order function that accepts those values, and return the function. And bam, and a monad was born.
+Replace ad‑hoc anonymous lambdas with well‑named higher‑order functions to clarify intent and improve reuse.
 
 ---
 
 ## 🎯 Goals
 
-- What are we trying to accomplish?
+- Reduce ambiguous inline lambdas throughout the codebase
+- Establish reusable helpers that capture shared closure logic
 
 ---
 
 ## 📦 Requirements
 
-- [ ] Detail requirements.
+- [ ] Each former lambda extracted into a named function or higher‑order wrapper
+- [ ] Added tests cover behavior of new helpers
 
 ---
 
 ## 📋 Subtasks
 
-- [ ] Outline steps to implement.
+- [ ] Audit modules for deeply nested lambdas
+- [ ] Refactor candidate lambdas into named functions
+- [ ] Create higher‑order utilities where closures are required
+- [ ] Update references and run tests
 
 ---
 
@@ -42,4 +45,7 @@ Nothing
 
 ## 🔍 Relevant Links
 
-- [[kanban.md]]
+- [kanban](../boards/kanban.md)
+
+#framework-core #accepted #breakdown
+

--- a/docs/agile/tasks/task generator system.md
+++ b/docs/agile/tasks/task generator system.md
@@ -1,22 +1,52 @@
-# Description
+## 🛠️ Description
 
-Describe your task
+Create a utility that scaffolds new task files from a template to keep the board organized and consistent.
 
-## Requirements/Definition of done
+---
 
-- If it doesn't have this, we can't accept it
+## 🎯 Goals
 
-## Tasks 
+- Automate task file creation with required metadata
+- Reduce manual effort when adding items to the board
 
-- [ ] Step 1
-- [ ] Step 2
-- [ ] Step 3
-- [ ] Step 4
+---
 
-## Relevent resources
+## 📦 Requirements
 
-You might find [this] useful while working on this task
+- [ ] Command-line script generates markdown from template
+- [ ] Ensures unique filenames and injects status hashtags
+- [ ] Includes minimal tests for generation logic
 
-## Comments
+---
 
-Useful for agents to engage in append only conversations about this task.
+## 📋 Subtasks
+
+- [ ] Define task template parameters
+- [ ] Implement generator script
+- [ ] Integrate with Makefile or npm script
+- [ ] Document usage in docs/agile/README
+
+---
+
+## 🔗 Related Epics
+
+#framework-core
+
+---
+
+## ⛓️ Blocked By
+
+Nothing
+
+## ⛓️ Blocks
+
+Nothing
+
+---
+
+## 🔍 Relevant Links
+
+- [kanban](../boards/kanban.md)
+
+#framework-core #accepted #breakdown
+


### PR DESCRIPTION
## Summary
- clarify Kanban breakdown tasks with descriptions, goals, requirements, and subtasks
- document Kanban refinements in changelog

## Testing
- `make format` *(fails: Unexpected token in shared/sibilant/src/node/kit-repl/index.js)*
- `make lint` *(fails: config uses unsupported "extends" in flat config system)*
- `make test` *(fails: KeyboardInterrupt while running JS tests)*
- `make build`


------
https://chatgpt.com/codex/tasks/task_e_68ae05e0fcbc83248a20040a1c75728e