### PR TITLE
chore: reset In Review tasks with notes and story points

### DIFF
--- a/docs/agile/tasks/File explorer.md
+++ b/docs/agile/tasks/File explorer.md
@@ -49,4 +49,9 @@ Nothing
 
 - [kanban](../boards/kanban.md)
 
-#accepted
+
+## Notes
+- Tests or documentation are missing; acceptance criteria not fully met.
+- Story Points: 5
+
+#in-progress

--- a/docs/agile/tasks/MVP local LLM chat interface with tool calls connected to gpt bridge.md
+++ b/docs/agile/tasks/MVP local LLM chat interface with tool calls connected to gpt bridge.md
@@ -232,3 +232,9 @@ feat(agent): Pythagoras-mirror via WS with OpenAPI-driven tools (/v1 smartgpt-br
 ```
 
 \#tags #promethean #pythagoras #ws #llm-worker #smartgpt-bridge #openapi #tool-calling #testing #docs
+
+## Notes
+- Tests or documentation are missing; acceptance criteria not fully met.
+- Story Points: 8
+
+#in-progress

--- a/docs/agile/tasks/Promethean Health Dashboard.md
+++ b/docs/agile/tasks/Promethean Health Dashboard.md
@@ -210,4 +210,9 @@ flowchart LR
 ---
 
 tags: #framework-core #observability #eidolon-visualization #dashboard #broker #realtime
-#accepted
+
+## Notes
+- Tests or documentation are missing; acceptance criteria not fully met.
+- Story Points: 8
+
+#in-progress

--- a/docs/agile/tasks/Webcrawler.md
+++ b/docs/agile/tasks/Webcrawler.md
@@ -290,3 +290,9 @@ CDC_ENABLED=false
 Append-only thread: record domain-specific deny-lists, prompt tweaks, and any integrity anomalies (# of orphans, dim mismatches, etc).
 
 \#tags #promethean #agent #crawler #hyperlink-graph #summarization #tags #obsidian #chroma #mongodb #dual-sink #fastify #ollama #qwen #readability #robots #search #observability
+
+## Notes
+- Tests or documentation are missing; acceptance criteria not fully met.
+- Story Points: 8
+
+#in-progress

--- a/docs/agile/tasks/breakdown cephalon voice commands file using ecs.md
+++ b/docs/agile/tasks/breakdown cephalon voice commands file using ecs.md
@@ -1,4 +1,9 @@
 # Task: Break down cephalon voice commands file
 
 This file is *really* complex, and we just added an ECS to deal with it. So we're dealing with it.
+
+## Notes
+- Tests or documentation are missing; acceptance criteria not fully met.
+- Story Points: 3
+
 #in-progress

--- a/docs/agile/tasks/discord_image_awareness_md_md.md
+++ b/docs/agile/tasks/discord_image_awareness_md_md.md
@@ -49,4 +49,9 @@ This allows the “Duck” to have **visual memory** tied to conversational cont
 
 #framework-core
 #ollama-integration
-#multimodal-context
+
+## Notes
+- Tests or documentation are missing; acceptance criteria not fully met.
+- Story Points: 5
+
+#in-progress

--- a/docs/agile/tasks/implement classes in compiler lisp incoming.md
+++ b/docs/agile/tasks/implement classes in compiler lisp incoming.md
@@ -52,3 +52,9 @@ Introduce a `defclass` macro to the Promethean Lisp compiler that supports class
 
 ## 💬 Comments
 Append-only thread for collaboration by agents implementing class support.
+
+## Notes
+- Tests or documentation are missing; acceptance criteria not fully met.
+- Story Points: 5
+
+#in-progress

--- a/docs/agile/tasks/implement defun in compiler lisp incoming.md
+++ b/docs/agile/tasks/implement defun in compiler lisp incoming.md
@@ -39,3 +39,9 @@ Introduce support for the `defun` special form in the Promethean Lisp compiler. 
 
 ## 💬 Comments
 Append-only thread for discussion by agents working on this task.
+
+## Notes
+- Tests or documentation are missing; acceptance criteria not fully met.
+- Story Points: 5
+
+#in-progress

--- a/docs/agile/tasks/periodicly the embedding service will get disconnected from the broker and not die, blocking other processes who require embeddings. incoming.md
+++ b/docs/agile/tasks/periodicly the embedding service will get disconnected from the broker and not die, blocking other processes who require embeddings. incoming.md
@@ -251,3 +251,9 @@ fix(embeddings): kill-on-disconnect/stall + admission control + heartbeat kill p
 ```
 
 \#tags #embeddings #reliability #heartbeat #watchdog #overload #backpressure #chaos #pm2 #broker #promethean
+
+## Notes
+- Tests or documentation are missing; acceptance criteria not fully met.
+- Story Points: 5
+
+#in-progress

--- a/docs/agile/tasks/pin_versions_in_configs_md.md
+++ b/docs/agile/tasks/pin_versions_in_configs_md.md
@@ -232,3 +232,9 @@ chore(versions): pin runtimes, deps, images, models; add pins linter
 * **Hidden installers**: scripts that call `pip install`/`npm i` at runtime undo reproducibility—purge them or freeze.
 
 \#tags #promethean #versioning #pinning #ci #docker #uv #ollama #openvino #sre #supplychain
+
+## Notes
+- Tests or documentation are missing; acceptance criteria not fully met.
+- Story Points: 5
+
+#in-progress

--- a/docs/agile/tasks/seperate discord commands from the actions they perform.md
+++ b/docs/agile/tasks/seperate discord commands from the actions they perform.md
@@ -460,4 +460,9 @@ export function attachBrokerBridge(store: { dispatch: (e: Event) => Promise<void
 ## 🔍 Relevant Links
 
 * \[\[kanban.md]]
+
+## Notes
+- Tests or documentation are missing; acceptance criteria not fully met.
+- Story Points: 3
+
 #in-progress

--- a/docs/agile/tasks/set up data migration pipeline and clearly describe conventions.md
+++ b/docs/agile/tasks/set up data migration pipeline and clearly describe conventions.md
@@ -202,3 +202,9 @@ feat(migrations): isolate test DBs and enforce migration contracts
 ```
 
 \#tags #promethean #mongodb #chroma #migration #contracts #testing #ci #safety #idempotent
+
+## Notes
+- Tests or documentation are missing; acceptance criteria not fully met.
+- Story Points: 8
+
+#in-progress

--- a/docs/agile/tasks/setup new service generator.md
+++ b/docs/agile/tasks/setup new service generator.md
@@ -49,4 +49,9 @@ Nothing
 
 - [kanban](../boards/kanban.md)
 
-#accepted
+
+## Notes
+- Tests or documentation are missing; acceptance criteria not fully met.
+- Story Points: 5
+
+#in-progress

--- a/docs/agile/tasks/setup_services_to_recieve_work_from_the_broker_via_push_md.md
+++ b/docs/agile/tasks/setup_services_to_recieve_work_from_the_broker_via_push_md.md
@@ -68,7 +68,6 @@ Each queue represents a task type or target service. Over time, this model will 
 #codex-task #broker #queueManager #service-oriented #push-queue #agent-mode
 
 ---
-#in-review
 
 ## Comments
 
@@ -76,3 +75,8 @@ This is kind of done. But also kind of not. I am not a fan of *how* many of thes
 
 We're gonna call it In Progress
 
+## Notes
+- Tests or documentation are missing; acceptance criteria not fully met.
+- Story Points: 8
+
+#in-progress

--- a/docs/agile/tasks/twitch_stream_title_generator_md_md.md
+++ b/docs/agile/tasks/twitch_stream_title_generator_md_md.md
@@ -53,4 +53,9 @@ The goal is for the system to produce engaging, accurate, and relevant stream ti
 
 If you want, I can also make you a **mermaid diagram** showing how the context flows from Discord transcripts → Ollama → storage → stream platform so we can see where it sits in the pipeline.
 That would make expansion easier later.
-#accepted
+
+## Notes
+- Tests or documentation are missing; acceptance criteria not fully met.
+- Story Points: 3
+
+#in-progress


### PR DESCRIPTION
## Summary
- move outstanding In Review tasks back to In Progress
- note missing tests/docs and capture story point estimates

## Testing
- `pre-commit run --files docs/agile/tasks/setup new service generator.md docs/agile/tasks/Webcrawler.md docs/agile/tasks/set up data migration pipeline and clearly describe conventions.md docs/agile/tasks/twitch_stream_title_generator_md_md.md docs/agile/tasks/File explorer.md docs/agile/tasks/implement classes in compiler lisp incoming.md docs/agile/tasks/MVP local LLM chat interface with tool calls connected to gpt bridge.md docs/agile/tasks/discord_image_awareness_md_md.md docs/agile/tasks/implement defun in compiler lisp incoming.md docs/agile/tasks/setup_services_to_recieve_work_from_the_broker_via_push_md.md docs/agile/tasks/pin_versions_in_configs_md.md docs/agile/tasks/Promethean Health Dashboard.md docs/agile/tasks/seperate discord commands from the actions they perform.md docs/agile/tasks/periodicly the embedding service will get disconnected from the broker and not die, blocking other processes who require embeddings. incoming.md docs/agile/tasks/breakdown cephalon voice commands file using ecs.md`
- `pre-commit run --files docs/agile/tasks/setup_services_to_recieve_work_from_the_broker_via_push_md.md`
- `make kanban-from-tasks` (fails: No such file or directory)

------
https://chatgpt.com/codex/tasks/task_e_68ae57e4915883248b544bd248fdcfc0