### PR TITLE
feat: centralize biome configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - v1 router exposing consolidated SmartGPT Bridge endpoints.
 - OpenAPI spec for `/v1` served at `/v1/openapi.json` with consolidated operations.
 - `distclean` target to remove ignored files via `git clean -fdX`.
+- Centralized Biome configuration at `templates/ts/biome.base.json` referenced by Discord bot template and Markdown Graph service.
 
 ### Changed
 
@@ -75,7 +76,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Pinned JavaScript dependencies, GitHub Actions, and documented version policy for reproducible builds.
 - Pre-commit now runs `pnpm tsc --noEmit` and `pytest -q` instead of `make build`; use `pre-commit run --hook-stage manual full-build` or `make build` for full builds.
 - Naive embedding driver now uses configurable `VECTOR_SIZE` constant.
- - Enhanced URL canonicalization helpers to remove tracking parameters and expand scheme denylist.
+- Enhanced URL canonicalization helpers to remove tracking parameters and expand scheme denylist.
 - Organized SmartGPT Bridge routes into versioned directories.
 - Embedding clients and related utilities now accept structured `{type, data}`
   items instead of using the `img:` prefix.

--- a/scripts/generate_service_templates.py
+++ b/scripts/generate_service_templates.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import argparse
 import json
 import pathlib
+import shutil
 
 ROOT = pathlib.Path(__file__).resolve().parents[1]
 SERVICES_DIR = ROOT / "services"
@@ -68,6 +69,8 @@ def generate_scaffold(target: pathlib.Path, language: str) -> None:
             "include": ["src"],
         }
         (target / "tsconfig.json").write_text(json.dumps(tsconfig, indent=2) + "\n")
+        biome_base = ROOT / "templates" / "ts" / "biome.base.json"
+        shutil.copy(biome_base, target / "biome.json")
     else:
         raise ValueError(f"Unsupported language: {language}")
 

--- a/services/ts/markdown-graph/biome.json
+++ b/services/ts/markdown-graph/biome.json
@@ -1,11 +1,1 @@
-{
-    "$schema": "https://biomejs.dev/schemas/2.1.3/schema.json",
-    "files": {
-        "includes": ["src/**", "tests/**"]
-    },
-    "linter": {
-        "rules": {
-            "recommended": false
-        }
-    }
-}
+../../../templates/ts/biome.base.json

--- a/templates/ts/biome.base.json
+++ b/templates/ts/biome.base.json
@@ -1,0 +1,11 @@
+{
+    "$schema": "https://biomejs.dev/schemas/2.1.3/schema.json",
+    "files": {
+        "includes": ["src/**", "tests/**"]
+    },
+    "linter": {
+        "rules": {
+            "recommended": false
+        }
+    }
+}

--- a/templates/ts/discord-bot/biome.json
+++ b/templates/ts/discord-bot/biome.json
@@ -1,11 +1,1 @@
-{
-    "$schema": "https://biomejs.dev/schemas/2.1.3/schema.json",
-    "files": {
-        "includes": ["src/**", "tests/**"]
-    },
-    "linter": {
-        "rules": {
-            "recommended": false
-        }
-    }
-}
+../biome.base.json


### PR DESCRIPTION
## Summary
- add shared biome base config for TS templates
- symlink markdown-graph service and discord-bot template to biome base config
- scaffold script copies biome base config into new TS projects

## Testing
- `black scripts/generate_service_templates.py`
- `pnpm exec biome format --write templates/ts/biome.base.json templates/ts/discord-bot/biome.json services/ts/markdown-graph/biome.json`
- `pnpm exec prettier -w CHANGELOG.md templates/ts/biome.base.json`
- `pnpm exec biome lint templates/ts/biome.base.json templates/ts/discord-bot/biome.json services/ts/markdown-graph/biome.json`
- `flake8 scripts/generate_service_templates.py --count`
- `make build`
- `make test` *(fails: ModuleNotFoundError: No module named 'chromadb' and other missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68ae3d63a724832494d250b16d4c6958