### PR TITLE
Clarify interruption threshold configuration task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Proxy route `/bridge` through the shared proxy service for SmartGPT Bridge.
 - Tool calling support for Codex Context service.
 - Image attachments captured, stored, and retrieved for multimodal prompting with cleanup.
+- Defined interruption‑threshold configuration task with measurable goals and
+  concrete implementation steps.
 - OAuth Authorization Code flow with PKCE for the auth-service, enabling OpenAI Custom GPT logins.
 - Template for building Discord bots in TypeScript based on the Cephalon service.
 - Tests validating bridge event mappings for identifiers and protocols.

--- a/docs/agile/tasks/allow_configuration_of_hyperparameters_through_discord_context_size_spectrogram_resolution_interuption_threshold_md.md
+++ b/docs/agile/tasks/allow_configuration_of_hyperparameters_through_discord_context_size_spectrogram_resolution_interuption_threshold_md.md
@@ -1,24 +1,41 @@
 ## 🛠️ Description
 
-Placeholder task stub generated from kanban board.
+Expose Discord commands that let users tune audio processing hyperparameters—context
+size, spectrogram resolution, and interruption thresholds—without redeploying the
+service.
 
 ---
 
 ## 🎯 Goals
 
-- What are we trying to accomplish?
+- Allow real‑time configuration of audio processing parameters via Discord.
+- Improve interruption handling by using audio‑based thresholds that pause output
+  when user speech exceeds configurable energy levels.
+- Detect interruptions within **200 ms** and correctly classify user speech with
+  **≥95 % accuracy** against background noise.
 
 ---
 
 ## 📦 Requirements
 
-- [ ] Detail requirements.
+- [ ] Provide `/config audio` commands for `context_size`, `spectrogram_res`, and
+      `interruption_threshold` values.
+- [ ] Implement adjustable voice‑activity detection that pauses TTS once the
+      energy threshold is crossed.
+- [ ] Log every interruption event with timestamps and configured parameters.
+- [ ] Meet **≤200 ms** interruption latency and **≥95 %** detection accuracy in
+      controlled tests.
 
 ---
 
 ## 📋 Subtasks
 
-- [ ] Outline steps to implement.
+- [ ] Add Discord command handlers exposing `context_size`, `spectrogram_res`, and
+      `interruption_threshold` options.
+- [ ] Integrate a VAD module using the configurable energy threshold.
+- [ ] Write tests measuring latency and accuracy of interruption detection.
+- [ ] Deploy changes to staging and collect metric samples.
+- [ ] Document tuning guidelines for operators.
 
 ---
 


### PR DESCRIPTION
## Summary
- detail audio-interruption goals with measurable latency and accuracy targets
- outline explicit requirements and subtasks for configurable audio hyperparameters via Discord
- log changes in changelog

## Testing
- `pre-commit run --files docs/agile/tasks/allow_configuration_of_hyperparameters_through_discord_context_size_spectrogram_resolution_interuption_threshold_md.md CHANGELOG.md`


------
https://chatgpt.com/codex/tasks/task_e_68ae479976548324a253a69d24e916c1