### PR TITLE
chore: remove Prettier config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Realtime Promethean Health Dashboard for monitoring heartbeat metrics.
 - Configurable timeout for remote embedding requests.
 - `defun` special form in Lisp compiler enabling named functions and recursion.
+- ESLint configuration updated to remove Prettier in favor of Biome.
 
 ### Changed
 
@@ -122,6 +123,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - Deprecated `scripts/serve-sites.js` static file server.
 - Per-file `sys.path.append` hacks in tests in favor of centralized setup.
+- `prettier.config.cjs` removed now that Biome handles formatting.
 
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,22 +1,22 @@
-import tseslint from '@typescript-eslint/eslint-plugin';
-import tsParser from '@typescript-eslint/parser';
+import tseslint from "@typescript-eslint/eslint-plugin";
+import tsParser from "@typescript-eslint/parser";
 
 export default [
   {
-    files: ['**/*.{js,ts,mjs}'],
-    ignores: ['node_modules/**', 'dist/**', 'coverage/**'],
+    files: ["**/*.{js,ts,mjs}"],
+    ignores: ["node_modules/**", "dist/**", "coverage/**"],
     languageOptions: {
       parser: tsParser,
     },
     plugins: {
-      '@typescript-eslint': tseslint,
+      "@typescript-eslint": tseslint,
     },
     rules: {},
+    // Biome handles formatting; Prettier config removed
     extends: [
-      'eslint:recommended',
-      'plugin:@typescript-eslint/recommended',
-      'plugin:import/recommended',
-      'prettier', // keeps ESLint from fighting Prettier
+      "eslint:recommended",
+      "plugin:@typescript-eslint/recommended",
+      "plugin:import/recommended",
     ],
   },
 ];

--- a/prettier.config.cjs
+++ b/prettier.config.cjs
@@ -1,9 +1,0 @@
-/** @type {import("prettier").Config} */
-module.exports = {
-    tabWidth: 4, // or your number
-    useTabs: false, // true if you want tabs
-    semi: true,
-    singleQuote: true,
-    trailingComma: 'all',
-    printWidth: 100,
-};


### PR DESCRIPTION
## Summary
- drop Prettier config now that Biome covers formatting
- note Biome usage in ESLint config
- document tooling change in changelog

## Testing
- `make format` *(fails: SyntaxError: '}' expected)*
- `make lint` *(fails: A config object is using the "extends" key, which is not supported in flat config system)*
- `make test` *(fails: See make output)*
- `make build`


------
https://chatgpt.com/codex/tasks/task_e_68ae496ea7e4832493efeaf5a2aed048