### PR TITLE
chore: return stalled tasks to in progress

### DIFF
--- a/docs/agile/tasks/identify_and_resolve_a_service_client_apparently_connecting_repeatedly_to_broker_with_new_session_ids.md
+++ b/docs/agile/tasks/identify_and_resolve_a_service_client_apparently_connecting_repeatedly_to_broker_with_new_session_ids.md
@@ -1,1 +1,10 @@
-#in-review
+#in-progress
+
+# Description
+
+Service client repeatedly reconnects to the broker creating new session IDs.
+
+## Blockers
+
+- No tests cover reconnection and session handling.
+- Missing documentation describing expected client behavior.

--- a/docs/agile/tasks/setup_services_to_recieve_work_from_the_broker_via_push_md.md
+++ b/docs/agile/tasks/setup_services_to_recieve_work_from_the_broker_via_push_md.md
@@ -68,7 +68,11 @@ Each queue represents a task type or target service. Over time, this model will 
 #codex-task #broker #queueManager #service-oriented #push-queue #agent-mode
 
 ---
-#in-review
+#in-progress
+
+## Blockers
+- Missing integration tests for push-based task delivery.
+- Shared broker client interface lacks documentation.
 
 ## Comments
 

--- a/docs/agile/tasks/update_cephalon_to_use_custom_embedding_function_md_md.md
+++ b/docs/agile/tasks/update_cephalon_to_use_custom_embedding_function_md_md.md
@@ -60,4 +60,9 @@ Nothing
 ## 🔍 Relevant Links
 - [kanban](../boards/kanban.md)
 - [pseudo/eidolon-field-scratchpad.lisp](../../pseudo/eidolon-field-scratchpad.lisp)
-#in-review
+#in-progress
+
+## Blockers
+- Embedding service implementation not linked.
+- Unit and integration tests for wrapper and service missing.
+- Documentation for the new embedding workflow is absent.


### PR DESCRIPTION
## Summary
- mark broker client reconnection issue task as in progress with missing tests and docs blockers
- mark broker push delivery refactor task as in progress and note missing tests and docs
- mark Cephalon embedding service migration task as in progress with explicit blockers

## Testing
- `pre-commit run --files docs/agile/tasks/identify_and_resolve_a_service_client_apparently_connecting_repeatedly_to_broker_with_new_session_ids.md docs/agile/tasks/setup_services_to_recieve_work_from_the_broker_via_push_md.md docs/agile/tasks/update_cephalon_to_use_custom_embedding_function_md_md.md`
- `make test` (failed: Couldn’t find any files to test)
- `make simulate-ci` (failed: Cannot find module 'shared/ts/prom-lib/naming/rules.ts')

------
https://chatgpt.com/codex/tasks/task_e_68ae57978ac883249bab95c9006ce992