### PR TITLE
Add snapshot tagging helper

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,6 +71,8 @@ All contributions must be validated locally before opening a pull request:
 4. Run `make lint` to check code style and formatting.
 5. Run `make format` to auto-format code.
 
+After tests pass, `make snapshot` can tag the current commit (e.g., `snapshot-2024.09.28`) as a lightweight return point without implying a full release. Set `PUSH=1` to push the tag upstream.
+
 ---
 
 ## 🗂️ Board Process
@@ -547,8 +549,6 @@ Follow the format:
 
 Persistence is handled via shared module: @shared/ts/persistence/DualStore
 
-
-
 ## Hashtags are your friend
 
 ## 📝 Architecture Decision Records (ADRs)
@@ -557,8 +557,8 @@ All agents are required to document **architectural decisions** that affect the 
 
 - ADRs live under `docs/architecture/adr/`
 - ADRs must be created for any changes to:
-  - File structure
-  - Agent/service contracts
-  - Core libraries or shared architecture
-  - Protocols or bridge definitions
+    - File structure
+    - Agent/service contracts
+    - Core libraries or shared architecture
+    - Protocols or bridge definitions
 - ADR filenames use a **timestamp-based convention**:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - v1 router exposing consolidated SmartGPT Bridge endpoints.
 - OpenAPI spec for `/v1` served at `/v1/openapi.json` with consolidated operations.
 - `distclean` target to remove ignored files via `git clean -fdX`.
+- `snapshot` target to tag the current commit with a timestamped snapshot.
 
 ### Changed
 
@@ -75,7 +76,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Pinned JavaScript dependencies, GitHub Actions, and documented version policy for reproducible builds.
 - Pre-commit now runs `pnpm tsc --noEmit` and `pytest -q` instead of `make build`; use `pre-commit run --hook-stage manual full-build` or `make build` for full builds.
 - Naive embedding driver now uses configurable `VECTOR_SIZE` constant.
- - Enhanced URL canonicalization helpers to remove tracking parameters and expand scheme denylist.
+- Enhanced URL canonicalization helpers to remove tracking parameters and expand scheme denylist.
 - Organized SmartGPT Bridge routes into versioned directories.
 - Embedding clients and related utilities now accept structured `{type, data}`
   items instead of using the `img:` prefix.

--- a/Makefile
+++ b/Makefile
@@ -97,6 +97,7 @@ COMMANDS := \
   docker-down \
   generate-python-requirements \
   generate-requirements \
+  snapshot \
   generate-makefile
 
 .PHONY: \

--- a/mk/commands.hy
+++ b/mk/commands.hy
@@ -676,6 +676,13 @@
 (defn-cmd generate-requirements []
   (generate-python-requirements))
 
+(defn-cmd snapshot []
+  (import datetime [datetime])
+  (setv version (.strftime (datetime.now) "%Y.%m.%d"))
+  (sh (.format "git tag -a snapshot-{} -m 'Snapshot {}'" version version) :shell True)
+  (when (os.environ.get "PUSH")
+    (sh (.format "git push origin snapshot-{}" version) :shell True)))
+
 (setv patterns (define-patterns
                    ["python"
                  [ ["uv-setup" (fn [service]


### PR DESCRIPTION
## Summary
- add `snapshot` make target to tag current commit with a timestamp and optionally push
- document `make snapshot` usage in contributor guide
- record new snapshot workflow in changelog

## Testing
- `pre-commit run --files AGENTS.md CHANGELOG.md Makefile mk/commands.hy`
- `make format` *(fails: KeyboardInterrupt)*
- `make lint` *(fails: ESLint config error and code style issues)*
- `make build` *(fails: KeyboardInterrupt)*
- `make test` *(fails: 10 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68ae3d3eb3c4832498477d5246c032ca