### PR TITLE
fix(cli): resolve lisp build errors

### DIFF
--- a/changelog.d/00000.fixed.md
+++ b/changelog.d/00000.fixed.md
@@ -1,0 +1,1 @@
+Fix TypeScript build errors in CLI lisp command.

--- a/packages/cli/src/lisp.ts
+++ b/packages/cli/src/lisp.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import fs from 'node:fs/promises';
 import path from 'node:path';
-import { fileURLToPath, pathToFileURL } from 'node:url';
+import { pathToFileURL } from 'node:url';
 
 import { compileLispToJS, runLisp } from '@promethean/compiler/lisp/driver.js';
 import { jsToLisp } from '@promethean/compiler/lisp/js2lisp.js';
@@ -95,8 +95,9 @@ async function cmdRun(args: Argv) {
     const importSpecs = args.filter((a) => a.startsWith('--import'));
     // remove all --import entries and their values if split form used
     for (let i = 0; i < args.length; ) {
-        if (args[i] === '--import') args.splice(i, 2);
-        else if (args[i].startsWith('--import=')) args.splice(i, 1);
+        const arg = args[i];
+        if (arg === '--import') args.splice(i, 2);
+        else if (arg?.startsWith('--import=')) args.splice(i, 1);
         else i++;
     }
     const file = args.shift();


### PR DESCRIPTION
## Summary
- remove unused `fileURLToPath` import
- guard `--import` option parsing against undefined values

## Testing
- `pnpm --filter @promethean/cli build`
- `pnpm --filter @promethean/cli test` *(fails: Couldn’t find any files to test)*

------
https://chatgpt.com/codex/tasks/task_e_68b74c1aed9c8324a9ecd0946ebfc421