### PR TITLE
chore: align Biome versions across packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
         "zod": "3.25.76"
     },
     "devDependencies": {
-        "@biomejs/biome": "2.2.2",
+        "@biomejs/biome": "^2.2.2",
         "@types/jest": "30.0.0",
         "@types/mongodb": "4.0.6",
         "@typescript-eslint/eslint-plugin": "8.39.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,7 +42,7 @@ importers:
                 version: 3.25.76
         devDependencies:
             '@biomejs/biome':
-                specifier: 2.2.2
+                specifier: ^2.2.2
                 version: 2.2.2
             '@types/jest':
                 specifier: 30.0.0
@@ -441,7 +441,7 @@ importers:
                 version: 8.18.3
         devDependencies:
             '@biomejs/biome':
-                specifier: ^2.1.4
+                specifier: ^2.2.2
                 version: 2.2.2
             '@types/node':
                 specifier: ^22.17.2
@@ -974,7 +974,7 @@ importers:
                 version: 9.0.1
         devDependencies:
             '@biomejs/biome':
-                specifier: ^2.1.4
+                specifier: ^2.2.2
                 version: 2.2.2
             ava:
                 specifier: ^6.1.3
@@ -14722,7 +14722,7 @@ snapshots:
 
     axios@1.11.0:
         dependencies:
-            follow-redirects: 1.15.11(debug@4.4.1)
+            follow-redirects: 1.15.11(debug@4.3.7)
             form-data: 4.0.4
             proxy-from-env: 1.1.0
         transitivePeerDependencies:
@@ -16930,7 +16930,7 @@ snapshots:
     http-proxy@1.18.1:
         dependencies:
             eventemitter3: 4.0.7
-            follow-redirects: 1.15.11(debug@4.4.1)
+            follow-redirects: 1.15.11(debug@4.3.7)
             requires-port: 1.0.0
         transitivePeerDependencies:
             - debug

--- a/services/ts/cephalon/package.json
+++ b/services/ts/cephalon/package.json
@@ -53,7 +53,7 @@
         "ws": "^8.17.0"
     },
     "devDependencies": {
-        "@biomejs/biome": "^2.1.4",
+        "@biomejs/biome": "^2.2.2",
         "@types/node": "^22.17.2",
         "@types/ws": "^8.5.12",
         "ava": "^6.4.1",

--- a/services/ts/smartgpt-bridge/package.json
+++ b/services/ts/smartgpt-bridge/package.json
@@ -38,7 +38,7 @@
         "uuid": "^9.0.1"
     },
     "devDependencies": {
-        "@biomejs/biome": "^2.1.4",
+        "@biomejs/biome": "^2.2.2",
         "ava": "^6.1.3",
         "c8": "^9.1.0",
         "mongodb-memory-server": "^10.2.0",

--- a/templates/ts/discord-bot/package.json
+++ b/templates/ts/discord-bot/package.json
@@ -18,7 +18,7 @@
         "dotenv": "^17.2.0"
     },
     "devDependencies": {
-        "@biomejs/biome": "^2.1.4",
+        "@biomejs/biome": "^2.2.2",
         "@types/node": "^22.17.0",
         "ava": "^6.4.1",
         "c8": "^9.1.0",


### PR DESCRIPTION
## Summary
- unify `@biomejs/biome` dependency to `^2.2.2` across workspace packages
- refresh lockfile after installing dependencies

## Testing
- `pnpm install`
- `pre-commit run --files package.json pnpm-lock.yaml templates/ts/discord-bot/package.json templates/ts/discord-bot/pnpm-lock.yaml services/ts/cephalon/package.json services/ts/smartgpt-bridge/package.json`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68ae496ddf508324b63af5042460f1a1