### PR TITLE
chore: centralize ecosystem dependencies for python services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Realtime Promethean Health Dashboard for monitoring heartbeat metrics.
 - Configurable timeout for remote embedding requests.
 - `defun` special form in Lisp compiler enabling named functions and recursion.
+- Centralized `ecosystem.dependencies.js` under `services/shared` and updated Python services to reference it.
 
 ### Changed
 

--- a/services/py/discord_attachment_embedder/ecosystem.config.js
+++ b/services/py/discord_attachment_embedder/ecosystem.config.js
@@ -1,31 +1,24 @@
-import path from "path";
-import { fileURLToPath } from "url";
-import { definePythonService } from "../../../dev/pm2Helpers.js";
-import deps from "./ecosystem.dependencies.js";
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { definePythonService } from '../../../dev/pm2Helpers.js';
+import deps from '../../shared/ecosystem.dependencies.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
-const root = path.join(__dirname, "../../..");
+const root = path.join(__dirname, '../../..');
 
 if (!process.env.PROMETHEAN_ROOT_ECOSYSTEM) {
-  defineApp.PYTHONPATH = root;
-  defineApp.HEARTBEAT_PORT = 5005;
+    defineApp.PYTHONPATH = root;
+    defineApp.HEARTBEAT_PORT = 5005;
 }
 
 const apps = [
-  definePythonService(
-    "discord_attachment_embedder",
-    "pipenv",
-    ["run", "python", "-m", "main"],
-    {
-      cwd: __dirname,
-      watch: [__dirname],
-    },
-  ),
+    definePythonService('discord_attachment_embedder', 'pipenv', ['run', 'python', '-m', 'main'], {
+        cwd: __dirname,
+        watch: [__dirname],
+    }),
 ];
 
-const allApps = !process.env.PROMETHEAN_ROOT_ECOSYSTEM
-  ? [...apps, ...(deps?.apps || [])]
-  : apps;
+const allApps = !process.env.PROMETHEAN_ROOT_ECOSYSTEM ? [...apps, ...(deps?.apps || [])] : apps;
 
 export default { apps: allApps };

--- a/services/py/embedding_service/ecosystem.config.js
+++ b/services/py/embedding_service/ecosystem.config.js
@@ -1,30 +1,28 @@
-import path from "path";
-import { fileURLToPath } from "url";
-import { defineApp } from "../../../dev/pm2Helpers.js";
-import deps from "./ecosystem.dependencies.js";
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { defineApp } from '../../../dev/pm2Helpers.js';
+import deps from '../../shared/ecosystem.dependencies.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
-const root = path.join(__dirname, "../../..");
+const root = path.join(__dirname, '../../..');
 
 if (!process.env.PROMETHEAN_ROOT_ECOSYSTEM) {
-  defineApp.PYTHONPATH = root;
-  defineApp.HEARTBEAT_PORT = 5005;
+    defineApp.PYTHONPATH = root;
+    defineApp.HEARTBEAT_PORT = 5005;
 }
 
 const apps = [
-  defineApp("embedding_service", "uv", ["run", "python", "-m", "main"], {
-    cwd: __dirname,
-    watch: [__dirname],
-    env: {
-      EMBEDDING_DRIVER: "ollama",
-      EMBEDDING_FUNCTION: "nomic-embed-text",
-    },
-  }),
+    defineApp('embedding_service', 'uv', ['run', 'python', '-m', 'main'], {
+        cwd: __dirname,
+        watch: [__dirname],
+        env: {
+            EMBEDDING_DRIVER: 'ollama',
+            EMBEDDING_FUNCTION: 'nomic-embed-text',
+        },
+    }),
 ];
 
-const allApps = !process.env.PROMETHEAN_ROOT_ECOSYSTEM
-  ? [...apps, ...(deps?.apps || [])]
-  : apps;
+const allApps = !process.env.PROMETHEAN_ROOT_ECOSYSTEM ? [...apps, ...(deps?.apps || [])] : apps;
 
 export default { apps: allApps };

--- a/services/py/embedding_service/ecosystem.dependencies.js
+++ b/services/py/embedding_service/ecosystem.dependencies.js
@@ -1,3 +1,0 @@
-export default {
-  apps: [],
-};

