### PR TITLE
chore: update Ready task statuses and regenerate kanban board

### DIFF
--- a/docs/agile/boards/kanban.md
+++ b/docs/agile/boards/kanban.md
@@ -4,466 +4,280 @@ kanban-plugin: board
 
 ---
 
-## 📊 Strategic Graphs
+## Rejected
 
-- [ ] [[architecture/project-evolution-timeline.md|Project Evolution Timeline]]
-- [ ] [[reports/persistence-dependency-graph.md|Persistence Migration Graph]]
-- [ ] [[architecture/compiler-evolution-graph.md|Lisp Compiler Evolution Graph]]
-- [ ] [[architecture/hy-migration-graph.md|Hy Migration Graph]]
-- [ ] [[architecture/persistence-migration-graph.md|DualStore Migration Graph]]
-
-
-## Migration Checklists
-
-- [ ] [[reports/persistence-migration-checklist.md|Persistence Migration Checklist]]
-
+- [ ] [add_dev_harness_int_test_ts_to_ci_integration_stag_md](../tasks/add_dev_harness_int_test_ts_to_ci_integration_stag_md.md) #rejected
+- [ ] [add_lag_checks_to_ci_smoke_ensure_small_lag_after_md](../tasks/add_lag_checks_to_ci_smoke_ensure_small_lag_after_md.md) #rejected
+- [ ] [add_manualack_to_event_bus_and_re_run_tests_md](../tasks/add_manualack_to_event_bus_and_re_run_tests_md.md) #rejected
+- [ ] [add_mongodedupe_and_replace_critical_consumers_wit_md](../tasks/add_mongodedupe_and_replace_critical_consumers_wit_md.md) #rejected
+- [ ] [add_mongooutbox_to_any_service_that_writes_db_chan_md](../tasks/add_mongooutbox_to_any_service_that_writes_db_chan_md.md) #rejected
+- [ ] [add_ollama_formally_to_pipeline_md_md](../tasks/add_ollama_formally_to_pipeline_md_md.md) #rejected
+- [ ] [add_ops_endpoint_to_list_partition_assignments_opt_md](../tasks/add_ops_endpoint_to_list_partition_assignments_opt_md.md) #rejected
+- [ ] [add_process_txn_projector_to_upsert_processes_host_md](../tasks/add_process_txn_projector_to_upsert_processes_host_md.md) #rejected
+- [ ] [add_prometheus_events_counters_in_ws_server_hook_p_md](../tasks/add_prometheus_events_counters_in_ws_server_hook_p_md.md) #rejected
+- [ ] [add_snapshot_consumer_to_warm_cache_on_boot_md](../tasks/add_snapshot_consumer_to_warm_cache_on_boot_md.md) #rejected
+- [ ] [add_startchangelogprojector_for_any_compaction_lik_md](../tasks/add_startchangelogprojector_for_any_compaction_lik_md.md) #rejected
+- [ ] [add_tokenbucket_to_ws_server_conn_per_topic_md](../tasks/add_tokenbucket_to_ws_server_conn_per_topic_md.md) #rejected
+- [ ] [add_ttls_per_topic_via_migration_script_md](../tasks/add_ttls_per_topic_via_migration_script_md.md) #rejected
+- [ ] [add_vault_instructions_to_main_readme_md_md_md](../tasks/add_vault_instructions_to_main_readme_md_md_md.md) #rejected
+- [ ] [define_default_scopes_publish_heartbeat_received_s_md](../tasks/define_default_scopes_publish_heartbeat_received_s_md.md) #rejected
+- [ ] [deploy_changefeed_for_collections_you_want_mirrore_md](../tasks/deploy_changefeed_for_collections_you_want_mirrore_md.md) #rejected
+- [ ] [detect_contradictions_in_memory_codex_task_md](../tasks/detect_contradictions_in_memory_codex_task_md.md) #rejected
+- [ ] [document_etag_semantics_and_cache_headers_for_snap_md](../tasks/document_etag_semantics_and_cache_headers_for_snap_md.md) #rejected
+- [ ] [enable_scripts_lint_topics_ts_in_ci_md](../tasks/enable_scripts_lint_topics_ts_in_ci_md.md) #rejected
+- [ ] [ensure_github_compatible_markdown_settings_are_doc_md](../tasks/ensure_github_compatible_markdown_settings_are_doc_md.md) #rejected
+- [ ] [ensure_mongo_indexes_key_1_unique_common_query_fie_md](../tasks/ensure_mongo_indexes_key_1_unique_common_query_fie_md.md) #rejected
+- [ ] [evaluate_and_reward_flow_satisfaction_framework_co_md](../tasks/evaluate_and_reward_flow_satisfaction_framework_co_md.md) #rejected
+- [ ] [expose_metrics_on_an_express_app_and_scrape_with_p_md](../tasks/expose_metrics_on_an_express_app_and_scrape_with_p_md.md) #rejected
+- [ ] [expose_snapshot_api_for_processes_collection_proce_md](../tasks/expose_snapshot_api_for_processes_collection_proce_md.md) #rejected
+- [ ] [finalize_stt_workflow_md_md](../tasks/finalize_stt_workflow_md_md.md) #rejected
+- [ ] [identify_ancestral_resonance_patterns_framework_co_md](../tasks/identify_ancestral_resonance_patterns_framework_co_md.md) #rejected
+- [ ] [implement_pause_resume_ops_on_gateway_md](../tasks/implement_pause_resume_ops_on_gateway_md.md) #rejected
+- [ ] [implement_timetravel_processat_processid_t_in_a_sm_md](../tasks/implement_timetravel_processat_processid_t_in_a_sm_md.md) #rejected
+- [ ] [implement_transcendence_cascade_framework_core_md](../tasks/implement_transcendence_cascade_framework_core_md.md) #rejected
+- [ ] [launch_replayapi_on_8083_test_replay_and_export_nd_md](../tasks/launch_replayapi_on_8083_test_replay_and_export_nd_md.md) #rejected
+- [ ] [move_all_testing_to_individual_services_md](../tasks/move_all_testing_to_individual_services_md.md) #rejected
+- [ ] [register_v_1_schema_for_any_evolving_topic_and_wri_md](../tasks/register_v_1_schema_for_any_evolving_topic_and_wri_md.md) #rejected
+- [ ] [snapshot_prompts_specs_to_repo_md](../tasks/snapshot_prompts_specs_to_repo_md.md) #rejected
+- [ ] [spin_up_ws_gateway_ws_port_8090_ws_token_devtoken_md](../tasks/spin_up_ws_gateway_ws_port_8090_ws_token_devtoken_md.md) #rejected
+- [ ] [suggest_metaprogramming_updates_codex_task_md](../tasks/suggest_metaprogramming_updates_codex_task_md.md) #rejected
+- [ ] [summarize_clarified_priorities_for_next_sprint_md_md](../tasks/summarize_clarified_priorities_for_next_sprint_md_md.md) #rejected
+- [ ] [switch_critical_readers_to_subscribenormalized_md](../tasks/switch_critical_readers_to_subscribenormalized_md.md) #rejected
+- [ ] [switch_gateway_auth_to_jwt_generate_temp_hs256_tok_md](../tasks/switch_gateway_auth_to_jwt_generate_temp_hs256_tok_md.md) #rejected
+- [ ] [use_subscribepartitioned_for_cpu_heavy_consumers_t_md](../tasks/use_subscribepartitioned_for_cpu_heavy_consumers_t_md.md) #rejected
+- [ ] [wire_runoutboxdrainer_in_event_hub_md](../tasks/wire_runoutboxdrainer_in_event_hub_md.md) #rejected
+- [ ] [wrap_event_hub_publish_path_with_withschemavalidat_md](../tasks/wrap_event_hub_publish_path_with_withschemavalidat_md.md) #rejected
+- [ ] [wrap_writers_with_withdualwrite_md](../tasks/wrap_writers_with_withdualwrite_md.md) #rejected
+- [ ] [write_a_replay_job_that_replays_process_state_snap_md](../tasks/write_a_replay_job_that_replays_process_state_snap_md.md) #rejected
+- [ ] [write_a_smoke_test_client_subscribes_publish_10_ms_md](../tasks/write_a_smoke_test_client_subscribes_publish_10_ms_md.md) #rejected
 
 ## Ice Box
 
