### PR TITLE
chore: prioritize to do tasks with estimates

### DIFF
--- a/docs/agile/boards/kanban.md
+++ b/docs/agile/boards/kanban.md
@@ -104,6 +104,11 @@ kanban-plugin: board
 - [ ] [[connect wikipedia]]
 - [ ] [[lisp ecosystem files]]
 - [ ] [[hy - js interop]]
+- [ ] [[frontend build tool chain]] (13 pts) — Oversized; refine build pipeline
+- [ ] [[flatten services]] (8 pts) — Oversized; restructure modules
+- [ ] [[lisp package files]] (8 pts) — Oversized; define packaging strategy
+- [ ] [[clearly standardize data models]] (8 pts) — Oversized; ensure cross-service consistency
+- [ ] [[dockerize the system]] (8 pts) — Oversized; plan containerization
 
 
 ## Ready
@@ -118,13 +123,8 @@ kanban-plugin: board
 
 ## Todo (21)
 
-- [ ] [[update_makefile_to_have_commands_specific_for_agents_md.md|Update Makefile to have commands specific for agents]] #devops #accepted
-- [ ] [[LLM service must accept tool calls]]
-- [ ] [[frontend build tool chain]]
-- [ ] [[flatten services]]
-- [ ] [[lisp package files]]
-- [ ] [[clearly standardize data models]]
-- [ ] [[dockerize the system]]
+- [ ] [[LLM service must accept tool calls]] (5 pts) — High priority: enables tool-driven workflows
+- [ ] [[update_makefile_to_have_commands_specific_for_agents_md.md|Update Makefile to have commands specific for agents]] (3 pts) — Medium priority: improves agent development
 
 
 ## In Progress (21)


### PR DESCRIPTION
## Summary
- add point estimates and priority notes for To Do tasks
- move oversized work items back to Breakdown for refinement

## Testing
- `make format` *(fails: SyntaxError in shared/ts/config/providers.yml)*
- `make lint` *(fails: ESLint config extends not supported in flat config)*
- `make test` *(fails: task queue tests error)*
- `make build`


------
https://chatgpt.com/codex/tasks/task_e_68ae57e2db60832492aff245b968b865