### PR TITLE
docs: tag Ollama model design task as breakdown

### DIFF
--- a/docs/agile/boards/kanban.md
+++ b/docs/agile/boards/kanban.md
@@ -55,7 +55,6 @@ kanban-plugin: board
 ## Incoming
 
 - [ ] [[allow_configuration_of_hyperparameters_through_discord_context_size_spectrogram_resolution_interuption_threshold_md.md|allow configuration of hyperparameters through discord context size spectrogram resolution interuption threshold md]] #framework-core #ice-box
-- [ ] [[Design Ollama Model file for use with codex cli 1]]
 - [ ] [[refactor_speech_interuption_system_to_be_more_inteligent_using_audio_data_to_decide_if_interupted_md_md|Refactor Speech interuption system]] #framework-core #breakdown
 - [ ] [[identify_ancestral_resonance_patterns_md_md.md|Identify ancestral resonance patterns]] #framework-core #ice-box
 - [ ] [[gather_open_questions_about_system_direction_md_md.md|Gather open questions about system direction]] #framework-core #ice-box
@@ -97,6 +96,7 @@ kanban-plugin: board
 
 ## Breakdown (13)
 
+- [ ] [[Design Ollama Model file for use with codex cli 1]] #breakdown
 - [ ] [[design_circular_buffers_for_inputs_with_layered_states_of_persistance_in_memory_on_disk_cold_storage_so_md.md|design circular buffers for inputs with layered states of persistance in memory on disk cold storage so md]] #framework-core #ice-box
 - [ ] [[thinking_model_integration_md_md.md|thinking model integration md md]] #framework-core #ice-box
 - [ ] [[connect reddit]]

--- a/docs/agile/tasks/Design Ollama Model file for use with codex cli 1.md
+++ b/docs/agile/tasks/Design Ollama Model file for use with codex cli 1.md
@@ -15,3 +15,4 @@ Having a preconfigured pre prompted model could help agents perform better as co
 - [ ] Select a range of hyper parameters to test each prompt with
 - [ ] Write a report on the outcome
 
+#Breakdown


### PR DESCRIPTION
## Summary
- add `#Breakdown` status to "Design Ollama Model file for use with codex cli 1" task
- sync Kanban board to reflect the new task status

## Testing
- `make format` *(fails: SyntaxError: '}' expected)*
- `make lint` *(fails: config uses unsupported extends key)*
- `make test` *(fails: make: *** [Makefile:140: test] Error 1)*
- `make build`


------
https://chatgpt.com/codex/tasks/task_e_68ae479d560883248adbbc62e4b43283