### PR TITLE
fix: resolve TypeScript build errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
         "@biomejs/biome": "^2.2.2",
         "@types/jest": "^30.0.0",
         "@types/mongodb": "^4.0.6",
+        "@types/node": "20.19.11",
         "@typescript-eslint/eslint-plugin": "^8.39.0",
         "@typescript-eslint/parser": "^8.39.0",
         "ava": "^6.4.1",

--- a/services/ts/codex-context/src/index.ts
+++ b/services/ts/codex-context/src/index.ts
@@ -1,6 +1,6 @@
 import { configDotenv } from 'dotenv';
 configDotenv();
-import express from 'express';
+import express, { type Express } from 'express';
 import bodyParser from 'body-parser';
 import { SmartGptrRetriever } from './retriever.js';
 import { buildAugmentedPrompt } from './prompt.js';
@@ -24,7 +24,7 @@ export type AppDeps = {
     docsDir?: string;
 };
 
-export function createApp(deps: AppDeps = {}) {
+export function createApp(deps: AppDeps = {}): Express {
     const app = express();
     app.use(bodyParser.json({ limit: '50mb' }));
 

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -17,5 +17,6 @@
         "sourceMap": true,
         "lib": ["ES2022"],
         "types": ["node", "ava"]
-    }
+    },
+    "exclude": ["**/src/tests/fixtures/**"]
 }


### PR DESCRIPTION
## Summary
- add Express return type to codex-context createApp
- ignore test fixture files in base tsconfig
- install @types/node for workspace types

## Testing
- `pnpm -r build`
- `pnpm --filter codex-context test`
- `pnpm --filter codex-context lint` *(fails: extends key not supported)*
- `pnpm --filter codex-context format` *(fails: extends key not supported)*

------
https://chatgpt.com/codex/tasks/task_e_68b4efd46504832494f67c7e4146d8a2