### PR TITLE
doc: scope breakdown tasks

### DIFF
--- a/changelog.d/12345.changed.md
+++ b/changelog.d/12345.changed.md
@@ -1,0 +1,1 @@
+- added dependencies, scope, and estimates for breakdown tasks and updated readiness

--- a/docs/agile/tasks/connect bluesky.md
+++ b/docs/agile/tasks/connect bluesky.md
@@ -7,12 +7,27 @@ Agent provider thingy
 
 - If it doesn't have this, we can't accept it
 
-## Tasks 
+## Tasks
 
 - [ ] Step 1
 - [ ] Step 2
 - [ ] Step 3
 - [ ] Step 4
+
+## Dependencies
+
+- AT Protocol client library
+- Bluesky developer account
+
+## Rough Scope
+
+- Authenticate with Bluesky using AT Protocol
+- Implement message retrieval and posting
+- Map data into existing messaging schema
+
+## Estimate
+
+- Story points: 3
 
 ## Relevent resources
 
@@ -21,3 +36,5 @@ You might find [this] useful while working on this task
 ## Comments
 
 Useful for agents to engage in append only conversations about this task.
+
+#Ready

--- a/docs/agile/tasks/connect reddit.md
+++ b/docs/agile/tasks/connect reddit.md
@@ -7,12 +7,27 @@
 
 - If it doesn't have this, we can't accept it
 
-## Tasks 
+## Tasks
 
 - [ ] Step 1
 - [ ] Step 2
 - [ ] Step 3
 - [ ] Step 4
+
+## Dependencies
+
+- Reddit API access and credentials
+- OAuth2 authentication library
+
+## Rough Scope
+
+- Set up API client with OAuth2 flow
+- Implement fetch and post operations for target subreddits
+- Integrate results with existing context pipeline
+
+## Estimate
+
+- Story points: 3
 
 ## Relevent resources
 
@@ -21,3 +36,5 @@ You might find [this] useful while working on this task
 ## Comments
 
 Useful for agents to engage in append only conversations about this task.
+
+#Ready

--- a/docs/agile/tasks/connect wikipedia.md
+++ b/docs/agile/tasks/connect wikipedia.md
@@ -6,12 +6,27 @@ Endpoint? tool calls? Indexer?
 
 - If it doesn't have this, we can't accept it
 
-## Tasks 
+## Tasks
 
 - [ ] Step 1
 - [ ] Step 2
 - [ ] Step 3
 - [ ] Step 4
+
+## Dependencies
+
+- Wikipedia API or library
+- Rate limiting awareness
+
+## Rough Scope
+
+- Determine whether to use direct API calls or existing library
+- Implement search and article retrieval
+- Normalize content for indexing or tool calls
+
+## Estimate
+
+- Story points: 2
 
 ## Relevent resources
 
@@ -20,3 +35,5 @@ You might find [this] useful while working on this task
 ## Comments
 
 Useful for agents to engage in append only conversations about this task.
+
+#Ready

--- a/docs/agile/tasks/design_circular_buffers_for_inputs_with_layered_states_of_persistance_in_memory_on_disk_cold_storage_so_md.md
+++ b/docs/agile/tasks/design_circular_buffers_for_inputs_with_layered_states_of_persistance_in_memory_on_disk_cold_storage_so_md.md
@@ -38,7 +38,28 @@ Nothing
 
 ---
 
+## Dependencies
+
+- DualStore persistence layer
+- Disk and cold-storage APIs
+
+---
+
+## Rough Scope
+
+- Design buffer tiers for memory, disk, and cold storage
+- Specify read/write and eviction strategies
+- Document data flow across layers
+
+---
+
+## Estimate
+
+- Story points: 8
+
+---
+
 ## 🔍 Relevant Links
 
 - [kanban](../boards/kanban.md)
-#ice-box
+#Breakdown

--- a/docs/agile/tasks/hy - js interop.md
+++ b/docs/agile/tasks/hy - js interop.md
@@ -6,12 +6,27 @@ Make it easier to use js from hy and hy from js
 
 - If it doesn't have this, we can't accept it
 
-## Tasks 
+## Tasks
 
 - [ ] Step 1
 - [ ] Step 2
 - [ ] Step 3
 - [ ] Step 4
+
+## Dependencies
+
+- Hy-to-JS transpilation tools
+- Existing JS interop modules
+
+## Rough Scope
+
+- Investigate current FFI capabilities between Hy and JS
+- Design helper utilities for calling JS from Hy
+- Outline approach for exposing Hy functions to JS runtime
+
+## Estimate
+
+- Story points: 5
 
 ## Relevent resources
 
@@ -20,3 +35,5 @@ You might find [this] useful while working on this task
 ## Comments
 
 Useful for agents to engage in append only conversations about this task.
+
+#Breakdown

--- a/docs/agile/tasks/lisp ecosystem files.md
+++ b/docs/agile/tasks/lisp ecosystem files.md
@@ -6,12 +6,27 @@ Describe your task
 
 - If it doesn't have this, we can't accept it
 
-## Tasks 
+## Tasks
 
 - [ ] Step 1
 - [ ] Step 2
 - [ ] Step 3
 - [ ] Step 4
+
+## Dependencies
+
+- Existing Lisp source tree
+- Documentation on standard Lisp packaging
+
+## Rough Scope
+
+- Audit current Lisp files and categorize by purpose
+- Define directory structure for packages and modules
+- Update build scripts to reflect new layout
+
+## Estimate
+
+- Story points: 2
 
 ## Relevent resources
 
@@ -20,3 +35,5 @@ You might find [this] useful while working on this task
 ## Comments
 
 Useful for agents to engage in append only conversations about this task.
+
+#Ready

--- a/docs/agile/tasks/thinking_model_integration_md_md.md
+++ b/docs/agile/tasks/thinking_model_integration_md_md.md
@@ -38,7 +38,28 @@ Nothing
 
 ---
 
+## Dependencies
+
+- Core reasoning modules
+- Training data for thinking model
+
+---
+
+## Rough Scope
+
+- Define interfaces between existing agents and thinking model
+- Prototype integration path for inference and feedback
+- Evaluate performance impacts
+
+---
+
+## Estimate
+
+- Story points: 5
+
+---
+
 ## 🔍 Relevant Links
 
 - [kanban](../boards/kanban.md)
-#ice-box
+#Breakdown


### PR DESCRIPTION
## Summary
- document dependencies, rough scope, and story point estimates for breakdown tasks
- mark straightforward tasks ready for implementation

## Testing
- `pre-commit run --files docs/agile/tasks/design_circular_buffers_for_inputs_with_layered_states_of_persistance_in_memory_on_disk_cold_storage_so_md.md docs/agile/tasks/thinking_model_integration_md_md.md docs/agile/tasks/connect\ reddit.md docs/agile/tasks/connect\ bluesky.md docs/agile/tasks/connect\ wikipedia.md docs/agile/tasks/lisp\ ecosystem\ files.md docs/agile/tasks/hy\ -\ js\ interop.md changelog.d/12345.changed.md`
- `make lint` *(fails: config object is using the "extends" key, which is not supported in flat config system)*
- `make test` *(terminated: KeyboardInterrupt)*
- `make build` *(terminated: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68ae57b6ceb48324863027c88205b14c