### PR TITLE
Detail social connector tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Changed
 
 - Refined Kanban breakdown tasks with clear goals, requirements, and subtasks.
+- Expanded task descriptions for Reddit, Bluesky, and Wikipedia integrations.
 - MCP server and stdio wrapper exposing `search.query` over WebSocket and CLI.
 - Packaging for `shared` modules to enable standard imports.
 - Central `tests/conftest.py` to configure the test environment.
@@ -75,7 +76,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Pinned JavaScript dependencies, GitHub Actions, and documented version policy for reproducible builds.
 - Pre-commit now runs `pnpm tsc --noEmit` and `pytest -q` instead of `make build`; use `pre-commit run --hook-stage manual full-build` or `make build` for full builds.
 - Naive embedding driver now uses configurable `VECTOR_SIZE` constant.
- - Enhanced URL canonicalization helpers to remove tracking parameters and expand scheme denylist.
+- Enhanced URL canonicalization helpers to remove tracking parameters and expand scheme denylist.
 - Organized SmartGPT Bridge routes into versioned directories.
 - Embedding clients and related utilities now accept structured `{type, data}`
   items instead of using the `img:` prefix.

--- a/docs/agile/tasks/connect bluesky.md
+++ b/docs/agile/tasks/connect bluesky.md
@@ -1,23 +1,31 @@
 # Description
 
-Agent provider thingy
-
+Establish connectivity with Bluesky's AT Protocol so agents can read and publish posts.
 
 ## Requirements/Definition of done
 
-- If it doesn't have this, we can't accept it
+- Authenticate using a Bluesky app password without exposing credentials.
+- Retrieve the latest posts for a configured account or feed.
+- Publish posts or replies through the bridge service.
+- Handle rate limits and error responses gracefully.
+- Include unit tests covering posting and retrieval.
 
-## Tasks 
+## Tasks
 
-- [ ] Step 1
-- [ ] Step 2
-- [ ] Step 3
-- [ ] Step 4
+- [ ] Create a Bluesky developer account and generate an app password.
+- [ ] Add a client using `@atproto/api` or HTTP calls to interact with the service.
+- [ ] Implement fetching of the home timeline and posting actions.
+- [ ] Expose configuration via environment variables and document them.
+- [ ] Write tests exercising posting and retrieval features.
+- [ ] Provide a README section describing the Bluesky integration.
 
-## Relevent resources
+## Relevant resources
 
-You might find [this] useful while working on this task
+- [Bluesky AT Protocol Docs](https://atproto.com)
+- [bluesky-social/atproto GitHub](https://github.com/bluesky-social/atproto)
 
 ## Comments
 
 Useful for agents to engage in append only conversations about this task.
+
+#Breakdown

--- a/docs/agile/tasks/connect reddit.md
+++ b/docs/agile/tasks/connect reddit.md
@@ -1,23 +1,30 @@
 # Description
 
-- Agent provider thingy
-- 
+Integrate Reddit as an external content source so agents can read from and post to specified subreddits.
 
 ## Requirements/Definition of done
 
-- If it doesn't have this, we can't accept it
+- Authenticate using Reddit OAuth2 with configurable client ID and secret.
+- Support retrieving posts and comments from configured subreddits.
+- Publish retrieved data to the Promethean event bus for downstream processing.
+- Provide a command or service endpoint to submit posts or comments.
+- Include unit tests for authentication and data retrieval.
 
-## Tasks 
+## Tasks
 
-- [ ] Step 1
-- [ ] Step 2
-- [ ] Step 3
-- [ ] Step 4
+- [ ] Register a Reddit application and store credentials in environment variables.
+- [ ] Implement a minimal Reddit client using the official API.
+- [ ] Create a service wrapper to fetch new posts and emit events.
+- [ ] Expose an endpoint or CLI command for submitting content through the bridge.
+- [ ] Write tests covering authentication and sample subreddit retrieval.
+- [ ] Document setup steps and required environment variables.
 
-## Relevent resources
+## Relevant resources
 
-You might find [this] useful while working on this task
+- [Reddit API Docs](https://www.reddit.com/dev/api/)
 
 ## Comments
 
 Useful for agents to engage in append only conversations about this task.
+
+#Breakdown

--- a/docs/agile/tasks/connect wikipedia.md
+++ b/docs/agile/tasks/connect wikipedia.md
@@ -1,22 +1,30 @@
 # Description
 
-Endpoint? tool calls? Indexer?
+Enable agents to query Wikipedia for article summaries and structured data.
 
 ## Requirements/Definition of done
 
-- If it doesn't have this, we can't accept it
+- Use the MediaWiki API to search and fetch article extracts.
+- Handle disambiguation pages and missing articles.
+- Cache results or respect rate limits to avoid throttling.
+- Provide a tool-call interface or endpoint for agents to request summaries.
+- Include unit tests for search and fetch operations.
 
-## Tasks 
+## Tasks
 
-- [ ] Step 1
-- [ ] Step 2
-- [ ] Step 3
-- [ ] Step 4
+- [ ] Investigate MediaWiki API endpoints for search and page extracts.
+- [ ] Implement a client wrapper for querying and retrieving summary data.
+- [ ] Add a caching layer or polite rate limiting.
+- [ ] Expose a tool call or service endpoint for agent use.
+- [ ] Write tests verifying retrieval of a known article.
+- [ ] Document usage and configuration steps.
 
-## Relevent resources
+## Relevant resources
 
-You might find [this] useful while working on this task
+- [MediaWiki API Docs](https://www.mediawiki.org/wiki/API:Main_page)
 
 ## Comments
 
 Useful for agents to engage in append only conversations about this task.
+
+#Breakdown


### PR DESCRIPTION
## Summary
- flesh out roadmap entries for Reddit, Bluesky, and Wikipedia connectors with real requirements and subtasks
- tag each task with #Breakdown status and reference API docs
- record task updates in CHANGELOG

## Testing
- `pnpm exec prettier --write docs/agile/tasks/'connect reddit.md' docs/agile/tasks/'connect bluesky.md' docs/agile/tasks/'connect wikipedia.md' CHANGELOG.md`
- `make kanban-from-tasks` *(fails: scripts/hashtags_to_kanban.py not found)*
- `make lint` *(fails: missing biome and lint dependencies)*
- `make test` *(terminated: SIGINT)*
- `make build` *(terminated early)*

------
https://chatgpt.com/codex/tasks/task_e_68ae3e6f24e0832491dc99a849429e6c