### PR TITLE
chore: add biome config and scripts

### DIFF
--- a/.biomeignore
+++ b/.biomeignore
@@ -1,0 +1,7 @@
+node_modules
+coverage
+dist
+services/ts/smartgpt-bridge/src/tests/fixtures/
+shared/sibilant/
+shared/ts/config/providers.yml
+**/biome.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - OpenAPI spec for `/v1` served at `/v1/openapi.json` with consolidated operations.
 - `distclean` target to remove ignored files via `git clean -fdX`.
 - `snapshot` target to tag the current commit with a timestamped snapshot.
+- Root Biome configuration and package scripts for linting and formatting.
 
 ### Changed
 

--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,12 @@
+{
+    "$schema": "https://biomejs.dev/schemas/2.2.2/schema.json",
+    "formatter": {
+        "lineWidth": 80,
+        "indentWidth": 4
+    },
+    "linter": {
+        "rules": {
+            "recommended": true
+        }
+    }
+}

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
         "coverage": "c8 ava tests/*.test.js",
         "build:docs": "node scripts/generate-service-docs.js",
         "health:node-abi": "node -p \"process.versions.node + ' ABI ' + process.versions.modules\"",
-        "prepare": "chmod +x ./bin/promethean.js"
+        "prepare": "chmod +x ./bin/promethean.js",
+        "lint": "biome lint --config-path=biome.json .",
+        "format": "biome format --config-path=biome.json --write ."
     },
     "bin": {
         "prom": "./bin/promethean.js"


### PR DESCRIPTION
## Summary
- add root Biome configuration and ignore list
- wire npm lint/format scripts to Biome
- document Biome usage in changelog

## Testing
- `make format`
- `make lint` *(fails: A config object is using the "extends" key, which is not supported in flat config system)*
- `pnpm lint` *(fails: Found a nested root configuration)*
- `make test` *(interrupted: KeyboardInterrupt)*
- `make build` *(interrupted: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68ae496e034c83249567fc3716908bc0