### PR TITLE
chore(agile): triage incoming tasks

### DIFF
--- a/changelog.d/board-triage.changed.md
+++ b/changelog.d/board-triage.changed.md
@@ -1,0 +1,1 @@
+Triage incoming tasks: move near-term items to Breakdown and duplicates to Ice Box.

--- a/docs/agile/tasks/Design Ollama Model file for use with codex cli 1.md
+++ b/docs/agile/tasks/Design Ollama Model file for use with codex cli 1.md
@@ -15,3 +15,5 @@ Having a preconfigured pre prompted model could help agents perform better as co
 - [ ] Select a range of hyper parameters to test each prompt with
 - [ ] Write a report on the outcome
 
+
+#Breakdown

--- a/docs/agile/tasks/Promethean Health Dashboard.md
+++ b/docs/agile/tasks/Promethean Health Dashboard.md
@@ -210,4 +210,4 @@ flowchart LR
 ---
 
 tags: #framework-core #observability #eidolon-visualization #dashboard #broker #realtime
-#accepted
+#IceBox

--- a/docs/agile/tasks/add_file_system_to_context_management_system_md_md.md
+++ b/docs/agile/tasks/add_file_system_to_context_management_system_md_md.md
@@ -41,4 +41,4 @@ Nothing
 ## 🔍 Relevant Links
 
 - [kanban](../boards/kanban.md)
-#ice-box
+#IceBox

--- a/docs/agile/tasks/add_semantic_overlays_for_layer1_through_layer8_md_md.md
+++ b/docs/agile/tasks/add_semantic_overlays_for_layer1_through_layer8_md_md.md
@@ -48,4 +48,4 @@ Nothing
 
 - [design overview](../../design/overview.md)
 - [kanban](../boards/kanban.md)
-#ice-box
+#IceBox

--- a/docs/agile/tasks/allow_configuration_of_hyperparameters_through_discord_context_size_spectrogram_resolution_interuption_threshold_md.md
+++ b/docs/agile/tasks/allow_configuration_of_hyperparameters_through_discord_context_size_spectrogram_resolution_interuption_threshold_md.md
@@ -41,4 +41,4 @@ Nothing
 ## 🔍 Relevant Links
 
 - [kanban](../boards/kanban.md)
-#ice-box
+#IceBox

--- a/docs/agile/tasks/allow_old_unnessisary_messages_to_decay_from_database_while_retaining_index_entries_ids_md_md.md
+++ b/docs/agile/tasks/allow_old_unnessisary_messages_to_decay_from_database_while_retaining_index_entries_ids_md_md.md
@@ -60,4 +60,4 @@ This task is not about strictly defining the scoring model for “relevance,” 
 
 If you want, I can also give you a **mermaid diagram showing the memory tier flow**—Working ↔ Recent ↔ Important—with promotion/demotion paths, which will help when we wire it into the Eidolon field loop.
 That would make it much easier to see where scoring and eviction logic plug in.
-#ice-box
+#IceBox

--- a/docs/agile/tasks/define_codex_cli_baseg_agent_md_md.md
+++ b/docs/agile/tasks/define_codex_cli_baseg_agent_md_md.md
@@ -41,4 +41,4 @@ Nothing
 ## 🔍 Relevant Links
 
 - [kanban](../boards/kanban.md)
-#ice-box
+#IceBox

--- a/docs/agile/tasks/describe_github_branching_workflow_md.md
+++ b/docs/agile/tasks/describe_github_branching_workflow_md.md
@@ -54,4 +54,4 @@ Nothing
 
 - [kanban](../boards/kanban.md)
 #agent-thinking
-#breakdown
+#Breakdown

--- a/docs/agile/tasks/detect_contradictions_in_memory_md_md.md
+++ b/docs/agile/tasks/detect_contradictions_in_memory_md_md.md
@@ -41,4 +41,4 @@ Nothing
 ## 🔍 Relevant Links
 
 - [kanban](../boards/kanban.md)
-#ice-box
+#IceBox

--- a/docs/agile/tasks/discord_chat_link_traversal_md_md.md
+++ b/docs/agile/tasks/discord_chat_link_traversal_md_md.md
@@ -41,4 +41,4 @@ Nothing
 ## 🔍 Relevant Links
 
 - [kanban](../boards/kanban.md)
-#ice-box
+#IceBox

--- a/docs/agile/tasks/evaluate_and_reward_flow_satisfaction_md_md.md
+++ b/docs/agile/tasks/evaluate_and_reward_flow_satisfaction_md_md.md
@@ -56,4 +56,4 @@ stability from Eidolon, and user feedback.
 
 - Should user feedback be captured explicitly or inferred from message content?
 - Do we need real-time updates to the reward signal or batched summaries?
-#ice-box
+#IceBox

