### PR TITLE
fix health service shutdown

### DIFF
--- a/changelog.d/0000.fixed.md
+++ b/changelog.d/0000.fixed.md
@@ -1,0 +1,1 @@
+Await broker disconnect in health service and ensure tests clean up heartbeat clients.

--- a/services/js/health/index.js
+++ b/services/js/health/index.js
@@ -1,6 +1,6 @@
-import express from 'express';
-import os from 'os';
-import { BrokerClient } from '@shared/js/brokerClient.js';
+import express from "express";
+import os from "os";
+import { BrokerClient } from "@shared/js/brokerClient.js";
 
 export const app = express();
 
@@ -9,66 +9,68 @@ let server;
 let broker;
 const heartbeats = new Map();
 
-app.get('/health', (req, res) => {
-    const now = Date.now();
-    let totalCpu = 0;
-    let totalMemory = 0;
-    for (const hb of heartbeats.values()) {
-        if (hb.last >= now - HEARTBEAT_TIMEOUT) {
-            totalCpu += hb.cpu || 0;
-            totalMemory += hb.memory || 0;
-        }
+app.get("/health", (req, res) => {
+  const now = Date.now();
+  let totalCpu = 0;
+  let totalMemory = 0;
+  for (const hb of heartbeats.values()) {
+    if (hb.last >= now - HEARTBEAT_TIMEOUT) {
+      totalCpu += hb.cpu || 0;
+      totalMemory += hb.memory || 0;
     }
-    const cores = os.cpus().length || 1;
-    const cpuRatio = totalCpu / (cores * 100);
-    const totalMem = os.totalmem() || 1;
-    const memoryRatio = totalMemory / totalMem;
-    let status = 'ok';
-    if (cpuRatio > 0.9 || memoryRatio > 0.9) status = 'critical';
-    else if (cpuRatio > 0.75 || memoryRatio > 0.75) status = 'high';
-    return res.json({
-        status,
-        cpu: { total: totalCpu, ratio: cpuRatio },
-        memory: { total: totalMemory, ratio: memoryRatio },
-    });
+  }
+  const cores = os.cpus().length || 1;
+  const cpuRatio = totalCpu / (cores * 100);
+  const totalMem = os.totalmem() || 1;
+  const memoryRatio = totalMemory / totalMem;
+  let status = "ok";
+  if (cpuRatio > 0.9 || memoryRatio > 0.9) status = "critical";
+  else if (cpuRatio > 0.75 || memoryRatio > 0.75) status = "high";
+  return res.json({
+    status,
+    cpu: { total: totalCpu, ratio: cpuRatio },
+    memory: { total: totalMemory, ratio: memoryRatio },
+  });
 });
 
 export async function start(port = process.env.PORT || 0) {
-    HEARTBEAT_TIMEOUT = parseInt(process.env.HEARTBEAT_TIMEOUT || '10000', 10);
-    const url = process.env.BROKER_URL || `ws://127.0.0.1:${process.env.BROKER_PORT || 7000}`;
-    broker = new BrokerClient({ url });
-    heartbeats.clear();
-    await broker.connect();
-    broker.subscribe('heartbeat', (event) => {
-        const { name, cpu = 0, memory = 0 } = event.payload || {};
-        const key = name || event.source;
-        heartbeats.set(key, { cpu, memory, last: Date.now() });
-    });
-    server = app.listen(port);
-    return server;
+  HEARTBEAT_TIMEOUT = parseInt(process.env.HEARTBEAT_TIMEOUT || "10000", 10);
+  const url =
+    process.env.BROKER_URL ||
+    `ws://127.0.0.1:${process.env.BROKER_PORT || 7000}`;
+  broker = new BrokerClient({ url });
+  heartbeats.clear();
+  await broker.connect();
+  broker.subscribe("heartbeat", (event) => {
+    const { name, cpu = 0, memory = 0 } = event.payload || {};
+    const key = name || event.source;
+    heartbeats.set(key, { cpu, memory, last: Date.now() });
+  });
+  server = app.listen(port);
+  return server;
 }
 
 export async function stop() {
-    if (server) {
-        server.close();
-        server = null;
-    }
-    if (broker) {
-        try {
-            broker.disconnect();
-        } catch {}
-        broker = null;
-    }
-    heartbeats.clear();
+  if (server) {
+    await new Promise((resolve) => server.close(resolve));
+    server = null;
+  }
+  if (broker) {
+    try {
+      await broker.disconnect();
+    } catch {}
+    broker = null;
+  }
+  heartbeats.clear();
 }
 
 export function reset() {
-    heartbeats.clear();
+  heartbeats.clear();
 }
 
-if (process.env.NODE_ENV !== 'test') {
-    start(process.env.PORT || 5006).catch((err) => {
-        console.error('Failed to start health service', err);
-        process.exit(1);
-    });
+if (process.env.NODE_ENV !== "test") {
+  start(process.env.PORT || 5006).catch((err) => {
+    console.error("Failed to start health service", err);
+    process.exit(1);
+  });
 }

--- a/services/js/health/tests/health.test.js
+++ b/services/js/health/tests/health.test.js
@@ -20,7 +20,12 @@ async function sendHeartbeat(payload) {
   client.publish("heartbeat", payload);
   await new Promise((r) => setTimeout(r, 50));
   // Ensure we don’t schedule reconnect timers that keep the process alive.
-  client.disconnect();
+  await new Promise((resolve) => {
+    const sock = client.socket;
+    if (sock) sock.once("close", resolve);
+    else resolve();
+    client.disconnect();
+  });
 }
 
 test.before(async () => {


### PR DESCRIPTION
## Summary
- ensure health service stop waits for broker disconnect and server close
- clean up heartbeat clients in health tests

## Testing
- `pnpm --filter ./services/js/health lint`
- `pnpm --filter ./services/js/health test`
- `pre-commit run --files services/js/health/index.js services/js/health/tests/health.test.js changelog.d/0000.fixed.md` *(fails: hashtags_to_kanban.py: error: unrecognized arguments: --check)*

------
https://chatgpt.com/codex/tasks/task_e_68ae6649aa248324b839c4dec4d99fce