### PR TITLE
chore: share python service dependencies config

### DIFF
--- a/changelog.d/0000.changed.md
+++ b/changelog.d/0000.changed.md
@@ -1,0 +1,1 @@
+Move Python services' ecosystem.dependencies.js to shared location and update configs.

--- a/services/py/discord_attachment_embedder/ecosystem.config.js
+++ b/services/py/discord_attachment_embedder/ecosystem.config.js
@@ -1,31 +1,24 @@
-import path from "path";
-import { fileURLToPath } from "url";
-import { definePythonService } from "../../../dev/pm2Helpers.js";
-import deps from "./ecosystem.dependencies.js";
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { definePythonService } from '../../../dev/pm2Helpers.js';
+import deps from '../../shared/ecosystem.dependencies.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
-const root = path.join(__dirname, "../../..");
+const root = path.join(__dirname, '../../..');
 
 if (!process.env.PROMETHEAN_ROOT_ECOSYSTEM) {
-  defineApp.PYTHONPATH = root;
-  defineApp.HEARTBEAT_PORT = 5005;
+    defineApp.PYTHONPATH = root;
+    defineApp.HEARTBEAT_PORT = 5005;
 }
 
 const apps = [
-  definePythonService(
-    "discord_attachment_embedder",
-    "pipenv",
-    ["run", "python", "-m", "main"],
-    {
-      cwd: __dirname,
-      watch: [__dirname],
-    },
-  ),
+    definePythonService('discord_attachment_embedder', 'pipenv', ['run', 'python', '-m', 'main'], {
+        cwd: __dirname,
+        watch: [__dirname],
+    }),
 ];
 
-const allApps = !process.env.PROMETHEAN_ROOT_ECOSYSTEM
-  ? [...apps, ...(deps?.apps || [])]
-  : apps;
+const allApps = !process.env.PROMETHEAN_ROOT_ECOSYSTEM ? [...apps, ...(deps?.apps || [])] : apps;
 
 export default { apps: allApps };

--- a/services/py/embedding_service/ecosystem.config.js
+++ b/services/py/embedding_service/ecosystem.config.js
@@ -1,30 +1,28 @@
-import path from "path";
-import { fileURLToPath } from "url";
-import { defineApp } from "../../../dev/pm2Helpers.js";
-import deps from "./ecosystem.dependencies.js";
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { defineApp } from '../../../dev/pm2Helpers.js';
+import deps from '../../shared/ecosystem.dependencies.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
-const root = path.join(__dirname, "../../..");
+const root = path.join(__dirname, '../../..');
 
 if (!process.env.PROMETHEAN_ROOT_ECOSYSTEM) {
-  defineApp.PYTHONPATH = root;
-  defineApp.HEARTBEAT_PORT = 5005;
+    defineApp.PYTHONPATH = root;
+    defineApp.HEARTBEAT_PORT = 5005;
 }
 
 const apps = [
-  defineApp("embedding_service", "uv", ["run", "python", "-m", "main"], {
-    cwd: __dirname,
-    watch: [__dirname],
-    env: {
-      EMBEDDING_DRIVER: "ollama",
-      EMBEDDING_FUNCTION: "nomic-embed-text",
-    },
-  }),
+    defineApp('embedding_service', 'uv', ['run', 'python', '-m', 'main'], {
+        cwd: __dirname,
+        watch: [__dirname],
+        env: {
+            EMBEDDING_DRIVER: 'ollama',
+            EMBEDDING_FUNCTION: 'nomic-embed-text',
+        },
+    }),
 ];
 
-const allApps = !process.env.PROMETHEAN_ROOT_ECOSYSTEM
-  ? [...apps, ...(deps?.apps || [])]
-  : apps;
+const allApps = !process.env.PROMETHEAN_ROOT_ECOSYSTEM ? [...apps, ...(deps?.apps || [])] : apps;
 
 export default { apps: allApps };

--- a/services/py/embedding_service/ecosystem.dependencies.js
+++ b/services/py/embedding_service/ecosystem.dependencies.js
@@ -1,3 +1,0 @@
-export default {
-  apps: [],
-};

