### PR TITLE
docs: add task anti-patterns guidance

### DIFF
--- a/docs/agile/Process.md
+++ b/docs/agile/Process.md
@@ -1,5 +1,7 @@
 # Board flow
 
+See [task anti-patterns](task-anti-patterns.md) for common mistakes when authoring tasks.
+
 ## 🌐 Updated Kanban Flow Diagram
 
 ```mermaid
@@ -69,8 +71,8 @@ A lightly-formed idea or proposal. We are not yet committed to doing it.
 
 **Transitions:**
 
-* `New -> Accepted`: we've discussed and decided it has value.
-* `New -> Rejected`: it's a duplicate, not feasible, or not relevant.
+- `New -> Accepted`: we've discussed and decided it has value.
+- `New -> Rejected`: it's a duplicate, not feasible, or not relevant.
 
 ### Rejected
 
@@ -99,9 +101,9 @@ Items from here usually return to **Breakdown** once concrete actions emerge.
 We break the idea down into requirements, values, and approaches.
 Outcomes:
 
-* Becomes `Ready`
-* Moves to `Blocked`
-* Gets `Rejected`
+- Becomes `Ready`
+- Moves to `Blocked`
+- Gets `Rejected`
 
 ### Blocked
 
@@ -143,7 +145,6 @@ A board manager agent keeps this flow consistent.
 
 The human contributor has final say on priorities and merges, but the agent maintains board hygiene and surfaces gaps.
 
-
 Codex and the board manager agent participate throughout this flow. The board
 manager keeps tasks synced between the Kanban board and `agile/tasks/`, while
 Codex provides code or documentation when a card carries the `#codex-task` tag.
@@ -155,13 +156,13 @@ suggests board movements based on metadata and helps enforce WIP limits.
 
 ## 🏷 Tags
 
-* `#codex-task` → Codex should code/test/doc
-* `#agent-mode` → Discussion-style exploration
-* `#framework-core` → Related to Promethean internals
-* `#agent-specific` → Tied to a named agent (e.g., Duck, Synthesis)
-* `#layer1`, `#layer2` → Tied to Eidolon/Cephalon layers
-* `#doc-this` → Task produces documentation
-* `#rewrite-later` → Placeholder
+- `#codex-task` → Codex should code/test/doc
+- `#agent-mode` → Discussion-style exploration
+- `#framework-core` → Related to Promethean internals
+- `#agent-specific` → Tied to a named agent (e.g., Duck, Synthesis)
+- `#layer1`, `#layer2` → Tied to Eidolon/Cephalon layers
+- `#doc-this` → Task produces documentation
+- `#rewrite-later` → Placeholder
 
 ---
 

--- a/docs/agile/task-anti-patterns.md
+++ b/docs/agile/task-anti-patterns.md
@@ -1,0 +1,10 @@
+# Task Anti-Patterns
+
+Common mistakes to avoid when working with tasks:
+
+- Creating empty files that never receive content
+- Leaving `TODO` placeholders instead of actionable details
+- Omitting required hashtags that drive board automation
+- Duplicating existing tasks or knowledge
+
+#agile #workflow #guidelines #promethean


### PR DESCRIPTION
## Summary
- document common task anti-patterns such as empty files, TODO placeholders, missing hashtags, and duplication
- reference task anti-pattern guidance from the agile process doc

## Testing
- `make lint` *(fails: config uses unsupported `extends` and Prettier reports issues)*
- `make test` *(fails: make: *** [Makefile:139: test] Error 1)*
- `make build`


------
https://chatgpt.com/codex/tasks/task_e_68ae405e246483248ae771f5a4f867ca