### PR TITLE
docs: prioritize ready tasks and assign points

### DIFF
--- a/docs/agile/boards/kanban.md
+++ b/docs/agile/boards/kanban.md
@@ -108,12 +108,12 @@ kanban-plugin: board
 
 ## Ready
 
-- [ ] [[create a generic markdown helper module]]
-- [ ] [[task generator system]]
-- [ ] [[redefine all existing lambdas with high order functions incoming]]
-- [ ] [[convert current services to packages, then redefine the services using config files]]
-- [ ] [[Phase out proxy in favor of bridge service]]
-- [ ] [[audio processing service]]
+- [ ] [[audio processing service]] (8 pts)
+- [ ] [[Phase out proxy in favor of bridge service]] (5 pts)
+- [ ] [[convert current services to packages, then redefine the services using config files]] (5 pts)
+- [ ] [[task generator system]] (3 pts)
+- [ ] [[create a generic markdown helper module]] (2 pts)
+- [ ] [[redefine all existing lambdas with high order functions incoming]] (1 pt)
 
 
 ## Todo (21)


### PR DESCRIPTION
## Summary
- prioritize Ready tasks in board by urgency
- assign story point estimates to prioritized tasks

## Testing
- `pre-commit run --files docs/agile/boards/kanban.md`
- `make lint` *(fails: A config object is using the "extends" key, which is not supported in flat config system)*
- `make test` *(interrupted: KeyboardInterrupt)*
- `make build` *(interrupted: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68ae57cfed1083248972d7fa0e264f58