### PR TITLE
chore: add service test hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,54 +1,89 @@
 repos:
-    - repo: local
-      hooks:
-          - id: generate-orphan-docs
-            name: Generate docs for orphaned files
-            entry: python scripts/generate_orphan_docs.py
-            language: system
-            pass_filenames: false
-            files: ^orphaned-files-report\.md$
-          - id: enforce-wiki-links
-            name: Enforce Wikilinks
-            entry: python scripts/kanban/hashtags_to_kanban.py --check --write --wikilinks
-            language: system
-            pass_filenames: false
-          - id: tsc-no-emit
-            name: TypeScript compile check
-            entry: make ts-type-check
-            language: system
-            types_or: [javascript, ts, tsx]
-            pass_filenames: false
-          - id: pytest
-            name: Python tests
-            entry: pytest -q
-            language: system
-            types: [python]
-            pass_filenames: false
-          - id: full-build
-            name: Full build
-            entry: make build
-            language: system
-            pass_filenames: false
-            stages: [manual]
+  - repo: local
+    hooks:
+      - id: generate-orphan-docs
+        name: Generate docs for orphaned files
+        entry: python scripts/generate_orphan_docs.py
+        language: system
+        pass_filenames: false
+        files: ^orphaned-files-report\.md$
+      - id: enforce-wiki-links
+        name: Enforce Wikilinks
+        entry: python scripts/kanban/hashtags_to_kanban.py --check --write --wikilinks
+        language: system
+        pass_filenames: false
+      - id: tsc-no-emit
+        name: TypeScript compile check
+        entry: make ts-type-check
+        language: system
+        types_or: [javascript, ts, tsx]
+        pass_filenames: false
+      - id: pytest
+        name: Python tests
+        entry: pytest -q
+        language: system
+        types: [python]
+        pass_filenames: false
+      - id: test-js-services
+        name: Run JS service tests
+        entry: pnpm test
+        language: system
+        files: ^services/js/
+        pass_filenames: false
+        stages: [manual]
+      - id: test-ts-services
+        name: Run TS service tests
+        entry: pnpm test
+        language: system
+        files: ^services/ts/
+        pass_filenames: false
+        stages: [manual]
+      - id: test-shared-js
+        name: Run shared JS library tests
+        entry: pnpm test
+        language: system
+        files: ^shared/js/
+        pass_filenames: false
+        stages: [manual]
+      - id: test-shared-ts
+        name: Run shared TS library tests
+        entry: pnpm test
+        language: system
+        files: ^shared/ts/
+        pass_filenames: false
+        stages: [manual]
+      - id: test-migration-fixtures
+        name: Run migration fixture tests
+        entry: pnpm test
+        language: system
+        files: ^(services/ts/migrations|shared/ts/src/migrations|tests/fixtures/migrations)/
+        pass_filenames: false
+        stages: [manual]
+      - id: full-build
+        name: Full build
+        entry: make build
+        language: system
+        pass_filenames: false
+        stages: [manual]
 
-    - repo: https://github.com/psf/black
-      rev: 24.4.2
-      hooks:
-          - id: black
-            language_version: python3
-    - repo: https://github.com/pycqa/flake8
-      rev: 7.3.0
-      hooks:
-          - id: flake8
-    - repo: https://github.com/pre-commit/mirrors-eslint
-      rev: v9.32.0
-      hooks:
-          - id: eslint
-            types: [javascript, ts, tsx]
-    - repo: https://github.com/pre-commit/mirrors-prettier
-      rev: v3.1.0
-      hooks:
-          - id: prettier
-            types_or: [javascript, ts, tsx, json, yaml]
-            exclude: ^legacy/
-            args: [--ignore-path=.prettierignore]
+  - repo: https://github.com/psf/black
+    rev: 24.4.2
+    hooks:
+      - id: black
+        language_version: python3
+  - repo: https://github.com/pycqa/flake8
+    rev: 7.3.0
+    hooks:
+      - id: flake8
+  - repo: https://github.com/pre-commit/mirrors-eslint
+    rev: v9.32.0
+    hooks:
+      - id: eslint
+        types: [javascript, ts, tsx]
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: v3.1.0
+    hooks:
+      - id: prettier
+        types_or: [javascript, ts, tsx, json, yaml]
+        exclude: ^legacy/
+        args: [--ignore-path=.prettierignore]

--- a/changelog.d/99990.added.md
+++ b/changelog.d/99990.added.md
@@ -1,0 +1,1 @@
+Add manual pre-commit hooks to run JS, TS, shared library, and migration fixture tests.


### PR DESCRIPTION
## Summary
- add manual pre-commit hooks to run tests for JS/TS services, shared libraries, and migrations

## Testing
- `pnpm test`
- `pre-commit run --hook-stage manual test-js-services --files services/js/heartbeat/package.json`
- `pre-commit run --hook-stage manual test-ts-services --files services/ts/discord-gateway/package.json`
- `pre-commit run --hook-stage manual test-shared-ts --files shared/ts/package.json`
- `pre-commit run --hook-stage manual test-migration-fixtures --files services/ts/migrations/package.json`
- `pre-commit run prettier --files .pre-commit-config.yaml changelog.d/99990.added.md`


------
https://chatgpt.com/codex/tasks/task_e_68ae694536f0832486d576dda4a03ae1