### PR TITLE
chore: expand Node engine range

### DIFF
--- a/changelog.d/node-engine-range.changed.md
+++ b/changelog.d/node-engine-range.changed.md
@@ -1,0 +1,1 @@
+Expand Node engine requirement to ">=20.19.4" to align with Volta configuration.

--- a/package.json
+++ b/package.json
@@ -1,54 +1,54 @@
 {
-    "type": "module",
-    "packageManager": "pnpm@9.0.0",
-    "scripts": {
-        "preinstall": "node -e \"const ua = process.env.npm_config_user_agent || ''; if (!ua.includes('pnpm')) { console.error('\\nERROR: pnpm is required for this repo. npm/yarn are not supported and often fail with EACCES permission errors.\\nInstall via: corepack enable && corepack prepare pnpm@latest --activate\\nThen re-run: pnpm install\\n'); process.exit(1); }\"",
-        "test": "ava tests/*.test.js",
-        "coverage": "c8 ava tests/*.test.js",
-        "build:docs": "node scripts/generate-service-docs.js",
-        "health:node-abi": "node -p \"process.versions.node + ' ABI ' + process.versions.modules\"",
-        "prepare": "chmod +x ./bin/promethean.js",
-        "lint": "biome lint --config-path=biome.json .",
-        "format": "biome format --config-path=biome.json --write ."
-    },
-    "bin": {
-        "prom": "./bin/promethean.js"
-    },
-    "dependencies": {
-        "@shared/js": "file:shared/js",
-        "@shared/sibilant": "file:shared/sibilant",
-        "@shared/ts": "file:shared/ts",
-        "adm-zip": "0.5.16",
-        "dotenv": "17.2.1",
-        "http-proxy": "1.18.1",
-        "mongodb": "6.18.0",
-        "pm2": "6.0.8",
-        "ws": "8.18.3",
-        "yaml": "2.8.1",
-        "zod": "3.25.76"
-    },
-    "devDependencies": {
-        "@biomejs/biome": "^2.2.2",
-        "@types/jest": "30.0.0",
-        "@types/mongodb": "4.0.6",
-        "@typescript-eslint/eslint-plugin": "8.39.0",
-        "@typescript-eslint/parser": "8.39.0",
-        "ava": "6.4.1",
-        "c8": "10.1.3",
-        "eslint": "9.33.0",
-        "jest": "30.0.5",
-        "puppeteer": "24.16.0",
-        "ts-jest": "29.4.1",
-        "ts-node": "10.9.2",
-        "tsx": "4.20.3",
-        "typescript": "5.9.2"
-    },
-    "license": "GPL-3.0-only",
-    "volta": {
-        "node": "20.19.4",
-        "pnpm": "9.0.0"
-    },
-    "engines": {
-        "node": "20.19.4"
-    }
+  "type": "module",
+  "packageManager": "pnpm@9.0.0",
+  "scripts": {
+    "preinstall": "node -e \"const ua = process.env.npm_config_user_agent || ''; if (!ua.includes('pnpm')) { console.error('\\nERROR: pnpm is required for this repo. npm/yarn are not supported and often fail with EACCES permission errors.\\nInstall via: corepack enable && corepack prepare pnpm@latest --activate\\nThen re-run: pnpm install\\n'); process.exit(1); }\"",
+    "test": "ava tests/*.test.js",
+    "coverage": "c8 ava tests/*.test.js",
+    "build:docs": "node scripts/generate-service-docs.js",
+    "health:node-abi": "node -p \"process.versions.node + ' ABI ' + process.versions.modules\"",
+    "prepare": "chmod +x ./bin/promethean.js",
+    "lint": "biome lint --config-path=biome.json .",
+    "format": "biome format --config-path=biome.json --write ."
+  },
+  "bin": {
+    "prom": "./bin/promethean.js"
+  },
+  "dependencies": {
+    "@shared/js": "file:shared/js",
+    "@shared/sibilant": "file:shared/sibilant",
+    "@shared/ts": "file:shared/ts",
+    "adm-zip": "0.5.16",
+    "dotenv": "17.2.1",
+    "http-proxy": "1.18.1",
+    "mongodb": "6.18.0",
+    "pm2": "6.0.8",
+    "ws": "8.18.3",
+    "yaml": "2.8.1",
+    "zod": "3.25.76"
+  },
+  "devDependencies": {
+    "@biomejs/biome": "^2.2.2",
+    "@types/jest": "30.0.0",
+    "@types/mongodb": "4.0.6",
+    "@typescript-eslint/eslint-plugin": "8.39.0",
+    "@typescript-eslint/parser": "8.39.0",
+    "ava": "6.4.1",
+    "c8": "10.1.3",
+    "eslint": "9.33.0",
+    "jest": "30.0.5",
+    "puppeteer": "24.16.0",
+    "ts-jest": "29.4.1",
+    "ts-node": "10.9.2",
+    "tsx": "4.20.3",
+    "typescript": "5.9.2"
+  },
+  "license": "GPL-3.0-only",
+  "volta": {
+    "node": "20.19.4",
+    "pnpm": "9.0.0"
+  },
+  "engines": {
+    "node": ">=20.19.4"
+  }
 }


### PR DESCRIPTION
## Summary
- widen Node engine requirement to allow v20.19.4 and newer
- note Node engine range in changelog

## Testing
- `pnpm install`
- `pnpm test`
- `pnpm run lint` *(fails: nested Biome configuration)*
- `pnpm run format` *(fails: nested Biome configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68ae67ad33648324b03b03a1bf43f6f6