### PR TITLE
feat(auth-service): support OAuth authorization code flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - `sites/` directory consolidating all frontend code.
 - Proxy route `/bridge` through the shared proxy service for SmartGPT Bridge.
 - Tool calling support for Codex Context service.
+- OAuth Authorization Code flow with PKCE for the auth-service, enabling OpenAI Custom GPT logins.
 - Template for building Discord bots in TypeScript based on the Cephalon service.
 - Tests validating bridge event mappings for identifiers and protocols.
 - Tests covering MongoDB connection string construction and collection setup.

--- a/services/ts/auth-service/README.md
+++ b/services/ts/auth-service/README.md
@@ -1,25 +1,27 @@
 Auth Service
 
 - Endpoints:
-  - GET `/.well-known/jwks.json`: Public JWKS for token verification.
-  - POST `/oauth/token`: Issues Bearer JWT via `client_credentials`.
-  - POST `/oauth/introspect`: Validates access tokens, returns `active` and claims.
-  - GET `/healthz`: Liveness check.
+    - GET `/.well-known/jwks.json`: Public JWKS for token verification.
+    - GET `/oauth/authorize`: Authorization Code endpoint (PKCE, OpenAI Custom GPT compatible).
+    - POST `/oauth/token`: Issues Bearer JWT via `client_credentials`, `authorization_code`, or `refresh_token`.
+    - POST `/oauth/introspect`: Validates access tokens, returns `active` and claims.
+    - GET `/healthz`: Liveness check.
 
 - Env vars:
