### PR TITLE
Guard NLTK resource download in TTS startup

### DIFF
--- a/changelog.d/tts-nltk.changed.md
+++ b/changelog.d/tts-nltk.changed.md
@@ -1,0 +1,1 @@
+Move NLTK dataset download to TTS startup routine and document dependency.

--- a/services/py/tts/README.md
+++ b/services/py/tts/README.md
@@ -7,6 +7,12 @@ endpoint (`/ws/tts`) on the same server. On startup the service also uses
 text tasks from the `tts.speak` queue and publishing synthesized audio as
 `tts-output` events.
 
+## Dependencies
+
+The service requires the NLTK package and its `averaged_perceptron_tagger_eng`
+resource for part-of-speech tagging. The model is downloaded at startup if it
+is not already present.
+
 ## Usage
 
 Run via pm2 or execute `run.sh` directly:

--- a/services/py/tts/app.py
+++ b/services/py/tts/app.py
@@ -1,8 +1,6 @@
 from fastapi import FastAPI, Form, Response, WebSocket
 import io
-import sys
 
-print(sys.path)
 from shared.py.service_template import start_service
 from shared.py.speech.audio_utils import wav_to_base64
 from shared.py.utils import websocket_endpoint
@@ -14,7 +12,14 @@ import torch
 import numpy as np
 from transformers import FastSpeech2ConformerTokenizer, FastSpeech2ConformerWithHifiGan
 
-nltk.download("averaged_perceptron_tagger_eng")
+
+def ensure_nltk_data():
+    """Download required NLTK resources if missing."""
+    try:
+        nltk.data.find("taggers/averaged_perceptron_tagger_eng")
+    except LookupError:
+        nltk.download("averaged_perceptron_tagger_eng")
+
 
 app = FastAPI()
 broker = None
@@ -23,6 +28,8 @@ broker = None
 @app.on_event("startup")
 async def startup_event():
     global broker
+
+    ensure_nltk_data()
 
     async def handle_task(task):
         payload = task.get("payload", {})

--- a/services/py/tts/tests/test_tts_websocket.py
+++ b/services/py/tts/tests/test_tts_websocket.py
@@ -1,4 +1,8 @@
-import os, sys, types, importlib, wave
+import importlib
+import os
+import sys
+import types
+import wave
 from fastapi.testclient import TestClient
 from unittest.mock import patch
 
@@ -32,7 +36,10 @@ def test_websocket_tts_returns_wav_bytes(monkeypatch):
     dummy_package.tts = dummy_module
 
     dummy_sf = types.SimpleNamespace(write=dummy_write)
-    dummy_nltk = types.SimpleNamespace(download=lambda *a, **k: None)
+    dummy_nltk = types.SimpleNamespace(
+        download=lambda *a, **k: None,
+        data=types.SimpleNamespace(find=lambda *a, **k: None),
+    )
 
     class DummyBroker:
         async def publish(self, *a, **k):


### PR DESCRIPTION
## Summary
- download NLTK's averaged perceptron tagger only if missing during TTS service startup
- adjust TTS tests for conditional NLTK download
- document NLTK dependency for the TTS service

## Testing
- `black services/py/tts/app.py services/py/tts/tests/test_tts_websocket.py`
- `ruff check services/py/tts/app.py services/py/tts/tests/test_tts_websocket.py`
- `make format SERVICE=tts` *(fails: SyntaxError in TypeScript and YAML configs)*
- `make lint SERVICE=tts` *(fails: ESLint config uses unsupported "extends")*
- `make build SERVICE=tts` *(fails: missing TS declaration in shared serviceTemplate.js)*
- `pytest services/py/tts/tests/test_tts_websocket.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae696243c48324ad0d7a31f944b251