### PR TITLE
Add story points for accepted tasks and clean board

### DIFF
--- a/docs/agile/boards/kanban.md
+++ b/docs/agile/boards/kanban.md
@@ -1,7 +1,5 @@
 ---
-
 kanban-plugin: board
-
 ---
 
 ## 📊 Strategic Graphs
@@ -12,11 +10,9 @@ kanban-plugin: board
 - [ ] [[architecture/hy-migration-graph.md|Hy Migration Graph]]
 - [ ] [[architecture/persistence-migration-graph.md|DualStore Migration Graph]]
 
-
 ## Migration Checklists
 
 - [ ] [[reports/persistence-migration-checklist.md|Persistence Migration Checklist]]
-
 
 ## Ice Box
 
@@ -42,7 +38,7 @@ kanban-plugin: board
 - [ ] [[schedule_alignment_meeting_with_stakeholders_md_md.md|Schedule alignment meeting with stakeholders]] #framework-core #ice-box
 - [ ] [[write_a_small_cutover_script_to_replay_historical_md.md|Write a small **cutover** script to replay historical events through upcasters into snapshots]] #ice-box
 - [ ] [[tool_chain_management_system_md_md.md|Tool chain management system.md]] #framework-core #ice-box
-- [ ] [[wire_mongoeventstore_mongocursorstore_in_place_of_md.md|Wire MongoEventStore + MongoCursorStore in place of InMemory]] #ice-box
+- [ ] [[wire_mongoeventstore_mongocursorstore_in_place_of_md.md|Wire MongoEventStore + MongoCursorStore in place of InMemory]] #rejected
 - [ ] [[snapshot_prompts_specs_to_repo_md_md.md|Snapshot prompts and specs to repo]] #ice-box
 - [ ] [[annotate_legacy_code_with_migration_tags_md.md|Annotate legacy code with migration tags]] #framework-core #ice-box
 - [ ] [[allow_configuration_of_hyperparameters_through_discord_context_size_spectrogram_resolution_interuption_threshold_md.md|Allow configuration of hyperparameters through discord (context size, spectrogram resolution, interuption threshold]] #framework-core #ice-box
@@ -50,7 +46,6 @@ kanban-plugin: board
 - [ ] [[define_permission_schema_in_agents_1_md.md|Define permission schema in AGENTS.md]] #framework-core #eidolon #Dorian #layer2 #ice-box
 - [ ] [[gather_open_questions_about_system_direction_md_md.md|Gather open questions about system direction]] #framework-core #ice-box
 - [ ] [[gather_baseline_emotion_metrics_for_eidolon_field_1_md.md|Gather baseline emotion metrics for Eidolon field]] #framework-core #ice-box
-
 
 ## Incoming
 
@@ -78,22 +73,13 @@ kanban-plugin: board
 - [ ] [[Promethean Health Dashboard|Web frontend for system management.md]] #framework-core #observability #eidolon-visualization #dashboard #broker #realtime #ice-box
 - [ ] [[setup_a_second_agent_md.md|setup a second agent md]] #framework-core #ice-box
 
-
 ## Accepted
 
 - [ ] [[LLM service must allow streamed responses]]
 - [ ] [[Set up new user roles and policies for the systems]]
 - [ ] [[tamper monkey script for using templates defined in the vault]]
 - [ ] [[Make the system hashtag aware]]
-- [ ] [[cache_decay_mechanisim_md_md.md|cache decay mechanisim.md]] #framework-core #ice-box
-- [ ] [[run_model_bakeoff_md.md|Run model bakeoff]] #ops #codex-task #ice-box
-- [ ] [[obsidian_replacement_md.md|obsidian replacement]] #framework-core #ice-box
-- [ ] [[run_model_bakeoff_md.md|Run model bakeoff]] #ops #codex-task #ice-box
-- [ ] [[annotate_legacy_code_with_migration_tags_md.md|Annotate legacy code with migration tags]] #framework-core #ice-box
-- [ ] [[allow_old_unnessisary_messages_to_decay_from_database_while_retaining_index_entries_ids_md_md.md|allow old unnessisary messages to decay from database while retaining index entries ids md md]] #framework-core #eidolon-support #ice-box
-- [ ] [[define_permission_schema_in_agents_1_md.md|Define permission schema in AGENTS.md]] #framework-core #eidolon #Dorian #layer2 #ice-box
 - [ ] [[Add codex layer to emacs]]
-
 
 ## Breakdown (13)
 
@@ -105,7 +91,6 @@ kanban-plugin: board
 - [ ] [[lisp ecosystem files]]
 - [ ] [[hy - js interop]]
 
-
 ## Ready
 
 - [ ] [[create a generic markdown helper module]]
@@ -114,7 +99,6 @@ kanban-plugin: board
 - [ ] [[convert current services to packages, then redefine the services using config files]]
 - [ ] [[Phase out proxy in favor of bridge service]]
 - [ ] [[audio processing service]]
-
 
 ## Todo (21)
 
@@ -125,7 +109,6 @@ kanban-plugin: board
 - [ ] [[lisp package files]]
 - [ ] [[clearly standardize data models]]
 - [ ] [[dockerize the system]]
-
 
 ## In Progress (21)
 
@@ -151,7 +134,6 @@ kanban-plugin: board
 - [ ] [[Agent Tasks Persistence Migration to DualStore]]
 - [ ] [[Create broker services that can handle all the same tasks as the gpt bridge]]
 
-
 ## In Review (34)
 
 - [ ] [[setup new service generator]]
@@ -169,7 +151,6 @@ kanban-plugin: board
 - [ ] [[seperate discord commands from the actions they perform]] #in-progress
 - [ ] [[periodicly the embedding service will get disconnected from the broker and not die, blocking other processes who require embeddings. incoming]]
 - [ ] [[breakdown cephalon voice commands file using ecs]] #in-progress
-
 
 ## Done
 
@@ -249,31 +230,19 @@ kanban-plugin: board
 - [ ] [[document_board_usage_guidelines_1_md.md|Document board usage guidelines]] #framework-core #done
 - [ ] [[start_eidolon_md_md.md|Start Eidolon]] #framework-core #done
 
-
 ## Rejected
 
-- [ ] [[enable_compactor_for_process_state_process_state_s_md.md|Enable compactor for `process.state` → `process.state.snapshot`]] #ice-box
-- [ ] [[pin_versions_in_configs_promethean_codex_md.md|Pin versions in configs (Promethean + Codex)]] #ice-box
-- [ ] [[run_bench_subscribe_ts_with_mongo_bus_and_record_p_md.md|Run `bench/subscribe.ts` with Mongo bus and record p50/p99]] #ice-box
-- [ ] [[run_bakeoff_see_below_md.md|Run bakeoff (see below)]] #ice-box
+- [ ] [[enable_compactor_for_process_state_process_state_s_md.md|Enable compactor for `process.state` → `process.state.snapshot`]] #rejected
+- [ ] [[run_bench_subscribe_ts_with_mongo_bus_and_record_p_md.md|Run \`bench/subscribe.ts\` with Mongo bus and record p50/p99]] #rejected
 - [ ] [[flatten sibilant src folders]]
-- [ ] [[snapshot_prompts_specs_to_repo_md_md.md|Snapshot prompts/specs to repo]] #ice-box
-- [ ] [[detect_contradictions_in_memory_md_md.md|Detect contradictions in memory]] #framework-core #ice-box
-- [ ] [[integrate_synthesis-agent_pass_on_unique_to_produce_draft_docs_1_md.md|Integrate synthesis-agent pass on \`unique/\` to produce draft docs]] #framework-core #ice-box
 - [ ] [[write_end_to_end_tests_md_md.md|write end to end tests md md]] #framework-core #accepted
-- [ ] [[add_file_system_to_context_management_system_md_md.md|add file system to context management system md md]] #framework-core #ice-box
-- [ ] [[cache_decay_mechanisim_md_md.md|cache decay mechanisim md md]] #framework-core #ice-box
-- [ ] [[suggest_metaprogramming_updates_md.md|Suggest metaprogramming updates]] #framework-core #ice-box
-- [ ] [[wire_mongoeventstore_mongocursorstore_in_place_of_md.md|Wire MongoEventStore + MongoCursorStore in place of InMemory]] #ice-box
-- [ ] [[run_bench_subscribe_ts_with_mongo_bus_and_record_p_md.md|Run `bench/subscribe.ts` with Mongo bus and record p50/p99]] #ice-box
-- [ ] [[migrate_server_side_sibilant_libs_to_promethean_ar_md.md|Migrate server side sibilant libs to Promethean architecture.]] #accepted
-- [ ] [[add_withdlq_around_risky_consumers_set_maxattempts_md.md|Add **withDLQ** around risky consumers; set `maxAttempts`]] #accepted
+- [ ] [[migrate_server_side_sibilant_libs_to_promethean_ar_md.md|Migrate server side sibilant libs to Promethean architecture.]] #rejected
+- [ ] [[add_withdlq_around_risky_consumers_set_maxattempts_md.md|Add **withDLQ** around risky consumers; set `maxAttempts`]] #rejected
 - [ ] [[Decouple Audio Processing Logic From Discord|Split out audio processing logic to a seperate service without changing the current behavior in cephalon.md]] #framework-core #ready
 - [ ] [[snapshot_prompts_specs_to_repo_md.md|snapshot prompts specs to repo md]] #rejected
 - [ ] [[add_startchangelogprojector_for_any_compaction_lik_md.md|Add **startChangelogProjector** for any compaction-like topic you want live-queryable]] #rejected
 - [ ] [[add_ollama_formally_to_pipeline_md_md.md|Add Ollama formally to pipeline]] #rejected
 - [ ] [[add_prometheus_events_counters_in_ws_server_hook_p_md.md|Add Prometheus `events_*` counters in WS server hook points]] #rejected
-- [ ] [[enable_compactor_for_process_state_process_state_s_md.md|Enable compactor for `process.state` → `process.state.snapshot`]] #rejected
 - [ ] [[add_ttls_per_topic_via_migration_script_md.md|Add TTLs per topic via migration script]] #rejected
 - [ ] [[add_lag_checks_to_ci_smoke_ensure_small_lag_after_md.md|Add `/lag` checks to CI smoke (ensure small lag after publishing bursts)]] #rejected
 - [ ] [[add_ops_endpoint_to_list_partition_assignments_opt_md.md|Add `/ops` endpoint to list **partition assignments** (optional: dump coordinator state)]] #rejected
@@ -314,100 +283,12 @@ kanban-plugin: board
 - [ ] [[write_a_replay_job_that_replays_process_state_snap_md.md|Write a replay job that replays `process.state.snapshot` to warm the `processes` collection]] #rejected
 - [ ] [[write_a_smoke_test_client_subscribes_publish_10_ms_md.md|Write a smoke test: client subscribes, publish 10 msgs, assert all ACKed]] #rejected
 - [ ] [[move_all_testing_to_individual_services_md.md|move all testing to individual services md]] #Duplicate #rejected
-- [ ] [[add_prometheus_events_counters_in_ws_server_hook_p_md.md|Add Prometheus \`events\_\*\` counters in WS server hook points]] #rejected
-- [ ] [[switch_gateway_auth_to_jwt_generate_temp_hs256_tok_md.md|Switch gateway auth to JWT; generate temp HS256 token for dev]] #rejected
-- [ ] [[add_vault_instructions_to_main_readme_md_md_md.md|Add vault instructions to main README.md]] #framework-core #rejected
-- [ ] [[ensure_github_compatible_markdown_settings_are_doc_md.md|Ensure GitHub-compatible markdown settings are documented]] #documentation #rejected
-- [ ] [[finalize_stt_workflow_md_md.md|Finalize STT workflow]] #codex-task #testing #rejected
 - [ ] [[annotate_legacy_code_with_migration_tags_md.md|Annotate legacy code with migration tags]] #framework-core #rejected
-- [ ] [[add_startchangelogprojector_for_any_compaction_lik_md.md|Add \*\*startChangelogProjector\*\* for any compaction-like topic you want live-queryable]] #rejected
-- [ ] [[detect_contradictions_in_memory_codex_task_md.md|Detect contradictions in memory #codex-task]] #codex-task #rejected
 - [ ] [[migrating_relevant_modules_from_riatzukiza_github_md.md|Migrating relevant modules from `riatzukiza.github.io` to `/sites/` and `/docs/`]] #rejected
-- [ ] [[register_v_1_schema_for_any_evolving_topic_and_wri_md.md|Register **v+1** schema for any evolving topic and write minimal **upcaster**]] #rejected
-- [ ] [[migrate_server_side_sibilant_libs_to_promethean_ar_md.md|Migrate server side sibilant libs to Promethean architecture.]] #rejected
-- [ ] [[implement_pause_resume_ops_on_gateway_md.md|Implement `PAUSE/RESUME` ops on gateway]] #rejected
-- [ ] [[implement_timetravel_processat_processid_t_in_a_sm_md.md|Implement `timetravel.processAt(processId, T)` in a small CLI for debugging]] #rejected
-- [ ] [[expose_metrics_on_an_express_app_and_scrape_with_p_md.md|Expose `/metrics` on an express app and scrape with Prom]] #rejected
-- [ ] [[add_startchangelogprojector_for_any_compaction_lik_md.md|Add **startChangelogProjector** for any compaction-like topic you want live-queryable]] #rejected
-- [ ] [[add_prometheus_events_counters_in_ws_server_hook_p_md.md|Add Prometheus `events_*` counters in WS server hook points]] #rejected
-- [ ] [[add_withdlq_around_risky_consumers_set_maxattempts_md.md|Add **withDLQ** around risky consumers; set `maxAttempts`]] #rejected
-- [ ] [[add_ollama_formally_to_pipeline_md_md.md|Add Ollama formally to pipeline]] #rejected
-- [ ] [[add_lag_checks_to_ci_smoke_ensure_small_lag_after_md.md|Add `/lag` checks to CI smoke (ensure small lag after publishing bursts)]] #rejected
-- [ ] [[add_ttls_per_topic_via_migration_script_md.md|Add TTLs per topic via migration script]] #rejected
-- [ ] [[add_ops_endpoint_to_list_partition_assignments_opt_md.md|Add `/ops` endpoint to list **partition assignments** (optional: dump coordinator state)]] #rejected
-- [ ] [[add_mongodedupe_and_replace_critical_consumers_wit_md.md|Add `MongoDedupe` and replace critical consumers with `subscribeExactlyOnce`]] #rejected
-- [ ] [[add_mongooutbox_to_any_service_that_writes_db_chan_md.md|Add `MongoOutbox` to any service that writes DB changes; swap local app emits → outbox writes]] #rejected
-- [ ] [[add_dev_harness_int_test_ts_to_ci_integration_stag_md.md|Add `dev.harness.int.test.ts` to CI integration stage]] #rejected
-- [ ] [[add_tokenbucket_to_ws_server_conn_per_topic_md.md|Add `TokenBucket` to WS server (conn + per-topic)]] #rejected
-- [ ] [[add_manualack_to_event_bus_and_re_run_tests_md.md|Add `manualAck` to event bus and re-run tests]] #rejected
-- [ ] [[add_process_txn_projector_to_upsert_processes_host_md.md|Add `process.txn` projector to upsert `processes` + `host_stats` atomically]] #rejected
-- [ ] [[document_etag_semantics_and_cache_headers_for_snap_md.md|Document ETag semantics and cache headers for `/snap/:key`]] #rejected
-- [ ] [[add_snapshot_consumer_to_warm_cache_on_boot_md.md|Add snapshot consumer to warm cache on boot]] #rejected
 - [ ] [[create_permission_gating_layer_codex_task_md.md|Create permission gating layer #codex-task]] #codex-task #rejected
 - [ ] [[create_permission_gating_layer_framework_core_md.md|Create permission gating layer #framework-core]] #framework-core #rejected
-- [ ] [[define_default_scopes_publish_heartbeat_received_s_md.md|Define default scopes: `publish:heartbeat.received`, `subscribe:process.state`]] #rejected
-- [ ] [[deploy_changefeed_for_collections_you_want_mirrore_md.md|Deploy **changefeed** for collections you want mirrored to topics]] #rejected
-- [ ] [[detect_contradictions_in_memory_codex_task_md.md|Detect contradictions in memory #codex-task]] #codex-task #rejected
-- [ ] [[enable_scripts_lint_topics_ts_in_ci_md.md|Enable **scripts/lint-topics.ts** in CI]] #rejected
-- [ ] [[ensure_mongo_indexes_key_1_unique_common_query_fie_md.md|Ensure Mongo indexes: `{ _key: 1 } unique` + common query fields]] #rejected
-- [ ] [[implement_transcendence_cascade_framework_core_md.md|Implement transcendence cascade #framework-core]] #framework-core #rejected
-- [ ] [[expose_snapshot_api_for_processes_collection_proce_md.md|Expose **Snapshot API** for `processes` (collection `processes`)]] #rejected
-- [ ] [[evaluate_and_reward_flow_satisfaction_framework_co_md.md|Evaluate and reward flow satisfaction #framework-core]] #framework-core #rejected
-- [ ] [[identify_ancestral_resonance_patterns_framework_co_md.md|Identify ancestral resonance patterns #framework-core]] #framework-core #rejected
-- [ ] [[launch_replayapi_on_8083_test_replay_and_export_nd_md.md|Launch `ReplayAPI` on `:8083`; test `/replay` and `/export?ndjson=1`]] #rejected
-- [ ] [[write_a_replay_job_that_replays_process_state_snap_md.md|Write a replay job that replays `process.state.snapshot` to warm the `processes` collection]] #rejected
-- [ ] [[spin_up_ws_gateway_ws_port_8090_ws_token_devtoken_md.md|Spin up WS gateway (`WS_PORT=8090 WS_TOKEN=devtoken node index.js`)]] #rejected
-- [ ] [[expose_snapshot_api_for_processes_collection_proce_md.md|Expose \*\*Snapshot API\*\* for \`processes\` (collection \`processes\`)]] #rejected
-- [ ] [[switch_critical_readers_to_subscribenormalized_md.md|Switch critical readers to **subscribeNormalized**]] #rejected
-- [ ] [[wrap_event_hub_publish_path_with_withschemavalidat_md.md|Wrap `event-hub` publish path with **withSchemaValidation**; fail fast on bad payloads]] #rejected
-- [ ] [[suggest_metaprogramming_updates_codex_task_md.md|Suggest metaprogramming updates #codex-task]] #codex-task #rejected
-- [ ] [[use_subscribepartitioned_for_cpu_heavy_consumers_t_md.md|Use \*\*subscribePartitioned\*\* for CPU-heavy consumers; tune \`partitions\` (power of 2 is fine)]] #rejected
-- [ ] [[switch_critical_readers_to_subscribenormalized_md.md|Switch critical readers to \*\*subscribeNormalized\*\*]] #rejected
-- [ ] [[suggest_metaprogramming_updates_codex_task_md.md|Suggest metaprogramming updates #codex-task]] #codex-task #rejected
-- [ ] [[use_subscribepartitioned_for_cpu_heavy_consumers_t_md.md|Use **subscribePartitioned** for CPU-heavy consumers; tune `partitions` (power of 2 is fine)]] #rejected
-- [ ] [[add_ttls_per_topic_via_migration_script_md.md|Add TTLs per topic via migration script]] #rejected
-- [ ] [[wire_runoutboxdrainer_in_event_hub_md.md|Wire `runOutboxDrainer` in event-hub]] #rejected
-- [ ] [[wrap_writers_with_withdualwrite_md.md|Wrap writers with **withDualWrite**]] #rejected
-- [ ] [[wire_runoutboxdrainer_in_event_hub_md.md|Wire \`runOutboxDrainer\` in event-hub]] #rejected
-- [ ] [[define_default_scopes_publish_heartbeat_received_s_md.md|Define default scopes: \`publish:heartbeat.received\`, \`subscribe:process.state\`]] #rejected
-- [ ] [[run_bench_subscribe_ts_with_mongo_bus_and_record_p_md.md|Run \`bench/subscribe.ts\` with Mongo bus and record p50/p99]] #rejected
-- [ ] [[expose_metrics_on_an_express_app_and_scrape_with_p_md.md|Expose \`/metrics\` on an express app and scrape with Prom]] #rejected
-- [ ] [[write_a_replay_job_that_replays_process_state_snap_md.md|Write a replay job that replays \`process.state.snapshot\` to warm the \`processes\` collection]] #rejected
-- [ ] [[wrap_writers_with_withdualwrite_md.md|Wrap writers with \*\*withDualWrite\*\*]] #rejected
-- [ ] [[write_a_smoke_test_client_subscribes_publish_10_ms_md.md|Write a smoke test: client subscribes, publish 10 msgs, assert all ACKed]] #rejected
-- [ ] [[identify_ancestral_resonance_patterns_framework_co_md.md|Identify ancestral resonance patterns #framework-core]] #framework-core #rejected
 - [ ] [[write_a_small_cutover_script_to_replay_historical_md.md|Write a small \*\*cutover\*\* script to replay historical events through upcasters into snapshots]] #rejected
-- [ ] [[write_a_smoke_test_client_subscribes_publish_10_ms_md.md|Write a smoke test: client subscribes, publish 10 msgs, assert all ACKed]] #rejected
-- [ ] [[wrap_event_hub_publish_path_with_withschemavalidat_md.md|Wrap \`event-hub\` publish path with \*\*withSchemaValidation\*\*; fail fast on bad payloads]] #rejected
-- [ ] [[switch_gateway_auth_to_jwt_generate_temp_hs256_tok_md.md|Switch gateway auth to JWT; generate temp HS256 token for dev]] #rejected
-- [ ] [[wire_mongoeventstore_mongocursorstore_in_place_of_md.md|Wire MongoEventStore + MongoCursorStore in place of InMemory]] #rejected
-- [ ] [[add_process_txn_projector_to_upsert_processes_host_md.md|Add \`process.txn\` projector to upsert \`processes\` + \`host\_stats\` atomically]] #rejected
-- [ ] [[spin_up_ws_gateway_ws_port_8090_ws_token_devtoken_md.md|Spin up WS gateway (\`WS\_PORT\=8090 WS\_TOKEN\=devtoken node index.js\`)]] #rejected
-- [ ] [[add_dev_harness_int_test_ts_to_ci_integration_stag_md.md|Add \`dev.harness.int.test.ts\` to CI integration stage]] #rejected
-- [ ] [[add_tokenbucket_to_ws_server_conn_per_topic_md.md|Add \`TokenBucket\` to WS server (conn + per-topic)]] #rejected
-- [ ] [[add_lag_checks_to_ci_smoke_ensure_small_lag_after_md.md|Add \`/lag\` checks to CI smoke (ensure small lag after publishing bursts)]] #rejected
-- [ ] [[add_mongooutbox_to_any_service_that_writes_db_chan_md.md|Add \`MongoOutbox\` to any service that writes DB changes; swap local app emits → outbox writes]] #rejected
-- [ ] [[add_ops_endpoint_to_list_partition_assignments_opt_md.md|Add \`/ops\` endpoint to list \*\*partition assignments\*\* (optional: dump coordinator state)]] #rejected
-- [ ] [[add_mongodedupe_and_replace_critical_consumers_wit_md.md|Add \`MongoDedupe\` and replace critical consumers with \`subscribeExactlyOnce\`]] #rejected
-- [ ] [[document_etag_semantics_and_cache_headers_for_snap_md.md|Document ETag semantics and cache headers for \`/snap/:key\`]] #rejected
-- [ ] [[enable_scripts_lint_topics_ts_in_ci_md.md|Enable \*\*scripts/lint-topics.ts\*\* in CI]] #rejected
-- [ ] [[evaluate_and_reward_flow_satisfaction_framework_co_md.md|Evaluate and reward flow satisfaction #framework-core]] #framework-core #rejected
-- [ ] [[move_all_testing_to_individual_services_md.md|Move all testing to individual services]] #Duplicate #rejected
-- [ ] [[summarize_clarified_priorities_for_next_sprint_md_md.md|Summarize clarified priorities for next sprint]] #framework-core #reject #rejected
-- [ ] [[implement_pause_resume_ops_on_gateway_md.md|Implement \`PAUSE/RESUME\` ops on gateway]] #rejected
-- [ ] [[register_v_1_schema_for_any_evolving_topic_and_wri_md.md|Register \*\*v+1\*\* schema for any evolving topic and write minimal \*\*upcaster\*\*]] #rejected
 - [ ] [[write_vault_config_readme_md_for_obsidian_vault_on_md.md|Write vault-config README.md for Obsidian vault onboarding]] #framework-core #rejected
-- [ ] [[ensure_github_compatible_markdown_settings_are_doc_md.md|Ensure GitHub-compatible markdown settings are documented \*(no link yet)\*]] #documentation #rejected
-- [ ] [[implement_timetravel_processat_processid_t_in_a_sm_md.md|Implement \`timetravel.processAt(processId, T)\` in a small CLI for debugging]] #rejected
-- [ ] [[add_snapshot_consumer_to_warm_cache_on_boot_md.md|Add snapshot consumer to warm cache on boot]] #rejected
-- [ ] [[deploy_changefeed_for_collections_you_want_mirrore_md.md|Deploy \*\*changefeed\*\* for collections you want mirrored to topics]] #rejected
-- [ ] [[implement_transcendence_cascade_framework_core_md.md|Implement transcendence cascade #framework-core]] #framework-core #rejected
-- [ ] [[ensure_mongo_indexes_key_1_unique_common_query_fie_md.md|Ensure Mongo indexes: \`{ \_key: 1 } unique\` + common query fields]] #rejected
-- [ ] [[add_manualack_to_event_bus_and_re_run_tests_md.md|Add \`manualAck\` to event bus and re-run tests]] #rejected
-- [ ] [[launch_replayapi_on_8083_test_replay_and_export_nd_md.md|Launch \`ReplayAPI\` on \`:8083\`; test \`/replay\` and \`/export?ndjson\=1\`]] #rejected
-- [ ] [[enable_compactor_for_process_state_process_state_s_md.md|Enable compactor for \`process.state\` → \`process.state.snapshot\`]] #rejected
-
-
 ## Archive
 
 - [ ] [[context service]]
@@ -452,8 +333,7 @@ kanban-plugin: board
 - [ ] [[add_unit_tests_for_gui_helpers_md_md.md|Add unit tests for GUI helpers]] #codex-task #testing #archive
 - [ ] [[build_tiny_web_page_that_uses_promclient_in_the_br_md.md|Build tiny web page that uses `PromClient` in the browser to show live `process.state` (optional)]] #archive
 
-
-***
+---
 
 ## Archive
 
@@ -463,7 +343,9 @@ kanban-plugin: board
 - [ ] [[extract_docs_from_riatzukiza_github_io_md_md.md|Extract docs from riatzukiza.github.io]] #framework-core #accepted
 
 %% kanban:settings
+
 ```
 {"kanban-plugin":"board","list-collapse":[false,false,false,false,false,false,false,false,false,false,false,true,false,false],"new-note-template":"agile/templates/task.stub.template.md","new-note-folder":"agile/tasks","metadata-keys":[{"metadataKey":"tags","label":"","shouldHideLabel":false,"containsMarkdown":false},{"metadataKey":"hashtags","label":"","shouldHideLabel":false,"containsMarkdown":false}]}
 ```
+
 %%

--- a/docs/agile/tasks/Add codex layer to emacs.md
+++ b/docs/agile/tasks/Add codex layer to emacs.md
@@ -6,7 +6,7 @@ Describe your task
 
 - If it doesn't have this, we can't accept it
 
-## Tasks 
+## Tasks
 
 - [ ] Step 1
 - [ ] Step 2
@@ -21,3 +21,9 @@ You might find [this] useful while working on this task
 ## Comments
 
 Useful for agents to engage in append only conversations about this task.
+
+## Story Points
+
+- Estimate: 3
+- Assumptions: Emacs environment can load the Codex integration layer.
+- Dependencies: Existing Codex CLI and Emacs plugin support.

--- a/docs/agile/tasks/LLM service must allow streamed responses.md
+++ b/docs/agile/tasks/LLM service must allow streamed responses.md
@@ -6,7 +6,7 @@ Describe your task
 
 - If it doesn't have this, we can't accept it
 
-## Tasks 
+## Tasks
 
 - [ ] Step 1
 - [ ] Step 2
@@ -20,3 +20,9 @@ You might find [this] useful while working on this task
 ## Comments
 
 Useful for agents to engage in append only conversations about this task.
+
+## Story Points
+
+- Estimate: 5
+- Assumptions: Underlying LLM and transport layer support streaming responses.
+- Dependencies: Streaming protocol implementation and client compatibility.

--- a/docs/agile/tasks/Make the system hashtag aware.md
+++ b/docs/agile/tasks/Make the system hashtag aware.md
@@ -1,13 +1,12 @@
 # Description
 
-
 We want agents to be aware of the available hashtags using the vault graph service
 
 ## Requirements/Definition of done
 
 - If it doesn't have this, we can't accept it
 
-## Tasks 
+## Tasks
 
 - [ ] Step 1
 - [ ] Step 2
@@ -21,3 +20,9 @@ You might find [this] useful while working on this task
 ## Comments
 
 Useful for agents to engage in append only conversations about this task.
+
+## Story Points
+
+- Estimate: 3
+- Assumptions: A consistent hashtag taxonomy is available.
+- Dependencies: Vault graph service and parsing hooks.

--- a/docs/agile/tasks/Set up new user roles and policies for the systems.md
+++ b/docs/agile/tasks/Set up new user roles and policies for the systems.md
@@ -11,7 +11,7 @@ We want it to be more than "yes" or "no" we want levels of approval like "yes", 
 
 - If it doesn't have this, we can't accept it
 
-## Tasks 
+## Tasks
 
 - [ ] Step 1
 - [ ] Step 2
@@ -25,3 +25,9 @@ You might find [this] useful while working on this task
 ## Comments
 
 Useful for agents to engage in append only conversations about this task.
+
+## Story Points
+
+- Estimate: 5
+- Assumptions: Existing auth framework can be extended for granular roles.
+- Dependencies: Permission schema design and configuration interface.

--- a/docs/agile/tasks/tamper monkey script for using templates defined in the vault.md
+++ b/docs/agile/tasks/tamper monkey script for using templates defined in the vault.md
@@ -6,13 +6,13 @@ Work on {task from board}
 
 Like basicly auto complete, turn the chat interfaces into little ide's with auto complete that are aware of the structure of my vault and able to upload/download files super easy peasy.
 
-As long as we don't use the scripts to send the message, we are gucci 
+As long as we don't use the scripts to send the message, we are gucci
 
 ## Requirements/Definition of done
 
 - If it doesn't have this, we can't accept it
 
-## Tasks 
+## Tasks
 
 - [ ] Step 1
 - [ ] Step 2
@@ -26,3 +26,9 @@ You might find [this] useful while working on this task
 ## Comments
 
 Useful for agents to engage in append only conversations about this task.
+
+## Story Points
+
+- Estimate: 2
+- Assumptions: Vault templates are organized and accessible.
+- Dependencies: Tampermonkey environment and vault API endpoints.


### PR DESCRIPTION
## Summary
- add story point estimates with assumptions and dependencies to accepted tasks
- tidy kanban board by removing #ice-box items from Accepted and deduping Rejected

## Testing
- `make format` *(fails: SyntaxError in unrelated files)*
- `make lint` *(fails: ESLint flat config extends key not supported)*
- `make test` *(fails: see task dispatch logs, exit 1)*
- `make build`


------
https://chatgpt.com/codex/tasks/task_e_68ae57ca34108324b8b2e4bebf6e2d1e