### PR TITLE
docs: add DoD and story points for breakdown tasks

### DIFF
--- a/docs/agile/tasks/connect bluesky.md
+++ b/docs/agile/tasks/connect bluesky.md
@@ -2,12 +2,21 @@
 
 Agent provider thingy
 
-
-## Requirements/Definition of done
+## Requirements
 
 - If it doesn't have this, we can't accept it
 
-## Tasks 
+## Definition of Done
+
+- [ ] Bluesky API client connects using ATProto
+- [ ] Posts can be pulled from a user or feed
+- [ ] Basic unit test covers fetching a post
+
+## Story Points
+
+3
+
+## Tasks
 
 - [ ] Step 1
 - [ ] Step 2
@@ -20,4 +29,6 @@ You might find [this] useful while working on this task
 
 ## Comments
 
-Useful for agents to engage in append only conversations about this task.
+No blockers.
+
+#Ready

--- a/docs/agile/tasks/connect reddit.md
+++ b/docs/agile/tasks/connect reddit.md
@@ -1,13 +1,22 @@
 # Description
 
 - Agent provider thingy
-- 
 
-## Requirements/Definition of done
+## Requirements
 
 - If it doesn't have this, we can't accept it
 
-## Tasks 
+## Definition of Done
+
+- [ ] Reddit API client authenticates using configured credentials
+- [ ] Posts can be fetched from a target subreddit
+- [ ] Basic unit test covers fetching and storing a post
+
+## Story Points
+
+3
+
+## Tasks
 
 - [ ] Step 1
 - [ ] Step 2
@@ -20,4 +29,6 @@ You might find [this] useful while working on this task
 
 ## Comments
 
-Useful for agents to engage in append only conversations about this task.
+No blockers.
+
+#Ready

--- a/docs/agile/tasks/connect wikipedia.md
+++ b/docs/agile/tasks/connect wikipedia.md
@@ -2,11 +2,21 @@
 
 Endpoint? tool calls? Indexer?
 
-## Requirements/Definition of done
+## Requirements
 
 - If it doesn't have this, we can't accept it
 
-## Tasks 
+## Definition of Done
+
+- [ ] Wikipedia API can be queried for article summaries
+- [ ] Retrieved content stored or returned in expected format
+- [ ] Unit test verifies lookup of a sample article
+
+## Story Points
+
+5
+
+## Tasks
 
 - [ ] Step 1
 - [ ] Step 2
@@ -19,4 +29,6 @@ You might find [this] useful while working on this task
 
 ## Comments
 
-Useful for agents to engage in append only conversations about this task.
+No blockers.
+
+#Ready

--- a/docs/agile/tasks/design_circular_buffers_for_inputs_with_layered_states_of_persistance_in_memory_on_disk_cold_storage_so_md.md
+++ b/docs/agile/tasks/design_circular_buffers_for_inputs_with_layered_states_of_persistance_in_memory_on_disk_cold_storage_so_md.md
@@ -22,6 +22,18 @@ Placeholder task stub generated from kanban board.
 
 ---
 
+## ✅ Definition of Done
+
+- [ ] Architecture document describes in‑memory, on‑disk, and cold‑storage tiers
+- [ ] Prototype circular buffer persists and rolls data across all tiers
+- [ ] Tests demonstrate data rollover between tiers without loss
+
+## 🧮 Story Points
+
+8
+
+---
+
 ## 🔗 Related Epics
 
 #framework-core
@@ -30,7 +42,7 @@ Placeholder task stub generated from kanban board.
 
 ## ⛓️ Blocked By
 
-Nothing
+- Pending design on memory hierarchy and storage strategy
 
 ## ⛓️ Blocks
 
@@ -41,4 +53,4 @@ Nothing
 ## 🔍 Relevant Links
 
 - [kanban](../boards/kanban.md)
-#ice-box
+#Breakdown

--- a/docs/agile/tasks/hy - js interop.md
+++ b/docs/agile/tasks/hy - js interop.md
@@ -2,11 +2,21 @@
 
 Make it easier to use js from hy and hy from js
 
-## Requirements/Definition of done
+## Requirements
 
 - If it doesn't have this, we can't accept it
 
-## Tasks 
+## Definition of Done
+
+- [ ] Provide utilities to call JavaScript from Hy
+- [ ] Allow Hy modules to be consumed from JavaScript
+- [ ] Example tests demonstrate bidirectional interop
+
+## Story Points
+
+8
+
+## Tasks
 
 - [ ] Step 1
 - [ ] Step 2
@@ -19,4 +29,6 @@ You might find [this] useful while working on this task
 
 ## Comments
 
-Useful for agents to engage in append only conversations about this task.
+Blocked: requires decisions on runtime bridging tools.
+
+#Breakdown

--- a/docs/agile/tasks/lisp ecosystem files.md
+++ b/docs/agile/tasks/lisp ecosystem files.md
@@ -2,11 +2,21 @@
 
 Describe your task
 
-## Requirements/Definition of done
+## Requirements
 
 - If it doesn't have this, we can't accept it
 
-## Tasks 
+## Definition of Done
+
+- [ ] Inventory existing Lisp ecosystem files in the repository
+- [ ] Map files to the intended modular structure
+- [ ] Documentation describes where each file lives and why
+
+## Story Points
+
+8
+
+## Tasks
 
 - [ ] Step 1
 - [ ] Step 2
@@ -19,4 +29,6 @@ You might find [this] useful while working on this task
 
 ## Comments
 
-Useful for agents to engage in append only conversations about this task.
+Blocked: needs clarity on target file organization.
+
+#Breakdown

--- a/docs/agile/tasks/thinking_model_integration_md_md.md
+++ b/docs/agile/tasks/thinking_model_integration_md_md.md
@@ -22,6 +22,18 @@ Placeholder task stub generated from kanban board.
 
 ---
 
+## ✅ Definition of Done
+
+- [ ] Integration points with existing agent pipeline are documented
+- [ ] API surface for the thinking model is defined and reviewed
+- [ ] Prototype demonstrates model hook executing within a test agent
+
+## 🧮 Story Points
+
+8
+
+---
+
 ## 🔗 Related Epics
 
 #framework-core
@@ -30,7 +42,7 @@ Placeholder task stub generated from kanban board.
 
 ## ⛓️ Blocked By
 
-Nothing
+- Awaiting selection of underlying thinking model and alignment with architecture
 
 ## ⛓️ Blocks
 
@@ -41,4 +53,4 @@ Nothing
 ## 🔍 Relevant Links
 
 - [kanban](../boards/kanban.md)
-#ice-box
+#Breakdown


### PR DESCRIPTION
## Summary
- add Definition of Done and story point estimates to tasks in Breakdown column
- move small tasks to Ready and note blockers on larger items

## Testing
- `pre-commit run --files docs/agile/tasks/design_circular_buffers_for_inputs_with_layered_states_of_persistance_in_memory_on_disk_cold_storage_so_md.md docs/agile/tasks/thinking_model_integration_md_md.md "docs/agile/tasks/connect reddit.md" "docs/agile/tasks/connect bluesky.md" "docs/agile/tasks/connect wikipedia.md" "docs/agile/tasks/lisp ecosystem files.md" "docs/agile/tasks/hy - js interop.md" docs/agile/boards/kanban.md`

------
https://chatgpt.com/codex/tasks/task_e_68ae57cd7b38832492b26273745fe0e1