### PR TITLE
chore: update task statuses

### DIFF
--- a/docs/agile/tasks/Agent Tasks Persistence Migration to DualStore.md
+++ b/docs/agile/tasks/Agent Tasks Persistence Migration to DualStore.md
@@ -1,5 +1,6 @@
 
 ## 🗂 Task 1 — Setup Shared Persistence Module
+**Status:** blocked
 
 * [ ] Create directory `shared/ts/persistence/`.
 * [ ] Add:
@@ -118,3 +119,8 @@
 * Obsidian diagrams show unified architecture.
 
 ---
+
+## Blockers
+- No active owner or unclear scope
+
+#breakdown

--- a/docs/agile/tasks/ChatGPT export injest with dedupe index and hashes.md
+++ b/docs/agile/tasks/ChatGPT export injest with dedupe index and hashes.md
@@ -1,4 +1,5 @@
 # Task: ChatGPT Export Ingest with De‑dup Index & Hashes
+**Status:** blocked
 
 ## Objective
 
@@ -225,3 +226,8 @@ pnpm tsx src/cli.ts --export ~/Downloads/chatgpt-export \
 * [ ] Editing one message in export results in exactly one UPDATED.
 * [ ] Index survives process restarts and supports resuming.
 * [ ] Report artifact written with accurate counts.
+
+## Blockers
+- No active owner or unclear scope
+
+#breakdown

--- a/docs/agile/tasks/Create broker services that can handle all the same tasks as the gpt bridge.md
+++ b/docs/agile/tasks/Create broker services that can handle all the same tasks as the gpt bridge.md
@@ -1,7 +1,7 @@
 # WebSocket Broker API Parity with GPT Bridge
 
 **Owner:** Codex / Agent
-**Status:** Planned
+**Status:** continue coding
 **Labels:** #broker #ws #api #gptbridge #parity #promethean #ops
 
 ---
@@ -184,3 +184,5 @@ Bring the **WebSocket broker API** up to full parity with the existing **GPT Bri
 ## Comments
 
 Append-only thread for agents to log discovered gaps, schema changes, or overload handling notes.
+
+#in-progress

--- a/docs/agile/tasks/LSP server for home brew lisp incoming.md
+++ b/docs/agile/tasks/LSP server for home brew lisp incoming.md
@@ -1,4 +1,5 @@
 # Description
+**Status:** blocked
 
 Create a Language Server Protocol (LSP) server for the home-brew Lisp to provide editor features such as completion and diagnostics.
 
