### PR TITLE
feat: add task linting script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - v1 router exposing consolidated SmartGPT Bridge endpoints.
 - OpenAPI spec for `/v1` served at `/v1/openapi.json` with consolidated operations.
 - `distclean` target to remove ignored files via `git clean -fdX`.
+- Task linting script with `lint-tasks` Makefile target for verifying agile task files.
 
 ### Changed
 

--- a/Makefile
+++ b/Makefile
@@ -91,6 +91,7 @@ COMMANDS := \
   kanban-from-tasks \
   kanban-to-hashtags \
   kanban-to-issues \
+  lint-tasks \
   simulate-ci \
   docker-build \
   docker-up \

--- a/docs/agile/Process.md
+++ b/docs/agile/Process.md
@@ -151,6 +151,10 @@ During **Prompt Refinement** and **Agent Thinking**, the user and the agent talk
 through rough ideas until they can be broken down into actionable work. The agent
 suggests board movements based on metadata and helps enforce WIP limits.
 
+### Task File Checklist
+
+Each task in `docs/agile/tasks/` must include sections for **Description**, **Goals**, **Requirements**, and **Subtasks** and contain one status hashtag such as `#Todo` or `#InProgress`. Run `make lint-tasks` to validate task files before updating the board.
+
 ---
 
 ## 🏷 Tags

--- a/mk/commands.hy
+++ b/mk/commands.hy
@@ -655,6 +655,9 @@
 (defn-cmd kanban-to-issues []
   (sh ["python" "scripts/kanban_to_issues.py"]))
 
+(defn-cmd lint-tasks []
+  (sh ["python" "scripts/lint_tasks.py"]))
+
 (defn-cmd simulate-ci []
   (if (os.environ.get "SIMULATE_CI_JOB")
       (sh ["python" "scripts/simulate_ci.py" "--job" (os.environ.get "SIMULATE_CI_JOB")])

--- a/scripts/lint_tasks.py
+++ b/scripts/lint_tasks.py
@@ -1,0 +1,41 @@
+import re
+import sys
+from pathlib import Path
+
+REQUIRED_SECTIONS = ["Description", "Goals", "Requirements", "Subtasks"]
+STATUS_TAGS = {"#IceBox", "#Accepted", "#Ready", "#Todo", "#InProgress", "#Done"}
+
+
+def check_file(path: Path):
+    text = path.read_text()
+    errors = []
+    for section in REQUIRED_SECTIONS:
+        pattern = re.compile(
+            rf"^#+\s*{re.escape(section)}", re.IGNORECASE | re.MULTILINE
+        )
+        if not pattern.search(text):
+            errors.append(f"Missing section: {section}")
+    if not any(tag in text for tag in STATUS_TAGS):
+        errors.append("Missing status hashtag")
+    if errors:
+        return path, errors
+    return None
+
+
+def main() -> None:
+    directory = Path(sys.argv[1]) if len(sys.argv) > 1 else Path("docs/agile/tasks")
+    failures = []
+    for md_file in sorted(directory.glob("*.md")):
+        result = check_file(md_file)
+        if result:
+            failures.append(result)
+    if failures:
+        for path, errs in failures:
+            for err in errs:
+                print(f"{path}: {err}")
+        sys.exit(1)
+    print("All task files have required sections and status hashtags.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/scripts/test_lint_tasks.py
+++ b/tests/scripts/test_lint_tasks.py
@@ -1,0 +1,31 @@
+import subprocess
+from pathlib import Path
+
+
+def run_lint(path: Path):
+    return subprocess.run(
+        [
+            "python",
+            "scripts/lint_tasks.py",
+            str(path),
+        ],
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_lint_tasks_pass(tmp_path):
+    good = tmp_path / "good.md"
+    good.write_text(
+        "# Description\n\n## Goals\n\n## Requirements\n\n## Subtasks\n\n#Todo\n"
+    )
+    result = run_lint(tmp_path)
+    assert result.returncode == 0
+
+
+def test_lint_tasks_fail(tmp_path):
+    bad = tmp_path / "bad.md"
+    bad.write_text("# Description\n\n#Todo\n")
+    result = run_lint(tmp_path)
+    assert result.returncode != 0
+    assert "Missing section" in result.stdout


### PR DESCRIPTION
## Summary
- check agile task docs for required sections and a status tag
- wire `lint-tasks` script into the Makefile
- document task linting workflow in Process guide

## Testing
- `pre-commit run --files scripts/lint_tasks.py mk/commands.hy docs/agile/Process.md tests/scripts/test_lint_tasks.py CHANGELOG.md Makefile`
- `pytest tests/scripts/test_lint_tasks.py -q`
- `python scripts/lint_tasks.py`
- `make build`
- `make lint` *(fails: A config object is using the "extends" key, which is not supported in flat config system.)*
- `make format` *(fails: SyntaxError in shared/sibilant and providers.yml)*
- `make test` *(fails: ERROR: file or directory not found: tests/scripts/test_lint_tasks.py and subsequent task execution errors)*

------
https://chatgpt.com/codex/tasks/task_e_68ae405f99808324b0c2750e9ecf9971