### PR TITLE
feat(migrations): add migration contract docs and validator scaffold

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@ dist/
 !shared/ts/prom-lib/dist/intention/
 !shared/ts/prom-lib/dist/intention/**
 data/
+!docs/data/
+!docs/data/**
 pulbic/
 .env
 agents/duck/chroma_data/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - STT and embedding services updated to use `run_service`.
 - Unit tests for ForwardTacotronIE and WaveRNNIE helper functions.
 - Test for GUI parameter defaults in `init_parameters_interactive`.
+- Initial migration contract validators and documentation outlining data migration conventions.
 - Tests for grammar correction in the shared speech spell checker.
 - Unit tests for Discord utility functions covering channel history and cursor management.
 - Tests for `shared.py.settings` confirming environment defaults and overrides.

--- a/docs/data/contracts/README.md
+++ b/docs/data/contracts/README.md
@@ -1,0 +1,30 @@
+# Data Migration Contracts
+
+This directory defines the canonical schemas for Promethean's persistence layer.
+Each contract captures the expected collections, indexes, and metadata for
+working and testing databases. Migrations must update these files whenever the
+schema changes.
+
+## MongoDB
+
+`mongo.schema.json` declares collections, required fields, and indexes. It is
+used during migration preflight to ensure the database matches the declared
+structure.
+
+## Chroma
+
+`chroma.schema.json` lists vector collections along with their
+`embedding_dim` and `embedding_model`. Migrations verify these values before
+writing embeddings.
+
+## Conventions
+
+- **Source of truth** – contract files live in version control and are reviewed
+  in every migration PR.
+- **No working data** – tests and contract verification run only against
+  ephemeral databases.
+- **Update together** – any migration that alters schema must update the
+  contract and provide fixtures or validation steps.
+
+For operational steps see
+[`../runbooks/test-migrations.md`](../runbooks/test-migrations.md).

--- a/docs/data/contracts/chroma.schema.json
+++ b/docs/data/contracts/chroma.schema.json
@@ -1,0 +1,8 @@
+{
+    "collections": {
+        "example": {
+            "embedding_dim": 1536,
+            "embedding_model": "text-embedding-3-small"
+        }
+    }
+}

--- a/docs/data/contracts/mongo.schema.json
+++ b/docs/data/contracts/mongo.schema.json
@@ -1,0 +1,8 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "collections": {
+        "example": {
+            "indexes": []
+        }
+    }
+}

--- a/docs/data/runbooks/test-migrations.md
+++ b/docs/data/runbooks/test-migrations.md
@@ -1,0 +1,29 @@
+# Test Migration Runbook
+
+This guide describes how to exercise migration scripts against ephemeral test
+databases.
+
+## 1. Start Test Databases
+
+```bash
+RUN_ID=$(date +%s) ./scripts/db/db-test-up.sh
+./scripts/db/db-test-seed.sh
+```
+
+## 2. Run Migrations with Contract Checks
+
+```bash
+MIGRATION_TARGET=test node services/ts/migrations/run.js --up latest
+```
+
+## 3. Verify Only
+
+```bash
+MIGRATION_TARGET=test node services/ts/migrations/run.js --verify-only
+```
+
+## 4. Tear Down
+
+```bash
+./scripts/db/db-test-down.sh
+```

--- a/readme.md
+++ b/readme.md
@@ -20,6 +20,7 @@ Promethean is a modular cognitive architecture for building embodied AI agents. 
 into small services that handle speech-to-text, text-to-speech, memory, and higher level reasoning.
 📖 For a high-level overview, see [docs/vision.md](docs/vision.md).
 📊 For architecture roadmaps and visualizations, see [docs/architecture/index.md](docs/architecture/index.md).
+📦 Data migration conventions and runbooks live under [docs/data](docs/data/contracts/README.md).
 
 ## 📊 Project Evolution Master Graph
 

--- a/shared/ts/src/index.ts
+++ b/shared/ts/src/index.ts
@@ -15,4 +15,5 @@ export * from './migrations/checkpoints.js';
 export * from './migrations/embedder.js';
 export * from './migrations/chroma.js';
 export * from './migrations/integrity.js';
+export * from './migrations/contract.js';
 export * from './providers/discord/normalize.js';

--- a/shared/ts/src/migrations/contract.ts
+++ b/shared/ts/src/migrations/contract.ts
@@ -1,0 +1,46 @@
+import type { Db } from 'mongodb';
+import type { ChromaWrapper } from './chroma.js';
+
+export interface ValidationReport {
+    ok: boolean;
+    issues: string[];
+}
+
+export interface MongoContract {
+    collections: Record<string, { indexes?: string[] }>;
+}
+
+export interface ChromaContract {
+    collections: Record<string, { embedding_dim: number; embedding_model: string }>;
+}
+
+export async function validateMongoContract(db: Db, contract: MongoContract): Promise<ValidationReport> {
+    const issues: string[] = [];
+    const existing = await db.collections();
+    const names = existing.map((c) => c.collectionName);
+
+    for (const [name, cfg] of Object.entries(contract.collections)) {
+        if (!names.includes(name)) {
+            issues.push(`missing collection ${name}`);
+            continue;
+        }
+        if (cfg.indexes) {
+            const idx = await db.collection(name).indexes();
+            for (const indexName of cfg.indexes) {
+                if (!idx.some((i) => i.name === indexName)) {
+                    issues.push(`missing index ${indexName} on ${name}`);
+                }
+            }
+        }
+    }
+    return { ok: issues.length === 0, issues };
+}
+
+export async function validateChromaContract(wrapper: ChromaWrapper): Promise<ValidationReport> {
+    try {
+        await wrapper.ensureCollection();
+        return { ok: true, issues: [] };
+    } catch (err) {
+        return { ok: false, issues: [String(err)] };
+    }
+}

--- a/shared/ts/src/migrations/index.ts
+++ b/shared/ts/src/migrations/index.ts
@@ -1,0 +1,5 @@
+export * from './checkpoints.js';
+export * from './embedder.js';
+export * from './chroma.js';
+export * from './integrity.js';
+export * from './contract.js';


### PR DESCRIPTION
## Summary
- document migration contract conventions and runbook
- scaffold MongoDB/Chroma contract validators
- expose contract helpers from shared TS package

## Testing
- `pnpm --filter @shared/ts exec biome lint src/migrations/contract.ts src/migrations/index.ts src/index.ts`
- `pnpm --filter @shared/ts build`
- `pnpm --filter @shared/ts test` *(fails: Missing file /workspace/promethean/shared/ts/config/providers.yml)*

------
https://chatgpt.com/codex/tasks/task_e_68ae063199648324a65b26e3d000dc72