### PR TITLE
chore: speed up pre-commit checks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,11 +12,24 @@ repos:
             entry: python scripts/kanban/hashtags_to_kanban.py --check --write --wikilinks
             language: system
             pass_filenames: false
-          - id: Build
-            name: Build
+          - id: tsc-no-emit
+            name: TypeScript compile check
+            entry: pnpm tsc --noEmit
+            language: system
+            types_or: [javascript, ts, tsx]
+            pass_filenames: false
+          - id: pytest
+            name: Python tests
+            entry: pytest -q
+            language: system
+            types: [python]
+            pass_filenames: false
+          - id: full-build
+            name: Full build
             entry: make build
             language: system
             pass_filenames: false
+            stages: [manual]
 
     - repo: https://github.com/psf/black
       rev: 24.4.2

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,6 +60,9 @@ Corepack enforcement: The root `package.json` sets `"packageManager": "pnpm@9"` 
 
 ## 🚥 CI Verification
 
+Pre-commit runs quick checks (`pnpm tsc --noEmit` and `pytest -q`) instead of the full build. Run the full build separately with
+`make build` or via `pre-commit run --hook-stage manual full-build` in CI.
+
 All contributions must be validated locally before opening a pull request:
 
 1. **Run `make setup` for the relevant services only.** Avoid global setup.
@@ -363,6 +366,9 @@ train_cephalon_align_lora.py
 ```
 
 ## 🚥 CI Verification
+
+Pre-commit runs `pnpm tsc --noEmit` and `pytest -q` for fast feedback but skips the full build. Execute `make build` manually or
+use `pre-commit run --hook-stage manual full-build` during CI to compile everything.
 
 All contributions must be validated locally before opening a pull request:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Changed
 
+- Pre-commit now runs `pnpm tsc --noEmit` and `pytest -q` instead of `make build`; use `pre-commit run --hook-stage manual full-build` or `make build` for full builds.
 - Naive embedding driver now uses configurable `VECTOR_SIZE` constant.
 - Organized SmartGPT Bridge routes into versioned directories.
 - Embedding clients and related utilities now accept structured `{type, data}`


### PR DESCRIPTION
## Summary
- replace full `make build` pre-commit hook with fast `pnpm tsc --noEmit` and `pytest -q`
- add manual `full-build` hook for CI
- document new workflow in AGENTS and changelog

## Testing
- `pnpm tsc -p services/ts/attachment-embedder/tsconfig.json --noEmit` *(fails: Cannot read file '/workspace/promethean/services/tsconfig.base.json')*
- `pytest -q shared/py/tests/test_numbers.py`
- `pre-commit run --files .pre-commit-config.yaml AGENTS.md CHANGELOG.md`


------
https://chatgpt.com/codex/tasks/task_e_68ae0ec89f988324a0c7441e1e7ee34b