### PR TITLE
test: add discord utils record retention test

### DIFF
--- a/shared/py/tests/test_discord_utils.py
+++ b/shared/py/tests/test_discord_utils.py
@@ -30,6 +30,17 @@ def test_get_or_create_channel_record_adds_cursor_field():
     collection.update_one.assert_called_once_with({"id": 1}, {"$set": {"cursor": None}})
 
 
+def test_get_or_create_channel_record_returns_existing():
+    collection = MagicMock()
+    collection.find_one.return_value = {"id": 1, "cursor": 7}
+
+    record = get_or_create_channel_record(collection, 1, "cursor")
+
+    assert record == {"id": 1, "cursor": 7}
+    collection.insert_one.assert_not_called()
+    collection.update_one.assert_not_called()
+
+
 def test_fetch_channel_history_without_cursor():
     messages = ["a", "b"]
     channel = MagicMock()


### PR DESCRIPTION
## Summary
- add test for get_or_create_channel_record to ensure no writes when cursor exists
- mock discord channel and db to verify history and cursor updates

## Testing
- `pre-commit run --files shared/py/tests/test_discord_utils.py` *(fails: No module named 'chromadb')*
- `PYTHONPATH=. pytest shared/py/tests/test_discord_utils.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae476df01c83248676049c845d3502