### PR TITLE
chore: bump Biome schema to 2.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - EmbeddingServiceClient now retries failed requests with exponential backoff and returns structured errors when service calls fail.
 - Waveform and spectrogram generation delegated to an external audio service injected via `CaptureDeps`.
 - Remote embedding function now surfaces broker connection errors and rejects pending requests on failure.
+- Updated Biome schema references to version 2.2.2.
 
 ### Fixed
 

--- a/services/ts/cephalon/biome.json
+++ b/services/ts/cephalon/biome.json
@@ -1,11 +1,11 @@
 {
-	"$schema": "https://biomejs.dev/schemas/2.1.3/schema.json",
-	"files": {
-		"includes": ["src/**", "tests/**"]
-	},
-	"linter": {
-		"rules": {
-			"recommended": false
-		}
-	}
+    "$schema": "https://biomejs.dev/schemas/2.2.2/schema.json",
+    "files": {
+        "includes": ["src/**", "tests/**"]
+    },
+    "linter": {
+        "rules": {
+            "recommended": false
+        }
+    }
 }

--- a/services/ts/markdown-graph/biome.json
+++ b/services/ts/markdown-graph/biome.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://biomejs.dev/schemas/2.1.3/schema.json",
+    "$schema": "https://biomejs.dev/schemas/2.2.2/schema.json",
     "files": {
         "includes": ["src/**", "tests/**"]
     },

--- a/templates/ts/discord-bot/biome.json
+++ b/templates/ts/discord-bot/biome.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://biomejs.dev/schemas/2.1.3/schema.json",
+    "$schema": "https://biomejs.dev/schemas/2.2.2/schema.json",
     "files": {
         "includes": ["src/**", "tests/**"]
     },


### PR DESCRIPTION
## Summary
- point ts service biome configs at Biome 2.2.2 schema
- document Biome schema upgrade in changelog

## Testing
- `make format` *(fails: KeyboardInterrupt)*
- `pnpm exec biome format services/ts/cephalon/biome.json services/ts/markdown-graph/biome.json templates/ts/discord-bot/biome.json` *(fails: nested root configuration)*
- `make lint` *(fails: command "@biomejs/biome" not found and ESLint config issues)*
- `make test` *(fails: Exiting due to SIGINT)*
- `make build` *(fails: KeyboardInterrupt)*


------
https://chatgpt.com/codex/tasks/task_e_68ae496e8f6c832489200903d646fc9f