### PR TITLE
feat: centralize discord service setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Added
 
+- Shared Discord service helper for client setup, heartbeat, and channel iteration.
+
 - Command definitions extracted into reusable modules and JSON descriptors for Makefile generation.
 
 - Extracted actionable tasks from unique notes into tasks/unique-notes.md
@@ -22,6 +24,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - `distclean` target to remove ignored files via `git clean -fdX`.
 
 ### Changed
+
+- Discord indexer and attachment indexer services now use the shared Discord service helper for consistent env loading and logging.
 
 - Refined Kanban breakdown tasks with clear goals, requirements, and subtasks.
 - MCP server and stdio wrapper exposing `search.query` over WebSocket and CLI.

--- a/services/py/discord_indexer/main.py
+++ b/services/py/discord_indexer/main.py
@@ -3,37 +3,22 @@ Crawl through discord history and fill in all messages that are not getting proc
 """
 
 import hy
-import os
-
-AGENT_NAME = os.environ.get("AGENT_NAME", "duck")
-print(f"Discord indexer running for {AGENT_NAME}")
-import sys
-
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../"))
 import asyncio
 import random
 from typing import List
+import logging
 
 import discord
 
 from shared.py import settings
 from shared.py.mongodb import discord_message_collection, discord_channel_collection
-from shared.py.heartbeat_broker import start_broker_heartbeat
-from shared.py.utils.discord import (
-    fetch_channel_history,
-    shuffle_array,
-    update_cursor,
-)
+from shared.py.utils.discord import fetch_channel_history, update_cursor
+from shared.py.discord_service import run_discord_service
 
-intents = discord.Intents.default()
-client = discord.Client(intents=intents)
-intents.message_content = True
-
-_hb_started = False
-_hb_ctx = None
+logger = logging.getLogger("discord_indexer")
 
 
-def format_message(message):
+def format_message(message: discord.Message) -> dict:
     channel = message.channel
     author = message.author
     if hasattr(channel, "name"):
@@ -56,23 +41,19 @@ def format_message(message):
 
 
 def index_message(message: discord.Message) -> None:
-    """
-    Index a message only if it has not already been added to mongo.
-    """
+    """Index a message only if it has not already been added to mongo."""
     message_record = discord_message_collection.find_one({"id": message.id})
     if message_record is None:
-        print(f"Indexing message {message.id} {message.content}")
+        logger.info("Indexing message %s %s", message.id, message.content)
         discord_message_collection.insert_one(format_message(message))
     else:
-        print(f"Message {message.id} already indexed")
-        print(message_record)
+        logger.debug("Message %s already indexed", message.id)
+        logger.debug(message_record)
 
 
 async def index_channel(channel: discord.TextChannel) -> None:
-    """
-    Index all messages in a channel.
-    """
-    print(f"Indexing channel {channel}")
+    """Index all messages in a channel."""
+    logger.info("Indexing channel %s", channel)
     messages = await fetch_channel_history(
         channel, discord_channel_collection, "cursor"
     )
@@ -85,7 +66,7 @@ async def index_channel(channel: discord.TextChannel) -> None:
         update_cursor(
             discord_channel_collection, channel.id, newest_message.id, "cursor"
         )
-    return print(f"Newest message: {newest_message}")
+        logger.info("Newest message: %s", newest_message)
 
 
 async def next_messages(channel: discord.TextChannel) -> List[discord.Message]:
@@ -99,32 +80,19 @@ async def next_messages(channel: discord.TextChannel) -> List[discord.Message]:
     return [m async for m in channel.history(limit=200, oldest_first=True, after=after)]
 
 
-@client.event
-async def on_ready():
-    global _hb_started, _hb_ctx
-    if not _hb_started:
-        # Start broker-tied heartbeat once the loop is running
-        try:
-            _hb_ctx = await start_broker_heartbeat(
-                service_id=os.environ.get("PM2_PROCESS_NAME", "discord_indexer")
-            )
-            _hb_started = True
-        except Exception as e:
-            print(f"[discord_indexer] failed to start broker heartbeat: {e}")
-
-    while True:
-        for channel in shuffle_array(list(client.get_all_channels())):
-            if isinstance(channel, discord.TextChannel):
-                print(f"Indexing channel {channel}")
-                random_sleep = random.randint(1, 10)
-                await asyncio.sleep(random_sleep)
-                await index_channel(channel)
+async def handle_channel(channel: discord.TextChannel) -> None:
+    random_sleep = random.randint(1, 10)
+    await asyncio.sleep(random_sleep)
+    await index_channel(channel)
 
 
-@client.event
-async def on_message(message):
-    print(message)
+async def handle_message(message: discord.Message) -> None:
+    logger.debug("Received message %s", message.id)
     index_message(message)
 
 
-client.run(settings.DISCORD_TOKEN)
+run_discord_service(
+    service_name="discord_indexer",
+    channel_handler=handle_channel,
+    message_handler=handle_message,
+)

--- a/shared/py/discord_service.py
+++ b/shared/py/discord_service.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+"""Shared helper for building Discord services.
+
+This module centralizes Discord client setup, environment handling, logging,
+heartbeat management, and channel iteration so individual services can remain
+focused on their domain logic.
+"""
+
+import asyncio
+import logging
+import os
+from typing import Awaitable, Callable, Optional
+
+import discord
+from dotenv import load_dotenv
+
+from shared.py import settings
+from shared.py.heartbeat_broker import start_broker_heartbeat
+from shared.py.utils.discord import shuffle_array
+
+load_dotenv()
+
+
+def _configure_logger(name: str) -> logging.Logger:
+    """Configure and return a logger for the service."""
+    logging.basicConfig(level=os.environ.get("LOG_LEVEL", "INFO"))
+    return logging.getLogger(name)
+
+
+def create_discord_client(
+    service_name: str,
+    channel_handler: Optional[Callable[[discord.TextChannel], Awaitable[None]]] = None,
+    message_handler: Optional[Callable[[discord.Message], Awaitable[None]]] = None,
+) -> discord.Client:
+    """Create a configured Discord client.
+
+    Parameters
+    ----------
+    service_name:
+        Identifier used for heartbeat logging and logger naming.
+    channel_handler:
+        Coroutine invoked for every ``TextChannel`` in the guild on a
+        background loop.
+    message_handler:
+        Coroutine invoked for every message event.
+    """
+
+    intents = discord.Intents.default()
+    intents.message_content = True
+    client = discord.Client(intents=intents)
+    logger = _configure_logger(service_name)
+
+    _hb_started = False
+    _hb_ctx = None
+
+    @client.event
+    async def on_ready():
+        nonlocal _hb_started, _hb_ctx
+        if not _hb_started:
+            try:
+                _hb_ctx = await start_broker_heartbeat(
+                    service_id=os.environ.get("PM2_PROCESS_NAME", service_name)
+                )
+                _hb_started = True
+                logger.info("heartbeat started")
+            except Exception as e:  # pragma: no cover - best effort
+                logger.error(f"failed to start broker heartbeat: {e}")
+
+        if channel_handler:
+            while True:
+                for channel in shuffle_array(list(client.get_all_channels())):
+                    if isinstance(channel, discord.TextChannel):
+                        try:
+                            await channel_handler(channel)
+                        except Exception as e:  # pragma: no cover - service-level
+                            logger.error(f"error processing channel {channel}: {e}")
+
+    if message_handler:
+
+        @client.event
+        async def on_message(message: discord.Message):
+            try:
+                await message_handler(message)
+            except Exception as e:  # pragma: no cover - service-level
+                logger.error(f"error handling message {message.id}: {e}")
+
+    return client
+
+
+def run_discord_service(
+    service_name: str,
+    channel_handler: Optional[Callable[[discord.TextChannel], Awaitable[None]]] = None,
+    message_handler: Optional[Callable[[discord.Message], Awaitable[None]]] = None,
+) -> None:
+    """Create and run a Discord service with the given callbacks."""
+
+    client = create_discord_client(
+        service_name=service_name,
+        channel_handler=channel_handler,
+        message_handler=message_handler,
+    )
+    logger = logging.getLogger(service_name)
+    logger.info("%s running for %s", service_name, settings.AGENT_NAME)
+    client.run(settings.DISCORD_TOKEN)


### PR DESCRIPTION
## Summary
- add reusable Discord service helper with env loading, heartbeat, and channel iteration
- refactor Discord indexer and attachment indexer to use shared helper and consistent logging
- document shared helper in changelog

## Testing
- `pytest services/py/discord_indexer/tests/test_discord_indexer.py -q`
- `pytest services/py/discord_attachment_indexer/tests/test_discord_attachment_indexer.py -q`
- `SKIP=pytest pre-commit run --files shared/py/discord_service.py services/py/discord_indexer/main.py services/py/discord_attachment_indexer/main.py CHANGELOG.md`


------
https://chatgpt.com/codex/tasks/task_e_68ae3d4c00108324830ac1d6ec2b6ecb