### PR TITLE
feat: add manual integration test hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,54 +1,60 @@
 repos:
-    - repo: local
-      hooks:
-          - id: generate-orphan-docs
-            name: Generate docs for orphaned files
-            entry: python scripts/generate_orphan_docs.py
-            language: system
-            pass_filenames: false
-            files: ^orphaned-files-report\.md$
-          - id: enforce-wiki-links
-            name: Enforce Wikilinks
-            entry: python scripts/kanban/hashtags_to_kanban.py --check --write --wikilinks
-            language: system
-            pass_filenames: false
-          - id: tsc-no-emit
-            name: TypeScript compile check
-            entry: make ts-type-check
-            language: system
-            types_or: [javascript, ts, tsx]
-            pass_filenames: false
-          - id: pytest
-            name: Python tests
-            entry: pytest -q
-            language: system
-            types: [python]
-            pass_filenames: false
-          - id: full-build
-            name: Full build
-            entry: make build
-            language: system
-            pass_filenames: false
-            stages: [manual]
+  - repo: local
+    hooks:
+      - id: generate-orphan-docs
+        name: Generate docs for orphaned files
+        entry: python scripts/generate_orphan_docs.py
+        language: system
+        pass_filenames: false
+        files: ^orphaned-files-report\.md$
+      - id: enforce-wiki-links
+        name: Enforce Wikilinks
+        entry: python scripts/kanban/hashtags_to_kanban.py --check --write --wikilinks
+        language: system
+        pass_filenames: false
+      - id: tsc-no-emit
+        name: TypeScript compile check
+        entry: make ts-type-check
+        language: system
+        types_or: [javascript, ts, tsx]
+        pass_filenames: false
+      - id: pytest
+        name: Python tests
+        entry: pytest -q
+        language: system
+        types: [python]
+        pass_filenames: false
+      - id: full-build
+        name: Full build
+        entry: make build
+        language: system
+        pass_filenames: false
+        stages: [manual]
+      - id: integration-tests
+        name: Integration and E2E tests
+        entry: make test-integration && make test-e2e
+        language: system
+        pass_filenames: false
+        stages: [manual]
 
-    - repo: https://github.com/psf/black
-      rev: 24.4.2
-      hooks:
-          - id: black
-            language_version: python3
-    - repo: https://github.com/pycqa/flake8
-      rev: 7.3.0
-      hooks:
-          - id: flake8
-    - repo: https://github.com/pre-commit/mirrors-eslint
-      rev: v9.32.0
-      hooks:
-          - id: eslint
-            types: [javascript, ts, tsx]
-    - repo: https://github.com/pre-commit/mirrors-prettier
-      rev: v3.1.0
-      hooks:
-          - id: prettier
-            types_or: [javascript, ts, tsx, json, yaml]
-            exclude: ^legacy/
-            args: [--ignore-path=.prettierignore]
+  - repo: https://github.com/psf/black
+    rev: 24.4.2
+    hooks:
+      - id: black
+        language_version: python3
+  - repo: https://github.com/pycqa/flake8
+    rev: 7.3.0
+    hooks:
+      - id: flake8
+  - repo: https://github.com/pre-commit/mirrors-eslint
+    rev: v9.32.0
+    hooks:
+      - id: eslint
+        types: [javascript, ts, tsx]
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: v3.1.0
+    hooks:
+      - id: prettier
+        types_or: [javascript, ts, tsx, json, yaml]
+        exclude: ^legacy/
+        args: [--ignore-path=.prettierignore]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,6 +63,14 @@ Corepack enforcement: The root `package.json` sets `"packageManager": "pnpm@9"` 
 Pre-commit runs quick checks (`pnpm tsc --noEmit` and `pytest -q`) instead of the full build. Run the full build separately with
 `make build` or via `pre-commit run --hook-stage manual full-build` in CI.
 
+Before pushing complex changes, manually trigger heavier tests with:
+
+```bash
+pre-commit run --hook-stage manual integration-tests
+```
+
+This runs `make test-integration` and `make test-e2e` to surface cross-module issues.
+
 All contributions must be validated locally before opening a pull request:
 
 1. **Run `make setup` for the relevant services only.** Avoid global setup.

--- a/changelog.d/6321.added.md
+++ b/changelog.d/6321.added.md
@@ -1,0 +1,1 @@
+Added manual pre-commit hook to run integration and end-to-end tests.

--- a/docs/pre-commit.md
+++ b/docs/pre-commit.md
@@ -32,3 +32,15 @@ git ls-files -z | xargs -0 pre-commit run --files
 
 The CI workflow runs the same command to verify that committed files pass
 the configured hooks.
+
+## Manual stage hooks
+
+Heavy checks such as integration and end-to-end tests run in the `manual`
+hook stage. Trigger them explicitly before pushing substantial changes:
+
+```bash
+pre-commit run --hook-stage manual integration-tests
+```
+
+This executes `make test-integration` followed by `make test-e2e` so you can
+catch cross-module issues early.


### PR DESCRIPTION
## Summary
- run integration and E2E tests through a manual pre-commit hook
- document manual hook usage for heavier checks
- note integration test hook in CI guidelines

## Testing
- `SKIP=enforce-wiki-links pre-commit run --files .pre-commit-config.yaml docs/pre-commit.md AGENTS.md changelog.d/6321.added.md`
- `pre-commit run --hook-stage manual integration-tests` *(fails: ModuleNotFoundError: No module named 'services.py.markdown_graph')*

------
https://chatgpt.com/codex/tasks/task_e_68ae695ba2cc8324a9e62b841c2b7a26