### PR TITLE
feat: add base Dockerfile for python services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - v1 router exposing consolidated SmartGPT Bridge endpoints.
 - OpenAPI spec for `/v1` served at `/v1/openapi.json` with consolidated operations.
 - `distclean` target to remove ignored files via `git clean -fdX`.
+- Base Dockerfile for Python Pipenv services and minimal service Dockerfiles extending it.
 
 ### Changed
 
@@ -38,6 +39,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Proxy route `/bridge` through the shared proxy service for SmartGPT Bridge.
 - Tool calling support for Codex Context service.
 - Image attachments captured, stored, and retrieved for multimodal prompting with cleanup.
+- `docker-build` now builds a shared base image before service images.
 - OAuth Authorization Code flow with PKCE for the auth-service, enabling OpenAI Custom GPT logins.
 - Template for building Discord bots in TypeScript based on the Cephalon service.
 - Tests validating bridge event mappings for identifiers and protocols.

--- a/mk/commands.hy
+++ b/mk/commands.hy
@@ -661,6 +661,7 @@
       (sh ["python" "scripts/simulate_ci.py"])) )
 
 (defn-cmd docker-build []
+  (sh ["docker" "build" "-f" "services/docker/base-python-pipenv.Dockerfile" "-t" "base-python-pipenv" "services/docker"])
   (sh ["docker" "compose" "build"]))
 
 (defn-cmd docker-up []

--- a/services/docker/base-python-pipenv.Dockerfile
+++ b/services/docker/base-python-pipenv.Dockerfile
@@ -1,0 +1,6 @@
+# syntax=docker/dockerfile:1
+FROM python:3.12-slim
+
+WORKDIR /app
+
+RUN pip install --no-cache-dir pipenv

--- a/services/hy/stt/Dockerfile
+++ b/services/hy/stt/Dockerfile
@@ -1,12 +1,10 @@
 # syntax=docker/dockerfile:1
-FROM python:3.12-slim
-
-WORKDIR /app
+ARG BASE_IMAGE=base-python-pipenv
+FROM ${BASE_IMAGE}
 
 # Install dependencies
 COPY Pipfile Pipfile.lock ./
-RUN pip install --no-cache-dir pipenv && \
-    pipenv install --deploy --ignore-pipfile
+RUN pipenv install --deploy --ignore-pipfile
 
 # Copy source code
 COPY . .

--- a/services/hy/tts/Dockerfile
+++ b/services/hy/tts/Dockerfile
@@ -1,12 +1,10 @@
 # syntax=docker/dockerfile:1
-FROM python:3.12-slim
-
-WORKDIR /app
+ARG BASE_IMAGE=base-python-pipenv
+FROM ${BASE_IMAGE}
 
 # Install dependencies
 COPY Pipfile Pipfile.lock ./
-RUN pip install --no-cache-dir pipenv && \
-    pipenv install --deploy --ignore-pipfile
+RUN pipenv install --deploy --ignore-pipfile
 
 # Copy source code
 COPY . .

--- a/services/py/stt/Dockerfile
+++ b/services/py/stt/Dockerfile
@@ -1,12 +1,10 @@
 # syntax=docker/dockerfile:1
-FROM python:3.12-slim
-
-WORKDIR /app
+ARG BASE_IMAGE=base-python-pipenv
+FROM ${BASE_IMAGE}
 
 # Install dependencies
 COPY Pipfile Pipfile.lock ./
-RUN pip install --no-cache-dir pipenv && \
-    pipenv install --deploy --ignore-pipfile
+RUN pipenv install --deploy --ignore-pipfile
 
 # Copy source code
 COPY . .

--- a/services/py/tts/Dockerfile
+++ b/services/py/tts/Dockerfile
@@ -1,12 +1,10 @@
 # syntax=docker/dockerfile:1
-FROM python:3.12-slim
-
-WORKDIR /app
+ARG BASE_IMAGE=base-python-pipenv
+FROM ${BASE_IMAGE}
 
 # Install dependencies
 COPY Pipfile Pipfile.lock ./
-RUN pip install --no-cache-dir pipenv && \
-    pipenv install --deploy --ignore-pipfile
+RUN pipenv install --deploy --ignore-pipfile
 
 # Copy source code
 COPY . .


### PR DESCRIPTION
## Summary
- add base Dockerfile for python pipenv services
- use shared base in stt/tts service Dockerfiles
- build base image before service images

## Testing
- `pre-commit run --files services/docker/base-python-pipenv.Dockerfile services/py/stt/Dockerfile services/py/tts/Dockerfile services/hy/stt/Dockerfile services/hy/tts/Dockerfile mk/commands.hy CHANGELOG.md`
- `pytest -q` *(fails: ModuleNotFoundError and missing scripts)*


------
https://chatgpt.com/codex/tasks/task_e_68ae3d43e4948324be437d3c46bbc8cd