### PR TITLE
docs: document Discord hyperparameter configuration task

### DIFF
--- a/docs/agile/tasks/allow_configuration_of_hyperparameters_through_discord_context_size_spectrogram_resolution_interuption_threshold_md.md
+++ b/docs/agile/tasks/allow_configuration_of_hyperparameters_through_discord_context_size_spectrogram_resolution_interuption_threshold_md.md
@@ -1,24 +1,60 @@
 ## 🛠️ Description
 
-Placeholder task stub generated from kanban board.
+Enable runtime tuning of core audio and language model settings through Discord.  Users with the
+appropriate role should be able to inspect and update hyperparameters without redeploying a
+service.
 
 ---
 
 ## 🎯 Goals
 
-- What are we trying to accomplish?
+- Allow authorized Discord users to configure model and audio pipeline hyperparameters on the fly.
+- Persist chosen values so they survive service restarts.
+- Provide clear feedback and validation when values are queried or updated.
 
 ---
 
 ## 📦 Requirements
 
-- [ ] Detail requirements.
+| Hyperparameter           | Allowed Range                        | Validation Rules |
+|-------------------------|--------------------------------------|------------------|
+| `context_size`          | `256`–`32768` tokens                 | Integer within range; reject unsupported values for active model |
+| `spectrogram_resolution`| `64`–`4096` bins per dimension, even | Input as `WIDTHxHEIGHT`; both integers, multiples of `2`, and in range |
+| `interruption_threshold`| `0.1`–`5.0` seconds                  | Float; clamp to range; round to two decimals |
+
+### Discord Interface
+
+- Slash command: `/config get <param>` to view current value.
+- Slash command: `/config set <param> <value>` to update a value.
+- Autocomplete or choices should limit input to valid ranges where possible.
+
+---
+
+## 🔐 Security & Privacy
+
+- Restrict `/config` commands to Discord roles flagged as administrators.
+- Log every change with user ID and timestamp for auditing.
+- Reject values containing code, markup, or unexpectedly long strings to prevent injection or abuse.
+- Avoid exposing model secrets or internal topology when responding to unauthenticated queries.
+
+---
+
+## ✅ Success Criteria
+
+- [ ] Valid commands update in-memory settings and persist to the service's configuration store.
+- [ ] Invalid ranges produce informative error messages without modifying existing values.
+- [ ] A `get` command reflects the latest stored value.
+- [ ] Security logging shows who changed what and when.
 
 ---
 
 ## 📋 Subtasks
 
-- [ ] Outline steps to implement.
+- [ ] Implement `/config get` and `/config set` Discord commands.
+- [ ] Add range validation utilities for each hyperparameter.
+- [ ] Persist updates to database or environment file.
+- [ ] Gate command usage behind role/permission checks and add audit logging.
+- [ ] Add unit tests for validation logic and command handlers.
 
 ---
 


### PR DESCRIPTION
## Summary
- specify hyperparameters, validation ranges, and Discord commands
- note security/privacy considerations
- outline success criteria and implementation subtasks

## Testing
- `pre-commit run --files docs/agile/tasks/allow_configuration_of_hyperparameters_through_discord_context_size_spectrogram_resolution_interuption_threshold_md.md`
- `pytest -q` *(fails: FileNotFoundError in multiple tests)*


------
https://chatgpt.com/codex/tasks/task_e_68ae4084728c8324aababd90b1e97570