--- a/docs/agile/tasks/gather_baseline_emotion_metrics_for_eidolon_field_1_md.md
+++ b/docs/agile/tasks/gather_baseline_emotion_metrics_for_eidolon_field_1_md.md
@@ -68,4 +68,4 @@ Nothing
 
 - What instrumentation already exists in Eidolon for metric export?
 - How much historical data is needed for a meaningful baseline?
-#ice-box
+#IceBox

--- a/docs/agile/tasks/gather_open_questions_about_system_direction_md_md.md
+++ b/docs/agile/tasks/gather_open_questions_about_system_direction_md_md.md
@@ -36,4 +36,4 @@ Nothing
 
 ## 🔍 Relevant Links
 - [kanban](../boards/kanban.md)
-#ice-box
+#IceBox

--- a/docs/agile/tasks/identify_ancestral_resonance_patterns_md_md.md
+++ b/docs/agile/tasks/identify_ancestral_resonance_patterns_md_md.md
@@ -54,4 +54,4 @@ fragments or emotional states that reappear in different contexts.
 
 - Should resonance search include emotional embeddings or just lexical ones?
 - What time span of logs is considered "ancestral" for this project?
-#ice-box
+#IceBox

--- a/docs/agile/tasks/implement_transcendence_cascade_md.md
+++ b/docs/agile/tasks/implement_transcendence_cascade_md.md
@@ -58,4 +58,4 @@ welp, guess we'll see
 
 - How should conflicting outputs from Cephalon and Eidolon be resolved?
 - What user-facing cue toggles the cascade mode?
-#ice-box
+#IceBox

--- a/docs/agile/tasks/integrate_synthesis-agent_pass_on_unique_to_produce_draft_docs_1_md.md
+++ b/docs/agile/tasks/integrate_synthesis-agent_pass_on_unique_to_produce_draft_docs_1_md.md
@@ -48,4 +48,4 @@ Nothing
 
 - [Process](../Process.md)
 - [kanban](../boards/kanban.md)
-#ice-box
+#IceBox

--- a/docs/agile/tasks/pin_versions_in_configs_md.md
+++ b/docs/agile/tasks/pin_versions_in_configs_md.md
@@ -232,3 +232,5 @@ chore(versions): pin runtimes, deps, images, models; add pins linter
 * **Hidden installers**: scripts that call `pip install`/`npm i` at runtime undo reproducibility—purge them or freeze.
 
 \#tags #promethean #versioning #pinning #ci #docker #uv #ollama #openvino #sre #supplychain
+
+#IceBox

--- a/docs/agile/tasks/reach_100_percent_complete_test_coverage_1_md_md.md
+++ b/docs/agile/tasks/reach_100_percent_complete_test_coverage_1_md_md.md
@@ -41,4 +41,4 @@ Nothing
 ## 🔍 Relevant Links
 
 - [kanban](../boards/kanban.md)
-#ice-box
+#IceBox

--- a/docs/agile/tasks/refactor_speech_interuption_system_to_be_more_inteligent_using_audio_data_to_decide_if_interupted_md_md.md
+++ b/docs/agile/tasks/refactor_speech_interuption_system_to_be_more_inteligent_using_audio_data_to_decide_if_interupted_md_md.md
@@ -41,4 +41,4 @@ Nothing
 ## 🔍 Relevant Links
 
 - [kanban](../boards/kanban.md)
-#breakdown
+#Breakdown

--- a/docs/agile/tasks/run_model_bakeoff_md.md
+++ b/docs/agile/tasks/run_model_bakeoff_md.md
@@ -38,4 +38,4 @@ Nothing
 
 ## 🔍 Relevant Links
 - [kanban](../boards/kanban.md)
-#ice-box
+#IceBox

--- a/docs/agile/tasks/setup_a_second_agent_md.md
+++ b/docs/agile/tasks/setup_a_second_agent_md.md
@@ -43,4 +43,4 @@ Nothing
 ## 🔍 Relevant Links
 
 - [kanban](../boards/kanban.md)
-#ice-box
+#IceBox

--- a/docs/agile/tasks/twitch_discord_general_auto_mod_md_md.md
+++ b/docs/agile/tasks/twitch_discord_general_auto_mod_md_md.md
@@ -128,4 +128,4 @@ flowchart LR
 ```
 
 If you want, I can spin this into a canvas-ready policy DSL starter (schema + a few exemplar rules) so you can start committing rules immediately.
-#ice-box
+#IceBox


### PR DESCRIPTION
## Summary
- Tag duplicate or low-priority incoming tasks as `#IceBox`
- Mark near-term work with `#Breakdown` for sizing
- Record board triage in changelog

## Testing
- `make format` *(fails: KeyboardInterrupt)*
- `make lint` *(fails: ESLint config uses unsupported `extends`)*
- `make test` *(fails: interrupted during pnpm tests)*
- `make build` *(fails: interrupted during pnpm build)*

------
https://chatgpt.com/codex/tasks/task_e_68ae57b2da448324a4de247b46980b53