### PR TITLE
Fix auth-service test script pattern

### DIFF
--- a/changelog.d/auth-service-test-script.changed.md
+++ b/changelog.d/auth-service-test-script.changed.md
@@ -1,0 +1,1 @@
+fix test script for auth-service to target .test.mjs files

--- a/services/ts/auth-service/package.json
+++ b/services/ts/auth-service/package.json
@@ -1,26 +1,26 @@
 {
-    "name": "auth-service",
-    "version": "0.1.0",
-    "private": true,
-    "type": "module",
-    "main": "dist/index.js",
-    "scripts": {
-        "build": "tsc",
-        "prestart": "pnpm run build",
-        "start": "node dist/src/index.js",
-        "start:dev": "node --loader ts-node/esm src/index.ts",
-        "build:check": "tsc --noEmit --incremental false",
-        "lint": "prettier --cache --check . && eslint . --cache || true",
-        "format": "prettier --cache --write . && eslint . --fix --cache || true",
-        "test": "pnpm run build && node --test test"
-    },
-    "dependencies": {
-        "fastify": "^4.28.1",
-        "jose": "^5.9.6"
-    },
-    "devDependencies": {
-        "@types/node": "^22.17.2",
-        "ts-node": "^10.9.2",
-        "typescript": "^5.7.3"
-    }
+  "name": "auth-service",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "dist/index.js",
+  "scripts": {
+    "build": "tsc",
+    "prestart": "pnpm run build",
+    "start": "node dist/src/index.js",
+    "start:dev": "node --loader ts-node/esm src/index.ts",
+    "build:check": "tsc --noEmit --incremental false",
+    "lint": "prettier --cache --check . && eslint . --cache || true",
+    "format": "prettier --cache --write . && eslint . --fix --cache || true",
+    "test": "pnpm run build && node --test test/*.test.mjs"
+  },
+  "dependencies": {
+    "fastify": "^4.28.1",
+    "jose": "^5.9.6"
+  },
+  "devDependencies": {
+    "@types/node": "^22.17.2",
+    "ts-node": "^10.9.2",
+    "typescript": "^5.7.3"
+  }
 }


### PR DESCRIPTION
## Summary
- run auth-service tests by targeting *.test.mjs files directly
- record changelog entry for auth-service test script

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68ae6965d2e08324999fb187242dadac