### PR TITLE
Persist Discord image attachments and enable multimodal context retrieval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - `sites/` directory consolidating all frontend code.
 - Proxy route `/bridge` through the shared proxy service for SmartGPT Bridge.
 - Tool calling support for Codex Context service.
+- Image attachments captured, stored, and retrieved for multimodal prompting with cleanup.
 - Template for building Discord bots in TypeScript based on the Cephalon service.
 - Tests validating bridge event mappings for identifiers and protocols.
 - Tests covering MongoDB connection string construction and collection setup.
@@ -77,6 +78,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Grep endpoint requires a regex pattern and returns validation errors for missing fields.
 - SSE agent log streaming cleans up listeners on disconnect to avoid leaks.
 - Python tests run without pipenv isolation.
+- DualStore skips image embeddings when the configured function only supports text.
 - Added missing `next_messages` helper for discord indexer tests.
 - CPU requirements no longer include NVIDIA packages and target PyTorch CPU wheels.
 

--- a/services/ts/cephalon/src/bot.ts
+++ b/services/ts/cephalon/src/bot.ts
@@ -18,6 +18,8 @@ import { BrokerClient } from '@shared/js/brokerClient.js';
 import { checkPermission } from '@shared/js/permissionGate.js';
 import { type Interaction } from './interactions.js';
 import { DesktopCaptureManager } from './desktop/desktopLoop.js';
+import { DualStoreManager } from '@shared/ts/dist/persistence/dualStore.js';
+import { cleanupChroma } from '@shared/ts/dist/persistence/maintenance.js';
 
 import { registerNewStyleCommands } from './bot/registerCommands.js';
 
@@ -147,29 +149,73 @@ export class Bot extends EventEmitter {
     }
 
     async forwardAttachments(message: discord.Message) {
-        if (!this.captureChannel) return;
         if (message.author?.bot) return;
         const imageAttachments = [...message.attachments.values()].filter(
             (att) => att.contentType?.startsWith('image/'),
         );
         if (!imageAttachments.length) return;
+
+        if (process.env.NODE_ENV !== 'test') {
+            let collection: DualStoreManager<'content', 'created_at'> | null = null;
+            try {
+                collection = this.context.getCollection('discord_messages') as DualStoreManager<
+                    'content',
+                    'created_at'
+                >;
+            } catch {
+                try {
+                    collection = (await this.context.createCollection(
+                        'discord_messages',
+                        'content',
+                        'created_at',
+                    )) as DualStoreManager<'content', 'created_at'>;
+                } catch (e) {
+                    console.warn(e);
+                }
+            }
+            if (collection) {
+                for (const att of imageAttachments) {
+                    try {
+                        await collection.insert({
+                            content: att.url,
+                            created_at: message.createdTimestamp,
+                            metadata: {
+                                type: 'image',
+                                messageId: message.id,
+                                channelId: message.channelId,
+                                userId: message.author.id,
+                                userName: message.author.username,
+                                filename: att.name,
+                                contentType: att.contentType,
+                                size: att.size,
+                            },
+                        });
+                    } catch (e) {
+                        console.warn(e);
+                    }
+                }
+                cleanupChroma(collection.name).catch((e) => console.warn(e));
+            }
+        }
+
+        if (this.agentWorld) {
+            const { w, agent, C } = this.agentWorld;
+            for (const att of imageAttachments) {
+                const ref = {
+                    type: 'url' as const,
+                    url: att.url,
+                    ...(att.contentType ? { mime: att.contentType } : {}),
+                };
+                pushVisionFrame(w, agent, C, ref);
+            }
+        }
+        if (!this.captureChannel) return;
         const files = imageAttachments.map((att) => ({
             attachment: att.url,
             name: att.name,
         }));
         try {
             await this.captureChannel.send({ files });
-            if (this.agentWorld) {
-                const { w, agent, C } = this.agentWorld;
-                for (const att of imageAttachments) {
-                    const ref = {
-                        type: 'url' as const,
-                        url: att.url,
-                        ...(att.contentType ? { mime: att.contentType } : {}),
-                    };
-                    pushVisionFrame(w, agent, C, ref);
-                }
-            }
         } catch (e) {
             console.warn('Failed to forward attachments', e);
         }


### PR DESCRIPTION
## Summary
- Persist Discord image attachments with metadata and cleanup hooks
- Query DualStore with metadata filters and surface images in compiled context
- Allow Cephalon bot to retrieve stored images for multimodal prompts
- Skip image embeddings when the configured function is text-only to avoid errors

## Testing
- `pnpm --filter @shared/ts exec biome lint src/persistence/dualStore.ts src/persistence/contextStore.ts`
- `pnpm --filter Cephalon exec biome lint src/bot.ts`
- `pnpm --filter Cephalon test`
- `pre-commit run --files CHANGELOG.md shared/ts/src/persistence/dualStore.ts`
- `pnpm --filter @shared/ts test` *(fails: ENOENT: no such file or directory, open '/workspace/promethean/shared/ts/config/providers.yml'; TokenBucket enforces capacity)*

------
https://chatgpt.com/codex/tasks/task_e_68ae0a5148548324a536e79bc20c3de9