### PR TITLE
chore: add lint-topics pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,54 +1,59 @@
 repos:
-    - repo: local
-      hooks:
-          - id: generate-orphan-docs
-            name: Generate docs for orphaned files
-            entry: python scripts/generate_orphan_docs.py
-            language: system
-            pass_filenames: false
-            files: ^orphaned-files-report\.md$
-          - id: enforce-wiki-links
-            name: Enforce Wikilinks
-            entry: python scripts/kanban/hashtags_to_kanban.py --check --write --wikilinks
-            language: system
-            pass_filenames: false
-          - id: tsc-no-emit
-            name: TypeScript compile check
-            entry: make ts-type-check
-            language: system
-            types_or: [javascript, ts, tsx]
-            pass_filenames: false
-          - id: pytest
-            name: Python tests
-            entry: pytest -q
-            language: system
-            types: [python]
-            pass_filenames: false
-          - id: full-build
-            name: Full build
-            entry: make build
-            language: system
-            pass_filenames: false
-            stages: [manual]
+  - repo: local
+    hooks:
+      - id: generate-orphan-docs
+        name: Generate docs for orphaned files
+        entry: python scripts/generate_orphan_docs.py
+        language: system
+        pass_filenames: false
+        files: ^orphaned-files-report\.md$
+      - id: enforce-wiki-links
+        name: Enforce Wikilinks
+        entry: python scripts/kanban/hashtags_to_kanban.py --check --write --wikilinks
+        language: system
+        pass_filenames: false
+      - id: lint-topics
+        name: Topic/Schema lints
+        entry: make lint-topics
+        language: system
+        pass_filenames: false
+      - id: tsc-no-emit
+        name: TypeScript compile check
+        entry: make ts-type-check
+        language: system
+        types_or: [javascript, ts, tsx]
+        pass_filenames: false
+      - id: pytest
+        name: Python tests
+        entry: pytest -q
+        language: system
+        types: [python]
+        pass_filenames: false
+      - id: full-build
+        name: Full build
+        entry: make build
+        language: system
+        pass_filenames: false
+        stages: [manual]
 
-    - repo: https://github.com/psf/black
-      rev: 24.4.2
-      hooks:
-          - id: black
-            language_version: python3
-    - repo: https://github.com/pycqa/flake8
-      rev: 7.3.0
-      hooks:
-          - id: flake8
-    - repo: https://github.com/pre-commit/mirrors-eslint
-      rev: v9.32.0
-      hooks:
-          - id: eslint
-            types: [javascript, ts, tsx]
-    - repo: https://github.com/pre-commit/mirrors-prettier
-      rev: v3.1.0
-      hooks:
-          - id: prettier
-            types_or: [javascript, ts, tsx, json, yaml]
-            exclude: ^legacy/
-            args: [--ignore-path=.prettierignore]
+  - repo: https://github.com/psf/black
+    rev: 24.4.2
+    hooks:
+      - id: black
+        language_version: python3
+  - repo: https://github.com/pycqa/flake8
+    rev: 7.3.0
+    hooks:
+      - id: flake8
+  - repo: https://github.com/pre-commit/mirrors-eslint
+    rev: v9.32.0
+    hooks:
+      - id: eslint
+        types: [javascript, ts, tsx]
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: v3.1.0
+    hooks:
+      - id: prettier
+        types_or: [javascript, ts, tsx, json, yaml]
+        exclude: ^legacy/
+        args: [--ignore-path=.prettierignore]

--- a/changelog.d/lint-topics-hook.added.md
+++ b/changelog.d/lint-topics-hook.added.md
@@ -1,0 +1,1 @@
+Add lint-topics pre-commit hook.

--- a/scripts/lint-topics.ts
+++ b/scripts/lint-topics.ts
@@ -1,10 +1,19 @@
 import fs from "fs";
 import path from "path";
-
-import { isValidTopic, headerOk } from "../shared/ts/prom-lib/naming/rules.ts";
-import { reg as schemaReg } from "../shared/ts/prom-lib/schema/topics.ts";
+import { pathToFileURL } from "url";
 
 const ROOT = process.env.REPO_ROOT || process.cwd();
+const rulesFile = path.join(ROOT, "shared/ts/prom-lib/naming/rules.ts");
+const schemaFile = path.join(ROOT, "shared/ts/prom-lib/schema/topics.ts");
+
+if (!fs.existsSync(rulesFile) || !fs.existsSync(schemaFile)) {
+  console.log("No prom-lib sources found, skipping lint-topics");
+  process.exit(0);
+}
+
+const { isValidTopic, headerOk } = await import(pathToFileURL(rulesFile).href);
+const { reg: schemaReg } = await import(pathToFileURL(schemaFile).href);
+
 // Limit initial lint scope to prom-lib; expand as other services adopt topic rules
 const SRC_DIRS = ["shared/ts/prom-lib"]; // add more if needed
 


### PR DESCRIPTION
## Summary
- add lint-topics hook to pre-commit configuration
- skip topic lints gracefully when prom-lib is missing

## Testing
- `make format` *(fails: SyntaxError and other configuration issues)*
- `make lint` *(fails: ESLint config error and formatting warnings)*
- `make test` *(fails: connection errors; interrupted)*
- `make build`
- `pre-commit run lint-topics --files .pre-commit-config.yaml scripts/lint-topics.ts changelog.d/lint-topics-hook.added.md`


------
https://chatgpt.com/codex/tasks/task_e_68ae69600fe88324bd3db3ae4990303f