### PR TITLE
Add tests for Ollama tag script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - OpenAPI spec for `/v1` served at `/v1/openapi.json` with consolidated operations.
 - `distclean` target to remove ignored files via `git clean -fdX`.
 
+- Tests covering `scripts.add_tags_ollama` tag generation and file processing.
+
 ### Changed
 
 - Refined Kanban breakdown tasks with clear goals, requirements, and subtasks.
@@ -75,7 +77,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Pinned JavaScript dependencies, GitHub Actions, and documented version policy for reproducible builds.
 - Pre-commit now runs `pnpm tsc --noEmit` and `pytest -q` instead of `make build`; use `pre-commit run --hook-stage manual full-build` or `make build` for full builds.
 - Naive embedding driver now uses configurable `VECTOR_SIZE` constant.
- - Enhanced URL canonicalization helpers to remove tracking parameters and expand scheme denylist.
+- Enhanced URL canonicalization helpers to remove tracking parameters and expand scheme denylist.
 - Organized SmartGPT Bridge routes into versioned directories.
 - Embedding clients and related utilities now accept structured `{type, data}`
   items instead of using the `img:` prefix.

--- a/tests/scripts/test_add_tags_ollama.py
+++ b/tests/scripts/test_add_tags_ollama.py
@@ -1,0 +1,74 @@
+"""Tests for :mod:`scripts.add_tags_ollama`."""
+
+"""Tests for :mod:`scripts.add_tags_ollama`."""
+
+"""Tests for :mod:`scripts.add_tags_ollama`."""
+
+import subprocess
+import types
+import shutil
+
+from tests.scripts.utils import load_script_module
+
+add_tags = load_script_module("add_tags_ollama")
+
+
+def test_generate_tags_success(monkeypatch):
+    """generate_tags should return hashtags when the CLI call succeeds."""
+
+    monkeypatch.setattr(shutil, "which", lambda cmd: "/usr/bin/ollama")
+
+    def fake_run(cmd, *, input, capture_output, text, check):
+        return types.SimpleNamespace(stdout="#one #two #three")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    tags = add_tags.generate_tags("content")
+    assert tags == "#one #two #three"
+    assert all(tag.startswith("#") for tag in tags.split())
+
+
+def test_generate_tags_missing_cli(monkeypatch):
+    """generate_tags returns an empty string when ollama is not installed."""
+
+    monkeypatch.setattr(shutil, "which", lambda cmd: None)
+    assert add_tags.generate_tags("content") == ""
+
+
+def test_generate_tags_subprocess_failure(monkeypatch):
+    """generate_tags returns an empty string when ollama run fails."""
+
+    monkeypatch.setattr(shutil, "which", lambda cmd: "/usr/bin/ollama")
+
+    def fake_run(cmd, *, input, capture_output, text, check):
+        raise subprocess.CalledProcessError(returncode=1, cmd=cmd)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    assert add_tags.generate_tags("content") == ""
+
+
+def test_process_file_appends_tags(tmp_path, monkeypatch):
+    """process_file appends generated tags to markdown files."""
+
+    file_path = tmp_path / "doc.md"
+    file_path.write_text("Hello\n", encoding="utf-8")
+
+    monkeypatch.setattr(add_tags, "generate_tags", lambda content: "#alpha #beta")
+    add_tags.process_file(file_path)
+
+    assert file_path.read_text(encoding="utf-8").splitlines() == [
+        "Hello",
+        "#alpha #beta",
+    ]
+
+
+def test_process_file_replaces_existing_tags(tmp_path, monkeypatch):
+    """Existing tag line is replaced with newly generated tags."""
+
+    file_path = tmp_path / "doc.md"
+    file_path.write_text("Hello\n#old\n", encoding="utf-8")
+
+    monkeypatch.setattr(add_tags, "generate_tags", lambda content: "#new")
+    add_tags.process_file(file_path)
+
+    assert file_path.read_text(encoding="utf-8").splitlines() == ["Hello", "#new"]


### PR DESCRIPTION
## Summary
- add tests for `scripts.add_tags_ollama`
- document new tests in changelog

## Testing
- `pytest tests/scripts/test_add_tags_ollama.py -q`
- `make format` *(fails: KeyboardInterrupt)*
- `make lint` *(fails: ESLint config error)*
- `make build` *(fails: KeyboardInterrupt)*
- `make test` *(fails: missing modules and file errors)*

------
https://chatgpt.com/codex/tasks/task_e_68ae412caf6883248a02d1f840fa7834