### PR TITLE
docs: refine accepted task specs

### DIFF
--- a/changelog.d/99999.added.md
+++ b/changelog.d/99999.added.md
@@ -1,0 +1,1 @@
+Added requirements and acceptance criteria for accepted agile tasks.

--- a/docs/agile/tasks/Add codex layer to emacs.md
+++ b/docs/agile/tasks/Add codex layer to emacs.md
@@ -1,23 +1,26 @@
-# Description
+## 🛠️ Description
 
 Describe your task
 
-## Requirements/Definition of done
+## 📦 Requirements
+- Provide an Emacs layer for interacting with Codex.
+- Include commands to send code and receive responses inside Emacs.
+- Document installation and configuration steps.
 
-- If it doesn't have this, we can't accept it
+## ✅ Acceptance Criteria
+- Emacs layer can initiate Codex prompts from a buffer.
+- Users can execute a command to send the current buffer to Codex and view the reply.
+- Setup instructions enable others to reproduce the integration.
 
-## Tasks 
-
+## Tasks
 - [ ] Step 1
 - [ ] Step 2
 - [ ] Step 3
 - [ ] Step 4
 
 ## Relevent resources
-
 You might find [this] useful while working on this task
 [ChatGPT - Codex CLI layer](https://chatgpt.com/share/68a74365-e284-8004-8911-bb2fb08b1f3e)
 
 ## Comments
-
 Useful for agents to engage in append only conversations about this task.

--- a/docs/agile/tasks/LLM service must allow streamed responses.md
+++ b/docs/agile/tasks/LLM service must allow streamed responses.md
@@ -1,22 +1,25 @@
-# Description
+## 🛠️ Description
 
 Describe your task
 
-## Requirements/Definition of done
+## 📦 Requirements
+- Add streaming endpoint to the LLM service for partial responses.
+- Update client libraries to consume streamed tokens.
+- Document how to enable and use the streaming API.
 
-- If it doesn't have this, we can't accept it
+## ✅ Acceptance Criteria
+- Clients receive incremental outputs from the LLM service.
+- Example integration demonstrates a streaming completion.
+- Documentation covers streaming usage.
 
-## Tasks 
-
+## Tasks
 - [ ] Step 1
 - [ ] Step 2
 - [ ] Step 3
 - [ ] Step 4
 
 ## Relevent resources
-
 You might find [this] useful while working on this task
 
 ## Comments
-
 Useful for agents to engage in append only conversations about this task.

--- a/docs/agile/tasks/Make the system hashtag aware.md
+++ b/docs/agile/tasks/Make the system hashtag aware.md
@@ -1,23 +1,25 @@
-# Description
-
+## 🛠️ Description
 
 We want agents to be aware of the available hashtags using the vault graph service
 
-## Requirements/Definition of done
+## 📦 Requirements
+- Query the vault graph service to retrieve available hashtags.
+- Expose a command or API for agents to list and search hashtags.
+- Sync task files and board entries with recognized hashtags.
 
-- If it doesn't have this, we can't accept it
+## ✅ Acceptance Criteria
+- Agents can list existing hashtags via the new command or API.
+- Updating a task with a hashtag is reflected on the Kanban board after sync.
+- Documentation describes how hashtags are discovered and used.
 
-## Tasks 
-
+## Tasks
 - [ ] Step 1
 - [ ] Step 2
 - [ ] Step 3
 - [ ] Step 4
 
 ## Relevent resources
-
 You might find [this] useful while working on this task
 
 ## Comments
-
 Useful for agents to engage in append only conversations about this task.

--- a/docs/agile/tasks/Set up new user roles and policies for the systems.md
+++ b/docs/agile/tasks/Set up new user roles and policies for the systems.md
@@ -1,27 +1,30 @@
-# Description
+## 🛠️ Description
 
 Right now we only have an admin role and a simple policy matrix.
 We want to be able to set up policies easily through an interface and config files.
 
-We want permissions to be fine grain, such that I could lock an agent into ./docs, forbid specific files with in docs to that same agent, prevent writes to certain files
+We want permissions to be fine grain, such that I could lock an agent into ./docs, forbid specific files within docs to that same agent, prevent writes to certain files
 
 We want it to be more than "yes" or "no" we want levels of approval like "yes", "no", "with explicit permission from user in a session", "with explicit permission from user every time", possibly defining the user that can give permission to be another agent who is solely responsible for managing certain kinds of permissions.
 
-## Requirements/Definition of done
+## 📦 Requirements
+- Support multiple user roles with distinct permission sets.
+- Policies configurable through both an interface and config files.
+- Allow path-level restrictions and multi-level approval workflows.
 
-- If it doesn't have this, we can't accept it
+## ✅ Acceptance Criteria
+- System defines and enforces at least two new roles beyond admin.
+- An agent can be confined to a specific directory path.
+- Users can grant elevated access via explicit approval flow.
 
-## Tasks 
-
+## Tasks
 - [ ] Step 1
 - [ ] Step 2
 - [ ] Step 3
 - [ ] Step 4
 
 ## Relevent resources
-
 You might find [this] useful while working on this task
 
 ## Comments
-
 Useful for agents to engage in append only conversations about this task.

--- a/docs/agile/tasks/allow_old_unnessisary_messages_to_decay_from_database_while_retaining_index_entries_ids_md_md.md
+++ b/docs/agile/tasks/allow_old_unnessisary_messages_to_decay_from_database_while_retaining_index_entries_ids_md_md.md
@@ -39,6 +39,13 @@ This task is not about strictly defining the scoring model for “relevance,” 
 
 ---
 
+## ✅ Acceptance Criteria
+- Messages beyond the retention threshold are removed from the database.
+- Index entries continue to return valid IDs after cleanup.
+- Retention settings are configurable and documented.
+
+---
+
 ## 📋 Subtasks
 
 * [ ] Create in-memory LRU cache for **Working** tier.

--- a/docs/agile/tasks/annotate_legacy_code_with_migration_tags_md.md
+++ b/docs/agile/tasks/annotate_legacy_code_with_migration_tags_md.md
@@ -16,6 +16,13 @@ Placeholder task stub generated from kanban board.
 
 ---
 
+## ✅ Acceptance Criteria
+- Sample legacy files contain migration tags.
+- Guidelines for tag format are documented.
+- Documentation references how to apply the tags.
+
+---
+
 ## 📋 Subtasks
 
 - [ ] Outline steps to implement.

--- a/docs/agile/tasks/cache_decay_mechanisim_md_md.md
+++ b/docs/agile/tasks/cache_decay_mechanisim_md_md.md
@@ -16,6 +16,13 @@ Placeholder task stub generated from kanban board.
 
 ---
 
+## ✅ Acceptance Criteria
+- Cache entries expire according to the decay schedule.
+- Decay timing is configurable.
+- Tests demonstrate expired entries are removed.
+
+---
+
 ## 📋 Subtasks
 
 - [ ] Outline steps to implement.

--- a/docs/agile/tasks/define_permission_schema_in_agents_1_md.md
+++ b/docs/agile/tasks/define_permission_schema_in_agents_1_md.md
@@ -27,6 +27,13 @@ execution.
 
 ---
 
+## ✅ Acceptance Criteria
+- Root `AGENTS.md` contains a permission schema section.
+- YAML and JSON examples illustrate read-only and full-access agents.
+- Sample config files for both roles exist under `agents/*/config/`.
+
+---
+
 ## 📋 Subtasks
 
 - [ ] Draft schema description inside `AGENTS.md`

--- a/docs/agile/tasks/obsidian_replacement_md.md
+++ b/docs/agile/tasks/obsidian_replacement_md.md
@@ -16,6 +16,13 @@ I can do better than this lag monster
 
 ---
 
+## ✅ Acceptance Criteria
+- Prototype loads notes with lower latency than Obsidian.
+- Users can create, edit, and link notes.
+- Migration path from existing vault is documented.
+
+---
+
 ## 📋 Subtasks
 
 - [ ] Outline steps to implement.

--- a/docs/agile/tasks/run_model_bakeoff_md.md
+++ b/docs/agile/tasks/run_model_bakeoff_md.md
@@ -17,6 +17,13 @@ Execute a comparative evaluation between current and candidate models using a fi
 
 ---
 
+## ✅ Acceptance Criteria
+- Bakeoff script runs and outputs comparison metrics.
+- Results highlight which model meets adoption thresholds.
+- Summary of findings is documented.
+
+---
+
 ## 📋 Subtasks
 - [ ] Script test harness
 - [ ] Summarize results

--- a/docs/agile/tasks/tamper monkey script for using templates defined in the vault.md
+++ b/docs/agile/tasks/tamper monkey script for using templates defined in the vault.md
@@ -1,28 +1,31 @@
-# Description
+## 🛠️ Description
 
 I want to be able to use templates from the vault to ask for things like:
 
 Work on {task from board}
 
-Like basicly auto complete, turn the chat interfaces into little ide's with auto complete that are aware of the structure of my vault and able to upload/download files super easy peasy.
+Basically auto complete, turn the chat interfaces into little IDEs with auto complete that are aware of the structure of my vault and able to upload/download files super easy peasy.
 
-As long as we don't use the scripts to send the message, we are gucci 
+As long as we don't use the scripts to send the message, we are gucci
 
-## Requirements/Definition of done
+## 📦 Requirements
+- Tampermonkey script loads templates from the vault.
+- Chat interfaces offer autocomplete for tasks using those templates.
+- Support simple upload and download interactions with the vault.
 
-- If it doesn't have this, we can't accept it
+## ✅ Acceptance Criteria
+- Typing a task phrase suggests a corresponding template.
+- Selected template inserts content into the chat input.
+- Files can be uploaded from and saved to the vault through the script.
 
-## Tasks 
-
+## Tasks
 - [ ] Step 1
 - [ ] Step 2
 - [ ] Step 3
 - [ ] Step 4
 
 ## Relevent resources
-
 You might find [this] useful while working on this task
 
 ## Comments
-
 Useful for agents to engage in append only conversations about this task.


### PR DESCRIPTION
## Summary
- document requirements and acceptance criteria for accepted agile tasks
- add changelog entry

## Testing
- `make kanban-to-hashtags` *(fails: can't open scripts/kanban_to_hashtags.py)*
- `make format` *(fails: KeyboardInterrupt while formatting repo)*
- `pre-commit run --files docs/agile/tasks/LLM\ service\ must\ allow\ streamed\ responses.md docs/agile/tasks/Set\ up\ new\ user\ roles\ and\ policies\ for\ the\ systems.md docs/agile/tasks/tamper\ monkey\ script\ for\ using\ templates\ defined\ in\ the\ vault.md docs/agile/tasks/Make\ the\ system\ hashtag\ aware.md docs/agile/tasks/Add\ codex\ layer\ to\ emacs.md docs/agile/tasks/cache_decay_mechanisim_md_md.md docs/agile/tasks/run_model_bakeoff_md.md docs/agile/tasks/obsidian_replacement_md.md docs/agile/tasks/annotate_legacy_code_with_migration_tags_md.md docs/agile/tasks/allow_old_unnessisary_messages_to_decay_from_database_while_retaining_index_entries_ids_md_md.md docs/agile/tasks/define_permission_schema_in_agents_1_md.md changelog.d/99999.added.md`
- `make lint` *(fails: config uses unsupported extends key)*
- `make test` *(fails: interrupted during test run)*
- `make build` *(fails: interrupted during build)*

------
https://chatgpt.com/codex/tasks/task_e_68ae57b416a483248c557b8d2acfaa7a