### PR TITLE
chore: centralize biome config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - OpenAPI spec for `/v1` served at `/v1/openapi.json` with consolidated operations.
 - `distclean` target to remove ignored files via `git clean -fdX`.
 
+- Shared Biome configuration template (`templates/ts/biome.base.json`) for TypeScript services.
+
 ### Changed
 
 - Refined Kanban breakdown tasks with clear goals, requirements, and subtasks.
@@ -38,6 +40,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Proxy route `/bridge` through the shared proxy service for SmartGPT Bridge.
 - Tool calling support for Codex Context service.
 - Image attachments captured, stored, and retrieved for multimodal prompting with cleanup.
+- Markdown Graph service and Discord bot template now extend the shared Biome configuration.
 - OAuth Authorization Code flow with PKCE for the auth-service, enabling OpenAI Custom GPT logins.
 - Template for building Discord bots in TypeScript based on the Cephalon service.
 - Tests validating bridge event mappings for identifiers and protocols.
@@ -75,7 +78,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Pinned JavaScript dependencies, GitHub Actions, and documented version policy for reproducible builds.
 - Pre-commit now runs `pnpm tsc --noEmit` and `pytest -q` instead of `make build`; use `pre-commit run --hook-stage manual full-build` or `make build` for full builds.
 - Naive embedding driver now uses configurable `VECTOR_SIZE` constant.
- - Enhanced URL canonicalization helpers to remove tracking parameters and expand scheme denylist.
+- Enhanced URL canonicalization helpers to remove tracking parameters and expand scheme denylist.
 - Organized SmartGPT Bridge routes into versioned directories.
 - Embedding clients and related utilities now accept structured `{type, data}`
   items instead of using the `img:` prefix.

--- a/services/ts/markdown-graph/biome.json
+++ b/services/ts/markdown-graph/biome.json
@@ -1,11 +1,3 @@
 {
-    "$schema": "https://biomejs.dev/schemas/2.1.3/schema.json",
-    "files": {
-        "includes": ["src/**", "tests/**"]
-    },
-    "linter": {
-        "rules": {
-            "recommended": false
-        }
-    }
+    "extends": ["../../../templates/ts/biome.base.json"]
 }

--- a/templates/ts/biome.base.json
+++ b/templates/ts/biome.base.json
@@ -1,0 +1,11 @@
+{
+    "$schema": "https://biomejs.dev/schemas/2.1.3/schema.json",
+    "files": {
+        "includes": ["src/**", "tests/**"]
+    },
+    "linter": {
+        "rules": {
+            "recommended": false
+        }
+    }
+}

--- a/templates/ts/discord-bot/biome.json
+++ b/templates/ts/discord-bot/biome.json
@@ -1,11 +1,3 @@
 {
-    "$schema": "https://biomejs.dev/schemas/2.1.3/schema.json",
-    "files": {
-        "includes": ["src/**", "tests/**"]
-    },
-    "linter": {
-        "rules": {
-            "recommended": false
-        }
-    }
+    "extends": ["../biome.base.json"]
 }


### PR DESCRIPTION
## Summary
- add shared Biome configuration at templates/ts/biome.base.json
- reference shared config in markdown-graph service and discord bot template
- document configuration change in changelog

## Testing
- `make format` *(fails: Command "@biomejs/biome" not found)*
- `make lint-ts-service-markdown-graph` *(fails: NameError: unless not defined)*
- `make test-ts-service-markdown-graph` *(fails: spawn chroma ENOENT)*
- `make build-ts SERVICE=markdown-graph`


------
https://chatgpt.com/codex/tasks/task_e_68ae3d4a6f488324b04a5ddae2ce8b7a