### PR TITLE
docs: detail social knowledge integrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Realtime Promethean Health Dashboard for monitoring heartbeat metrics.
 - Configurable timeout for remote embedding requests.
 - `defun` special form in Lisp compiler enabling named functions and recursion.
+- Documented API integration details for Reddit, Bluesky, and Wikipedia tasks.
 
 ### Changed
 

--- a/docs/agile/tasks/connect bluesky.md
+++ b/docs/agile/tasks/connect bluesky.md
@@ -1,22 +1,35 @@
 # Description
 
-Agent provider thingy
+Enable agents to interact with Bluesky using the AT Protocol APIs and app-password authentication.
 
+## Target APIs and Authentication
+
+- **API**: [Bluesky AT Protocol](https://docs.bsky.app/docs/api) via `https://bsky.social/xrpc`
+- **Authentication**: App password exchange for session token (JWT)
+
+## Data Flow & Rate Limiting
+
+- Agent authenticates ➜ session token ➜ Bluesky endpoint ➜ internal broker/storage
+- Monitor `x-ratelimit-*` headers and throttle (~200 requests/minute). Back off when `429` is returned.
 
 ## Requirements/Definition of done
 
-- If it doesn't have this, we can't accept it
+- Authenticated session can publish and read posts
+- Data flows into broker or storage services
+- Rate limit handling prevents API throttling
 
-## Tasks 
+## Tasks
 
-- [ ] Step 1
-- [ ] Step 2
-- [ ] Step 3
-- [ ] Step 4
+- [ ] Create app password and configure credentials
+- [ ] Implement session login and client wrappers
+- [ ] Publish and fetch posts via internal queue
+- [ ] Implement rate limit checks and exponential backoff
+- [ ] Integration tests for posting and retrieval
+- [ ] Unit tests for session refresh and error paths
 
 ## Relevent resources
 
-You might find [this] useful while working on this task
+You might find [Bluesky API docs](https://docs.bsky.app/docs/api) useful while working on this task
 
 ## Comments
 

--- a/docs/agile/tasks/connect reddit.md
+++ b/docs/agile/tasks/connect reddit.md
@@ -1,22 +1,35 @@
 # Description
 
-- Agent provider thingy
-- 
+Integrate Reddit so agents can read and post subreddit content using the Reddit REST API with OAuth2.
+
+## Target APIs and Authentication
+
+- **API**: [Reddit API](https://www.reddit.com/dev/api)
+- **Authentication**: OAuth2 via client ID/secret and refresh token stored in service configuration
+
+## Data Flow & Rate Limiting
+
+- Agent queues request ➜ OAuth client ➜ Reddit endpoint ➜ internal broker/storage
+- Respect Reddit rate limits (~60 requests/minute per app) and backoff on `429` or `Retry-After` headers
 
 ## Requirements/Definition of done
 
-- If it doesn't have this, we can't accept it
+- Authenticated requests can fetch and post subreddit data
+- Data flows through the broker into internal storage
+- Rate limiting and backoff logic prevents API throttling
 
-## Tasks 
+## Tasks
 
-- [ ] Step 1
-- [ ] Step 2
-- [ ] Step 3
-- [ ] Step 4
+- [ ] Register Reddit application and configure OAuth2 credentials
+- [ ] Implement OAuth client and endpoint wrappers
+- [ ] Stream or poll subreddit content into internal queue
+- [ ] Implement rate limit handler with exponential backoff
+- [ ] Integration test covering happy path and 429 handling
+- [ ] Unit tests for data mapping and error cases
 
 ## Relevent resources
 
-You might find [this] useful while working on this task
+You might find [Reddit API docs](https://www.reddit.com/dev/api) useful while working on this task
 
 ## Comments
 

--- a/docs/agile/tasks/connect wikipedia.md
+++ b/docs/agile/tasks/connect wikipedia.md
@@ -1,21 +1,35 @@
 # Description
 
-Endpoint? tool calls? Indexer?
+Integrate Wikipedia article lookup using the MediaWiki API for knowledge retrieval.
+
+## Target APIs and Authentication
+
+- **API**: [MediaWiki API](https://www.mediawiki.org/wiki/API:Main_page)
+- **Authentication**: Read requests require no auth but must send a descriptive `User-Agent`; OAuth is optional for high-volume or write operations
+
+## Data Flow & Rate Limiting
+
+- Agent issues search/query ➜ MediaWiki API ➜ parse summary ➜ internal knowledge store or broker
+- Follow Wikimedia guidelines: throttle to ~1 request/second and honor `Retry-After`/`maxlag` responses
 
 ## Requirements/Definition of done
 
-- If it doesn't have this, we can't accept it
+- Agents can query and retrieve article summaries
+- Data is routed through broker or storage services
+- Requests respect rate limits and include required headers
 
-## Tasks 
+## Tasks
 
-- [ ] Step 1
-- [ ] Step 2
-- [ ] Step 3
-- [ ] Step 4
+- [ ] Implement client for search and page retrieval
+- [ ] Add User-Agent and optional OAuth credentials
+- [ ] Queue results into knowledge store or broker
+- [ ] Add throttling and `maxlag` handling
+- [ ] Integration tests for search and retrieval
+- [ ] Unit tests for rate-limit/backoff logic
 
 ## Relevent resources
 
-You might find [this] useful while working on this task
+You might find [MediaWiki API docs](https://www.mediawiki.org/wiki/API:Main_page) useful while working on this task
 
 ## Comments
 


### PR DESCRIPTION
## Summary
- outline Reddit API OAuth2 usage, data flow, and rate limiting in `connect reddit.md`
- document Bluesky AT Protocol authentication and throttling in `connect bluesky.md`
- specify MediaWiki query flow, user-agent requirements, and throttling for `connect wikipedia.md`
- note these additions in the changelog

## Testing
- `pre-commit run --files docs/agile/tasks/connect\ reddit.md docs/agile/tasks/connect\ bluesky.md docs/agile/tasks/connect\ wikipedia.md CHANGELOG.md`
- `make format` *(fails: SyntaxError in Prettier while formatting unrelated file)*
- `make lint` *(fails: ESLint flat config extends not supported)*
- `make test` *(interrupted: keyboard interrupt during JS tests)*
- `make build` *(interrupted: keyboard interrupt during TypeScript build)*
- `make kanban-from-tasks` *(fails: missing hashtags_to_kanban.py script)*

------
https://chatgpt.com/codex/tasks/task_e_68ae409079888324b6c64a080b55ba7c