### PR TITLE
feat: add batch transcription script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,8 @@
 node_modules/
 onnx_model/
 models/
-data/
+data/*
+!data/README.md
 open_vino_modelfp16/
 pulbic/
 .env

--- a/data/README.md
+++ b/data/README.md
@@ -1,0 +1,20 @@
+# Data
+
+This directory holds datasets and artifacts used by Promethean. Raw
+recordings for transcription should be placed in `raw-wav/` and processed
+with [`scripts/batch_transcribe.py`](../scripts/batch_transcribe.py).
+See [docs/maintenance/orphaned-files.md](../docs/maintenance/orphaned-files.md)
+for more details.
+
+## Source
+N/A – developer-provided recordings.
+
+## Format
+- `raw-wav/`: input WAV files awaiting transcription
+- `transcripts/{model_name}/`: generated text outputs
+
+## Licensing
+Internal development data only.
+
+## Intended use
+Testing and maintenance of speech-to-text pipelines.

--- a/docs/maintenance/orphaned-files.md
+++ b/docs/maintenance/orphaned-files.md
@@ -1,0 +1,15 @@
+# Orphaned audio files
+
+Raw recordings that have not been transcribed live under `data/raw-wav/`.
+Use the batch transcription script to convert them into text files for
+further processing or archival.
+
+## Batch transcription
+
+```bash
+python scripts/batch_transcribe.py
+```
+
+The script scans `data/raw-wav/` for WAV files and runs each available
+`transcribe_pcm` implementation (e.g. `shared.py.speech.wisper_stt`).
+Results are written to `data/transcripts/{model_name}/<basename>.txt`.

--- a/scripts/batch_transcribe.py
+++ b/scripts/batch_transcribe.py
@@ -1,0 +1,88 @@
+"""Batch transcription utility.
+
+Iterates over WAV files in ``data/raw-wav`` and transcribes them using any
+available ``transcribe_pcm`` implementations from ``shared.py.speech``.
+
+Outputs are written to ``data/transcripts/{model_name}/<basename>.txt``.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+import wave
+from typing import Callable, Dict
+
+# Ensure project root on sys.path so shared modules are importable
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+Transcriber = Callable[[bytearray, int, int], str]
+
+
+def discover_transcribers() -> Dict[str, Transcriber]:
+    """Return a mapping of model name to ``transcribe_pcm`` functions.
+
+    Imports are attempted lazily so environments lacking optional
+    dependencies can still run this script. Only successfully imported
+    models are returned.
+    """
+    transcribers: Dict[str, Transcriber] = {}
+
+    try:
+        from shared.py.speech.wisper_stt import transcribe_pcm as whisper_transcribe
+
+        transcribers["wisper_stt"] = whisper_transcribe
+    except Exception as exc:  # pragma: no cover - best effort discovery
+        print(f"Skipping wisper_stt: {exc}")
+
+    try:
+        from shared.py.speech.stt import transcribe_pcm as base_transcribe
+
+        transcribers["stt"] = base_transcribe
+    except Exception as exc:  # pragma: no cover - best effort discovery
+        print(f"Skipping stt: {exc}")
+
+    return transcribers
+
+
+def transcribe_file(path: Path, transcribers: Dict[str, Transcriber], out_root: Path) -> None:
+    """Transcribe ``path`` with each ``transcriber`` and save outputs."""
+    with wave.open(str(path), "rb") as wf:
+        pcm = wf.readframes(wf.getnframes())
+        rate = wf.getframerate()
+        channels = wf.getnchannels()
+
+    base = path.stem
+    for name, fn in transcribers.items():
+        try:
+            text = fn(bytearray(pcm), sample_rate=rate, num_channels=channels)
+        except Exception as exc:  # pragma: no cover - avoid failing whole batch
+            print(f"Failed {name} on {path.name}: {exc}")
+            continue
+        out_file = out_root / name / f"{base}.txt"
+        out_file.parent.mkdir(parents=True, exist_ok=True)
+        out_file.write_text(text.strip())
+        print(f"Saved {name} transcription for {path.name} -> {out_file}")
+
+
+def main() -> None:
+    raw_dir = Path("data/raw-wav")
+    out_root = Path("data/transcripts")
+
+    transcribers = discover_transcribers()
+    if not transcribers:
+        print("No transcription models available")
+        return
+
+    wav_files = sorted(raw_dir.glob("*.wav"))
+    if not wav_files:
+        print(f"No wav files found in {raw_dir}")
+        return
+
+    for wav in wav_files:
+        transcribe_file(wav, transcribers, out_root)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()


### PR DESCRIPTION
## Summary
- add batch_transcribe.py to process WAV files with available speech-to-text models
- document orphaned audio handling and batch transcription usage
- add data README referencing new script and maintenance doc

## Testing
- `make install` *(fails: ModuleNotFoundError or missing packages)*
- `make format`
- `make lint` *(fails: flake8 not found)*
- `make test` *(fails: ModuleNotFoundError: pluggy)*
- `make build` *(fails: rimraf not found)*
- `python scripts/batch_transcribe.py` *(skipped models due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_688d63b3f9348324a8c4c3affd3e96e6