@@ -25,4 +26,7 @@ You might find [the LSP specification](https://microsoft.github.io/language-serv
 
 Useful for agents to engage in append only conversations about this task.
 
-#Breakdown
+#breakdown
+
+## Blockers
+- No active owner or unclear scope

--- a/docs/agile/tasks/Mock broker.md
+++ b/docs/agile/tasks/Mock broker.md
@@ -3,7 +3,7 @@ Here’s a no-nonsense expansion that you can drop into your board. I’ve treat
 # Mock the Broker for Tests
 
 **Owner:** Codex / Agent
-**Status:** Planned
+**Status:** needs review
 **Labels:** #framework-core #testing #infra #typescript #fastify #websockets #mongodb #chroma #promethean
 
 ---
@@ -238,3 +238,5 @@ it('can inject latency and drop messages', async () => {
 * Docs + examples merged.
 
 #promethean #broker #mock #testing #vitest #typescript #di #inmemory #deterministic
+
+#in-review

--- a/docs/agile/tasks/Replace all python properly with hy incoming.md
+++ b/docs/agile/tasks/Replace all python properly with hy incoming.md
@@ -1,7 +1,7 @@
 # Ban Python; Migrate to Hy; Compile to `./dist`
 
 **Owner:** Codex / Agent
-**Status:** Planned
+**Status:** continue coding
 **Labels:** #architecture #lang #hy #python-ban #build #ci #tooling #promethean
 
 ---
@@ -236,3 +236,5 @@ Append-only thread for agents. Note blockers, weird Hy interop, or macro decisio
 * **Performance:** Hy compiles to Python AST; runtime perf should be on par with equivalent Python once compiled.
 
 \#tags #promethean #hy #lisp #python #build #ci #git #precommit #policy #docs
+
+#in-progress

--- a/docs/agile/tasks/Set up proper openai custom gpt compatable oauth login flow.md
+++ b/docs/agile/tasks/Set up proper openai custom gpt compatable oauth login flow.md
@@ -1,4 +1,5 @@
 ## 🛠️ Description
+**Status:** blocked
 
 Implement a secure OAuth flow for OpenAI custom GPT integrations, including redirect handling and token management.
 
@@ -51,3 +52,8 @@ Nothing
 - [kanban](../boards/kanban.md)
 
 #accepted
+
+## Blockers
+- No active owner or unclear scope
+
+#breakdown

--- a/docs/agile/tasks/add_twitch_chat_integration_md_md.md
+++ b/docs/agile/tasks/add_twitch_chat_integration_md_md.md
@@ -1,4 +1,5 @@
 ## 🛠️ Description
+**Status:** blocked
 
 Integrate Twitch chat so agents can read and respond to messages during live streams.
 
@@ -50,4 +51,7 @@ Nothing
 
 - [kanban](../boards/kanban.md)
 
-#Breakdown
+#breakdown
+
+## Blockers
+- No active owner or unclear scope

--- a/docs/agile/tasks/breakdown Makefile.hy.md
+++ b/docs/agile/tasks/breakdown Makefile.hy.md
@@ -1,4 +1,5 @@
 ## 🛠️ Description
+**Status:** blocked
 
 Analyze the existing `Makefile.hy` and break it into clearer, maintainable components.
 
@@ -49,4 +50,7 @@ Nothing
 
 - [kanban](../boards/kanban.md)
 
-#Breakdown
+#breakdown
+
+## Blockers
+- No active owner or unclear scope

--- a/docs/agile/tasks/broker gpt bridge parity plan.md
+++ b/docs/agile/tasks/broker gpt bridge parity plan.md
@@ -1,7 +1,7 @@
 # Broker ↔ GPT Bridge Parity Test Plan
 
 **Owner:** Codex / Agent
-**Status:** Planned
+**Status:** needs review
 **Labels:** #broker #gptbridge #testing #parity #ws #http #ci #observability #promethean
 
 ---
@@ -311,3 +311,5 @@ test(parity): add broker↔bridge parity suites + normalizers + CI gate
 ```
 
 \#tags #broker #gptbridge #parity #ws #http #testing #ci #observability #promethean
+
+#in-review

--- a/docs/agile/tasks/database migration system.md
+++ b/docs/agile/tasks/database migration system.md
@@ -1,4 +1,5 @@
 # Description
+**Status:** blocked
 
 Design and implement a versioned migration system for persistent data stores so services can evolve schemas safely.
 
@@ -24,4 +25,7 @@ You might find [Alembic](https://alembic.sqlalchemy.org/) or [migrate](https://g
 
 Useful for agents to engage in append only conversations about this task.
 
-#Breakdown
+#breakdown
+
+## Blockers
+- No active owner or unclear scope

--- a/docs/agile/tasks/discord_image_awareness_md_md.md
+++ b/docs/agile/tasks/discord_image_awareness_md_md.md
@@ -1,4 +1,5 @@
 ## 🛠️ Description
+**Status:** blocked
 
 Enable the system to **ingest and selectively include Discord images** into the context pipeline.
 Currently, image handling is limited to a single “moving frame” model, where only the latest image passes through the system. This change will allow **multiple relevant images** to be retained, filtered, and passed selectively based on context needs.
@@ -50,3 +51,8 @@ This allows the “Duck” to have **visual memory** tied to conversational cont
 #framework-core
 #ollama-integration
 #multimodal-context
+
+## Blockers
+- No active owner or unclear scope
+
+#breakdown

--- a/docs/agile/tasks/finish_whisper_npu_system_md_md.md
+++ b/docs/agile/tasks/finish_whisper_npu_system_md_md.md
@@ -3,6 +3,7 @@ Here’s the refined version, keeping it focused on **NPU-accelerated transcript
 ---
 
 ## 🛠️ Description
+**Status:** blocked
 
 Offload **speech-to-text transcription** from the CPU/GPU to the **Intel NPU** to free up processor cycles for other system components.
 This will involve adapting the current transcription pipeline (likely Whisper or similar model) to run efficiently on the NPU via **OpenVINO** or compatible inference runtime.
@@ -54,3 +55,8 @@ The goal is to maintain or improve transcription speed and accuracy while signif
 If you want, I can also make you a **mermaid diagram** showing the current CPU-bound STT flow vs. the new NPU-accelerated flow so we can see where the changes happen and how fallbacks work.
 That’ll make it easier to slot into the Promethean pipeline.
 #accepted
+
+## Blockers
+- No active owner or unclear scope
+
+#breakdown

--- a/docs/agile/tasks/full_agent_mode_text_chat_selectively_join_channels_etc_md.md
+++ b/docs/agile/tasks/full_agent_mode_text_chat_selectively_join_channels_etc_md.md
@@ -1,4 +1,5 @@
 ## 🛠️ Description
+**Status:** blocked
 
 Enable "full agent mode" in Discord where agents can join or leave channels, send messages, and run tasks in the background without spamming users.
 
@@ -50,4 +51,7 @@ Nothing
 
 - [kanban](../boards/kanban.md)
 
-#Breakdown
+#breakdown
+
+## Blockers
+- No active owner or unclear scope

--- a/docs/agile/tasks/gpt bridge fuzzy lookup should return multiple matches when it is used..md
+++ b/docs/agile/tasks/gpt bridge fuzzy lookup should return multiple matches when it is used..md
@@ -1,4 +1,5 @@
 ## 🛠️ Description
+**Status:** blocked
 
 Update the GPT bridge fuzzy lookup so it returns multiple potential matches instead of only the first result.
 
@@ -51,3 +52,8 @@ Nothing
 - [kanban](../boards/kanban.md)
 
 #accepted
+
+## Blockers
+- No active owner or unclear scope
+
+#breakdown

--- a/docs/agile/tasks/harden precommit hooks.md
+++ b/docs/agile/tasks/harden precommit hooks.md
@@ -1,4 +1,5 @@
 # Description
+**Status:** blocked
 
 We want to make it as hard as possible for bad code and bad documentation to be committed to the git repository.
 
@@ -24,4 +25,7 @@ You might find [this](https://pre-commit.com/) useful while working on this task
 
 Useful for agents to engage in append only conversations about this task.
 
-#Breakdown
+#breakdown
+
+## Blockers
+- No active owner or unclear scope

--- a/docs/agile/tasks/move discord scraper to ts.md
+++ b/docs/agile/tasks/move discord scraper to ts.md
@@ -1,4 +1,5 @@
 ## 🛠️ Description
+**Status:** blocked
 
 Port the existing Discord scraper to TypeScript to align with the rest of the JS toolchain.
 
@@ -50,3 +51,8 @@ Nothing
 - [kanban](../boards/kanban.md)
 
 #accepted
+
+## Blockers
+- No active owner or unclear scope
+
+#breakdown

--- a/docs/agile/tasks/refactor_any_python_modules_not_currently_for_ml_stuff_discord_etc_2_md.md
+++ b/docs/agile/tasks/refactor_any_python_modules_not_currently_for_ml_stuff_discord_etc_2_md.md
@@ -1,4 +1,5 @@
 ## 🛠️ Description
+**Status:** blocked
 
 Minimize Python usage in the Promethean framework by **isolating and containing Python code** to only where it is unavoidable—primarily for machine learning model execution—while moving orchestration, glue code, and non-ML logic to faster, more maintainable languages (JavaScript/TypeScript, Sibilant, Hy, etc.).
 
@@ -42,3 +43,8 @@ The aim is to reduce Python’s footprint in the system, improve performance, an
 #framework-core
 #language-strategy
 #performance-optimization
+
+## Blockers
+- No active owner or unclear scope
+
+#breakdown

--- a/docs/agile/tasks/script for getting github action workflow states for a branch.md
+++ b/docs/agile/tasks/script for getting github action workflow states for a branch.md
@@ -1,4 +1,5 @@
 # Description
+**Status:** blocked
 
 Create a script that fetches GitHub Actions workflow runs for a given branch and outputs their status so they can be reviewed or fed to language models.
 
@@ -24,4 +25,7 @@ You might find [GitHub's Actions API](https://docs.github.com/en/rest/actions) u
 
 Useful for agents to engage in append only conversations about this task.
 
-#Breakdown
+#breakdown
+
+## Blockers
+- No active owner or unclear scope

--- a/docs/agile/tasks/smart_task_templater_md.md
+++ b/docs/agile/tasks/smart_task_templater_md.md
@@ -1,4 +1,5 @@
 ## 🛠️ Description
+**Status:** blocked
 
 Automate the creation of new task files using a command-line script or Obsidian Templater so every Kanban card has a properly formatted markdown stub.
 
@@ -50,4 +51,7 @@ Nothing
 
 - [kanban](../boards/kanban.md)
 
-#Breakdown
+#breakdown
+
+## Blockers
+- No active owner or unclear scope

--- a/docs/agile/tasks/structure_vault_to_mirror_services_agents_docs_md_md.md
+++ b/docs/agile/tasks/structure_vault_to_mirror_services_agents_docs_md_md.md
@@ -1,4 +1,5 @@
 ## 🛠️ Task: Document-Driven Development for Service Scripts
+**Status:** blocked
 
 We are following a **document-driven development** process.  
 This means **each program file must have a corresponding documentation file** that fully describes its behavior, purpose, and relationships—*before or alongside implementation*.
@@ -71,3 +72,8 @@ Nothing
 - [doc-template](doc-template.md)
 - [docdrivendev-principles](docdrivendev-principles.md)
 #ice-box
+
+## Blockers
+- No active owner or unclear scope
+
+#breakdown


### PR DESCRIPTION
## Summary
- flag tasks without owners as blocked and return them to Breakdown
- mark review-ready tasks and keep active items in progress

## Testing
- `pre-commit run --files docs/agile/tasks/*`
- `make kanban-from-tasks` (fails: can't open file `/workspace/promethean/scripts/hashtags_to_kanban.py`)


------
https://chatgpt.com/codex/tasks/task_e_68ae57e3b6bc8324b79f8c21b699074f