### PR TITLE
test: cover authorize token and origin checks

### DIFF
--- a/changelog.d/auth-tests.added.md
+++ b/changelog.d/auth-tests.added.md
@@ -1,0 +1,1 @@
+Add tests for authorize token mismatch and origin allowlist handling in MCP server.

--- a/packages/mcp-server/test/auth.spec.ts
+++ b/packages/mcp-server/test/auth.spec.ts
@@ -1,0 +1,21 @@
+import test from 'ava';
+
+import { authorize } from '../src/auth.js';
+
+test('returns false when token mismatches', (t) => {
+    const old = process.env.MCP_TOKEN;
+    process.env.MCP_TOKEN = 'secret';
+    t.false(authorize('wrong', undefined));
+    t.true(authorize('secret', undefined));
+    if (old === undefined) delete process.env.MCP_TOKEN;
+    else process.env.MCP_TOKEN = old;
+});
+
+test('respects MCP_ORIGIN_ALLOWLIST', (t) => {
+    const old = process.env.MCP_ORIGIN_ALLOWLIST;
+    process.env.MCP_ORIGIN_ALLOWLIST = 'https://allowed.com';
+    t.true(authorize(undefined, 'https://allowed.com'));
+    t.false(authorize(undefined, 'https://blocked.com'));
+    if (old === undefined) delete process.env.MCP_ORIGIN_ALLOWLIST;
+    else process.env.MCP_ORIGIN_ALLOWLIST = old;
+});


### PR DESCRIPTION
## Summary
- add unit tests for authorize to check token mismatch and origin allowlist handling
- record tests in changelog

## Testing
- `pnpm --filter mcp-server format`
- `pnpm --filter mcp-server lint`
- `pnpm --filter mcp-server build`
- `pnpm --filter mcp-server test`


------
https://chatgpt.com/codex/tasks/task_e_68ae547785cc8324b3cf3a638d1b1f64