### PR TITLE
feat: scaffold service templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - STT and embedding services updated to use `run_service`.
 - Unit tests for ForwardTacotronIE and WaveRNNIE helper functions.
 - Test for GUI parameter defaults in `init_parameters_interactive`.
+- CLI to scaffold Python or TypeScript service templates.
 - Tests for grammar correction in the shared speech spell checker.
 - Unit tests for Discord utility functions covering channel history and cursor management.
 - Tests for `shared.py.settings` confirming environment defaults and overrides.

--- a/scripts/generate_service_templates.py
+++ b/scripts/generate_service_templates.py
@@ -1,12 +1,14 @@
 #!/usr/bin/env python3
-"""Generate README templates from existing service READMEs.
+"""Generate service scaffolding and README templates.
 
-Scans service directories under ``services/`` for ``README.md`` files and
-creates templated copies with the heading replaced by ``{{SERVICE_NAME}}``.
-Templates are written to ``services/templates``.
+This script previously generated README templates from existing services.
+It now also supports creating boilerplate directories for new services in
+either Python or TypeScript.
 """
 from __future__ import annotations
 
+import argparse
+import json
 import pathlib
 
 ROOT = pathlib.Path(__file__).resolve().parents[1]
@@ -15,18 +17,82 @@ TEMPLATE_DIR = SERVICES_DIR / "templates"
 
 
 def generate_templates() -> None:
+    """Generate README templates from existing service READMEs."""
     TEMPLATE_DIR.mkdir(exist_ok=True)
     for readme in SERVICES_DIR.glob("*/*/README.md"):
-        service_dir = readme.parent
-        service_slug = service_dir.name
-        service_title = service_slug.replace("_", " ").title()
-
         lines = readme.read_text().splitlines()
         if lines and lines[0].startswith("#"):
             lines[0] = "# {{SERVICE_NAME}} Service"
-        template_path = TEMPLATE_DIR / f"{service_slug}_README.template.md"
+        template_path = TEMPLATE_DIR / f"{readme.parent.name}_README.template.md"
         template_path.write_text("\n".join(lines) + "\n")
 
 
+def generate_scaffold(target: pathlib.Path, language: str) -> None:
+    """Create boilerplate project structure for ``language`` at ``target``."""
+    target.mkdir(parents=True, exist_ok=True)
+    src = target / "src"
+    tests = target / "tests"
+    src.mkdir(exist_ok=True)
+    tests.mkdir(exist_ok=True)
+
+    if language == "python":
+        (src / "__init__.py").write_text("\n")
+        (tests / "test_basic.py").write_text(
+            "def test_placeholder():\n    assert True\n"
+        )
+        (target / "Dockerfile").write_text(
+            "FROM python:3.11-slim\nWORKDIR /app\nCOPY . .\n"
+        )
+        (target / "pyproject.toml").write_text(
+            f'[project]\nname = "{target.name}"\nversion = "0.1.0"\n'
+        )
+    elif language == "typescript":
+        (src / "index.ts").write_text("console.log('hello');\n")
+        (tests / "basic.test.ts").write_text(
+            "test('placeholder', () => {\n  expect(true).toBe(true);\n});\n"
+        )
+        (target / "Dockerfile").write_text("FROM node:20\nWORKDIR /app\nCOPY . .\n")
+        package_json = {
+            "name": target.name,
+            "version": "0.1.0",
+            "type": "module",
+            "scripts": {"build": "tsc", "lint": "eslint ."},
+        }
+        (target / "package.json").write_text(json.dumps(package_json, indent=2) + "\n")
+        tsconfig = {
+            "compilerOptions": {
+                "target": "ES2020",
+                "module": "ESNext",
+                "outDir": "dist",
+            },
+            "include": ["src"],
+        }
+        (target / "tsconfig.json").write_text(json.dumps(tsconfig, indent=2) + "\n")
+    else:
+        raise ValueError(f"Unsupported language: {language}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="command")
+
+    sub.add_parser("readme", help="Generate README templates from services")
+
+    scaffold = sub.add_parser("scaffold", help="Generate service boilerplate")
+    scaffold.add_argument("path", type=pathlib.Path, help="Target directory")
+    lang = scaffold.add_mutually_exclusive_group(required=True)
+    lang.add_argument("--python", action="store_true", help="Generate Python template")
+    lang.add_argument(
+        "--typescript", action="store_true", help="Generate TypeScript template"
+    )
+
+    args = parser.parse_args()
+    if args.command == "readme" or args.command is None:
+        generate_templates()
+    elif args.command == "scaffold":
+        language = "python" if args.python else "typescript"
+        generate_scaffold(args.path, language)
+
+
 if __name__ == "__main__":
-    generate_templates()
+    main()

--- a/tests/scripts/test_generate_service_templates.py
+++ b/tests/scripts/test_generate_service_templates.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from tests.scripts.utils import load_script_module
+
+
+gst = load_script_module("generate_service_templates")
+
+
+def test_python_scaffold_compiles(tmp_path: Path) -> None:
+    target = tmp_path / "py_service"
+    gst.generate_scaffold(target, "python")
+    assert (target / "src").is_dir()
+    assert (target / "tests").is_dir()
+    subprocess.run(
+        ["python", "-m", "py_compile", str(target / "src" / "__init__.py")], check=True
+    )
+
+
+def test_typescript_scaffold_typechecks(tmp_path: Path) -> None:
+    target = tmp_path / "ts_service"
+    gst.generate_scaffold(target, "typescript")
+    assert (target / "src").is_dir()
+    assert (target / "package.json").exists()
+    subprocess.run(
+        [
+            "pnpm",
+            "exec",
+            "tsc",
+            "--project",
+            str(target / "tsconfig.json"),
+            "--noEmit",
+        ],
+        check=True,
+    )


### PR DESCRIPTION
## Summary
- extend service template script to scaffold Python or TypeScript services with basic project structure
- add tests validating generated scaffolds compile or typecheck
- document scaffolding tool in changelog

## Testing
- `pytest tests/scripts/test_generate_service_templates.py -q`
- `make format` *(fails: Command "@biomejs/biome" not found)*
- `make lint` *(fails: Prettier reported code style issues)*
- `make test` *(fails: 2 tests failed, 16 skipped)*
- `make build`


------
https://chatgpt.com/codex/tasks/task_e_68ae0e8cba848324a5cadb63be8ad5f4