### PR TITLE
Lazy-init TTS models with optional offline mode

### DIFF
--- a/changelog.d/tts-offline.fixed.md
+++ b/changelog.d/tts-offline.fixed.md
@@ -1,0 +1,1 @@
+Move TTS model initialization to startup and allow offline downloads.

--- a/services/py/tts/app.py
+++ b/services/py/tts/app.py
@@ -1,8 +1,6 @@
 from fastapi import FastAPI, Form, Response, WebSocket
 import io
-import sys
-
-print(sys.path)
+import os
 from shared.py.service_template import start_service
 from shared.py.speech.audio_utils import wav_to_base64
 from shared.py.utils import websocket_endpoint
@@ -12,9 +10,35 @@ import soundfile as sf
 import nltk
 import torch
 import numpy as np
-from transformers import FastSpeech2ConformerTokenizer, FastSpeech2ConformerWithHifiGan
+from transformers import (
+    FastSpeech2ConformerTokenizer,
+    FastSpeech2ConformerWithHifiGan,
+)
 
-nltk.download("averaged_perceptron_tagger_eng")
+TOKENIZER = None
+MODEL = None
+DEVICE = None
+
+
+def init_tts() -> None:
+    """Load tokenizer and model if they haven't been initialized."""
+    global TOKENIZER, MODEL, DEVICE
+    if TOKENIZER is not None and MODEL is not None:
+        return
+    skip_downloads = os.environ.get("TTS_SKIP_DOWNLOADS") == "1"
+    if not skip_downloads:
+        nltk.download("averaged_perceptron_tagger_eng", quiet=True)
+    DEVICE = "cuda" if torch.cuda.is_available() else "cpu"
+    print("Running on device", DEVICE)
+    TOKENIZER = FastSpeech2ConformerTokenizer.from_pretrained(
+        "espnet/fastspeech2_conformer", local_files_only=skip_downloads
+    )
+    MODEL = FastSpeech2ConformerWithHifiGan.from_pretrained(
+        "espnet/fastspeech2_conformer_with_hifigan",
+        use_safetensors=True,
+        local_files_only=skip_downloads,
+    ).to(DEVICE)
+
 
 app = FastAPI()
 broker = None
@@ -23,6 +47,7 @@ broker = None
 @app.on_event("startup")
 async def startup_event():
     global broker
+    init_tts()
 
     async def handle_task(task):
         payload = task.get("payload", {})
@@ -47,25 +72,12 @@ def shutdown_event():
     pass
 
 
-# Load the model and processor
-
-# Ensure GPU usage
-device = "cuda" if torch.cuda.is_available() else "cpu"
-print("Running on device", device)
-
-tokenizer = FastSpeech2ConformerTokenizer.from_pretrained(
-    "espnet/fastspeech2_conformer"
-)
-model = FastSpeech2ConformerWithHifiGan.from_pretrained(
-    "espnet/fastspeech2_conformer_with_hifigan", use_safetensors=True
-).to(device)
-
-
 def synthesize(text: str) -> np.ndarray:
     """Generate a waveform for the provided text."""
-    input_ids = tokenizer(text, return_tensors="pt").input_ids.to(device)
+    init_tts()
+    input_ids = TOKENIZER(text, return_tensors="pt").input_ids.to(DEVICE)
     with torch.no_grad():
-        output = model(input_ids, return_dict=True)
+        output = MODEL(input_ids, return_dict=True)
         return output.waveform.squeeze().cpu().numpy()
 
 


### PR DESCRIPTION
## Summary
- defer TTS tokenizer and model loading to startup with `init_tts`
- allow offline execution via `TTS_SKIP_DOWNLOADS` environment flag
- remove stray `sys.path` print

## Testing
- `make setup-quick SERVICE=tts` *(fails: no version of torch==2.7.1+cpu)*
- `black services/py/tts/app.py`
- `flake8 services/py/tts/app.py`
- `pytest services/py/tts/tests/test_tts_websocket.py -q`
- `make build-python SERVICE=tts`


------
https://chatgpt.com/codex/tasks/task_e_68ae6e9558a083249b95178643a08d1f