### PR TITLE
Add changelog validation pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,54 +1,60 @@
 repos:
-    - repo: local
-      hooks:
-          - id: generate-orphan-docs
-            name: Generate docs for orphaned files
-            entry: python scripts/generate_orphan_docs.py
-            language: system
-            pass_filenames: false
-            files: ^orphaned-files-report\.md$
-          - id: enforce-wiki-links
-            name: Enforce Wikilinks
-            entry: python scripts/kanban/hashtags_to_kanban.py --check --write --wikilinks
-            language: system
-            pass_filenames: false
-          - id: tsc-no-emit
-            name: TypeScript compile check
-            entry: make ts-type-check
-            language: system
-            types_or: [javascript, ts, tsx]
-            pass_filenames: false
-          - id: pytest
-            name: Python tests
-            entry: pytest -q
-            language: system
-            types: [python]
-            pass_filenames: false
-          - id: full-build
-            name: Full build
-            entry: make build
-            language: system
-            pass_filenames: false
-            stages: [manual]
+  - repo: local
+    hooks:
+      - id: generate-orphan-docs
+        name: Generate docs for orphaned files
+        entry: python scripts/generate_orphan_docs.py
+        language: system
+        pass_filenames: false
+        files: ^orphaned-files-report\.md$
+      - id: enforce-wiki-links
+        name: Enforce Wikilinks
+        entry: python scripts/kanban/hashtags_to_kanban.py --check --write --wikilinks
+        language: system
+        pass_filenames: false
+      - id: changelog-fragments
+        name: Changelog fragments check
+        entry: python scripts/check_changelog.py
+        language: system
+        files: ^(changelog\.d/|CHANGELOG\.md$)
+        pass_filenames: false
+      - id: tsc-no-emit
+        name: TypeScript compile check
+        entry: make ts-type-check
+        language: system
+        types_or: [javascript, ts, tsx]
+        pass_filenames: false
+      - id: pytest
+        name: Python tests
+        entry: pytest -q
+        language: system
+        types: [python]
+        pass_filenames: false
+      - id: full-build
+        name: Full build
+        entry: make build
+        language: system
+        pass_filenames: false
+        stages: [manual]
 
-    - repo: https://github.com/psf/black
-      rev: 24.4.2
-      hooks:
-          - id: black
-            language_version: python3
-    - repo: https://github.com/pycqa/flake8
-      rev: 7.3.0
-      hooks:
-          - id: flake8
-    - repo: https://github.com/pre-commit/mirrors-eslint
-      rev: v9.32.0
-      hooks:
-          - id: eslint
-            types: [javascript, ts, tsx]
-    - repo: https://github.com/pre-commit/mirrors-prettier
-      rev: v3.1.0
-      hooks:
-          - id: prettier
-            types_or: [javascript, ts, tsx, json, yaml]
-            exclude: ^legacy/
-            args: [--ignore-path=.prettierignore]
+  - repo: https://github.com/psf/black
+    rev: 24.4.2
+    hooks:
+      - id: black
+        language_version: python3
+  - repo: https://github.com/pycqa/flake8
+    rev: 7.3.0
+    hooks:
+      - id: flake8
+  - repo: https://github.com/pre-commit/mirrors-eslint
+    rev: v9.32.0
+    hooks:
+      - id: eslint
+        types: [javascript, ts, tsx]
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: v3.1.0
+    hooks:
+      - id: prettier
+        types_or: [javascript, ts, tsx, json, yaml]
+        exclude: ^legacy/
+        args: [--ignore-path=.prettierignore]

--- a/docs/pre-commit.md
+++ b/docs/pre-commit.md
@@ -32,3 +32,10 @@ git ls-files -z | xargs -0 pre-commit run --files
 
 The CI workflow runs the same command to verify that committed files pass
 the configured hooks.
+
+## Changelog fragments
+
+A custom hook blocks commits that modify `CHANGELOG.md` directly or add
+multiple fragments for the same pull request in `changelog.d/`. Run
+`pre-commit run --files changelog.d/<fragment>.md` after creating a
+changelog entry to ensure the check passes.

--- a/scripts/check_changelog.py
+++ b/scripts/check_changelog.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Pre-commit hook to validate changelog entries.
+
+- Ensures each PR adds at most one fragment in ``changelog.d`` by checking for
+  duplicate filename prefixes.
+- Fails if ``CHANGELOG.md`` is staged for commit.
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+CHANGELOG_DIR = REPO_ROOT / "changelog.d"
+CHANGELOG_MD = REPO_ROOT / "CHANGELOG.md"
+
+
+def check_duplicate_fragments() -> bool:
+    """Return ``True`` if no duplicate changelog fragment prefixes exist."""
+    prefixes: dict[str, Path] = {}
+    for fragment in CHANGELOG_DIR.glob("*.md"):
+        prefix = fragment.name.split(".")[0]
+        if prefix in prefixes:
+            print(
+                "Duplicate changelog fragments detected for PR",
+                prefix,
+                f"({prefixes[prefix].name}, {fragment.name})",
+                file=sys.stderr,
+            )
+            return False
+        prefixes[prefix] = fragment
+    return True
+
+
+def changelog_modified() -> bool:
+    """Return ``True`` if ``CHANGELOG.md`` is staged for commit."""
+    result = subprocess.run(
+        ["git", "diff", "--name-only", "--cached", str(CHANGELOG_MD)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return bool(result.stdout.strip())
+
+
+def main() -> int:
+    ok = True
+    if not check_duplicate_fragments():
+        ok = False
+    if changelog_modified():
+        print(
+            "Direct modifications to CHANGELOG.md are not allowed. "
+            "Add a fragment under changelog.d/ instead.",
+            file=sys.stderr,
+        )
+        ok = False
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- ensure changelog fragments have unique filenames and forbid direct `CHANGELOG.md` edits
- document new pre-commit hook

## Testing
- `pre-commit run --files .pre-commit-config.yaml scripts/check_changelog.py docs/pre-commit.md` *(fails: import file mismatches and missing PyTorch)*
- `pip install numpy httpx fastapi websockets discord.py ollama`
- `pip install transformers soundfile pymongo requests inflect scipy uvicorn`

------
https://chatgpt.com/codex/tasks/task_e_68ae6e85a9548324b1df8d24cbac106c