### PR TITLE
feat: rebalance kanban lanes

### DIFF
--- a/changelog.d/0000.added.md
+++ b/changelog.d/0000.added.md
@@ -1,0 +1,1 @@
+- Rebalance Kanban lanes when capacity is exceeded, moving oldest cards left.


### PR DESCRIPTION
## Summary
- compute lane totals and shift oldest cards left when capacity exceeded
- render updated Kanban board and support dry-run mode by default
- document WIP rebalancing in changelog

## Testing
- `pre-commit run --files scripts/kanban/wip-sheriff.ts changelog.d/0000.added.md`


------
https://chatgpt.com/codex/tasks/task_e_68ae59d34f00832492c3c4512f86f756