### PR TITLE
Rank ready tasks and document story points

### DIFF
--- a/docs/agile/boards/kanban.md
+++ b/docs/agile/boards/kanban.md
@@ -108,15 +108,14 @@ kanban-plugin: board
 
 ## Ready
 
+- [ ] [[convert current services to packages, then redefine the services using config files]]
+- [ ] [[audio processing service]]
 - [ ] [[create a generic markdown helper module]]
 - [ ] [[task generator system]]
 - [ ] [[redefine all existing lambdas with high order functions incoming]]
-- [ ] [[convert current services to packages, then redefine the services using config files]]
-- [ ] [[Phase out proxy in favor of bridge service]]
-- [ ] [[audio processing service]]
-
 
 ## Todo (21)
+- [ ] [[Phase out proxy in favor of bridge service]]
 
 - [ ] [[update_makefile_to_have_commands_specific_for_agents_md.md|Update Makefile to have commands specific for agents]] #devops #accepted
 - [ ] [[LLM service must accept tool calls]]

--- a/docs/agile/tasks/Phase out proxy in favor of bridge service.md
+++ b/docs/agile/tasks/Phase out proxy in favor of bridge service.md
@@ -28,6 +28,11 @@ Retire the existing proxy layer and expose all external APIs through the broker-
 - [ ] Remove legacy proxy code
 
 ---
+## 🧮 Story Points
+
+8
+
+---
 
 ## 🔗 Related Epics
 
@@ -50,5 +55,5 @@ Nothing
 - [API spec](https://err-stealth-16-ai-studio-a1vgg.tailbe888a.ts.net/v1/openapi.json)
 - [kanban](../boards/kanban.md)
 
-#framework-core #accepted #breakdown
+#framework-core #Todo
 

--- a/docs/agile/tasks/audio processing service.md
+++ b/docs/agile/tasks/audio processing service.md
@@ -27,6 +27,11 @@ Isolate audio manipulation (e.g., encoding, normalization, filtering) into a ded
 - [ ] Write unit tests and usage docs
 
 ---
+## 🧮 Story Points
+
+5
+
+---
 
 ## 🔗 Related Epics
 
@@ -48,5 +53,5 @@ Nothing
 
 - [kanban](../boards/kanban.md)
 
-#framework-core #accepted #breakdown
+#framework-core #Ready
 

--- a/docs/agile/tasks/convert current services to packages, then redefine the services using config files.md
+++ b/docs/agile/tasks/convert current services to packages, then redefine the services using config files.md
@@ -27,6 +27,11 @@ Transition existing services into reusable packages and instantiate concrete ser
 - [ ] Update build pipeline to consume packages
 
 ---
+## 🧮 Story Points
+
+5
+
+---
 
 ## 🔗 Related Epics
 
@@ -48,5 +53,5 @@ Nothing
 
 - [kanban](../boards/kanban.md)
 
-#framework-core #accepted #breakdown
+#framework-core #Ready
 

--- a/docs/agile/tasks/create a generic markdown helper module.md
+++ b/docs/agile/tasks/create a generic markdown helper module.md
@@ -27,6 +27,11 @@ Develop a shared module for reading, writing, and manipulating markdown files us
 - [ ] Document usage in scripts README
 
 ---
+## 🧮 Story Points
+
+3
+
+---
 
 ## 🔗 Related Epics
 
@@ -48,5 +53,5 @@ Nothing
 
 - [kanban](../boards/kanban.md)
 
-#framework-core #accepted #breakdown
+#framework-core #Ready
 

--- a/docs/agile/tasks/redefine all existing lambdas with high order functions incoming.md
+++ b/docs/agile/tasks/redefine all existing lambdas with high order functions incoming.md
@@ -26,6 +26,11 @@ Replace ad‑hoc anonymous lambdas with well‑named higher‑order functions to
 - [ ] Update references and run tests
 
 ---
+## 🧮 Story Points
+
+5
+
+---
 
 ## 🔗 Related Epics
 
@@ -47,5 +52,5 @@ Nothing
 
 - [kanban](../boards/kanban.md)
 
-#framework-core #accepted #breakdown
+#framework-core #Ready
 

--- a/docs/agile/tasks/task generator system.md
+++ b/docs/agile/tasks/task generator system.md
@@ -27,6 +27,11 @@ Create a utility that scaffolds new task files from a template to keep the board
 - [ ] Document usage in docs/agile/README
 
 ---
+## 🧮 Story Points
+
+2
+
+---
 
 ## 🔗 Related Epics
 
@@ -48,5 +53,5 @@ Nothing
 
 - [kanban](../boards/kanban.md)
 
-#framework-core #accepted #breakdown
+#framework-core #Ready
 


### PR DESCRIPTION
## Summary
- Prioritized the Kanban board's Ready column and shifted the top item to Todo.
- Added story points to six task files for better effort tracking.

## Testing
- `pre-commit run --files docs/agile/tasks/Phase\ out\ proxy\ in\ favor\ of\ bridge\ service.md docs/agile/tasks/convert\ current\ services\ to\ packages,\ then\ redefine\ the\ services\ using\ config\ files.md docs/agile/tasks/audio\ processing\ service.md docs/agile/tasks/create\ a\ generic\ markdown\ helper\ module.md docs/agile/tasks/task\ generator\ system.md docs/agile/tasks/redefine\ all\ existing\ lambdas\ with\ high\ order\ functions\ incoming.md docs/agile/boards/kanban.md`


------
https://chatgpt.com/codex/tasks/task_e_68ae57b86fd48324a58d79af34a1956a