-  - `PORT`: Listen port (default 8088)
-  - `AUTH_ISSUER`: Issuer URL (default http://localhost:8088)
-  - `AUTH_AUDIENCE`: Default audience (optional)
-  - `AUTH_ALG`: JWT alg (default EdDSA)
-  - `AUTH_PRIVATE_KEY_PEM` / `AUTH_PUBLIC_KEY_PEM`: PEM for asymmetric keys (optional)
-  - `AUTH_PRIVATE_JWK` / `AUTH_PUBLIC_JWK`: JWKs (optional)
-  - `AUTH_KID`: Key id (optional)
-  - `AUTH_TOKEN_TTL_SECONDS`: Access token TTL seconds (default 3600)
-  - `AUTH_DEFAULT_SCOPES`: Space-delimited default scopes (optional)
-  - `AUTH_STATIC_CLIENTS`: JSON map of static clients, e.g.
-    `{ "bridge": { "client_secret": "dev-secret", "scopes": ["index:write"], "aud": "internal" } }`
+    - `PORT`: Listen port (default 8088)
+    - `AUTH_ISSUER`: Issuer URL (default http://localhost:8088)
+    - `AUTH_AUDIENCE`: Default audience (optional)
+    - `AUTH_ALG`: JWT alg (default EdDSA)
+    - `AUTH_PRIVATE_KEY_PEM` / `AUTH_PUBLIC_KEY_PEM`: PEM for asymmetric keys (optional)
+    - `AUTH_PRIVATE_JWK` / `AUTH_PUBLIC_JWK`: JWKs (optional)
+    - `AUTH_KID`: Key id (optional)
+    - `AUTH_TOKEN_TTL_SECONDS`: Access token TTL seconds (default 3600)
+    - `AUTH_DEFAULT_SCOPES`: Space-delimited default scopes (optional)
+    - `AUTH_STATIC_CLIENTS`: JSON map of static clients, e.g.
+      `{ "bridge": { "client_secret": "dev-secret", "scopes": ["index:write"], "aud": "internal" } }`
+        - For Authorization Code flow, omit `client_secret` to treat client as public and allow PKCE-based login.
 
 - Dev
-  - `pnpm -C services/ts/auth-service install`
-  - `pnpm -C services/ts/auth-service start:dev`
-
+    - `pnpm -C services/ts/auth-service install`
+    - `pnpm -C services/ts/auth-service start:dev`
+    - `pnpm -C services/ts/auth-service test`

--- a/services/ts/auth-service/package.json
+++ b/services/ts/auth-service/package.json
@@ -11,7 +11,8 @@
         "start:dev": "node --loader ts-node/esm src/index.ts",
         "build:check": "tsc --noEmit --incremental false",
         "lint": "prettier --cache --check . && eslint . --cache || true",
-        "format": "prettier --cache --write . && eslint . --fix --cache || true"
+        "format": "prettier --cache --write . && eslint . --fix --cache || true",
+        "test": "pnpm run build && node --test test"
     },
     "dependencies": {
         "fastify": "^4.28.1",

--- a/services/ts/auth-service/src/index.ts
+++ b/services/ts/auth-service/src/index.ts
@@ -1,12 +1,27 @@
 import Fastify from 'fastify';
 import { jwks, signAccessToken, verifyToken, initKeys } from './keys.js';
+import crypto from 'node:crypto';
 import { configDotenv } from 'dotenv';
 configDotenv();
 
 type ClientDef = {
-    client_secret: string;
+    client_secret?: string;
     scopes?: string[];
     aud?: string | string[];
+};
+
+type AuthCode = {
+    client_id: string;
+    redirect_uri: string;
+    code_challenge: string;
+    sub: string;
+    scope: string;
+};
+
+type RefreshToken = {
+    client_id: string;
+    sub: string;
+    scope: string;
 };
 
 function readClients(): Record<string, ClientDef> {
@@ -24,14 +39,60 @@ const PORT = Number(process.env.PORT || 8088);
 const ISSUER = process.env.AUTH_ISSUER || `http://localhost:${PORT}`;
 const DEFAULT_SCOPES = (process.env.AUTH_DEFAULT_SCOPES || '').split(/\s+/).filter(Boolean);
 
+const authCodes = new Map<string, AuthCode>();
+const refreshTokens = new Map<string, RefreshToken>();
+
+function randomString(bytes = 32) {
+    return crypto.randomBytes(bytes).toString('base64url');
+}
+
+function pkceChallenge(verifier: string) {
+    return crypto.createHash('sha256').update(verifier).digest('base64url');
+}
+
 export async function buildServer() {
     await initKeys();
     const app = Fastify({ logger: true });
+
+    app.addContentTypeParser(
+        'application/x-www-form-urlencoded',
+        { parseAs: 'string' },
+        (_req, body, done) => done(null, body as string),
+    );
 
     app.get('/healthz', async () => ({ status: 'ok' }));
 
     app.get('/.well-known/jwks.json', async (_req, reply) => {
         return reply.send(await jwks());
+    });
+
+    app.get('/oauth/authorize', async (req, reply) => {
+        const q = (req.query || {}) as Record<string, string>;
+        if (q.response_type !== 'code') {
+            return reply.code(400).send({ error: 'unsupported_response_type' });
+        }
+        const {
+            client_id,
+            redirect_uri,
+            state,
+            scope = '',
+            code_challenge,
+            code_challenge_method,
+            login_hint,
+        } = q;
+        if (!client_id || !redirect_uri || !code_challenge) {
+            return reply.code(400).send({ error: 'invalid_request' });
+        }
+        if (code_challenge_method && code_challenge_method !== 'S256') {
+            return reply.code(400).send({ error: 'invalid_request' });
+        }
+        const sub = login_hint || client_id;
+        const code = randomString();
+        authCodes.set(code, { client_id, redirect_uri, code_challenge, sub, scope });
+        const redir = new URL(redirect_uri);
+        redir.searchParams.set('code', code);
+        if (state) redir.searchParams.set('state', state);
+        return reply.redirect(redir.toString());
     });
 
     app.post('/oauth/token', async (req, reply) => {
@@ -42,49 +103,107 @@ export async function buildServer() {
             body = Object.fromEntries(new URLSearchParams(body));
         }
         const grantType = body.grant_type || 'client_credentials';
-        if (grantType !== 'client_credentials') {
-            return reply.code(400).send({ error: 'unsupported_grant_type' });
+
+        if (grantType === 'client_credentials') {
+            // Basic auth fallback
+            let client_id = body.client_id as string | undefined;
+            let client_secret = body.client_secret as string | undefined;
+            const auth = req.headers.authorization;
+            if ((!client_id || !client_secret) && auth?.startsWith('Basic ')) {
+                const creds = Buffer.from(auth.slice(6), 'base64').toString('utf8');
+                const [id, secret] = creds.split(':');
+                client_id = client_id || id;
+                client_secret = client_secret || secret;
+            }
+            if (!client_id || !client_secret) {
+                return reply.code(401).send({ error: 'invalid_client' });
+            }
+            const client = clients[client_id];
+            if (!client || client.client_secret !== client_secret) {
+                return reply.code(401).send({ error: 'invalid_client' });
+            }
+
+            const reqScopes =
+                (body.scope as string | undefined)?.split(/\s+/).filter(Boolean) || DEFAULT_SCOPES;
+            const allowed = new Set((client.scopes || []).concat(DEFAULT_SCOPES));
+            const granted = reqScopes.filter((s) => allowed.has(s));
+            const scopeStr = granted.join(' ');
+
+            const aud = body.aud || client.aud || process.env.AUTH_AUDIENCE;
+            const ttl = process.env.AUTH_TOKEN_TTL_SECONDS
+                ? Number(process.env.AUTH_TOKEN_TTL_SECONDS)
+                : 3600;
+            const access_token = await signAccessToken(
+                { sub: client_id, aud, scope: scopeStr, iss: ISSUER },
+                { expiresIn: ttl },
+            );
+            return reply.send({
+                access_token,
+                token_type: 'Bearer',
+                expires_in: ttl,
+                scope: scopeStr,
+                issued_token_type: 'urn:ietf:params:oauth:token-type:access_token',
+            });
+        } else if (grantType === 'authorization_code') {
+            const { code, redirect_uri, code_verifier, client_id } = body as Record<string, string>;
+            if (!code || !redirect_uri || !code_verifier || !client_id) {
+                return reply.code(400).send({ error: 'invalid_request' });
+            }
+            const entry = authCodes.get(code);
+            if (!entry || entry.client_id !== client_id || entry.redirect_uri !== redirect_uri) {
+                return reply.code(400).send({ error: 'invalid_grant' });
+            }
+            if (pkceChallenge(code_verifier) !== entry.code_challenge) {
+                return reply.code(400).send({ error: 'invalid_grant' });
+            }
+            authCodes.delete(code);
+            const ttl = process.env.AUTH_TOKEN_TTL_SECONDS
+                ? Number(process.env.AUTH_TOKEN_TTL_SECONDS)
+                : 3600;
+            const access_token = await signAccessToken(
+                { sub: entry.sub, aud: client_id, scope: entry.scope, iss: ISSUER },
+                { expiresIn: ttl },
+            );
+            const refresh = randomString();
+            refreshTokens.set(refresh, {
+                client_id,
+                sub: entry.sub,
+                scope: entry.scope,
+            });
+            return reply.send({
+                access_token,
+                refresh_token: refresh,
+                token_type: 'Bearer',
+                expires_in: ttl,
+                scope: entry.scope,
+                issued_token_type: 'urn:ietf:params:oauth:token-type:access_token',
+            });
+        } else if (grantType === 'refresh_token') {
+            const { refresh_token, client_id } = body as Record<string, string>;
+            if (!refresh_token || !client_id) {
+                return reply.code(400).send({ error: 'invalid_request' });
+            }
+            const entry = refreshTokens.get(refresh_token);
+            if (!entry || entry.client_id !== client_id) {
+                return reply.code(400).send({ error: 'invalid_grant' });
+            }
+            const ttl = process.env.AUTH_TOKEN_TTL_SECONDS
+                ? Number(process.env.AUTH_TOKEN_TTL_SECONDS)
+                : 3600;
+            const access_token = await signAccessToken(
+                { sub: entry.sub, aud: client_id, scope: entry.scope, iss: ISSUER },
+                { expiresIn: ttl },
+            );
+            return reply.send({
+                access_token,
+                token_type: 'Bearer',
+                expires_in: ttl,
+                scope: entry.scope,
+                issued_token_type: 'urn:ietf:params:oauth:token-type:access_token',
+            });
         }
 
-        // Basic auth fallback
-        let client_id = body.client_id as string | undefined;
-        let client_secret = body.client_secret as string | undefined;
-        const auth = req.headers.authorization;
-        if ((!client_id || !client_secret) && auth?.startsWith('Basic ')) {
-            const creds = Buffer.from(auth.slice(6), 'base64').toString('utf8');
-            const [id, secret] = creds.split(':');
-            client_id = client_id || id;
-            client_secret = client_secret || secret;
-        }
-        if (!client_id || !client_secret) {
-            return reply.code(401).send({ error: 'invalid_client' });
-        }
-        const client = clients[client_id];
-        if (!client || client.client_secret !== client_secret) {
-            return reply.code(401).send({ error: 'invalid_client' });
-        }
-
-        const reqScopes =
-            (body.scope as string | undefined)?.split(/\s+/).filter(Boolean) || DEFAULT_SCOPES;
-        const allowed = new Set((client.scopes || []).concat(DEFAULT_SCOPES));
-        const granted = reqScopes.filter((s) => allowed.has(s));
-        const scopeStr = granted.join(' ');
-
-        const aud = body.aud || client.aud || process.env.AUTH_AUDIENCE;
-        const ttl = process.env.AUTH_TOKEN_TTL_SECONDS
-            ? Number(process.env.AUTH_TOKEN_TTL_SECONDS)
-            : 3600;
-        const access_token = await signAccessToken(
-            { sub: client_id, aud, scope: scopeStr, iss: ISSUER },
-            { expiresIn: ttl },
-        );
-        return reply.send({
-            access_token,
-            token_type: 'Bearer',
-            expires_in: ttl,
-            scope: scopeStr,
-            issued_token_type: 'urn:ietf:params:oauth:token-type:access_token',
-        });
+        return reply.code(400).send({ error: 'unsupported_grant_type' });
     });
 
     app.post('/oauth/introspect', async (req, reply) => {

--- a/services/ts/auth-service/test/oauth-flow.test.mjs
+++ b/services/ts/auth-service/test/oauth-flow.test.mjs
@@ -1,0 +1,58 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+import crypto from 'node:crypto';
+import { buildServer } from '../dist/index.js';
+
+function pkcePair() {
+    const verifier = crypto.randomBytes(32).toString('base64url');
+    const challenge = crypto.createHash('sha256').update(verifier).digest('base64url');
+    return { verifier, challenge };
+}
+
+test('authorization code flow issues and refreshes tokens', async (t) => {
+    const app = await buildServer();
+    const { verifier, challenge } = pkcePair();
+    const authorize = await app.inject({
+        method: 'GET',
+        url:
+            '/oauth/authorize?response_type=code&client_id=test-client&redirect_uri=https://example.com/cb&state=xyz&scope=read&code_challenge=' +
+            challenge +
+            '&code_challenge_method=S256&login_hint=user1',
+    });
+    assert.equal(authorize.statusCode, 302);
+    const loc = authorize.headers.location;
+    assert.ok(loc);
+    const url = new URL(loc);
+    assert.equal(url.searchParams.get('state'), 'xyz');
+    const code = url.searchParams.get('code');
+    assert.ok(code);
+
+    const tokenRes = await app.inject({
+        method: 'POST',
+        url: '/oauth/token',
+        headers: { 'content-type': 'application/x-www-form-urlencoded' },
+        payload: new URLSearchParams({
+            grant_type: 'authorization_code',
+            code,
+            redirect_uri: 'https://example.com/cb',
+            client_id: 'test-client',
+            code_verifier: verifier,
+        }).toString(),
+    });
+    assert.equal(tokenRes.statusCode, 200);
+    const body = tokenRes.json();
+    assert.ok(body.access_token);
+    assert.ok(body.refresh_token);
+
+    const refreshRes = await app.inject({
+        method: 'POST',
+        url: '/oauth/token',
+        headers: { 'content-type': 'application/x-www-form-urlencoded' },
+        payload: new URLSearchParams({
+            grant_type: 'refresh_token',
+            refresh_token: body.refresh_token,
+            client_id: 'test-client',
+        }).toString(),
+    });
+    assert.equal(refreshRes.statusCode, 200);
+});


### PR DESCRIPTION
## Summary
- add OAuth Authorization Code + refresh token flow with PKCE
- expose `/oauth/authorize` endpoint for OpenAI Custom GPT login
- document usage and add integration test for full flow

## Testing
- `pnpm -F auth-service format`
- `pnpm -F auth-service lint`
- `pnpm -F auth-service build`
- `pnpm -F auth-service test`

------
https://chatgpt.com/codex/tasks/task_e_68ae060a7aa483249cfaf7eae7cb3a3c