### PR TITLE
fix broker client open handler

### DIFF
--- a/changelog.d/99999.fixed.md
+++ b/changelog.d/99999.fixed.md
@@ -1,0 +1,1 @@
+BrokerClient handles connection setup in a single 'open' handler to avoid duplicate resolve calls.

--- a/shared/js/brokerClient.js
+++ b/shared/js/brokerClient.js
@@ -1,149 +1,148 @@
 // shared/js/brokerClient.js
 
-import WebSocket from 'ws';
-import { randomUUID } from 'crypto';
+import WebSocket from "ws";
+import { randomUUID } from "node:crypto";
 
 export class BrokerClient {
-    constructor({
-        url = 'ws://localhost:7000',
-        id = randomUUID(),
-        heartbeatInterval = Number(process.env.BROKER_HEARTBEAT_MS) || 30000,
-    } = {}) {
-        this.url = url;
-        this.id = id;
-        this.socket = null;
-        this.handlers = new Map();
-        this.onTask = null; // callback(task)
-        this.messageQueue = [];
+  constructor({
+    url = "ws://localhost:7000",
+    id = randomUUID(),
+    heartbeatInterval = Number(process.env.BROKER_HEARTBEAT_MS) || 30000,
+  } = {}) {
+    this.url = url;
+    this.id = id;
+    this.socket = null;
+    this.handlers = new Map();
+    this.onTask = null; // callback(task)
+    this.messageQueue = [];
+    this.reconnectAttempts = 0;
+    this.shouldReconnect = true;
+    this.reconnectTimer = null;
+    this.heartbeatInterval = heartbeatInterval;
+    this.heartbeatTimer = null;
+  }
+
+  connect() {
+    return new Promise((resolve, reject) => {
+      this.socket = new WebSocket(this.url);
+
+      this.socket.once("open", () => {
         this.reconnectAttempts = 0;
-        this.shouldReconnect = true;
-        this.reconnectTimer = null;
-        this.heartbeatInterval = heartbeatInterval;
-        this.heartbeatTimer = null;
-    }
-
-    connect() {
-        return new Promise((resolve, reject) => {
-            this.socket = new WebSocket(this.url);
-
-            this.socket.on('open', () => {
-                this.reconnectAttempts = 0;
-                this.flushQueue();
-                for (const topic of this.handlers.keys()) {
-                    this.socket.send(JSON.stringify({ action: 'subscribe', topic }));
-                }
-                resolve();
-            });
-
-            this.socket.on('error', reject);
-            this.socket.on('open', () => {
-                this.heartbeatTimer = setInterval(() => this.heartbeat(), this.heartbeatInterval);
-                resolve();
-            });
-            this.socket.on('error', reject);
-            this.socket.on('close', () => {
-                if (this.heartbeatTimer) {
-                    clearInterval(this.heartbeatTimer);
-                    this.heartbeatTimer = null;
-                }
-            });
-            this.socket.on('message', (data) => {
-                try {
-                    const msg = JSON.parse(data);
-                    if (msg.action === 'task-assigned' && this.onTask) {
-                        this.onTask(msg.task);
-                    } else if (msg.event) {
-                        const handler = this.handlers.get(msg.event.type);
-                        if (handler) handler(msg.event);
-                    }
-                } catch (err) {
-                    console.warn('Invalid broker message', err);
-                }
-            });
-
-            this.socket.on('close', () => {
-                if (!this.shouldReconnect) return;
-                const delay = Math.min(1000 * 2 ** this.reconnectAttempts, 30000);
-                this.reconnectAttempts += 1;
-                this.reconnectTimer = setTimeout(() => this.connect(), delay);
-            });
-        });
-    }
-
-    subscribe(topic, handler) {
-        this.handlers.set(topic, handler);
-        this.send({ action: 'subscribe', topic });
-    }
-
-    unsubscribe(topic) {
-        this.handlers.delete(topic);
-        this.send({ action: 'unsubscribe', topic });
-    }
-
-    publish(type, payload, opts = {}) {
-        const message = {
-            type,
-            payload,
-            source: this.id,
-            timestamp: new Date().toISOString(),
-            ...opts,
-        };
-
-        this.send({ action: 'publish', message });
-    }
-
-    enqueue(queue, task) {
-        this.send({ action: 'enqueue', queue, task });
-    }
-
-    ready(queue) {
-        this.send({ action: 'ready', queue });
-    }
-
-    ack(taskId) {
-        this.send({ action: 'ack', taskId });
-    }
-
-    heartbeat() {
-        this.send({ action: 'heartbeat' });
-    }
-
-    onTaskReceived(callback) {
-        this.onTask = callback;
-    }
-
-    send(obj) {
-        const msg = JSON.stringify(obj);
-        if (this.socket && this.socket.readyState === WebSocket.OPEN) {
-            this.socket.send(msg);
-        } else {
-            this.messageQueue.push(msg);
+        this.flushQueue();
+        for (const topic of this.handlers.keys()) {
+          this.socket.send(JSON.stringify({ action: "subscribe", topic }));
         }
-    }
+        this.heartbeatTimer = setInterval(
+          () => this.heartbeat(),
+          this.heartbeatInterval,
+        );
+        resolve();
+      });
 
-    flushQueue() {
-        while (
-            this.messageQueue.length > 0 &&
-            this.socket &&
-            this.socket.readyState === WebSocket.OPEN
-        ) {
-            this.socket.send(this.messageQueue.shift());
-        }
-    }
-
-    disconnect() {
-        this.shouldReconnect = false;
-        if (this.reconnectTimer) {
-            clearTimeout(this.reconnectTimer);
-            this.reconnectTimer = null;
-        }
+      this.socket.on("error", reject);
+      this.socket.on("close", () => {
         if (this.heartbeatTimer) {
-            clearInterval(this.heartbeatTimer);
-            this.heartbeatTimer = null;
+          clearInterval(this.heartbeatTimer);
+          this.heartbeatTimer = null;
         }
-        if (this.socket) {
-            this.socket.close();
-            this.socket = null;
+      });
+      this.socket.on("message", (data) => {
+        try {
+          const msg = JSON.parse(data);
+          if (msg.action === "task-assigned" && this.onTask) {
+            this.onTask(msg.task);
+          } else if (msg.event) {
+            const handler = this.handlers.get(msg.event.type);
+            if (handler) handler(msg.event);
+          }
+        } catch (err) {
+          console.warn("Invalid broker message", err);
         }
+      });
+
+      this.socket.on("close", () => {
+        if (!this.shouldReconnect) return;
+        const delay = Math.min(1000 * 2 ** this.reconnectAttempts, 30000);
+        this.reconnectAttempts += 1;
+        this.reconnectTimer = setTimeout(() => this.connect(), delay);
+      });
+    });
+  }
+
+  subscribe(topic, handler) {
+    this.handlers.set(topic, handler);
+    this.send({ action: "subscribe", topic });
+  }
+
+  unsubscribe(topic) {
+    this.handlers.delete(topic);
+    this.send({ action: "unsubscribe", topic });
+  }
+
+  publish(type, payload, opts = {}) {
+    const message = {
+      type,
+      payload,
+      source: this.id,
+      timestamp: new Date().toISOString(),
+      ...opts,
+    };
+
+    this.send({ action: "publish", message });
+  }
+
+  enqueue(queue, task) {
+    this.send({ action: "enqueue", queue, task });
+  }
+
+  ready(queue) {
+    this.send({ action: "ready", queue });
+  }
+
+  ack(taskId) {
+    this.send({ action: "ack", taskId });
+  }
+
+  heartbeat() {
+    this.send({ action: "heartbeat" });
+  }
+
+  onTaskReceived(callback) {
+    this.onTask = callback;
+  }
+
+  send(obj) {
+    const msg = JSON.stringify(obj);
+    if (this.socket && this.socket.readyState === WebSocket.OPEN) {
+      this.socket.send(msg);
+    } else {
+      this.messageQueue.push(msg);
     }
+  }
+
+  flushQueue() {
+    while (
+      this.messageQueue.length > 0 &&
+      this.socket &&
+      this.socket.readyState === WebSocket.OPEN
+    ) {
+      this.socket.send(this.messageQueue.shift());
+    }
+  }
+
+  disconnect() {
+    this.shouldReconnect = false;
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
+    if (this.heartbeatTimer) {
+      clearInterval(this.heartbeatTimer);
+      this.heartbeatTimer = null;
+    }
+    if (this.socket) {
+      this.socket.close();
+      this.socket = null;
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- use a single broker `open` handler that resets counters, flushes queued messages, and starts heartbeats
- remove duplicate connection handler to prevent multiple resolves

## Testing
- `make setup-js`
- `make format-js` *(fails: SyntaxError in other files)*
- `pnpm biome format shared/js/brokerClient.js --write`
- `make lint-js` *(fails: ESLint flat config extends unsupported)*
- `pnpm biome lint shared/js/brokerClient.js`
- `make test-js` *(fails: test-js-services command failure)*
- `pnpm test`
- `make build-js`


------
https://chatgpt.com/codex/tasks/task_e_68ae665b87bc83248dcc0a080154aa73