### PR TITLE
feat(vision): add stop function and clean test shutdown

### DIFF
--- a/changelog.d/1234.fixed.md
+++ b/changelog.d/1234.fixed.md
@@ -1,0 +1,1 @@
+Ensure vision service can shut down cleanly by exposing a stop function and updating tests.

--- a/services/js/vision/index.js
+++ b/services/js/vision/index.js
@@ -1,134 +1,191 @@
 // vision service
-import express from 'express';
-import { spawn } from 'node:child_process';
-import { HeartbeatClient } from '../../../shared/js/heartbeat/index.js';
-import { startService } from '../../../shared/js/serviceTemplate.js';
-import { WebSocketServer } from 'ws';
+import express from "express";
+import { spawn } from "node:child_process";
+import { HeartbeatClient } from "../../../shared/js/heartbeat/index.js";
+import { WebSocketServer } from "ws";
+import { BrokerClient } from "../../../shared/js/brokerClient.js";
 
 export const app = express();
 
 // --- streaming capture (no maxBuffer) ---
 const W = Number(process.env.SCREEN_W) || 2560;
 const H = Number(process.env.SCREEN_H) || 1600;
-const FORMAT = (process.env.VISION_FORMAT || 'png').toLowerCase();
+const FORMAT = (process.env.VISION_FORMAT || "png").toLowerCase();
 
 async function captureStreamed() {
-    const args = ['-silent', '-window', 'root', '-crop', `${W}x${H}+0+0`, '-screen'];
+  const args = [
+    "-silent",
+    "-window",
+    "root",
+    "-crop",
+    `${W}x${H}+0+0`,
+    "-screen",
+  ];
 
-    if (FORMAT === 'png') {
-        args.push('-depth', '8', '-strip', 'png:-');
-    } else if (FORMAT === 'jpg' || FORMAT === 'jpeg') {
-        args.push('-quality', process.env.VISION_QUALITY || '85', 'jpg:-');
-    } else if (FORMAT === 'webp') {
-        args.push('-quality', process.env.VISION_QUALITY || '85', 'webp:-');
-    } else {
-        throw new Error(`Unsupported format: ${FORMAT}`);
-    }
+  if (FORMAT === "png") {
+    args.push("-depth", "8", "-strip", "png:-");
+  } else if (FORMAT === "jpg" || FORMAT === "jpeg") {
+    args.push("-quality", process.env.VISION_QUALITY || "85", "jpg:-");
+  } else if (FORMAT === "webp") {
+    args.push("-quality", process.env.VISION_QUALITY || "85", "webp:-");
+  } else {
+    throw new Error(`Unsupported format: ${FORMAT}`);
+  }
 
-    return new Promise((resolve, reject) => {
-        const p = spawn('import', args, { stdio: ['ignore', 'pipe', 'pipe'] });
-        const bufs = [];
-        let stderr = '';
-        p.stdout.on('data', (d) => bufs.push(d));
-        p.stderr.on('data', (d) => (stderr += d));
-        p.on('error', reject);
-        p.on('close', (code) => {
-            if (code !== 0) return reject(new Error(`import exited ${code}: ${stderr}`));
-            resolve(Buffer.concat(bufs));
-        });
+  return new Promise((resolve, reject) => {
+    const p = spawn("import", args, { stdio: ["ignore", "pipe", "pipe"] });
+    const bufs = [];
+    let stderr = "";
+    p.stdout.on("data", (d) => bufs.push(d));
+    p.stderr.on("data", (d) => (stderr += d));
+    p.on("error", reject);
+    p.on("close", (code) => {
+      if (code !== 0)
+        return reject(new Error(`import exited ${code}: ${stderr}`));
+      resolve(Buffer.concat(bufs));
     });
+  });
 }
 
 let capture = captureStreamed;
 if (process.env.VISION_STUB) {
-    capture = async () => Buffer.from('stub');
+  capture = async () => Buffer.from("stub");
 }
 
 export function setCaptureFn(fn) {
-    capture = fn;
+  capture = fn;
 }
+
+let hb;
+let server;
+let wss;
+let broker;
 
 export async function start(port = process.env.PORT || 5003) {
+  if (process.env.NODE_ENV !== "test") {
     try {
-        const hb = new HeartbeatClient({ name: process.env.name || 'vision' });
-        await hb.sendOnce();
-        hb.start();
-    } catch {}
+      hb = new HeartbeatClient({ name: process.env.name || "vision" });
+      await hb.sendOnce();
+      hb.start();
+    } catch {
+      try {
+        hb?.stop();
+      } catch {}
+      hb = null;
+    }
+  }
 
-    const server = app.listen(port, () => {
-        console.log(`vision service listening on ${port}`);
-    });
+  server = app.listen(port, () => {
+    console.log(`vision service listening on ${port}`);
+  });
 
-    // Helpful WS tweaks: lower CPU and add simple “busy” gate
-    const wss = new WebSocketServer({
-        server,
-        path: '/capture',
-        perMessageDeflate: { threshold: 64 * 1024 }, // avoid compressing giant frames
-        // maxPayload defaults to 100 MiB; leave it unless you want stricter limits
-    });
+  // Helpful WS tweaks: lower CPU and add simple “busy” gate
+  wss = new WebSocketServer({
+    server,
+    path: "/capture",
+    perMessageDeflate: { threshold: 64 * 1024 }, // avoid compressing giant frames
+    // maxPayload defaults to 100 MiB; leave it unless you want stricter limits
+  });
 
-    wss.on('connection', (ws) => {
-        let busy = false;
-        ws.on('message', async () => {
-            if (busy || ws.readyState !== ws.OPEN) return;
-            busy = true;
-            try {
-                const img = await capture();
-                // Backpressure: if network is slow, avoid piling up
-                if (ws.readyState === ws.OPEN && ws.bufferedAmount < 16 * 1024 * 1024) {
-                    ws.send(img, { binary: true });
-                }
-            } catch (e) {
-                console.error('capture failed', e);
-                if (ws.readyState === ws.OPEN) ws.send(JSON.stringify({ error: 'capture_failed' }));
-            } finally {
-                busy = false;
-            }
-        });
-    });
-
-    let broker;
-    const handleTask = async (task) => {
-        if (task.queue === 'vision-capture') {
-            try {
-                const img = await capture();
-                // base64 expands ~33%; consider sending binary via your broker if possible
-                broker?.publish('vision-capture', { image: img.toString('base64') });
-            } catch (err) {
-                console.error('capture task failed', err);
-            }
+  wss.on("connection", (ws) => {
+    let busy = false;
+    ws.on("message", async () => {
+      if (busy || ws.readyState !== ws.OPEN) return;
+      busy = true;
+      try {
+        const img = await capture();
+        // Backpressure: if network is slow, avoid piling up
+        if (ws.readyState === ws.OPEN && ws.bufferedAmount < 16 * 1024 * 1024) {
+          ws.send(img, { binary: true });
         }
-    };
+      } catch (e) {
+        console.error("capture failed", e);
+        if (ws.readyState === ws.OPEN)
+          ws.send(JSON.stringify({ error: "capture_failed" }));
+      } finally {
+        busy = false;
+      }
+    });
+  });
 
-    startService({
-        id: process.env.name || 'vision',
-        queues: ['vision-capture'],
-        handleTask,
-    })
-        .then((b) => {
-            broker = b;
-        })
-        .catch((err) => {
-            console.warn('[vision] broker connection failed', err);
-        });
+  const handleTask = async (task) => {
+    if (task.queue === "vision-capture") {
+      try {
+        const img = await capture();
+        // base64 expands ~33%; consider sending binary via your broker if possible
+        broker?.publish("vision-capture", { image: img.toString("base64") });
+      } catch (err) {
+        console.error("capture task failed", err);
+      }
+    }
+  };
 
-    return server;
+  if (process.env.NODE_ENV !== "test") {
+    try {
+      broker = new BrokerClient({ id: process.env.name || "vision" });
+      await broker.connect();
+      broker.onTaskReceived(async (task) => {
+        broker.ack(task.id);
+        try {
+          await handleTask(task);
+        } finally {
+          broker.ready(task.queue);
+        }
+      });
+      broker.ready("vision-capture");
+    } catch (err) {
+      console.warn("[vision] broker connection failed", err);
+      try {
+        broker?.disconnect();
+      } catch {}
+      broker = null;
+    }
+  }
+
+  return server;
 }
 
-app.get('/capture', async (_req, res) => {
-    try {
-        const img = await capture();
-        res.set('Content-Type', `image/${FORMAT === 'jpg' ? 'jpeg' : FORMAT}`);
-        res.send(img);
-    } catch (err) {
-        console.error('capture failed', err);
-        res.status(500).send('capture failed');
+export async function stop() {
+  if (wss) {
+    for (const client of wss.clients) {
+      try {
+        client.terminate();
+      } catch {}
     }
+    await new Promise((resolve) => wss.close(resolve));
+    wss = null;
+  }
+
+  if (server) {
+    await new Promise((resolve) => server.close(resolve));
+    server = null;
+  }
+
+  try {
+    hb?.stop();
+  } catch {}
+  hb = null;
+
+  try {
+    broker?.disconnect();
+  } catch {}
+  broker = null;
+}
+
+app.get("/capture", async (_req, res) => {
+  try {
+    const img = await capture();
+    res.set("Content-Type", `image/${FORMAT === "jpg" ? "jpeg" : FORMAT}`);
+    res.send(img);
+  } catch (err) {
+    console.error("capture failed", err);
+    res.status(500).send("capture failed");
+  }
 });
 
-if (process.env.NODE_ENV !== 'test') {
-    start().catch((err) => {
-        console.error('Failed to start vision service', err);
-        process.exit(1);
-    });
+if (process.env.NODE_ENV !== "test") {
+  start().catch((err) => {
+    console.error("Failed to start vision service", err);
+    process.exit(1);
+  });
 }

--- a/services/js/vision/tests/capture.test.js
+++ b/services/js/vision/tests/capture.test.js
@@ -1,14 +1,18 @@
-import test from 'ava';
-import request from 'supertest';
+import test from "ava";
+import request from "supertest";
 
-process.env.NODE_ENV = 'test';
-import { app, setCaptureFn } from '../index.js';
+process.env.NODE_ENV = "test";
+import { app, setCaptureFn, stop } from "../index.js";
 
-test('capture endpoint returns png buffer', async (t) => {
-    const fake = Buffer.from('fake');
-    setCaptureFn(async () => fake);
-    const res = await request(app).get('/capture');
-    t.is(res.status, 200);
-    t.is(res.headers['content-type'], 'image/png');
-    t.true(Buffer.compare(res.body, fake) === 0);
+test.after.always(async () => {
+  await stop();
+});
+
+test("capture endpoint returns png buffer", async (t) => {
+  const fake = Buffer.from("fake");
+  setCaptureFn(async () => fake);
+  const res = await request(app).get("/capture");
+  t.is(res.status, 200);
+  t.is(res.headers["content-type"], "image/png");
+  t.true(Buffer.compare(res.body, fake) === 0);
 });

--- a/services/js/vision/tests/websocket.test.js
+++ b/services/js/vision/tests/websocket.test.js
@@ -1,27 +1,30 @@
-import test from 'ava';
-import { WebSocket } from 'ws';
-import { start, setCaptureFn } from '../index.js';
+import test from "ava";
+import { WebSocket } from "ws";
+import { start, setCaptureFn, stop } from "../index.js";
 
 let server;
 
 test.before(async () => {
-    process.env.NODE_ENV = 'test';
-    setCaptureFn(async () => Buffer.from('fake'));
-    server = await start(0);
+  process.env.NODE_ENV = "test";
+  setCaptureFn(async () => Buffer.from("fake"));
+  server = await start(0);
 });
 
-test.after.always(() => {
-    if (server) server.close();
+test.after.always(async () => {
+  await stop();
 });
 
-test('capture via websocket', async (t) => {
-    const port = server.address().port;
-    const ws = new WebSocket(`ws://127.0.0.1:${port}/capture`);
-    const data = await new Promise((resolve, reject) => {
-        ws.on('open', () => ws.send('go'));
-        ws.on('message', (msg) => resolve(msg));
-        ws.on('error', reject);
-    });
-    t.true(Buffer.compare(data, Buffer.from('fake')) === 0);
+test("capture via websocket", async (t) => {
+  const port = server.address().port;
+  const ws = new WebSocket(`ws://127.0.0.1:${port}/capture`);
+  const data = await new Promise((resolve, reject) => {
+    ws.on("open", () => ws.send("go"));
+    ws.on("message", (msg) => resolve(msg));
+    ws.on("error", reject);
+  });
+  t.true(Buffer.compare(data, Buffer.from("fake")) === 0);
+  await new Promise((resolve) => {
+    ws.on("close", resolve);
     ws.close();
+  });
 });


### PR DESCRIPTION
## Summary
- add tracked server, heartbeat and broker with a stop() helper
- call stop() in vision tests for clean shutdown
- document change in changelog

## Testing
- `pnpm lint`
- `pnpm test`
- `make build-js`
- `make format-js` *(fails: SyntaxError: '}' expected. (6:1))*


------
https://chatgpt.com/codex/tasks/task_e_68ae69673bb88324ba16a8b31eaa6c8e