### PR TITLE
refactor: share ts service run script

### DIFF
--- a/services/ts/file-watcher/README.md
+++ b/services/ts/file-watcher/README.md
@@ -19,9 +19,9 @@ Additionally, the repo watcher:
   SmartGPT bridge (URL configurable via `SMARTGPT_BRIDGE_URL`).
 - On file delete: POSTs `{ path }` to `POST /indexer/remove` on the SmartGPT
   bridge.
- - If auth is enabled on the bridge, include a static bearer token via
-   `SMARTGPT_BRIDGE_TOKEN` (or `BRIDGE_AUTH_TOKEN`/`AUTH_TOKEN`) — requests send
-   `Authorization: Bearer <token>`.
+- If auth is enabled on the bridge, include a static bearer token via
+  `SMARTGPT_BRIDGE_TOKEN` (or `BRIDGE_AUTH_TOKEN`/`AUTH_TOKEN`) — requests send
+  `Authorization: Bearer <token>`.
 
 Environment variables:
 
@@ -32,5 +32,6 @@ Environment variables:
   index/remove requests (default `2000`). Higher values reduce request volume.
 - `SMARTGPT_BRIDGE_TOKEN` (optional) – bearer token for SmartGPT Bridge.
 
-`pnpm start` will compile the TypeScript source before launching.
-Use `pnpm run start:dev` while developing to watch TypeScript files.
+Run the service with `./run.sh` (requires `pnpm`); the script checks for the
+package manager and prints setup instructions if it's missing. Use
+`pnpm run start:dev` during development to watch TypeScript files.

--- a/services/ts/file-watcher/run.sh
+++ b/services/ts/file-watcher/run.sh
@@ -1,8 +1,1 @@
-#!/usr/bin/bash
-if command -v pnpm >/dev/null 2>&1; then
-  pnpm start
-else
-  echo "ERROR: pnpm is required. Enable Corepack and activate pnpm:"
-  echo "  corepack enable && corepack prepare pnpm@latest --activate"
-  exit 1
-fi
+../run.sh

--- a/services/ts/llm/README.md
+++ b/services/ts/llm/README.md
@@ -4,10 +4,11 @@ This service exposes HTTP and WebSocket endpoints for text generation through pl
 
 ## Usage
 
-Install dependencies and start the service (pnpm required):
+Start the service with `./run.sh` (requires `pnpm`; the script prints setup
+instructions if the package manager is missing):
 
 ```bash
-pnpm start
+./run.sh
 ```
 
 POST `/generate` with JSON containing `prompt`, `context` and optional `format` to receive the generated reply.
@@ -25,8 +26,8 @@ Example `config/config.yml` entry:
 
 ```yaml
 llm:
-  driver: ollama
-  model: gemma3:latest
+    driver: ollama
+    model: gemma3:latest
 ```
 
 For HuggingFace, set `HF_API_TOKEN` for authenticated requests.

--- a/services/ts/llm/run.sh
+++ b/services/ts/llm/run.sh
@@ -1,8 +1,1 @@
-#!/usr/bin/bash
-if command -v pnpm >/dev/null 2>&1; then
-  pnpm start
-else
-  echo "ERROR: pnpm is required. Enable Corepack and activate pnpm:"
-  echo "  corepack enable && corepack prepare pnpm@latest --activate"
-  exit 1
-fi
+../run.sh

--- a/services/ts/run.sh
+++ b/services/ts/run.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/bash
+if command -v pnpm >/dev/null 2>&1; then
+  pnpm start
+else
+  echo "ERROR: pnpm is required. Enable Corepack and activate pnpm:"
+  echo "  corepack enable && corepack prepare pnpm@latest --activate"
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- centralize pnpm-based run script for TypeScript services
- link file-watcher and llm run scripts to shared helper
- document shared run.sh usage in file-watcher and llm READMEs

## Testing
- `pnpm run lint` (file-watcher) *(warn: code style issues for package-lock.json and README.md)*
- `pnpm run format` (file-watcher)
- `pnpm run build` (file-watcher)
- `pnpm run test` (file-watcher) *(fails: TypeError Cannot assign to read only property 'checkGitIgnored')*
- `pnpm exec biome lint .` (llm)
- `pnpm run build` (llm)
- `pnpm run test` (llm)

------
https://chatgpt.com/codex/tasks/task_e_68ae3d5d3e48832484d6439f6aa3181c