--- a/services/py/stt/ecosystem.config.js
+++ b/services/py/stt/ecosystem.config.js
@@ -1,30 +1,28 @@
-import path from "path";
-import { fileURLToPath } from "url";
-import { defineApp } from "../../../dev/pm2Helpers.js";
-import deps from "./ecosystem.dependencies.js";
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { defineApp } from '../../../dev/pm2Helpers.js';
+import deps from '../../shared/ecosystem.dependencies.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
-const root = path.join(__dirname, "../../..");
+const root = path.join(__dirname, '../../..');
 
 if (!process.env.PROMETHEAN_ROOT_ECOSYSTEM) {
-  defineApp.PYTHONPATH = root;
-  defineApp.HEARTBEAT_PORT = 5005;
+    defineApp.PYTHONPATH = root;
+    defineApp.HEARTBEAT_PORT = 5005;
 }
 
 const apps = [
-  defineApp("stt", "uv", ["run", "python", "-m", "service"], {
-    cwd: __dirname,
-    watch: [__dirname],
-    env: {
-      FLASK_APP: "app.py",
-      FLASK_ENV: "production",
-    },
-  }),
+    defineApp('stt', 'uv', ['run', 'python', '-m', 'service'], {
+        cwd: __dirname,
+        watch: [__dirname],
+        env: {
+            FLASK_APP: 'app.py',
+            FLASK_ENV: 'production',
+        },
+    }),
 ];
 
-const allApps = !process.env.PROMETHEAN_ROOT_ECOSYSTEM
-  ? [...apps, ...(deps?.apps || [])]
-  : apps;
+const allApps = !process.env.PROMETHEAN_ROOT_ECOSYSTEM ? [...apps, ...(deps?.apps || [])] : apps;
 
 export default { apps: allApps };

--- a/services/py/stt/ecosystem.dependencies.js
+++ b/services/py/stt/ecosystem.dependencies.js
@@ -1,3 +1,0 @@
-export default {
-  apps: [],
-};

--- a/services/py/tts/ecosystem.config.js
+++ b/services/py/tts/ecosystem.config.js
@@ -1,32 +1,25 @@
-import path from "path";
-import { fileURLToPath } from "url";
-import { defineApp } from "../../../dev/pm2Helpers.js";
-import deps from "./ecosystem.dependencies.js";
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { defineApp } from '../../../dev/pm2Helpers.js';
+import deps from '../../shared/ecosystem.dependencies.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
-const root = path.join(__dirname, "../../..");
+const root = path.join(__dirname, '../../..');
 
 if (!process.env.PROMETHEAN_ROOT_ECOSYSTEM) {
-  defineApp.PYTHONPATH = root;
-  defineApp.HEARTBEAT_PORT = 5005;
+    defineApp.PYTHONPATH = root;
+    defineApp.HEARTBEAT_PORT = 5005;
 }
 
 const apps = [
-  defineApp(
-    "tts",
-    "uv",
-    ["run", "uvicorn", "--host", "0.0.0.0", "--port", "5001", "app:app"],
-    {
-      cwd: __dirname,
-      watch: [__dirname],
-      env: {},
-    },
-  ),
+    defineApp('tts', 'uv', ['run', 'uvicorn', '--host', '0.0.0.0', '--port', '5001', 'app:app'], {
+        cwd: __dirname,
+        watch: [__dirname],
+        env: {},
+    }),
 ];
 
-const allApps = !process.env.PROMETHEAN_ROOT_ECOSYSTEM
-  ? [...apps, ...(deps?.apps || [])]
-  : apps;
+const allApps = !process.env.PROMETHEAN_ROOT_ECOSYSTEM ? [...apps, ...(deps?.apps || [])] : apps;
 
 export default { apps: allApps };

--- a/services/py/tts/ecosystem.dependencies.js
+++ b/services/py/tts/ecosystem.dependencies.js
@@ -1,3 +1,0 @@
-export default {
-  apps: [],
-};

--- a/services/shared/ecosystem.dependencies.js
+++ b/services/shared/ecosystem.dependencies.js
@@ -1,3 +1,3 @@
 export default {
-  apps: [],
+    apps: [],
 };


### PR DESCRIPTION
## Summary
- move ecosystem dependency config to `services/shared`
- remove duplicate configs from python services and update imports
- record change in changelog

## Testing
- `pre-commit run --files services/shared/ecosystem.dependencies.js services/py/discord_attachment_embedder/ecosystem.config.js services/py/embedding_service/ecosystem.config.js services/py/stt/ecosystem.config.js services/py/tts/ecosystem.config.js CHANGELOG.md`


------
https://chatgpt.com/codex/tasks/task_e_68ae3d5a17388324a1f9dc8f8b187dc5