### PR TITLE
Add tests for environment-based settings defaults and overrides

### DIFF
--- a/shared/py/tests/test_settings.py
+++ b/shared/py/tests/test_settings.py
@@ -1,5 +1,7 @@
 import importlib
 
+import pytest
+
 
 def reload_settings():
     """Import and reload the settings module to apply environment changes."""
@@ -36,3 +38,15 @@ def test_overrides(monkeypatch):
     assert reloaded.AGENT_NAME == "eagle"
     assert reloaded.MIN_TEMP == 0.5
     assert reloaded.DEFAULT_CHANNEL == "456"
+
+
+def test_default_channel_required(monkeypatch):
+    """DEFAULT_CHANNEL must be provided via the environment."""
+    monkeypatch.delenv("DEFAULT_CHANNEL", raising=False)
+    monkeypatch.delenv("DEFAULT_CHANNEL_NAME", raising=False)
+    monkeypatch.delenv("AGENT_NAME", raising=False)
+    monkeypatch.delenv("MIN_TEMP", raising=False)
+    monkeypatch.setenv("DISCORD_TOKEN", "token")
+
+    with pytest.raises(KeyError):
+        reload_settings()


### PR DESCRIPTION
## Summary
- add tests that reload `shared.py.settings` to verify default and overridden values for `AGENT_NAME`, `MIN_TEMP`, and `DEFAULT_CHANNEL`
- ensure missing `DEFAULT_CHANNEL` raises `KeyError`

## Testing
- `make format` *(fails: SyntaxError in unrelated files)*
- `make lint` *(fails: ESLint config and Prettier style errors)*
- `pytest shared/py/tests/test_settings.py -q`
- `make build`


------
https://chatgpt.com/codex/tasks/task_e_68ae476f07cc8324bea428606c3aa75a