### PR TITLE
Use FastAPI lifespan in TTS service

### DIFF
--- a/changelog.d/12346.changed.md
+++ b/changelog.d/12346.changed.md
@@ -1,0 +1,1 @@
+Replace on_event with FastAPI lifespan in TTS service and ensure broker shutdown.


### PR DESCRIPTION
## Summary
- use FastAPI lifespan context to start and stop broker in TTS app
- add changelog entry for TTS lifespan refactor

## Testing
- `make lint-python-service-tts` *(fails: NameError: 'unless' is not defined)*
- `make format-python`
- `pytest services/py/tts/tests`


------
https://chatgpt.com/codex/tasks/task_e_68ae6964ad9883248fe0cbf08969aa56