### PR TITLE
chore: prioritize todo backlog

### DIFF
--- a/docs/agile/boards/kanban.md
+++ b/docs/agile/boards/kanban.md
@@ -118,13 +118,13 @@ kanban-plugin: board
 
 ## Todo (21)
 
-- [ ] [[update_makefile_to_have_commands_specific_for_agents_md.md|Update Makefile to have commands specific for agents]] #devops #accepted
-- [ ] [[LLM service must accept tool calls]]
-- [ ] [[frontend build tool chain]]
-- [ ] [[flatten services]]
-- [ ] [[lisp package files]]
-- [ ] [[clearly standardize data models]]
-- [ ] [[dockerize the system]]
+- [ ] [[LLM service must accept tool calls]] #feature (1)
+- [ ] [[flatten services]] #refactor (2)
+- [ ] [[update_makefile_to_have_commands_specific_for_agents_md.md|Update Makefile to have commands specific for agents]] #infrastructure (3)
+- [ ] [[frontend build tool chain]] #infrastructure (4)
+- [ ] [[clearly standardize data models]] #refactor (5)
+- [ ] [[dockerize the system]] #infrastructure (6)
+- [ ] [[lisp package files]] #feature (7)
 
 
 ## In Progress (21)


### PR DESCRIPTION
## Summary
- categorize To Do items by feature, infrastructure, or refactor
- prioritize backlog items with numbered ordering

## Testing
- `make format` *(fails: SyntaxError in services/ts/smartgpt-bridge and config files)*
- `make lint` *(fails: ESLint config uses unsupported extends; Prettier found issues)*
- `make test` *(fails: Couldn’t find any files to test in attachment-embedder)*
- `make build`


------
https://chatgpt.com/codex/tasks/task_e_68ae57b99c14832482d323bbe09ab1b7