--- a/services/py/stt/ecosystem.config.js
+++ b/services/py/stt/ecosystem.config.js
@@ -1,30 +1,28 @@
-import path from "path";
-import { fileURLToPath } from "url";
-import { defineApp } from "../../../dev/pm2Helpers.js";
-import deps from "./ecosystem.dependencies.js";
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { defineApp } from '../../../dev/pm2Helpers.js';
+import deps from '../../shared/ecosystem.dependencies.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
-const root = path.join(__dirname, "../../..");
+const root = path.join(__dirname, '../../..');
 
 if (!process.env.PROMETHEAN_ROOT_ECOSYSTEM) {
-  defineApp.PYTHONPATH = [root, path.join(root, "services/py/shared")].join(":");
-  defineApp.HEARTBEAT_PORT = 5005;
+    defineApp.PYTHONPATH = [root, path.join(root, 'services/py/shared')].join(':');
+    defineApp.HEARTBEAT_PORT = 5005;
 }
 
 const apps = [
-  defineApp("stt", "uv", ["run", "python", "-m", "service"], {
-    cwd: __dirname,
-    watch: [__dirname],
-    env: {
-      FLASK_APP: "app.py",
-      FLASK_ENV: "production",
-    },
-  }),
+    defineApp('stt', 'uv', ['run', 'python', '-m', 'service'], {
+        cwd: __dirname,
+        watch: [__dirname],
+        env: {
+            FLASK_APP: 'app.py',
+            FLASK_ENV: 'production',
+        },
+    }),
 ];
 
-const allApps = !process.env.PROMETHEAN_ROOT_ECOSYSTEM
-  ? [...apps, ...(deps?.apps || [])]
-  : apps;
+const allApps = !process.env.PROMETHEAN_ROOT_ECOSYSTEM ? [...apps, ...(deps?.apps || [])] : apps;
 
 export default { apps: allApps };

--- a/services/py/stt/ecosystem.dependencies.js
+++ b/services/py/stt/ecosystem.dependencies.js
@@ -1,3 +1,0 @@
-export default {
-  apps: [],
-};

--- a/services/py/tts/ecosystem.config.js
+++ b/services/py/tts/ecosystem.config.js
@@ -1,32 +1,25 @@
-import path from "path";
-import { fileURLToPath } from "url";
-import { defineApp } from "../../../dev/pm2Helpers.js";
-import deps from "./ecosystem.dependencies.js";
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { defineApp } from '../../../dev/pm2Helpers.js';
+import deps from '../../shared/ecosystem.dependencies.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
-const root = path.join(__dirname, "../../..");
+const root = path.join(__dirname, '../../..');
 
 if (!process.env.PROMETHEAN_ROOT_ECOSYSTEM) {
-  defineApp.PYTHONPATH = [root, path.join(root, "services/py/shared")].join(":");
-  defineApp.HEARTBEAT_PORT = 5005;
+    defineApp.PYTHONPATH = [root, path.join(root, 'services/py/shared')].join(':');
+    defineApp.HEARTBEAT_PORT = 5005;
 }
 
 const apps = [
-  defineApp(
-    "tts",
-    "uv",
-    ["run", "uvicorn", "--host", "0.0.0.0", "--port", "5001", "app:app"],
-    {
-      cwd: __dirname,
-      watch: [__dirname],
-      env: {},
-    },
-  ),
+    defineApp('tts', 'uv', ['run', 'uvicorn', '--host', '0.0.0.0', '--port', '5001', 'app:app'], {
+        cwd: __dirname,
+        watch: [__dirname],
+        env: {},
+    }),
 ];
 
-const allApps = !process.env.PROMETHEAN_ROOT_ECOSYSTEM
-  ? [...apps, ...(deps?.apps || [])]
-  : apps;
+const allApps = !process.env.PROMETHEAN_ROOT_ECOSYSTEM ? [...apps, ...(deps?.apps || [])] : apps;
 
 export default { apps: allApps };

--- a/services/py/tts/ecosystem.dependencies.js
+++ b/services/py/tts/ecosystem.dependencies.js
@@ -1,3 +1,0 @@
-export default {
-  apps: [],
-};

--- a/services/shared/ecosystem.dependencies.js
+++ b/services/shared/ecosystem.dependencies.js
@@ -1,3 +1,3 @@
 export default {
-  apps: [],
+    apps: [],
 };


### PR DESCRIPTION
## Summary
- move ecosystem.dependencies.js into services/shared for python services
- remove per-service dependency config copies
- update python service configs to reference shared dependencies file

## Testing
- `pre-commit run --files services/shared/ecosystem.dependencies.js services/py/discord_attachment_embedder/ecosystem.config.js services/py/embedding_service/ecosystem.config.js services/py/stt/ecosystem.config.js services/py/tts/ecosystem.config.js changelog.d/0000.changed.md` *(fails: TypeScript type check in services/ts/config)*
- `pre-commit run --hook-stage manual full-build --files services/shared/ecosystem.dependencies.js services/py/discord_attachment_embedder/ecosystem.config.js services/py/embedding_service/ecosystem.config.js services/py/stt/ecosystem.config.js services/py/tts/ecosystem.config.js changelog.d/0000.changed.md`


------
https://chatgpt.com/codex/tasks/task_e_68ae51f94178832489b4cfa259fe7405