### PR TITLE
refactor(ts): share run script

### DIFF
--- a/changelog.d/0000.changed.md
+++ b/changelog.d/0000.changed.md
@@ -1,0 +1,1 @@
+Centralize TypeScript service runner script and symlink service run.sh files.

--- a/services/ts/file-watcher/README.md
+++ b/services/ts/file-watcher/README.md
@@ -32,6 +32,7 @@ Environment variables:
   index/remove requests (default `2000`). Higher values reduce request volume.
 - `SMARTGPT_BRIDGE_TOKEN` (optional) – bearer token for SmartGPT Bridge.
 
-Run the service with `./run.sh` (requires `pnpm`); the script checks for the
-package manager and prints setup instructions if it's missing. Use
-`pnpm run start:dev` during development to watch TypeScript files.
+Run the service with `./run.sh`, a symlink to the shared `services/ts/run.sh`
+script (requires `pnpm`); the script checks for the package manager and prints
+setup instructions if it's missing. Use `pnpm run start:dev` during development
+to watch TypeScript files.

--- a/services/ts/llm/README.md
+++ b/services/ts/llm/README.md
@@ -4,8 +4,9 @@ This service exposes HTTP and WebSocket endpoints for text generation through pl
 
 ## Usage
 
-Start the service with `./run.sh` (requires `pnpm`; the script prints setup
-instructions if the package manager is missing):
+Start the service with `./run.sh`, a symlink to the shared `services/ts/run.sh`
+script (requires `pnpm`; the script prints setup instructions if the package
+manager is missing):
 
 ```bash
 ./run.sh

--- a/services/ts/run.sh
+++ b/services/ts/run.sh
@@ -1,4 +1,6 @@
-#!/usr/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
+
 if command -v pnpm >/dev/null 2>&1; then
   pnpm start
 else


### PR DESCRIPTION
## Summary
- refine reusable pnpm runner at `services/ts/run.sh`
- document shared run script in File Watcher and LLM READMEs
- add changelog entry for shared TS runner

## Testing
- `pre-commit run --files services/ts/run.sh services/ts/file-watcher/README.md services/ts/llm/README.md changelog.d/0000.changed.md`
- `pnpm tsc --noEmit -p tsconfig.base.json` (fails: services/ts/smartgpt-bridge/src/tests/fixtures/broken.ts: error TS1005: '}' expected)
- `pytest -q` (fails: 29 errors during collection)


------
https://chatgpt.com/codex/tasks/task_e_68ae520d7f888324861c89e6405ac200