-- [ ] [[Find music that triggered copyright mute on twitch for analysis incoming]]
-- [ ] [[evaluate_and_reward_flow_satisfaction_md_md.md|Evaluate and reward flow satisfaction]] #framework-core #ice-box
-- [ ] [[finish_whisper_npu_system_md_md.md|finish whisper npu system md md]] #framework-core #performance-optimization #npu-integration #accepted
-- [ ] [[implement_fragment_ingestion_with_activation_vecto_md.md|Implement fragment ingestion with activation vectors]] #framework-core #ice-box
-- [ ] [[schedule_alignment_meeting_with_stakeholders_md_md.md|Schedule alignment meeting with stakeholders]] #framework-core #ice-box
-- [ ] [[write_a_small_cutover_script_to_replay_historical_md.md|Write a small **cutover** script to replay historical events through upcasters into snapshots]] #ice-box
-- [ ] [[define_codex_cli_baseg_agent_md_md.md|define codex cli baseg agent md md]] #framework-core #ice-box
-- [ ] [[discord_chat_link_traversal_md_md.md|discord chat link traversal md md]] #framework-core #ice-box
-- [ ] [[obsidian_replacement_md.md|obsidian replacement md]] #framework-core #ice-box
-- [ ] [[reach_100_percent_complete_test_coverage_1_md_md.md|reach 100 percent complete test coverage 1 md md]] #framework-core #ice-box
-- [ ] [[snapshot_prompts_specs_to_repo_md_md.md|snapshot prompts specs to repo md md]] #ice-box
-- [ ] [[tool_chain_management_system_md_md.md|tool chain management system md md]] #framework-core #ice-box
-- [ ] [[implement_fragment_ingestion_with_activation_vecto_md.md|Implement fragment ingestion with activation vectors #codex-task]] #framework-core #ice-box
-- [ ] [[design_circular_buffers_for_inputs_with_layered_states_of_persistance_in_memory_on_disk_cold_storage_so_md.md|design circular buffers for inputs with layered states of persistance (in memory, on disk, cold storage, so )]] #framework-core #ice-box
-- [ ] [[gather_baseline_emotion_metrics_for_eidolon_field_1_md.md|Gather baseline emotion metrics for Eidolon field]] #framework-core #ice-box
-- [ ] [[identify_ancestral_resonance_patterns_md_md.md|Identify ancestral resonance patterns]] #framework-core #ice-box
-- [ ] [[implement_fragment_ingestion_with_activation_vecto_md.md|Implement fragment ingestion with activation vectors]] #framework-core #ice-box
-- [ ] [[thinking_model_integration_md_md.md|Thinking Model integration.md]] #framework-core #ice-box
-- [ ] [[integrate_synthesis-agent_pass_on_unique_to_produce_draft_docs_1_md.md|Integrate synthesis-agent pass on `unique/` to produce draft docs]] #framework-core #ice-box
-- [ ] [[schedule_alignment_meeting_with_stakeholders_md_md.md|Schedule alignment meeting with stakeholders]] #framework-core #ice-box
-- [ ] [[write_a_small_cutover_script_to_replay_historical_md.md|Write a small **cutover** script to replay historical events through upcasters into snapshots]] #ice-box
-- [ ] [[tool_chain_management_system_md_md.md|Tool chain management system.md]] #framework-core #ice-box
-- [ ] [[wire_mongoeventstore_mongocursorstore_in_place_of_md.md|Wire MongoEventStore + MongoCursorStore in place of InMemory]] #ice-box
-- [ ] [[snapshot_prompts_specs_to_repo_md_md.md|Snapshot prompts and specs to repo]] #ice-box
-- [ ] [[annotate_legacy_code_with_migration_tags_md.md|Annotate legacy code with migration tags]] #framework-core #ice-box
-- [ ] [[allow_configuration_of_hyperparameters_through_discord_context_size_spectrogram_resolution_interuption_threshold_md.md|Allow configuration of hyperparameters through discord (context size, spectrogram resolution, interuption threshold]] #framework-core #ice-box
-- [ ] [[add_semantic_overlays_for_layer1_through_layer8_md_md.md|Add semantic overlays for layer1 through layer8]] #layerX #framework-core #ice-box
-- [ ] [[define_permission_schema_in_agents_1_md.md|Define permission schema in AGENTS.md]] #framework-core #eidolon #Dorian #layer2 #ice-box
-- [ ] [[gather_open_questions_about_system_direction_md_md.md|Gather open questions about system direction]] #framework-core #ice-box
-- [ ] [[gather_baseline_emotion_metrics_for_eidolon_field_1_md.md|Gather baseline emotion metrics for Eidolon field]] #framework-core #ice-box
-
+- [ ] [add_file_system_to_context_management_system_md_md](../tasks/add_file_system_to_context_management_system_md_md.md) #ice-box
+- [ ] [add_semantic_overlays_for_layer1_through_layer8_md_md](../tasks/add_semantic_overlays_for_layer1_through_layer8_md_md.md) #ice-box
+- [ ] [allow_configuration_of_hyperparameters_through_discord_context_size_spectrogram_resolution_interuption_threshold_md](../tasks/allow_configuration_of_hyperparameters_through_discord_context_size_spectrogram_resolution_interuption_threshold_md.md) #ice-box
+- [ ] [allow_old_unnessisary_messages_to_decay_from_database_while_retaining_index_entries_ids_md_md](../tasks/allow_old_unnessisary_messages_to_decay_from_database_while_retaining_index_entries_ids_md_md.md) #ice-box
+- [ ] [annotate_legacy_code_with_migration_tags_md](../tasks/annotate_legacy_code_with_migration_tags_md.md) #ice-box
+- [ ] [cache_decay_mechanisim_md_md](../tasks/cache_decay_mechanisim_md_md.md) #ice-box
+- [ ] [define_codex_cli_baseg_agent_md_md](../tasks/define_codex_cli_baseg_agent_md_md.md) #ice-box
+- [ ] [define_permission_schema_in_agents_1_md](../tasks/define_permission_schema_in_agents_1_md.md) #ice-box
+- [ ] [design_circular_buffers_for_inputs_with_layered_states_of_persistance_in_memory_on_disk_cold_storage_so_md](../tasks/design_circular_buffers_for_inputs_with_layered_states_of_persistance_in_memory_on_disk_cold_storage_so_md.md) #ice-box
+- [ ] [detect_contradictions_in_memory_md_md](../tasks/detect_contradictions_in_memory_md_md.md) #ice-box
+- [ ] [discord_chat_link_traversal_md_md](../tasks/discord_chat_link_traversal_md_md.md) #ice-box
+- [ ] [enable_compactor_for_process_state_process_state_s_md](../tasks/enable_compactor_for_process_state_process_state_s_md.md) #ice-box
+- [ ] [evaluate_and_reward_flow_satisfaction_md_md](../tasks/evaluate_and_reward_flow_satisfaction_md_md.md) #ice-box
+- [ ] [gather_baseline_emotion_metrics_for_eidolon_field_1_md](../tasks/gather_baseline_emotion_metrics_for_eidolon_field_1_md.md) #ice-box
+- [ ] [gather_open_questions_about_system_direction_md_md](../tasks/gather_open_questions_about_system_direction_md_md.md) #ice-box
+- [ ] [identify_ancestral_resonance_patterns_md_md](../tasks/identify_ancestral_resonance_patterns_md_md.md) #ice-box
+- [ ] [implement_fragment_ingestion_with_activation_vecto_md](../tasks/implement_fragment_ingestion_with_activation_vecto_md.md) #ice-box
+- [ ] [implement_transcendence_cascade_md](../tasks/implement_transcendence_cascade_md.md) #ice-box
+- [ ] [integrate_synthesis-agent_pass_on_unique_to_produce_draft_docs_1_md](../tasks/integrate_synthesis-agent_pass_on_unique_to_produce_draft_docs_1_md.md) #ice-box
+- [ ] [obsidian_replacement_md](../tasks/obsidian_replacement_md.md) #ice-box
+- [ ] [reach_100_percent_complete_test_coverage_1_md_md](../tasks/reach_100_percent_complete_test_coverage_1_md_md.md) #ice-box
+- [ ] [run_bench_subscribe_ts_with_mongo_bus_and_record_p_md](../tasks/run_bench_subscribe_ts_with_mongo_bus_and_record_p_md.md) #ice-box
+- [ ] [run_model_bakeoff_md](../tasks/run_model_bakeoff_md.md) #ice-box
+- [ ] [schedule_alignment_meeting_with_stakeholders_md_md](../tasks/schedule_alignment_meeting_with_stakeholders_md_md.md) #ice-box
+- [ ] [setup_a_second_agent_md](../tasks/setup_a_second_agent_md.md) #ice-box
+- [ ] [snapshot_prompts_specs_to_repo_md_md](../tasks/snapshot_prompts_specs_to_repo_md_md.md) #ice-box
+- [ ] [structure_vault_to_mirror_services_agents_docs_md_md](../tasks/structure_vault_to_mirror_services_agents_docs_md_md.md) #ice-box
+- [ ] [suggest_metaprogramming_updates_md](../tasks/suggest_metaprogramming_updates_md.md) #ice-box
+- [ ] [thinking_model_integration_md_md](../tasks/thinking_model_integration_md_md.md) #ice-box
+- [ ] [tool_chain_management_system_md_md](../tasks/tool_chain_management_system_md_md.md) #ice-box
+- [ ] [twitch_discord_general_auto_mod_md_md](../tasks/twitch_discord_general_auto_mod_md_md.md) #ice-box
+- [ ] [wire_mongoeventstore_mongocursorstore_in_place_of_md](../tasks/wire_mongoeventstore_mongocursorstore_in_place_of_md.md) #ice-box
+- [ ] [write_a_small_cutover_script_to_replay_historical_md](../tasks/write_a_small_cutover_script_to_replay_historical_md.md) #ice-box
 
 ## Incoming
 
-- [ ] [[allow_configuration_of_hyperparameters_through_discord_context_size_spectrogram_resolution_interuption_threshold_md.md|allow configuration of hyperparameters through discord context size spectrogram resolution interuption threshold md]] #framework-core #ice-box
-- [ ] [[Design Ollama Model file for use with codex cli 1]]
-- [ ] [[refactor_speech_interuption_system_to_be_more_inteligent_using_audio_data_to_decide_if_interupted_md_md|Refactor Speech interuption system]] #framework-core #breakdown
-- [ ] [[identify_ancestral_resonance_patterns_md_md.md|Identify ancestral resonance patterns]] #framework-core #ice-box
-- [ ] [[gather_open_questions_about_system_direction_md_md.md|Gather open questions about system direction]] #framework-core #ice-box
-- [ ] [[gather_baseline_emotion_metrics_for_eidolon_field_1_md.md|Gather baseline emotion metrics for Eidolon field]] #framework-core #ice-box
-- [ ] [[add_file_system_to_context_management_system_md_md.md|Add file system to context management system.md]] #framework-core #ice-box
-- [ ] [[implement_transcendence_cascade_md.md|Implement transcendence cascade]] #framework-core #ice-box
-- [ ] [[evaluate_and_reward_flow_satisfaction_md_md.md|Evaluate and reward flow satisfaction]] #framework-core #ice-box
-- [ ] [[define_codex_cli_baseg_agent_md_md.md|Define codex CLI baseg agent.md]] #framework-core #ice-box
-- [ ] [[discord_chat_link_traversal_md_md.md|Discord chat link traversal.md]] #framework-core #ice-box
-- [ ] [[allow_old_unnessisary_messages_to_decay_from_database_while_retaining_index_entries_ids_md_md.md|Allow old unnessisary messages to decay from database while retaining index entries ids.md]] #framework-core #eidolon-support #ice-box
-- [ ] [[pin_versions_in_configs_md.md|Pin versions in configs]] #ops #codex-task #ice-box
-- [ ] [[reach_100_percent_complete_test_coverage_1_md_md.md|Reach 100 percent complete test coverage 1.md]] #framework-core #ice-box
-- [ ] [[run_model_bakeoff_md.md|Run model bakeoff]] #ops #codex-task #ice-box
-- [ ] [[integrate_synthesis-agent_pass_on_unique_to_produce_draft_docs_1_md.md|Integrate synthesis-agent pass on `unique/` to produce draft docs]] #framework-core #ice-box
-- [ ] [[detect_contradictions_in_memory_md_md.md|Detect contradictions in memory]] #framework-core #ice-box
-- [ ] [[add_semantic_overlays_for_layer1_through_layer8_md_md.md|Add semantic overlays for layer1 through layer8]] #layerX #framework-core #ice-box
-- [ ] [[smart_task_templater_md.md|Smart Task templater]] #framework-core #ice-box
-- [ ] [[describe_github_branching_workflow_md.md|describe github branching workflow md]] #framework-core #agent-thinking #breakdown
-- [ ] [[twitch_discord_general_auto_mod_md_md.md|twitch discord general auto mod md md]] #framework-core #observability #multimodal-context #risk #ice-box
-- [ ] [[Promethean Health Dashboard|Web frontend for system management.md]] #framework-core #observability #eidolon-visualization #dashboard #broker #realtime #ice-box
-- [ ] [[setup_a_second_agent_md.md|setup a second agent md]] #framework-core #ice-box
-
+- [ ] [Mock broker](../tasks/Mock%20broker.md) #incoming
+- [ ] [auth_ci_and_load_tests](../tasks/auth_ci_and_load_tests.md) #incoming
+- [ ] [auth_key_rotation_and_bootstrap](../tasks/auth_key_rotation_and_bootstrap.md) #incoming
+- [ ] [auth_migrate_services_to_jwt](../tasks/auth_migrate_services_to_jwt.md) #incoming
+- [ ] [auth_service_rfc_and_architecture](../tasks/auth_service_rfc_and_architecture.md) #incoming
+- [ ] [auth_service_scaffold_and_endpoints](../tasks/auth_service_scaffold_and_endpoints.md) #incoming
+- [ ] [auth_shared_clients_and_middleware](../tasks/auth_shared_clients_and_middleware.md) #incoming
+- [ ] [cephalon_backfill_conversation_history](../tasks/cephalon_backfill_conversation_history.md) #incoming
+- [ ] [cephalon_context_window_from_collections](../tasks/cephalon_context_window_from_collections.md) #incoming
+- [ ] [cephalon_event_schema_updates](../tasks/cephalon_event_schema_updates.md) #incoming
+- [ ] [cephalon_feature_flag_path_selection](../tasks/cephalon_feature_flag_path_selection.md) #incoming
+- [ ] [cephalon_persist_llm_replies_to_agent_messages](../tasks/cephalon_persist_llm_replies_to_agent_messages.md) #incoming
+- [ ] [cephalon_persist_utterance_timing_metadata](../tasks/cephalon_persist_utterance_timing_metadata.md) #incoming
+- [ ] [cephalon_store_user_transcripts_unified](../tasks/cephalon_store_user_transcripts_unified.md) #incoming
+- [ ] [cephalon_tests_for_persistence_and_ecs](../tasks/cephalon_tests_for_persistence_and_ecs.md) #incoming
+- [ ] [ecs_component_schemas_core](../tasks/ecs_component_schemas_core.md) #incoming
+- [ ] [ecs_migration_path_docs](../tasks/ecs_migration_path_docs.md) #incoming
+- [ ] [ecs_mongo_adapter_library](../tasks/ecs_mongo_adapter_library.md) #incoming
+- [ ] [ecs_persistence_integration_cephalon](../tasks/ecs_persistence_integration_cephalon.md) #incoming
+- [ ] [ecs_projection_jobs](../tasks/ecs_projection_jobs.md) #incoming
+- [ ] [ecs_query_api_gateway](../tasks/ecs_query_api_gateway.md) #incoming
+- [ ] [scripts_add_folder_readmes_and_usage](../tasks/scripts_add_folder_readmes_and_usage.md) #incoming
+- [ ] [scripts_add_make_targets_and_aliases](../tasks/scripts_add_make_targets_and_aliases.md) #incoming
+- [ ] [scripts_audit_and_standardize_cli_flags](../tasks/scripts_audit_and_standardize_cli_flags.md) #incoming
+- [ ] [scripts_group_audio_tools](../tasks/scripts_group_audio_tools.md) #incoming
+- [ ] [scripts_group_docs_utilities](../tasks/scripts_group_docs_utilities.md) #incoming
+- [ ] [scripts_group_indexing_tools](../tasks/scripts_group_indexing_tools.md) #incoming
+- [ ] [scripts_group_kanban_remaining](../tasks/scripts_group_kanban_remaining.md) #incoming
+- [ ] [scripts_update_ci_and_refs](../tasks/scripts_update_ci_and_refs.md) #incoming
 
 ## Accepted
 
-- [ ] [[LLM service must allow streamed responses]]
-- [ ] [[Set up new user roles and policies for the systems]]
-- [ ] [[tamper monkey script for using templates defined in the vault]]
-- [ ] [[Make the system hashtag aware]]
-- [ ] [[cache_decay_mechanisim_md_md.md|cache decay mechanisim.md]] #framework-core #ice-box
-- [ ] [[run_model_bakeoff_md.md|Run model bakeoff]] #ops #codex-task #ice-box
-- [ ] [[obsidian_replacement_md.md|obsidian replacement]] #framework-core #ice-box
-- [ ] [[run_model_bakeoff_md.md|Run model bakeoff]] #ops #codex-task #ice-box
-- [ ] [[annotate_legacy_code_with_migration_tags_md.md|Annotate legacy code with migration tags]] #framework-core #ice-box
-- [ ] [[allow_old_unnessisary_messages_to_decay_from_database_while_retaining_index_entries_ids_md_md.md|allow old unnessisary messages to decay from database while retaining index entries ids md md]] #framework-core #eidolon-support #ice-box
-- [ ] [[define_permission_schema_in_agents_1_md.md|Define permission schema in AGENTS.md]] #framework-core #eidolon #Dorian #layer2 #ice-box
-- [ ] [[Add codex layer to emacs]]
+- [ ] [File explorer](../tasks/File%20explorer.md) #accepted
+- [ ] [Promethean Health Dashboard](../tasks/Promethean%20Health%20Dashboard.md) #accepted
+- [ ] [Set up proper openai custom gpt compatable oauth login flow](../tasks/Set%20up%20proper%20openai%20custom%20gpt%20compatable%20oauth%20login%20flow.md) #accepted
+- [ ] [add_withdlq_around_risky_consumers_set_maxattempts_md](../tasks/add_withdlq_around_risky_consumers_set_maxattempts_md.md) #accepted
+- [ ] [clean_up_notes_into_design_docs_md](../tasks/clean_up_notes_into_design_docs_md.md) #accepted
+- [ ] [discord_link_indexer_md](../tasks/discord_link_indexer_md.md) #accepted
+- [ ] [extract_docs_from_riatzukiza_github_io_md_md](../tasks/extract_docs_from_riatzukiza_github_io_md_md.md) #accepted
+- [ ] [extract_site_modules_from_riatzukiza_github_io_md_md](../tasks/extract_site_modules_from_riatzukiza_github_io_md_md.md) #accepted
+- [ ] [finish_whisper_npu_system_md_md](../tasks/finish_whisper_npu_system_md_md.md) #accepted
+- [ ] [gpt bridge fuzzy lookup should return multiple matches when it is used.](../tasks/gpt%20bridge%20fuzzy%20lookup%20should%20return%20multiple%20matches%20when%20it%20is%20used..md) #accepted
+- [ ] [migrate_portfolio_client_code_to_promethean_md](../tasks/migrate_portfolio_client_code_to_promethean_md.md) #accepted
+- [ ] [migrate_server_side_sibilant_libs_to_promethean_ar_md](../tasks/migrate_server_side_sibilant_libs_to_promethean_ar_md.md) #accepted
+- [ ] [migrating_relevant_modules_from_riatzukiza_github_md](../tasks/migrating_relevant_modules_from_riatzukiza_github_md.md) #accepted
+- [ ] [move discord scraper to ts](../tasks/move%20discord%20scraper%20to%20ts.md) #accepted
+- [ ] [setup new service generator](../tasks/setup%20new%20service%20generator.md) #accepted
+- [ ] [setup_code_in_wsl_md](../tasks/setup_code_in_wsl_md.md) #accepted
+- [ ] [twitch_stream_title_generator_md_md](../tasks/twitch_stream_title_generator_md_md.md) #accepted
+- [ ] [write_end_to_end_tests_md_md](../tasks/write_end_to_end_tests_md_md.md) #accepted
 
+## Breakdown
 
-## Breakdown (13)
-
-- [ ] [[design_circular_buffers_for_inputs_with_layered_states_of_persistance_in_memory_on_disk_cold_storage_so_md.md|design circular buffers for inputs with layered states of persistance in memory on disk cold storage so md]] #framework-core #ice-box
-- [ ] [[thinking_model_integration_md_md.md|thinking model integration md md]] #framework-core #ice-box
-- [ ] [[connect reddit]]
-- [ ] [[connect bluesky]]
-- [ ] [[connect wikipedia]]
-- [ ] [[lisp ecosystem files]]
-- [ ] [[hy - js interop]]
-
+- [ ] [LSP server for home brew lisp incoming](../tasks/LSP%20server%20for%20home%20brew%20lisp%20incoming.md) #breakdown
+- [ ] [add_twitch_chat_integration_md_md](../tasks/add_twitch_chat_integration_md_md.md) #breakdown
+- [ ] [breakdown Makefile.hy](../tasks/breakdown%20Makefile.hy.md) #breakdown
+- [ ] [database migration system](../tasks/database%20migration%20system.md) #breakdown
+- [ ] [describe_github_branching_workflow_md](../tasks/describe_github_branching_workflow_md.md) #breakdown
+- [ ] [full_agent_mode_text_chat_selectively_join_channels_etc_md](../tasks/full_agent_mode_text_chat_selectively_join_channels_etc_md.md) #breakdown
+- [ ] [harden precommit hooks](../tasks/harden%20precommit%20hooks.md) #breakdown
+- [ ] [refactor_speech_interuption_system_to_be_more_inteligent_using_audio_data_to_decide_if_interupted_md_md](../tasks/refactor_speech_interuption_system_to_be_more_inteligent_using_audio_data_to_decide_if_interupted_md_md.md) #breakdown
+- [ ] [script for getting github action workflow states for a branch](../tasks/script%20for%20getting%20github%20action%20workflow%20states%20for%20a%20branch.md) #breakdown
+- [ ] [smart_task_templater_md](../tasks/smart_task_templater_md.md) #breakdown
 
 ## Ready
 
-- [ ] [[dockerize the system]]
-- [ ] [[lisp package files]]
-- [ ] [[clearly standardize data models]]
-- [ ] [[flatten services]]
-- [ ] [[frontend build tool chain]]
-- [ ] [[LLM service must accept tool calls]]
-- [ ] [[update_makefile_to_have_commands_specific_for_agents_md.md|Update Makefile to have commands specific for agents]] #devops #accepted
-- [ ] [[create a generic markdown helper module]]
-- [ ] [[task generator system]]
-- [ ] [[redefine all existing lambdas with high order functions incoming]]
-- [ ] [[convert current services to packages, then redefine the services using config files]]
-- [ ] [[Phase out proxy in favor of bridge service]]
-- [ ] [[audio processing service]]
+- [ ] [LLM service must accept tool calls](../tasks/LLM%20service%20must%20accept%20tool%20calls.md) #ready
+- [ ] [Phase out proxy in favor of bridge service](../tasks/Phase%20out%20proxy%20in%20favor%20of%20bridge%20service.md) #ready
+- [ ] [audio processing service](../tasks/audio%20processing%20service.md) #ready
+- [ ] [clearly standardize data models](../tasks/clearly%20standardize%20data%20models.md) #ready
+- [ ] [convert current services to packages, then redefine the services using config files](../tasks/convert%20current%20services%20to%20packages%2C%20then%20redefine%20the%20services%20using%20config%20files.md) #ready
+- [ ] [create a generic markdown helper module](../tasks/create%20a%20generic%20markdown%20helper%20module.md) #ready
+- [ ] [decouple_from_ollama_md](../tasks/decouple_from_ollama_md.md) #ready
+- [ ] [dockerize the system](../tasks/dockerize%20the%20system.md) #ready
+- [ ] [finalize_migration_plan_md_md_md](../tasks/finalize_migration_plan_md_md_md.md) #ready
+- [ ] [flatten services](../tasks/flatten%20services.md) #ready
+- [ ] [frontend build tool chain](../tasks/frontend%20build%20tool%20chain.md) #ready
+- [ ] [lisp package files](../tasks/lisp%20package%20files.md) #ready
+- [ ] [migrate_server_side_sibilant_libs_to_promethean_architecture_md](../tasks/migrate_server_side_sibilant_libs_to_promethean_architecture_md.md) #ready
+- [ ] [migrating_relevant_modules_from_riatzukiza_github_io_to_-site-_and_-docs-_md](../tasks/migrating_relevant_modules_from_riatzukiza_github_io_to_-site-_and_-docs-_md.md) #ready
+- [ ] [redefine all existing lambdas with high order functions incoming](../tasks/redefine%20all%20existing%20lambdas%20with%20high%20order%20functions%20incoming.md) #ready
+- [ ] [task generator system](../tasks/task%20generator%20system.md) #ready
+- [ ] [update_makefile_to_have_commands_specific_for_agents_md](../tasks/update_makefile_to_have_commands_specific_for_agents_md.md) #ready
 
+## Todo
 
-## Todo (21)
+- [ ] [Add codex layer to emacs](../tasks/Add%20codex%20layer%20to%20emacs.md) #todo
+- [ ] [Add git commands to gpt bridge](../tasks/Add%20git%20commands%20to%20gpt%20bridge.md) #todo
+- [ ] [Add tool calls to codex context](../tasks/Add%20tool%20calls%20to%20codex%20context.md) #todo
+- [ ] [Agent Tasks Persistence Migration to DualStore](../tasks/Agent%20Tasks%20Persistence%20Migration%20to%20DualStore.md) #todo
+- [ ] [ChatGPT export injest with dedupe index and hashes](../tasks/ChatGPT%20export%20injest%20with%20dedupe%20index%20and%20hashes.md) #todo
+- [ ] [Create broker services that can handle all the same tasks as the gpt bridge](../tasks/Create%20broker%20services%20that%20can%20handle%20all%20the%20same%20tasks%20as%20the%20gpt%20bridge.md) #todo
+- [ ] [Curate code from personal repository](../tasks/Curate%20code%20from%20personal%20repository.md) #todo
+- [ ] [Decouple Audio Processing Logic From Discord](../tasks/Decouple%20Audio%20Processing%20Logic%20From%20Discord.md) #todo
+- [ ] [Design Ollama Model file for use with codex cli](../tasks/Design%20Ollama%20Model%20file%20for%20use%20with%20codex%20cli.md) #todo
+- [ ] [Design Ollama Model file for use with codex cli 1](../tasks/Design%20Ollama%20Model%20file%20for%20use%20with%20codex%20cli%201.md) #todo
+- [ ] [Ensure openapi specs are automaticly updated when an endpoint is changed](../tasks/Ensure%20openapi%20specs%20are%20automaticly%20updated%20when%20an%20endpoint%20is%20changed.md) #todo
+- [ ] [Find music that triggered copyright mute on twitch for analysis incoming](../tasks/Find%20music%20that%20triggered%20copyright%20mute%20on%20twitch%20for%20analysis%20incoming.md) #todo
+- [ ] [Finish work on gptbridge agent integration](../tasks/Finish%20work%20on%20gptbridge%20agent%20integration.md) #todo
+- [ ] [Fully convert js ts projects to pnpm incoming](../tasks/Fully%20convert%20js%20ts%20projects%20to%20pnpm%20incoming.md) #todo
+- [ ] [LLM service must allow streamed responses](../tasks/LLM%20service%20must%20allow%20streamed%20responses.md) #todo
+- [ ] [MVP local LLM chat interface with tool calls connected to gpt bridge](../tasks/MVP%20local%20LLM%20chat%20interface%20with%20tool%20calls%20connected%20to%20gpt%20bridge.md) #todo
+- [ ] [Make the system hashtag aware](../tasks/Make%20the%20system%20hashtag%20aware.md) #todo
+- [ ] [OpenAI compatable api](../tasks/OpenAI%20compatable%20api.md) #todo
+- [ ] [Replace all python properly with hy incoming](../tasks/Replace%20all%20python%20properly%20with%20hy%20incoming.md) #todo
+- [ ] [Set up new user roles and policies for the systems](../tasks/Set%20up%20new%20user%20roles%20and%20policies%20for%20the%20systems.md) #todo
+- [ ] [Webcrawler](../tasks/Webcrawler.md) #todo
+- [ ] [broker gpt bridge parity plan](../tasks/broker%20gpt%20bridge%20parity%20plan.md) #todo
+- [ ] [connect bluesky](../tasks/connect%20bluesky.md) #todo
+- [ ] [connect reddit](../tasks/connect%20reddit.md) #todo
+- [ ] [connect wikipedia](../tasks/connect%20wikipedia.md) #todo
+- [ ] [context service](../tasks/context%20service.md) #todo
+- [ ] [convert smartgpt bridge to ts](../tasks/convert%20smartgpt%20bridge%20to%20ts.md) #todo
+- [ ] [discord_image_awareness_md_md](../tasks/discord_image_awareness_md_md.md) #todo
+- [ ] [flatten sibilant src folders](../tasks/flatten%20sibilant%20src%20folders.md) #todo
+- [ ] [hy - js interop](../tasks/hy%20-%20js%20interop.md) #todo
+- [ ] [implement classes in compiler lisp incoming](../tasks/implement%20classes%20in%20compiler%20lisp%20incoming.md) #todo
+- [ ] [implement defun in compiler lisp incoming](../tasks/implement%20defun%20in%20compiler%20lisp%20incoming.md) #todo
+- [ ] [kanban-processor](../tasks/kanban-processor.md) #todo
+- [ ] [lisp ecosystem files](../tasks/lisp%20ecosystem%20files.md) #todo
+- [ ] [periodicly the embedding service will get disconnected from the broker and not die, blocking other processes who require embeddings. incoming](../tasks/periodicly%20the%20embedding%20service%20will%20get%20disconnected%20from%20the%20broker%20and%20not%20die%2C%20blocking%20other%20processes%20who%20require%20embeddings.%20incoming.md) #todo
+- [ ] [pin_versions_in_configs_md](../tasks/pin_versions_in_configs_md.md) #todo
+- [ ] [refactor_any_python_modules_not_currently_for_ml_stuff_discord_etc_2_md](../tasks/refactor_any_python_modules_not_currently_for_ml_stuff_discord_etc_2_md.md) #todo
+- [ ] [set up data migration pipeline and clearly describe conventions](../tasks/set%20up%20data%20migration%20pipeline%20and%20clearly%20describe%20conventions.md) #todo
+- [ ] [tamper monkey script for using templates defined in the vault](../tasks/tamper%20monkey%20script%20for%20using%20templates%20defined%20in%20the%20vault.md) #todo
 
+## In Progress
 
+- [ ] [breakdown cephalon voice commands file using ecs](../tasks/breakdown%20cephalon%20voice%20commands%20file%20using%20ecs.md) #in-progress
+- [ ] [seperate discord commands from the actions they perform](../tasks/seperate%20discord%20commands%20from%20the%20actions%20they%20perform.md) #in-progress
 
-## In Progress (21)
+## In Review
 
-- [ ] [[ChatGPT export injest with dedupe index and hashes]]
-- [ ] [[structure_vault_to_mirror_services_agents_docs_md_md.md|Document-Driven Development for Service Scripts]] #cephalon #layer1 #cicd #buildtools #devtools #devops #documentation #knowledge-graph #docdrivendev #ice-box
-- [ ] [[finish_whisper_npu_system_md_md.md|finish whisper NPU system.md]] #framework-core #performance-optimization #npu-integration #accepted
-- [ ] [[database migration system]]
-- [ ] [[LSP server for home brew lisp incoming]]
-- [ ] [[smart_task_templater_md.md|Smart Task templater]] #framework-core #ice-box
-- [ ] [[full_agent_mode_text_chat_selectively_join_channels_etc_md.md|Full agent mode (Text chat, selectively join channels, etc]] #framework-core #accepted
-- [ ] [[add_twitch_chat_integration_md_md.md|Add twitch chat integration.md]] #framework-core #accepted
-- [ ] [[script for getting github action workflow states for a branch]]
-- [ ] [[harden precommit hooks]]
-- [ ] [[breakdown Makefile.hy]]
-- [ ] [[move discord scraper to ts]]
-- [ ] [[gpt bridge fuzzy lookup should return multiple matches when it is used.]]
-- [ ] [[Mock broker]] #incoming
-- [ ] [[discord_image_awareness_md_md.md|discord image awareness md md]] #framework-core #ollama-integration #multimodal-context #accepted
-- [ ] [[broker gpt bridge parity plan]]
-- [ ] [[Set up proper openai custom gpt compatable oauth login flow]]
-- [ ] [[refactor_any_python_modules_not_currently_for_ml_stuff_discord_etc_2_md.md|refactor any python modules not currently for ml stuff discord etc 2 md]] #framework-core #language-strategy #performance-optimization #ice-box
-- [ ] [[Replace all python properly with hy incoming]]
-- [ ] [[Agent Tasks Persistence Migration to DualStore]]
-- [ ] [[Create broker services that can handle all the same tasks as the gpt bridge]]
-
-
-## In Review (34)
-
-- [ ] [[setup new service generator]]
-- [ ] [[Webcrawler]]
-- [ ] [[set up data migration pipeline and clearly describe conventions]]
-- [ ] [[twitch_stream_title_generator_md_md.md|Twitch stream title generator.md]] #framework-core #ollama-integration #stream-automation #accepted
-- [ ] [[File explorer]]
-- [ ] [[implement classes in compiler lisp incoming]]
-- [ ] [[MVP local LLM chat interface with tool calls connected to gpt bridge]]
-- [ ] [[discord_image_awareness_md_md.md|discord image awareness.md]] #framework-core #ollama-integration #multimodal-context #accepted
-- [ ] [[implement defun in compiler lisp incoming]]
-- [ ] [[setup_services_to_recieve_work_from_the_broker_via_push_md.md|setup services to recieve work from the broker via push]] #codex-task #broker #queueManager #service-oriented #push-queue #agent-mode #in-review
-- [ ] [[pin_versions_in_configs_md.md|Pin versions in configs]] #ops #codex-task #accepted
-- [ ] [[Promethean Health Dashboard]] #framework-core #observability #eidolon-visualization #dashboard #broker #realtime #accepted
-- [ ] [[seperate discord commands from the actions they perform]] #in-progress
-- [ ] [[periodicly the embedding service will get disconnected from the broker and not die, blocking other processes who require embeddings. incoming]]
-- [ ] [[breakdown cephalon voice commands file using ecs]] #in-progress
-
+- [ ] [identify_and_resolve_a_service_client_apparently_connecting_repeatedly_to_broker_with_new_session_ids](../tasks/identify_and_resolve_a_service_client_apparently_connecting_repeatedly_to_broker_with_new_session_ids.md) #in-review
+- [ ] [setup_services_to_recieve_work_from_the_broker_via_push_md](../tasks/setup_services_to_recieve_work_from_the_broker_via_push_md.md) #in-review
+- [ ] [update_cephalon_to_use_custom_embedding_function_md_md](../tasks/update_cephalon_to_use_custom_embedding_function_md_md.md) #in-review
 
 ## Done
 
-- [ ] [[Curate code from personal repository]]
-- [ ] [[Add tool calls to codex context]]
-- [ ] [[migrate_portfolio_client_code_to_promethean_md.md|Migrate portfolio client code to Promethean]] #framework-core #accepted
-- [ ] [[Finish work on gptbridge agent integration]]
-- [ ] File explorer
-- [ ] [[clarify_promethean_project_vision_1_md.md|Clarify Promethean project vision]] #framework-core #accepted
-- [ ] finish moving the smartgpt bridge to fastify
-- [ ] [[Fully convert js ts projects to pnpm incoming]]
-- [ ] [[Ensure openapi specs are automaticly updated when an endpoint is changed]]
-- [ ] [[setup_services_to_recieve_work_from_the_broker_via_push_md.md|setup services to recieve work from the broker via push md]] #codex-task #broker #queueManager #service-oriented #push-queue #agent-mode #in-review
-- [ ] [[create_base_readme_md_templates_for_each_service_md.md|create base readme md templates for each service]] #doc-this #framework-core #ritual #in-review
-- [ ] [[identify_and_resolve_a_service_client_apparently_connecting_repeatedly_to_broker_with_new_session_ids.md|identify and resolve a service client apparently connecting repeatedly to broker with new session ids]] #in-review
-- [ ] [[OpenAI compatable api]]
-- [ ] [[update_cephalon_to_use_custom_embedding_function_md_md.md|Update cephalon to use custom embedding function]] #framework-core #cephalon #discord #embedding #typescript #in-review
-- [ ] [[discord_image_attachment_indexer_md.md|discord image attachment indexer md]] #framework-core #discord #images #attachments #indexing #memory #done
-- [ ] [[clearly_seperate_service_dependency_files_md.md|clearly seperate service dependency files md]] #devops #cicd #done
-- [ ] [[add_obsidian_to_gitignore_md_md.md|Add .obsidian to .gitignore]] #framework-core #done
-- [ ] [[add_stt_service_tests_md.md|Add STT service tests]] #codex-task #testing #done
-- [ ] [[add_starter_notes_-_eidolon_fields_cephalon_inner_monologue_1_md.md|Add starter notes - eidolon_fields, cephalon_inner_monologue]] #framework-core #done
-- [ ] [[add_unit_tests_for_date_tools_py_md.md|Add unit tests for date_tools.py]] #codex-task #testing #done
-- [ ] [[add_unit_tests_for_wav_processing_md.md|Add unit tests for wav_processing]] #codex-task #testing #done
-- [ ] [[auto-generate_agents_md_stubs_from_services_structure_md_md.md|Auto-generate AGENTS.md stubs from services structure]] #framework-core #done
-- [ ] [[build_data_structures_for_eidolon_field_md_md.md|Build data structures for Eidolon field]] #framework-core #done
-- [ ] [[build_data_structures_for_eidolon_field_codex_task_md.md|Build data structures for Eidolon field #codex-task]] #codex-task #done
-- [ ] [[create_permission_gating_layer_1_md_md.md|Create permission gating layer]] #framework-core #done
-- [ ] [[create_permission_gating_layer_framework_core_md.md|Create permission gating layer #framework-core]] #framework-core #done
-- [ ] [[create_vault-config_obsidian_with_kanban_and_minimal_vault_setup_1_md_md.md|Create vault-config .obsidian with Kanban and minimal vault setup]] #framework-core #done
-- [ ] [[determine_pm2_configuration_for_agents_1_md.md|Determine PM2 configuration for agents]] #framework-core #done
-- [ ] [[document_board_usage_guidelines_1_md.md|Document board usage guidelines]] #framework-core #done
-- [ ] [[document_local_testing_setup_md_md.md|Document local testing setup]] #codex-task #testing #done
-- [ ] [[fix_makefile_test_target_md.md|Fix Makefile test target]] #codex-task #testing #done
-- [ ] [[mirror_shared_utils_with_language-specific_doc_folders_md_md.md|Mirror shared utils with language-specific doc folders]] #framework-core #done
-- [ ] [[research_github_projects_board_api_md.md|Research GitHub Projects board API]] #framework-core #done
-- [ ] [[write_board_sync_script_md_md.md|Write board sync script]] #framework-core #done
-- [ ] [[write_meaningful_tests_for_cephalon_md_md.md|Write meaningful tests for Cephalon]] #codex-task #testing #done
-- [ ] [[write_vault_config_readme_md_for_obsidian_vault_on_md.md|Write vault-config README.md for Obsidian vault onboarding]] #framework-core #done
-- [ ] [[create_permission_gating_layer_1_md.md|create permission gating layer 1 md]] #done
-- [ ] [[make_seperate_execution_pathways_1_md_md.md|make seperate execution pathways 1 md md]] #framework-core #done
-- [ ] [[separate_all_testing_pipelines_in_github_actions_md.md|seperate all testing pipelines in GitHub Actions]] #cicd #framework-core #done
-- [ ] [[start_eidolon_md.md|start eidolon md]] #done
-- [ ] [[update_github_actions_to_use_makefile_md_md.md|update GitHub Actions to use Makefile]] #cicd #devops #framework-core #done
-- [ ] [[write_simple_ecosystem_declaration_library_for_new_md_md.md|write simple ecosystem declaration library for new agents]] #framework-core #done
-- [ ] [[write_vault_config_readme_md_for_obsidian_vault_on_md.md|Write \`vault-config/README.md\` for Obsidian vault onboarding]] #framework-core #done
-- [ ] [[document_local_testing_setup_md_md.md|Document local testing setup]] #codex-task #testing #done
-- [ ] [[add_obsidian_to_gitignore_md_md.md|Add .obsidian to .gitignore]] #framework-core #done
-- [ ] [[auto-generate_agents_md_stubs_from_services_structure_md_md.md|Auto-generate AGENTS.md stubs from services structure]] #framework-core #done
-- [ ] [[build_data_structures_for_eidolon_field_md_md.md|Build data structures for Eidolon field]] #framework-core #done
-- [ ] [[build_data_structures_for_eidolon_field_codex_task_md.md|Build data structures for Eidolon field #codex-task]] #codex-task #done
-- [ ] [[set_up_makefile_for_python_js_build_test_dev_md.md|Set up Makefile for Python + JS build test dev]] #cicd #buildtools #devtools #devops #done
-- [ ] [[separate_all_testing_pipelines_in_github_actions_md.md|Separate all testing pipelines in GitHub Actions]] #cicd #framework-core #done
-- [ ] [[fix_makefile_test_target_md.md|Fix Makefile test target]] #codex-task #testing #done
-- [ ] [[create_permission_gating_layer_framework_core_md.md|Create permission gating layer #framework-core]] #framework-core #done
-- [ ] [[write_simple_ecosystem_declaration_library_for_new_md_md.md|write simple ecosystem declaration library for new agents]] #framework-core #done
-- [ ] [[determine_pm2_configuration_for_agents_1_md.md|Determine PM2 configuration for agents]] #framework-core #done
-- [ ] [[mirror_shared_utils_with_language-specific_doc_folders_md_md.md|Mirror shared utils with language-specific doc folders]] #framework-core #done
-- [ ] [[write_board_sync_script_md_md.md|Write board sync script]] #framework-core #done
-- [ ] [[fix_makefile_test_target_md.md|Fix Makefile test target]] #codex-task #testing #done
-- [ ] [[add_unit_tests_for_wav_processing_md.md|Add unit tests for wav_processing]] #codex-task #testing #done
-- [ ] [[document_board_usage_guidelines_1_md.md|Document board usage guidelines]] #framework-core #done
-- [ ] [[add_stt_service_tests_md.md|Add STT service tests]] #codex-task #testing #done
-- [ ] [[create_permission_gating_layer_1_md_md.md|Create permission gating layer]] #framework-core #done
-- [ ] [[add_starter_notes_-_eidolon_fields_cephalon_inner_monologue_1_md.md|Add starter notes - eidolon_fields, cephalon_inner_monologue]] #framework-core #done
-- [ ] [[add_unit_tests_for_date_tools_py_md.md|Add unit tests for date_tools.py]] #codex-task #testing #done
-- [ ] [[write_meaningful_tests_for_cephalon_md_md.md|Write meaningful tests for Cephalon]] #codex-task #testing #done
-- [ ] [[create_vault-config_obsidian_with_kanban_and_minimal_vault_setup_1_md_md.md|Create vault-config .obsidian with Kanban and minimal vault setup]] #framework-core #done
-- [ ] [[separate_all_testing_pipelines_in_github_actions_md.md|seperate all testing pipelines in GitHub Actions]] #cicd #framework-core #done
-- [ ] [[update_github_actions_to_use_makefile_md_md.md|update GitHub Actions to use Makefile]] #cicd #devops #framework-core #done
-- [ ] [[make_seperate_execution_pathways_1_md_md.md|Make seperate execution pathways 1.md]] #framework-core #done
-- [ ] [[add_unit_tests_for_wav_processing_md.md|Add unit tests for wav\_processing]] #codex-task #testing #done
-- [ ] [[add_stt_service_tests_md.md|Add STT service tests]] #codex-task #testing #done
-- [ ] [[add_unit_tests_for_date_tools_py_md.md|Add unit tests for date\_tools.py]] #codex-task #testing #done
-- [ ] [[add_starter_notes_-_eidolon_fields_cephalon_inner_monologue_1_md.md|Add starter notes - eidolon\_fields, cephalon\_inner\_monologue]] #framework-core #done
-- [ ] [[create_permission_gating_layer_1_md_md.md|Create permission gating layer]] #framework-core #done
-- [ ] [[document_board_usage_guidelines_1_md.md|Document board usage guidelines]] #framework-core #done
-- [ ] [[start_eidolon_md_md.md|Start Eidolon]] #framework-core #done
-
-
-## Rejected
-
-- [ ] [[enable_compactor_for_process_state_process_state_s_md.md|Enable compactor for `process.state` → `process.state.snapshot`]] #ice-box
-- [ ] [[pin_versions_in_configs_promethean_codex_md.md|Pin versions in configs (Promethean + Codex)]] #ice-box
-- [ ] [[run_bench_subscribe_ts_with_mongo_bus_and_record_p_md.md|Run `bench/subscribe.ts` with Mongo bus and record p50/p99]] #ice-box
-- [ ] [[run_bakeoff_see_below_md.md|Run bakeoff (see below)]] #ice-box
-- [ ] [[flatten sibilant src folders]]
-- [ ] [[snapshot_prompts_specs_to_repo_md_md.md|Snapshot prompts/specs to repo]] #ice-box
-- [ ] [[detect_contradictions_in_memory_md_md.md|Detect contradictions in memory]] #framework-core #ice-box
-- [ ] [[integrate_synthesis-agent_pass_on_unique_to_produce_draft_docs_1_md.md|Integrate synthesis-agent pass on \`unique/\` to produce draft docs]] #framework-core #ice-box
-- [ ] [[write_end_to_end_tests_md_md.md|write end to end tests md md]] #framework-core #accepted
-- [ ] [[add_file_system_to_context_management_system_md_md.md|add file system to context management system md md]] #framework-core #ice-box
-- [ ] [[cache_decay_mechanisim_md_md.md|cache decay mechanisim md md]] #framework-core #ice-box
-- [ ] [[suggest_metaprogramming_updates_md.md|Suggest metaprogramming updates]] #framework-core #ice-box
-- [ ] [[wire_mongoeventstore_mongocursorstore_in_place_of_md.md|Wire MongoEventStore + MongoCursorStore in place of InMemory]] #ice-box
-- [ ] [[run_bench_subscribe_ts_with_mongo_bus_and_record_p_md.md|Run `bench/subscribe.ts` with Mongo bus and record p50/p99]] #ice-box
-- [ ] [[migrate_server_side_sibilant_libs_to_promethean_ar_md.md|Migrate server side sibilant libs to Promethean architecture.]] #accepted
-- [ ] [[add_withdlq_around_risky_consumers_set_maxattempts_md.md|Add **withDLQ** around risky consumers; set `maxAttempts`]] #accepted
-- [ ] [[Decouple Audio Processing Logic From Discord|Split out audio processing logic to a seperate service without changing the current behavior in cephalon.md]] #framework-core #ready
-- [ ] [[snapshot_prompts_specs_to_repo_md.md|snapshot prompts specs to repo md]] #rejected
-- [ ] [[add_startchangelogprojector_for_any_compaction_lik_md.md|Add **startChangelogProjector** for any compaction-like topic you want live-queryable]] #rejected
-- [ ] [[add_ollama_formally_to_pipeline_md_md.md|Add Ollama formally to pipeline]] #rejected
-- [ ] [[add_prometheus_events_counters_in_ws_server_hook_p_md.md|Add Prometheus `events_*` counters in WS server hook points]] #rejected
-- [ ] [[enable_compactor_for_process_state_process_state_s_md.md|Enable compactor for `process.state` → `process.state.snapshot`]] #rejected
-- [ ] [[add_ttls_per_topic_via_migration_script_md.md|Add TTLs per topic via migration script]] #rejected
-- [ ] [[add_lag_checks_to_ci_smoke_ensure_small_lag_after_md.md|Add `/lag` checks to CI smoke (ensure small lag after publishing bursts)]] #rejected
-- [ ] [[add_ops_endpoint_to_list_partition_assignments_opt_md.md|Add `/ops` endpoint to list **partition assignments** (optional: dump coordinator state)]] #rejected
-- [ ] [[add_mongodedupe_and_replace_critical_consumers_wit_md.md|Add `MongoDedupe` and replace critical consumers with `subscribeExactlyOnce`]] #rejected
-- [ ] [[add_mongooutbox_to_any_service_that_writes_db_chan_md.md|Add `MongoOutbox` to any service that writes DB changes; swap local app emits → outbox writes]] #rejected
-- [ ] [[add_tokenbucket_to_ws_server_conn_per_topic_md.md|Add `TokenBucket` to WS server (conn + per-topic)]] #rejected
-- [ ] [[add_dev_harness_int_test_ts_to_ci_integration_stag_md.md|Add `dev.harness.int.test.ts` to CI integration stage]] #rejected
-- [ ] [[add_manualack_to_event_bus_and_re_run_tests_md.md|Add `manualAck` to event bus and re-run tests]] #rejected
-- [ ] [[add_process_txn_projector_to_upsert_processes_host_md.md|Add `process.txn` projector to upsert `processes` + `host_stats` atomically]] #rejected
-- [ ] [[add_snapshot_consumer_to_warm_cache_on_boot_md.md|Add snapshot consumer to warm cache on boot]] #rejected
-- [ ] [[add_vault_instructions_to_main_readme_md_md_md.md|Add vault instructions to main README.md]] #framework-core #rejected
-- [ ] [[define_default_scopes_publish_heartbeat_received_s_md.md|Define default scopes: `publish:heartbeat.received`, `subscribe:process.state`]] #rejected
-- [ ] [[deploy_changefeed_for_collections_you_want_mirrore_md.md|Deploy **changefeed** for collections you want mirrored to topics]] #rejected
-- [ ] [[detect_contradictions_in_memory_codex_task_md.md|Detect contradictions in memory #codex-task]] #codex-task #rejected
-- [ ] [[document_etag_semantics_and_cache_headers_for_snap_md.md|Document ETag semantics and cache headers for `/snap/:key`]] #rejected
-- [ ] [[enable_scripts_lint_topics_ts_in_ci_md.md|Enable **scripts/lint-topics.ts** in CI]] #rejected
-- [ ] [[ensure_github_compatible_markdown_settings_are_doc_md.md|Ensure GitHub-compatible markdown settings are documented]] #documentation #rejected
-- [ ] [[ensure_mongo_indexes_key_1_unique_common_query_fie_md.md|Ensure Mongo indexes: `{ _key: 1 } unique` + common query fields]] #rejected
-- [ ] [[evaluate_and_reward_flow_satisfaction_framework_co_md.md|Evaluate and reward flow satisfaction #framework-core]] #framework-core #rejected
-- [ ] [[expose_snapshot_api_for_processes_collection_proce_md.md|Expose **Snapshot API** for `processes` (collection `processes`)]] #rejected
-- [ ] [[expose_metrics_on_an_express_app_and_scrape_with_p_md.md|Expose `/metrics` on an express app and scrape with Prom]] #rejected
-- [ ] [[finalize_stt_workflow_md_md.md|Finalize STT workflow]] #codex-task #testing #rejected
-- [ ] [[identify_ancestral_resonance_patterns_framework_co_md.md|Identify ancestral resonance patterns #framework-core]] #framework-core #rejected
-- [ ] [[implement_pause_resume_ops_on_gateway_md.md|Implement `PAUSE/RESUME` ops on gateway]] #rejected
-- [ ] [[implement_timetravel_processat_processid_t_in_a_sm_md.md|Implement `timetravel.processAt(processId, T)` in a small CLI for debugging]] #rejected
-- [ ] [[implement_transcendence_cascade_framework_core_md.md|Implement transcendence cascade #framework-core]] #framework-core #rejected
-- [ ] [[launch_replayapi_on_8083_test_replay_and_export_nd_md.md|Launch `ReplayAPI` on `:8083`; test `/replay` and `/export?ndjson=1`]] #rejected
-- [ ] [[register_v_1_schema_for_any_evolving_topic_and_wri_md.md|Register **v+1** schema for any evolving topic and write minimal **upcaster**]] #rejected
-- [ ] [[spin_up_ws_gateway_ws_port_8090_ws_token_devtoken_md.md|Spin up WS gateway (`WS_PORT=8090 WS_TOKEN=devtoken node index.js`)]] #rejected
-- [ ] [[suggest_metaprogramming_updates_codex_task_md.md|Suggest metaprogramming updates #codex-task]] #codex-task #rejected
-- [ ] [[summarize_clarified_priorities_for_next_sprint_md_md.md|Summarize clarified priorities for next sprint]] #framework-core #reject #rejected
-- [ ] [[switch_critical_readers_to_subscribenormalized_md.md|Switch critical readers to **subscribeNormalized**]] #rejected
-- [ ] [[switch_gateway_auth_to_jwt_generate_temp_hs256_tok_md.md|Switch gateway auth to JWT; generate temp HS256 token for dev]] #rejected
-- [ ] [[use_subscribepartitioned_for_cpu_heavy_consumers_t_md.md|Use **subscribePartitioned** for CPU-heavy consumers; tune `partitions` (power of 2 is fine)]] #rejected
-- [ ] [[wire_runoutboxdrainer_in_event_hub_md.md|Wire `runOutboxDrainer` in event-hub]] #rejected
-- [ ] [[wrap_event_hub_publish_path_with_withschemavalidat_md.md|Wrap `event-hub` publish path with **withSchemaValidation**; fail fast on bad payloads]] #rejected
-- [ ] [[wrap_writers_with_withdualwrite_md.md|Wrap writers with **withDualWrite**]] #rejected
-- [ ] [[write_a_replay_job_that_replays_process_state_snap_md.md|Write a replay job that replays `process.state.snapshot` to warm the `processes` collection]] #rejected
-- [ ] [[write_a_smoke_test_client_subscribes_publish_10_ms_md.md|Write a smoke test: client subscribes, publish 10 msgs, assert all ACKed]] #rejected
-- [ ] [[move_all_testing_to_individual_services_md.md|move all testing to individual services md]] #Duplicate #rejected
-- [ ] [[add_prometheus_events_counters_in_ws_server_hook_p_md.md|Add Prometheus \`events\_\*\` counters in WS server hook points]] #rejected
-- [ ] [[switch_gateway_auth_to_jwt_generate_temp_hs256_tok_md.md|Switch gateway auth to JWT; generate temp HS256 token for dev]] #rejected
-- [ ] [[add_vault_instructions_to_main_readme_md_md_md.md|Add vault instructions to main README.md]] #framework-core #rejected
-- [ ] [[ensure_github_compatible_markdown_settings_are_doc_md.md|Ensure GitHub-compatible markdown settings are documented]] #documentation #rejected
-- [ ] [[finalize_stt_workflow_md_md.md|Finalize STT workflow]] #codex-task #testing #rejected
-- [ ] [[annotate_legacy_code_with_migration_tags_md.md|Annotate legacy code with migration tags]] #framework-core #rejected
-- [ ] [[add_startchangelogprojector_for_any_compaction_lik_md.md|Add \*\*startChangelogProjector\*\* for any compaction-like topic you want live-queryable]] #rejected
-- [ ] [[detect_contradictions_in_memory_codex_task_md.md|Detect contradictions in memory #codex-task]] #codex-task #rejected
-- [ ] [[migrating_relevant_modules_from_riatzukiza_github_md.md|Migrating relevant modules from `riatzukiza.github.io` to `/sites/` and `/docs/`]] #rejected
-- [ ] [[register_v_1_schema_for_any_evolving_topic_and_wri_md.md|Register **v+1** schema for any evolving topic and write minimal **upcaster**]] #rejected
-- [ ] [[migrate_server_side_sibilant_libs_to_promethean_ar_md.md|Migrate server side sibilant libs to Promethean architecture.]] #rejected
-- [ ] [[implement_pause_resume_ops_on_gateway_md.md|Implement `PAUSE/RESUME` ops on gateway]] #rejected
-- [ ] [[implement_timetravel_processat_processid_t_in_a_sm_md.md|Implement `timetravel.processAt(processId, T)` in a small CLI for debugging]] #rejected
-- [ ] [[expose_metrics_on_an_express_app_and_scrape_with_p_md.md|Expose `/metrics` on an express app and scrape with Prom]] #rejected
-- [ ] [[add_startchangelogprojector_for_any_compaction_lik_md.md|Add **startChangelogProjector** for any compaction-like topic you want live-queryable]] #rejected
-- [ ] [[add_prometheus_events_counters_in_ws_server_hook_p_md.md|Add Prometheus `events_*` counters in WS server hook points]] #rejected
-- [ ] [[add_withdlq_around_risky_consumers_set_maxattempts_md.md|Add **withDLQ** around risky consumers; set `maxAttempts`]] #rejected
-- [ ] [[add_ollama_formally_to_pipeline_md_md.md|Add Ollama formally to pipeline]] #rejected
-- [ ] [[add_lag_checks_to_ci_smoke_ensure_small_lag_after_md.md|Add `/lag` checks to CI smoke (ensure small lag after publishing bursts)]] #rejected
-- [ ] [[add_ttls_per_topic_via_migration_script_md.md|Add TTLs per topic via migration script]] #rejected
-- [ ] [[add_ops_endpoint_to_list_partition_assignments_opt_md.md|Add `/ops` endpoint to list **partition assignments** (optional: dump coordinator state)]] #rejected
-- [ ] [[add_mongodedupe_and_replace_critical_consumers_wit_md.md|Add `MongoDedupe` and replace critical consumers with `subscribeExactlyOnce`]] #rejected
-- [ ] [[add_mongooutbox_to_any_service_that_writes_db_chan_md.md|Add `MongoOutbox` to any service that writes DB changes; swap local app emits → outbox writes]] #rejected
-- [ ] [[add_dev_harness_int_test_ts_to_ci_integration_stag_md.md|Add `dev.harness.int.test.ts` to CI integration stage]] #rejected
-- [ ] [[add_tokenbucket_to_ws_server_conn_per_topic_md.md|Add `TokenBucket` to WS server (conn + per-topic)]] #rejected
-- [ ] [[add_manualack_to_event_bus_and_re_run_tests_md.md|Add `manualAck` to event bus and re-run tests]] #rejected
-- [ ] [[add_process_txn_projector_to_upsert_processes_host_md.md|Add `process.txn` projector to upsert `processes` + `host_stats` atomically]] #rejected
-- [ ] [[document_etag_semantics_and_cache_headers_for_snap_md.md|Document ETag semantics and cache headers for `/snap/:key`]] #rejected
-- [ ] [[add_snapshot_consumer_to_warm_cache_on_boot_md.md|Add snapshot consumer to warm cache on boot]] #rejected
-- [ ] [[create_permission_gating_layer_codex_task_md.md|Create permission gating layer #codex-task]] #codex-task #rejected
-- [ ] [[create_permission_gating_layer_framework_core_md.md|Create permission gating layer #framework-core]] #framework-core #rejected
-- [ ] [[define_default_scopes_publish_heartbeat_received_s_md.md|Define default scopes: `publish:heartbeat.received`, `subscribe:process.state`]] #rejected
-- [ ] [[deploy_changefeed_for_collections_you_want_mirrore_md.md|Deploy **changefeed** for collections you want mirrored to topics]] #rejected
-- [ ] [[detect_contradictions_in_memory_codex_task_md.md|Detect contradictions in memory #codex-task]] #codex-task #rejected
-- [ ] [[enable_scripts_lint_topics_ts_in_ci_md.md|Enable **scripts/lint-topics.ts** in CI]] #rejected
-- [ ] [[ensure_mongo_indexes_key_1_unique_common_query_fie_md.md|Ensure Mongo indexes: `{ _key: 1 } unique` + common query fields]] #rejected
-- [ ] [[implement_transcendence_cascade_framework_core_md.md|Implement transcendence cascade #framework-core]] #framework-core #rejected
-- [ ] [[expose_snapshot_api_for_processes_collection_proce_md.md|Expose **Snapshot API** for `processes` (collection `processes`)]] #rejected
-- [ ] [[evaluate_and_reward_flow_satisfaction_framework_co_md.md|Evaluate and reward flow satisfaction #framework-core]] #framework-core #rejected
-- [ ] [[identify_ancestral_resonance_patterns_framework_co_md.md|Identify ancestral resonance patterns #framework-core]] #framework-core #rejected
-- [ ] [[launch_replayapi_on_8083_test_replay_and_export_nd_md.md|Launch `ReplayAPI` on `:8083`; test `/replay` and `/export?ndjson=1`]] #rejected
-- [ ] [[write_a_replay_job_that_replays_process_state_snap_md.md|Write a replay job that replays `process.state.snapshot` to warm the `processes` collection]] #rejected
-- [ ] [[spin_up_ws_gateway_ws_port_8090_ws_token_devtoken_md.md|Spin up WS gateway (`WS_PORT=8090 WS_TOKEN=devtoken node index.js`)]] #rejected
-- [ ] [[expose_snapshot_api_for_processes_collection_proce_md.md|Expose \*\*Snapshot API\*\* for \`processes\` (collection \`processes\`)]] #rejected
-- [ ] [[switch_critical_readers_to_subscribenormalized_md.md|Switch critical readers to **subscribeNormalized**]] #rejected
-- [ ] [[wrap_event_hub_publish_path_with_withschemavalidat_md.md|Wrap `event-hub` publish path with **withSchemaValidation**; fail fast on bad payloads]] #rejected
-- [ ] [[suggest_metaprogramming_updates_codex_task_md.md|Suggest metaprogramming updates #codex-task]] #codex-task #rejected
-- [ ] [[use_subscribepartitioned_for_cpu_heavy_consumers_t_md.md|Use \*\*subscribePartitioned\*\* for CPU-heavy consumers; tune \`partitions\` (power of 2 is fine)]] #rejected
-- [ ] [[switch_critical_readers_to_subscribenormalized_md.md|Switch critical readers to \*\*subscribeNormalized\*\*]] #rejected
-- [ ] [[suggest_metaprogramming_updates_codex_task_md.md|Suggest metaprogramming updates #codex-task]] #codex-task #rejected
-- [ ] [[use_subscribepartitioned_for_cpu_heavy_consumers_t_md.md|Use **subscribePartitioned** for CPU-heavy consumers; tune `partitions` (power of 2 is fine)]] #rejected
-- [ ] [[add_ttls_per_topic_via_migration_script_md.md|Add TTLs per topic via migration script]] #rejected
-- [ ] [[wire_runoutboxdrainer_in_event_hub_md.md|Wire `runOutboxDrainer` in event-hub]] #rejected
-- [ ] [[wrap_writers_with_withdualwrite_md.md|Wrap writers with **withDualWrite**]] #rejected
-- [ ] [[wire_runoutboxdrainer_in_event_hub_md.md|Wire \`runOutboxDrainer\` in event-hub]] #rejected
-- [ ] [[define_default_scopes_publish_heartbeat_received_s_md.md|Define default scopes: \`publish:heartbeat.received\`, \`subscribe:process.state\`]] #rejected
-- [ ] [[run_bench_subscribe_ts_with_mongo_bus_and_record_p_md.md|Run \`bench/subscribe.ts\` with Mongo bus and record p50/p99]] #rejected
-- [ ] [[expose_metrics_on_an_express_app_and_scrape_with_p_md.md|Expose \`/metrics\` on an express app and scrape with Prom]] #rejected
-- [ ] [[write_a_replay_job_that_replays_process_state_snap_md.md|Write a replay job that replays \`process.state.snapshot\` to warm the \`processes\` collection]] #rejected
-- [ ] [[wrap_writers_with_withdualwrite_md.md|Wrap writers with \*\*withDualWrite\*\*]] #rejected
-- [ ] [[write_a_smoke_test_client_subscribes_publish_10_ms_md.md|Write a smoke test: client subscribes, publish 10 msgs, assert all ACKed]] #rejected
-- [ ] [[identify_ancestral_resonance_patterns_framework_co_md.md|Identify ancestral resonance patterns #framework-core]] #framework-core #rejected
-- [ ] [[write_a_small_cutover_script_to_replay_historical_md.md|Write a small \*\*cutover\*\* script to replay historical events through upcasters into snapshots]] #rejected
-- [ ] [[write_a_smoke_test_client_subscribes_publish_10_ms_md.md|Write a smoke test: client subscribes, publish 10 msgs, assert all ACKed]] #rejected
-- [ ] [[wrap_event_hub_publish_path_with_withschemavalidat_md.md|Wrap \`event-hub\` publish path with \*\*withSchemaValidation\*\*; fail fast on bad payloads]] #rejected
-- [ ] [[switch_gateway_auth_to_jwt_generate_temp_hs256_tok_md.md|Switch gateway auth to JWT; generate temp HS256 token for dev]] #rejected
-- [ ] [[wire_mongoeventstore_mongocursorstore_in_place_of_md.md|Wire MongoEventStore + MongoCursorStore in place of InMemory]] #rejected
-- [ ] [[add_process_txn_projector_to_upsert_processes_host_md.md|Add \`process.txn\` projector to upsert \`processes\` + \`host\_stats\` atomically]] #rejected
-- [ ] [[spin_up_ws_gateway_ws_port_8090_ws_token_devtoken_md.md|Spin up WS gateway (\`WS\_PORT\=8090 WS\_TOKEN\=devtoken node index.js\`)]] #rejected
-- [ ] [[add_dev_harness_int_test_ts_to_ci_integration_stag_md.md|Add \`dev.harness.int.test.ts\` to CI integration stage]] #rejected
-- [ ] [[add_tokenbucket_to_ws_server_conn_per_topic_md.md|Add \`TokenBucket\` to WS server (conn + per-topic)]] #rejected
-- [ ] [[add_lag_checks_to_ci_smoke_ensure_small_lag_after_md.md|Add \`/lag\` checks to CI smoke (ensure small lag after publishing bursts)]] #rejected
-- [ ] [[add_mongooutbox_to_any_service_that_writes_db_chan_md.md|Add \`MongoOutbox\` to any service that writes DB changes; swap local app emits → outbox writes]] #rejected
-- [ ] [[add_ops_endpoint_to_list_partition_assignments_opt_md.md|Add \`/ops\` endpoint to list \*\*partition assignments\*\* (optional: dump coordinator state)]] #rejected
-- [ ] [[add_mongodedupe_and_replace_critical_consumers_wit_md.md|Add \`MongoDedupe\` and replace critical consumers with \`subscribeExactlyOnce\`]] #rejected
-- [ ] [[document_etag_semantics_and_cache_headers_for_snap_md.md|Document ETag semantics and cache headers for \`/snap/:key\`]] #rejected
-- [ ] [[enable_scripts_lint_topics_ts_in_ci_md.md|Enable \*\*scripts/lint-topics.ts\*\* in CI]] #rejected
-- [ ] [[evaluate_and_reward_flow_satisfaction_framework_co_md.md|Evaluate and reward flow satisfaction #framework-core]] #framework-core #rejected
-- [ ] [[move_all_testing_to_individual_services_md.md|Move all testing to individual services]] #Duplicate #rejected
-- [ ] [[summarize_clarified_priorities_for_next_sprint_md_md.md|Summarize clarified priorities for next sprint]] #framework-core #reject #rejected
-- [ ] [[implement_pause_resume_ops_on_gateway_md.md|Implement \`PAUSE/RESUME\` ops on gateway]] #rejected
-- [ ] [[register_v_1_schema_for_any_evolving_topic_and_wri_md.md|Register \*\*v+1\*\* schema for any evolving topic and write minimal \*\*upcaster\*\*]] #rejected
-- [ ] [[write_vault_config_readme_md_for_obsidian_vault_on_md.md|Write vault-config README.md for Obsidian vault onboarding]] #framework-core #rejected
-- [ ] [[ensure_github_compatible_markdown_settings_are_doc_md.md|Ensure GitHub-compatible markdown settings are documented \*(no link yet)\*]] #documentation #rejected
-- [ ] [[implement_timetravel_processat_processid_t_in_a_sm_md.md|Implement \`timetravel.processAt(processId, T)\` in a small CLI for debugging]] #rejected
-- [ ] [[add_snapshot_consumer_to_warm_cache_on_boot_md.md|Add snapshot consumer to warm cache on boot]] #rejected
-- [ ] [[deploy_changefeed_for_collections_you_want_mirrore_md.md|Deploy \*\*changefeed\*\* for collections you want mirrored to topics]] #rejected
-- [ ] [[implement_transcendence_cascade_framework_core_md.md|Implement transcendence cascade #framework-core]] #framework-core #rejected
-- [ ] [[ensure_mongo_indexes_key_1_unique_common_query_fie_md.md|Ensure Mongo indexes: \`{ \_key: 1 } unique\` + common query fields]] #rejected
-- [ ] [[add_manualack_to_event_bus_and_re_run_tests_md.md|Add \`manualAck\` to event bus and re-run tests]] #rejected
-- [ ] [[launch_replayapi_on_8083_test_replay_and_export_nd_md.md|Launch \`ReplayAPI\` on \`:8083\`; test \`/replay\` and \`/export?ndjson\=1\`]] #rejected
-- [ ] [[enable_compactor_for_process_state_process_state_s_md.md|Enable compactor for \`process.state\` → \`process.state.snapshot\`]] #rejected
-
+- [ ] [add_obsidian_to_gitignore_md_md](../tasks/add_obsidian_to_gitignore_md_md.md) #done
+- [ ] [add_starter_notes_-_eidolon_fields_cephalon_inner_monologue_1_md](../tasks/add_starter_notes_-_eidolon_fields_cephalon_inner_monologue_1_md.md) #done
+- [ ] [add_stt_service_tests_md](../tasks/add_stt_service_tests_md.md) #done
+- [ ] [add_unit_tests_for_date_tools_py_md](../tasks/add_unit_tests_for_date_tools_py_md.md) #done
+- [ ] [add_unit_tests_for_wav_processing_md](../tasks/add_unit_tests_for_wav_processing_md.md) #done
+- [ ] [auto-generate_agents_md_stubs_from_services_structure_md_md](../tasks/auto-generate_agents_md_stubs_from_services_structure_md_md.md) #done
+- [ ] [build_data_structures_for_eidolon_field_codex_task_md](../tasks/build_data_structures_for_eidolon_field_codex_task_md.md) #done
+- [ ] [build_data_structures_for_eidolon_field_md_md](../tasks/build_data_structures_for_eidolon_field_md_md.md) #done
+- [ ] [clarify_promethean_project_vision_1_md](../tasks/clarify_promethean_project_vision_1_md.md) #done
+- [ ] [clearly_seperate_service_dependency_files_md](../tasks/clearly_seperate_service_dependency_files_md.md) #done
+- [ ] [create_permission_gating_layer_1_md](../tasks/create_permission_gating_layer_1_md.md) #done
+- [ ] [create_permission_gating_layer_1_md_md](../tasks/create_permission_gating_layer_1_md_md.md) #done
+- [ ] [create_permission_gating_layer_framework_core_md](../tasks/create_permission_gating_layer_framework_core_md.md) #done
+- [ ] [create_vault-config_obsidian_with_kanban_and_minimal_vault_setup_1_md_md](../tasks/create_vault-config_obsidian_with_kanban_and_minimal_vault_setup_1_md_md.md) #done
+- [ ] [determine_pm2_configuration_for_agents_1_md](../tasks/determine_pm2_configuration_for_agents_1_md.md) #done
+- [ ] [discord_image_attachment_indexer_md](../tasks/discord_image_attachment_indexer_md.md) #done
+- [ ] [document_board_usage_guidelines_1_md](../tasks/document_board_usage_guidelines_1_md.md) #done
+- [ ] [document_local_testing_setup_md_md](../tasks/document_local_testing_setup_md_md.md) #done
+- [ ] [fix_makefile_test_target_md](../tasks/fix_makefile_test_target_md.md) #done
+- [ ] [make_seperate_execution_pathways_1_md_md](../tasks/make_seperate_execution_pathways_1_md_md.md) #done
+- [ ] [mirror_shared_utils_with_language-specific_doc_folders_md_md](../tasks/mirror_shared_utils_with_language-specific_doc_folders_md_md.md) #done
+- [ ] [research_github_projects_board_api_md](../tasks/research_github_projects_board_api_md.md) #done
+- [ ] [separate_all_testing_pipelines_in_github_actions_md](../tasks/separate_all_testing_pipelines_in_github_actions_md.md) #done
+- [ ] [start_eidolon_md](../tasks/start_eidolon_md.md) #done
+- [ ] [update_github_actions_to_use_makefile_md_md](../tasks/update_github_actions_to_use_makefile_md_md.md) #done
+- [ ] [write_board_sync_script_md_md](../tasks/write_board_sync_script_md_md.md) #done
+- [ ] [write_meaningful_tests_for_cephalon_md_md](../tasks/write_meaningful_tests_for_cephalon_md_md.md) #done
+- [ ] [write_simple_ecosystem_declaration_library_for_new_md_md](../tasks/write_simple_ecosystem_declaration_library_for_new_md_md.md) #done
+- [ ] [write_vault_config_readme_md_for_obsidian_vault_on_md](../tasks/write_vault_config_readme_md_for_obsidian_vault_on_md.md) #done
 
 ## Archive
 
-- [ ] [[context service]]
-- [ ] [[extract_site_modules_from_riatzukiza_github_io_md_md.md|Extract site modules from riatzukiza.github.io]] #framework-core #accepted
-- [ ] [[migrate_portfolio_client_code_to_promethean_md.md|Migrate portfolio client code to Promethean]] #framework-core #accepted
-- [ ] [[migrate_server_side_sibilant_libs_to_promethean_ar_md.md|Migrate server side sibilant libs to Promethean architecture.]] #accepted
-- [ ] [[migrate_portfolio_client_code_to_promethean_md.md|Migrate portfolio client code to Promethean]] #framework-core #accepted
-- [ ] [[setup_code_in_wsl_md.md|setup code in wsl md]] #framework-core #accepted
-- [ ] [[discord_link_indexer_md.md|discord link indexer md]] #framework-core #prompt-refinement #accepted
-- [ ] [[Add git commands to gpt bridge]]
-- [ ] [[add_unit_tests_for_gui_helpers_md_md.md|Add unit tests for GUI helpers]] #codex-task #testing #archive
-- [ ] [[build_tiny_web_page_that_uses_promclient_in_the_br_md.md|Build tiny web page that uses `PromClient` in the browser to show live `process.state` (optional)]] #archive
-- [ ] [[create_permission_gating_layer_codex_task_md.md|Create permission gating layer #codex-task]] #codex-task #archive
-- [ ] [[document_board_sync_workflow_md_md.md|Document board sync workflow]] #framework-core #archive
-- [ ] [[obsidian_kanban_github_project_board_mirror_system_md_md.md|Obsidian Kanban Github Project Board Mirror system]] #framework-core #archive
-- [ ] [[pin_versions_in_configs_promethean_codex_md.md|Pin versions in configs (Promethean + Codex)]] #archive
-- [ ] [[run_bakeoff_see_below_md.md|Run bakeoff (see below)]] #archive
-- [ ] [[set_up_makefile_for_python_js_build_test_dev_md.md|Set up Makefile for Python + JS build test dev]] #cicd #buildtools #devtools #devops #archive
-- [ ] [[start_eidolon_md_md.md|Start Eidolon]] #framework-core #archive
-- [ ] [[update_makefile_to_have_commands_specific_for_agents_md.md|Update Makefile to have commands specific for agents]] #devops #archive
-- [ ] [[create_base_readme_md_templates_for_each_service_md.md|create base readme md templates for each service md]] #doc-this #framework-core #ritual #archive
-- [ ] [[each_service_registers_a_pid_with_a_heartbeat_service_if_they_do_not_successfully_check_in_terminate_the_process_using_the_pid_md_md.md|each service registers a pid with a heartbeat service if they do not successfully check in terminate the process using the pid md md]] #framework-core #archive
-- [ ] [[look_into_why_the_state_object_never_seems_to_get_updated_md_md.md|look into why the state object never seems to get updated md md]] #framework-core #archive
-- [ ] [[make_discord_channel_aware_contextualizer_md_md.md|make discord channel aware contextualizer md md]] #framework-core #archive
-- [ ] [[prevent_dangling_processes_when_a_process_fails_due_to_error_or_automaticly_clean_them_up_1_md_md.md|prevent dangling processes when a process fails due to error or automaticly clean them up 1 md md]] #framework-core #resources #process-management #aionian #archive
-- [ ] [[send_waveforms_spectrograms_and_dekstop_screenshots_to_discord_for_remote_storage_md_md.md|send waveforms spectrograms and dekstop screenshots to discord for remote storage md md]] #framework-core #archive
-- [ ] [[each_service_registers_a_pid_with_a_heartbeat_service_if_they_do_not_successfully_check_in_terminate_the_process_using_the_pid_md_md.md|each service registers a pid with a heartbeat service. If they do not successfully check in, terminate the process using the pid.md]] #framework-core #archive
-- [ ] [[create_base_readme_md_templates_for_each_service_md.md|create base readme md templates for each service.md]] #doc-this #framework-core #ritual #archive
-- [ ] [[set_up_makefile_for_python_js_build_test_dev_md.md|Set up Makefile for Python + JS build test dev]] #cicd #buildtools #devtools #devops #archive
-- [ ] [[send_waveforms_spectrograms_and_dekstop_screenshots_to_discord_for_remote_storage_md_md.md|Send waveforms, spectrograms, and dekstop screenshots to discord for remote storage.md]] #framework-core #archive
-- [ ] [[look_into_why_the_state_object_never_seems_to_get_updated_md_md.md|Look into why the state object never seems to get updated..md]] #framework-core #archive
-- [ ] [[start_eidolon_md_md.md|Start Eidolon]] #framework-core #archive
-- [ ] [[update_makefile_to_have_commands_specific_for_agents_md.md|Update Makefile to have commands specific for agents]] #devops #archive
-- [ ] [[document_board_sync_workflow_md_md.md|Document board sync workflow]] #framework-core #archive
-- [ ] [[prevent_dangling_processes_when_a_process_fails_due_to_error_or_automaticly_clean_them_up_1_md_md.md|Prevent dangling processes when a process fails due to error, or automaticly clean them up 1.md]] #framework-core #resources #process-management #aionian #archive
-- [ ] [[make_discord_channel_aware_contextualizer_md_md.md|Make discord channel aware contextualizer.md]] #framework-core #archive
-- [ ] [[obsidian_kanban_github_project_board_mirror_system_md_md.md|Obsidian Kanban Github Project Board Mirror system]] #framework-core #archive
-- [ ] [[run_bakeoff_see_below_md.md|Run bakeoff (see below)]] #archive
-- [ ] [[pin_versions_in_configs_promethean_codex_md.md|Pin versions in configs (Promethean + Codex)]] #archive
-- [ ] [[build_tiny_web_page_that_uses_promclient_in_the_br_md.md|Build tiny web page that uses \`PromClient\` in the browser to show live \`process.state\` (optional)]] #archive
-- [ ] [[create_permission_gating_layer_codex_task_md.md|Create permission gating layer #codex-task]] #codex-task #archive
-- [ ] [[add_unit_tests_for_gui_helpers_md_md.md|Add unit tests for GUI helpers]] #codex-task #testing #archive
-- [ ] [[build_tiny_web_page_that_uses_promclient_in_the_br_md.md|Build tiny web page that uses `PromClient` in the browser to show live `process.state` (optional)]] #archive
-
-
-***
-
-## Archive
-
-- [ ] [[clean_up_notes_into_design_docs_md.md|clean up notes into design docs md]] #framework-core #agent-thinking #accepted
-- [ ] [[migrating_relevant_modules_from_riatzukiza_github_md.md|Migrating relevant modules from `riatzukiza.github.io` to `/sites/` and `/docs/`]] #accepted
-- [ ] [[Curate code from personal repository]]
-- [ ] [[extract_docs_from_riatzukiza_github_io_md_md.md|Extract docs from riatzukiza.github.io]] #framework-core #accepted
+- [ ] [add_unit_tests_for_gui_helpers_md_md](../tasks/add_unit_tests_for_gui_helpers_md_md.md) #archive
+- [ ] [build_tiny_web_page_that_uses_promclient_in_the_br_md](../tasks/build_tiny_web_page_that_uses_promclient_in_the_br_md.md) #archive
+- [ ] [create_base_readme_md_templates_for_each_service_md](../tasks/create_base_readme_md_templates_for_each_service_md.md) #archive
+- [ ] [create_permission_gating_layer_codex_task_md](../tasks/create_permission_gating_layer_codex_task_md.md) #archive
+- [ ] [document_board_sync_workflow_md_md](../tasks/document_board_sync_workflow_md_md.md) #archive
+- [ ] [each_service_registers_a_pid_with_a_heartbeat_service_if_they_do_not_successfully_check_in_terminate_the_process_using_the_pid_md_md](../tasks/each_service_registers_a_pid_with_a_heartbeat_service_if_they_do_not_successfully_check_in_terminate_the_process_using_the_pid_md_md.md) #archive
+- [ ] [look_into_why_the_state_object_never_seems_to_get_updated_md_md](../tasks/look_into_why_the_state_object_never_seems_to_get_updated_md_md.md) #archive
+- [ ] [make_discord_channel_aware_contextualizer_md_md](../tasks/make_discord_channel_aware_contextualizer_md_md.md) #archive
+- [ ] [obsidian_kanban_github_project_board_mirror_system_md_md](../tasks/obsidian_kanban_github_project_board_mirror_system_md_md.md) #archive
+- [ ] [pin_versions_in_configs_promethean_codex_md](../tasks/pin_versions_in_configs_promethean_codex_md.md) #archive
+- [ ] [prevent_dangling_processes_when_a_process_fails_due_to_error_or_automaticly_clean_them_up_1_md_md](../tasks/prevent_dangling_processes_when_a_process_fails_due_to_error_or_automaticly_clean_them_up_1_md_md.md) #archive
+- [ ] [run_bakeoff_see_below_md](../tasks/run_bakeoff_see_below_md.md) #archive
+- [ ] [send_waveforms_spectrograms_and_dekstop_screenshots_to_discord_for_remote_storage_md_md](../tasks/send_waveforms_spectrograms_and_dekstop_screenshots_to_discord_for_remote_storage_md_md.md) #archive
+- [ ] [set_up_makefile_for_python_js_build_test_dev_md](../tasks/set_up_makefile_for_python_js_build_test_dev_md.md) #archive
+- [ ] [start_eidolon_md_md](../tasks/start_eidolon_md_md.md) #archive
 
 %% kanban:settings
 ```
-{"kanban-plugin":"board","list-collapse":[false,false,false,false,false,false,false,false,false,false,false,true,false,false],"new-note-template":"agile/templates/task.stub.template.md","new-note-folder":"agile/tasks","metadata-keys":[{"metadataKey":"tags","label":"","shouldHideLabel":false,"containsMarkdown":false},{"metadataKey":"hashtags","label":"","shouldHideLabel":false,"containsMarkdown":false}]}
+{"kanban-plugin":"board","list-collapse":[false,false,true,false,false,false,false,false,false,false,false,false,false,false],"new-note-template":"docs/agile/templates/task.stub.template.md","new-note-folder":"docs/agile/tasks","metadata-keys":[{"metadataKey":"tags","label":"","shouldHideLabel":false,"containsMarkdown":false},{"metadataKey":"hashtags","label":"","shouldHideLabel":false,"containsMarkdown":false}]}
 ```
 %%

--- a/docs/agile/tasks/LLM service must accept tool calls.md
+++ b/docs/agile/tasks/LLM service must accept tool calls.md
@@ -49,5 +49,5 @@ Nothing
 
 - [kanban](../boards/kanban.md)
 
-#framework-core #accepted #breakdown
+#framework-core #Ready
 

--- a/docs/agile/tasks/Phase out proxy in favor of bridge service.md
+++ b/docs/agile/tasks/Phase out proxy in favor of bridge service.md
@@ -50,5 +50,5 @@ Nothing
 - [API spec](https://err-stealth-16-ai-studio-a1vgg.tailbe888a.ts.net/v1/openapi.json)
 - [kanban](../boards/kanban.md)
 
-#framework-core #accepted #breakdown
+#framework-core #Ready
 

--- a/docs/agile/tasks/audio processing service.md
+++ b/docs/agile/tasks/audio processing service.md
@@ -48,5 +48,5 @@ Nothing
 
 - [kanban](../boards/kanban.md)
 
-#framework-core #accepted #breakdown
+#framework-core #Ready
 

--- a/docs/agile/tasks/clearly standardize data models.md
+++ b/docs/agile/tasks/clearly standardize data models.md
@@ -48,5 +48,5 @@ Nothing
 
 - [kanban](../boards/kanban.md)
 
-#framework-core #accepted #breakdown
+#framework-core #Ready
 

--- a/docs/agile/tasks/convert current services to packages, then redefine the services using config files.md
+++ b/docs/agile/tasks/convert current services to packages, then redefine the services using config files.md
@@ -48,5 +48,5 @@ Nothing
 
 - [kanban](../boards/kanban.md)
 
-#framework-core #accepted #breakdown
+#framework-core #Ready
 

--- a/docs/agile/tasks/create a generic markdown helper module.md
+++ b/docs/agile/tasks/create a generic markdown helper module.md
@@ -48,5 +48,5 @@ Nothing
 
 - [kanban](../boards/kanban.md)
 
-#framework-core #accepted #breakdown
+#framework-core #Ready
 

--- a/docs/agile/tasks/dockerize the system.md
+++ b/docs/agile/tasks/dockerize the system.md
@@ -48,5 +48,5 @@ Nothing
 
 - [kanban](../boards/kanban.md)
 
-#devops #accepted #breakdown
+#devops #Ready
 

--- a/docs/agile/tasks/flatten services.md
+++ b/docs/agile/tasks/flatten services.md
@@ -48,5 +48,5 @@ Nothing
 
 - [kanban](../boards/kanban.md)
 
-#framework-core #accepted #breakdown
+#framework-core #Ready
 

--- a/docs/agile/tasks/frontend build tool chain.md
+++ b/docs/agile/tasks/frontend build tool chain.md
@@ -48,5 +48,5 @@ Nothing
 
 - [kanban](../boards/kanban.md)
 
-#devops #accepted #breakdown
+#devops #Ready
 

--- a/docs/agile/tasks/lisp package files.md
+++ b/docs/agile/tasks/lisp package files.md
@@ -48,5 +48,5 @@ Nothing
 
 - [kanban](../boards/kanban.md)
 
-#framework-core #accepted #breakdown
+#framework-core #Ready
 

--- a/docs/agile/tasks/redefine all existing lambdas with high order functions incoming.md
+++ b/docs/agile/tasks/redefine all existing lambdas with high order functions incoming.md
@@ -47,5 +47,5 @@ Nothing
 
 - [kanban](../boards/kanban.md)
 
-#framework-core #accepted #breakdown
+#framework-core #Ready
 

--- a/docs/agile/tasks/task generator system.md
+++ b/docs/agile/tasks/task generator system.md
@@ -48,5 +48,5 @@ Nothing
 
 - [kanban](../boards/kanban.md)
 
-#framework-core #accepted #breakdown
+#framework-core #Ready
 

--- a/docs/agile/tasks/update_makefile_to_have_commands_specific_for_agents_md.md
+++ b/docs/agile/tasks/update_makefile_to_have_commands_specific_for_agents_md.md
@@ -51,4 +51,4 @@ Nothing
 - [write simple ecosystem declaration library for new agents](write%20simple%20ecosystem%20declaration%20library%20for%20new%20agents.md)
 
 
-#archive
+#devops #Ready


### PR DESCRIPTION
## Summary
- mark Ready tasks with `#Ready` status
- regenerate kanban board from task files

## Testing
- `make lint` *(fails: A config object is using the "extends" key, which is not supported in flat config system)*
- `pytest -q` *(fails: 30 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68ae3e7772448324aa10534c570a171f