### PR TITLE
feat: add broker heartbeats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - STT and embedding services updated to use `run_service`.
 - Unit tests for ForwardTacotronIE and WaveRNNIE helper functions.
 - Test for GUI parameter defaults in `init_parameters_interactive`.
+- Configurable heartbeat interval and automatic timer management in `BrokerClient`.
 - Tests for grammar correction in the shared speech spell checker.
 - Unit tests for Discord utility functions covering channel history and cursor management.
 - Tests for `shared.py.settings` confirming environment defaults and overrides.

--- a/readme.md
+++ b/readme.md
@@ -21,9 +21,13 @@ into small services that handle speech-to-text, text-to-speech, memory, and high
 📖 For a high-level overview, see [docs/vision.md](docs/vision.md).
 📊 For architecture roadmaps and visualizations, see [docs/architecture/index.md](docs/architecture/index.md).
 
+### Broker Heartbeat
+
+`BrokerClient` sends periodic heartbeats to keep connections alive. Configure the interval in milliseconds with the `BROKER_HEARTBEAT_MS` environment variable (default `30000`).
+
 ## 📊 Project Evolution Master Graph
 
-```mermaid
+````mermaid
 
 graph TD
 
@@ -79,8 +83,7 @@ gantt
 
     Ecosystem + Packages    :crit,    des11, 2025-09-05, 25d
 
-```
-
+````
 
 Activate the environment when developing or running Python services:
 

--- a/services/ts/cephalon/src/tests/transcriber.test.ts
+++ b/services/ts/cephalon/src/tests/transcriber.test.ts
@@ -6,7 +6,9 @@ import { Transcriber } from '../transcriber.js';
 class DummyBroker extends EventEmitter {
     socket: any = null;
     lastEnqueue: { queue: string; task: any } | null = null;
+    heartbeatInterval = 0;
     async connect() {}
+    disconnect() {}
     subscribe(_topic: string, handler: (event: any) => void) {
         this.on('event', handler);
     }

--- a/shared/js/brokerClient.d.ts
+++ b/shared/js/brokerClient.d.ts
@@ -1,15 +1,17 @@
-import type { WebSocket } from "ws";
+import type { WebSocket } from 'ws';
 
 export class BrokerClient {
-  socket: WebSocket | null;
-  constructor(options?: { url?: string; id?: string });
-  connect(): Promise<void>;
-  subscribe(topic: string, handler: (event: any) => void): void;
-  unsubscribe(topic: string): void;
-  publish(type: string, payload: any, opts?: any): void;
-  enqueue(queue: string, task: any): void;
-  ready(queue: string): void;
-  ack(taskId: string): void;
-  heartbeat(): void;
-  onTaskReceived(callback: (task: any) => void): void;
+    socket: WebSocket | null;
+    heartbeatInterval: number;
+    constructor(options?: { url?: string; id?: string; heartbeatInterval?: number });
+    connect(): Promise<void>;
+    disconnect(): void;
+    subscribe(topic: string, handler: (event: any) => void): void;
+    unsubscribe(topic: string): void;
+    publish(type: string, payload: any, opts?: any): void;
+    enqueue(queue: string, task: any): void;
+    ready(queue: string): void;
+    ack(taskId: string): void;
+    heartbeat(): void;
+    onTaskReceived(callback: (task: any) => void): void;
 }

--- a/shared/js/serviceTemplate.js
+++ b/shared/js/serviceTemplate.js
@@ -1,48 +1,49 @@
 // shared/js/serviceTemplate.js
 
-import { BrokerClient } from "./brokerClient.js";
+import { BrokerClient } from './brokerClient.js';
 
 export async function startService({
-  id,
-  queues = [],
-  topics = [],
-  handleEvent = async (event) => {},
-  handleTask = async (task) => {},
+    id,
+    queues = [],
+    topics = [],
+    handleEvent = async (event) => {},
+    handleTask = async (task) => {},
 }) {
-  const broker = new BrokerClient({ id });
-  await broker.connect();
-  console.log(`[${id}] connected to broker`);
+    const broker = new BrokerClient({ id });
+    await broker.connect();
+    console.log(`[${id}] connected to broker`);
+    // Heartbeats are sent automatically; override interval with BROKER_HEARTBEAT_MS
 
-  // Subscribe to topics
-  for (const topic of topics) {
-    broker.subscribe(topic, async (event) => {
-      console.log(`[${id}] received event:`, event.type);
-      try {
-        await handleEvent(event);
-      } catch (err) {
-        console.error(`[${id}] event handler error:`, err);
-      }
-    });
-  }
-
-  // Handle task delivery
-  if (queues.length > 0) {
-    broker.onTaskReceived(async (task) => {
-      console.log(`[${id}] received task:`, task.queue);
-      broker.ack(task.id);
-      try {
-        await handleTask(task);
-      } catch (err) {
-        console.error(`[${id}] task failed:`, err);
-      } finally {
-        broker.ready(task.queue);
-      }
-    });
-
-    for (const queue of queues) {
-      broker.ready(queue);
+    // Subscribe to topics
+    for (const topic of topics) {
+        broker.subscribe(topic, async (event) => {
+            console.log(`[${id}] received event:`, event.type);
+            try {
+                await handleEvent(event);
+            } catch (err) {
+                console.error(`[${id}] event handler error:`, err);
+            }
+        });
     }
-  }
 
-  return broker;
+    // Handle task delivery
+    if (queues.length > 0) {
+        broker.onTaskReceived(async (task) => {
+            console.log(`[${id}] received task:`, task.queue);
+            broker.ack(task.id);
+            try {
+                await handleTask(task);
+            } catch (err) {
+                console.error(`[${id}] task failed:`, err);
+            } finally {
+                broker.ready(task.queue);
+            }
+        });
+
+        for (const queue of queues) {
+            broker.ready(queue);
+        }
+    }
+
+    return broker;
 }


### PR DESCRIPTION
## Summary
- send periodic heartbeats from BrokerClient with configurable interval
- document BROKER_HEARTBEAT_MS in README and service template
- align Cephalon dummy broker test with new BrokerClient API

## Testing
- `pnpm test tests/brokerClient.test.js`
- `pnpm --filter Cephalon test`
- `pnpm --filter Cephalon run build`
- `pnpm --filter @shared/ts run build`
- `pnpm exec eslint shared/js/brokerClient.js shared/js/serviceTemplate.js` *(fails: config uses unsupported `extends` in flat config)*

------
https://chatgpt.com/codex/tasks/task_e_68ae090b1d3c8324b7ccad4c0a4ff3c0