### PR TITLE
refactor: share base pipenv Dockerfile across STT/TTS services

### DIFF
--- a/dev/build/commands.hy
+++ b/dev/build/commands.hy
@@ -508,6 +508,7 @@
       (sh ["python" "scripts/simulate_ci.py"])) )
 
 (defn-cmd docker-build []
+  (sh ["docker" "build" "-f" "services/docker/base-python-pipenv.Dockerfile" "-t" "base-python-pipenv" "services/docker"])
   (sh ["docker" "compose" "build"]))
 
 (defn-cmd docker-up []

--- a/mk/commands.hy
+++ b/mk/commands.hy
@@ -661,6 +661,7 @@
       (sh ["python" "scripts/simulate_ci.py"])) )
 
 (defn-cmd docker-build []
+  (sh ["docker" "build" "-f" "services/docker/base-python-pipenv.Dockerfile" "-t" "base-python-pipenv" "services/docker"])
   (sh ["docker" "compose" "build"]))
 
 (defn-cmd docker-up []

--- a/services/docker/base-python-pipenv.Dockerfile
+++ b/services/docker/base-python-pipenv.Dockerfile
@@ -1,0 +1,6 @@
+# syntax=docker/dockerfile:1
+FROM python:3.12-slim
+
+WORKDIR /app
+
+RUN pip install --no-cache-dir pipenv

--- a/services/hy/stt/Dockerfile
+++ b/services/hy/stt/Dockerfile
@@ -1,14 +1,10 @@
 # syntax=docker/dockerfile:1
-FROM python:3.12-slim
+ARG BASE_IMAGE=base-python-pipenv
+FROM ${BASE_IMAGE}
 
-WORKDIR /app
-
-# Install dependencies
 COPY Pipfile Pipfile.lock ./
-RUN pip install --no-cache-dir pipenv && \
-    pipenv install --deploy --ignore-pipfile
+RUN pipenv install --deploy --ignore-pipfile
 
-# Copy source code
 COPY . .
 
 EXPOSE 5002

--- a/services/hy/tts/Dockerfile
+++ b/services/hy/tts/Dockerfile
@@ -1,14 +1,10 @@
 # syntax=docker/dockerfile:1
-FROM python:3.12-slim
+ARG BASE_IMAGE=base-python-pipenv
+FROM ${BASE_IMAGE}
 
-WORKDIR /app
-
-# Install dependencies
 COPY Pipfile Pipfile.lock ./
-RUN pip install --no-cache-dir pipenv && \
-    pipenv install --deploy --ignore-pipfile
+RUN pipenv install --deploy --ignore-pipfile
 
-# Copy source code
 COPY . .
 
 EXPOSE 5001

--- a/services/py/stt/Dockerfile
+++ b/services/py/stt/Dockerfile
@@ -1,14 +1,10 @@
 # syntax=docker/dockerfile:1
-FROM python:3.12-slim
+ARG BASE_IMAGE=base-python-pipenv
+FROM ${BASE_IMAGE}
 
-WORKDIR /app
-
-# Install dependencies
 COPY Pipfile Pipfile.lock ./
-RUN pip install --no-cache-dir pipenv && \
-    pipenv install --deploy --ignore-pipfile
+RUN pipenv install --deploy --ignore-pipfile
 
-# Copy source code
 COPY . .
 
 EXPOSE 5002

--- a/services/py/tts/Dockerfile
+++ b/services/py/tts/Dockerfile
@@ -1,14 +1,10 @@
 # syntax=docker/dockerfile:1
-FROM python:3.12-slim
+ARG BASE_IMAGE=base-python-pipenv
+FROM ${BASE_IMAGE}
 
-WORKDIR /app
-
-# Install dependencies
 COPY Pipfile Pipfile.lock ./
-RUN pip install --no-cache-dir pipenv && \
-    pipenv install --deploy --ignore-pipfile
+RUN pipenv install --deploy --ignore-pipfile
 
-# Copy source code
 COPY . .
 
 EXPOSE 5001


### PR DESCRIPTION
## Summary
- add services/docker/base-python-pipenv.Dockerfile with common Python + Pipenv setup
- refactor STT and TTS service Dockerfiles to extend the base image
- build base image before docker-compose build

## Testing
- `pre-commit run --files services/docker/base-python-pipenv.Dockerfile services/hy/stt/Dockerfile services/hy/tts/Dockerfile services/py/stt/Dockerfile services/py/tts/Dockerfile mk/commands.hy dev/build/commands.hy`
- `make lint` *(fails: A config object is using the "extends" key, which is not supported in flat config system.)*
- `make test-hy-service-stt` *(fails: NameError: name 'unless' is not defined)*
- `make test-hy-service-tts` *(fails: NameError: name 'unless' is not defined)*
- `make test-python-service-stt` *(fails: NameError: name 'unless' is not defined)*
- `make test-python-service-tts` *(fails: NameError: name 'unless' is not defined)*
- `make build`


------
https://chatgpt.com/codex/tasks/task_e_68ae3d595d008324b9e4126fcb4415f7