### PR TITLE
fix: handle undefined args in cookbookflow

### DIFF
--- a/packages/cookbookflow/src/01-scan.ts
+++ b/packages/cookbookflow/src/01-scan.ts
@@ -16,18 +16,18 @@ function* mdCodeBlocks(md: string): Generator<{lang:string, code:string, header:
   let m; while ( (m = fence.exec(md)) ) {
     const before = md.slice(0, m.index);
     const header = (before.match(/(?:^|\n)#{1,6}\s+[^\n]+$/m)?.[0] ?? "").trim();
-    yield { lang: (m[1]||"").toLowerCase(), code: m[2], header };
+      yield { lang: (m[1] ?? "").toLowerCase(), code: m[2] ?? "", header };
   }
 }
 
 async function main() {
-  const roots = args["--roots"].split(/\s+/).filter(Boolean);
+  const roots = (args["--roots"] ?? "").split(/\s+/).filter(Boolean);
   const files = await globby([
     ...roots.map(r => `${r.replace(/\\/g,"/")}/**/*.{md,mdx}`),
     "examples/**/*.{ts,tsx,js,jsx,sh,bash}"
   ], { dot: false });
 
-  const maxCtx = Number(args["--max-context"]);
+  const maxCtx = Number(args["--max-context"] ?? 0);
   const blocks: CodeBlock[] = [];
 
   for (const f of files) {
@@ -44,7 +44,8 @@ async function main() {
   }
 
   const out: ScanOutput = { createdAt: new Date().toISOString(), blocks };
-  await writeJSON(path.resolve(args["--out"]), out);
-  console.log(`cookbook: scanned ${blocks.length} block(s) → ${args["--out"]}`);
+  const outPath = args["--out"] ?? ".cache/cookbook/blocks.json";
+  await writeJSON(path.resolve(outPath), out);
+  console.log(`cookbook: scanned ${blocks.length} block(s) → ${outPath}`);
 }
 main().catch(e => { console.error(e); process.exit(1); });

--- a/packages/cookbookflow/src/03-group.ts
+++ b/packages/cookbookflow/src/03-group.ts
@@ -12,36 +12,37 @@ const args = parseArgs({
 });
 
 async function main() {
-  const cf = JSON.parse(await fs.readFile(path.resolve(args["--in"]), "utf-8")) as ClassesFile;
+    const cf = JSON.parse(await fs.readFile(path.resolve(args["--in"] ?? ""), "utf-8")) as ClassesFile;
   const ids = Object.keys(cf.classes);
   const seen = new Set<string>();
   const groups: Group[] = [];
-  const minSim = Number(args["--min-sim"]);
-  const maxSize = Number(args["--max-size"]);
+    const minSim = Number(args["--min-sim"] ?? 0);
+    const maxSize = Number(args["--max-size"] ?? 0);
 
   for (const id of ids) {
     if (seen.has(id)) continue;
-    const seed = cf.classes[id];
-    const key = `${seed.task}|${seed.runtime}|${seed.language}`;
-    const centroid = cf.embeddings[id];
+      const seed = cf.classes[id]!;
+      const key = `${seed.task}|${seed.runtime}|${seed.language}`;
+      const centroid = cf.embeddings[id]!;
     const members = [id];
 
     // greedy nearest neighbors within same key
     for (const other of ids) {
       if (id === other || seen.has(other)) continue;
-      const c = cf.classes[other];
-      if (`${c.task}|${c.runtime}|${c.language}` !== key) continue;
-      const sim = cosine(centroid, cf.embeddings[other] || []);
+        const c = cf.classes[other]!;
+        if (`${c.task}|${c.runtime}|${c.language}` !== key) continue;
+        const sim = cosine(centroid, cf.embeddings[other] ?? []);
       if (sim >= minSim) members.push(other);
       if (members.length >= maxSize) break;
     }
 
     members.forEach(m => seen.add(m));
-    groups.push({ key, blockIds: members, centroid });
+      groups.push({ key, blockIds: members, centroid });
   }
 
-  const out: GroupsFile = { groupedAt: new Date().toISOString(), groups };
-  await writeJSON(path.resolve(args["--out"]), out);
-  console.log(`cookbook: formed ${groups.length} group(s) → ${args["--out"]}`);
+    const out: GroupsFile = { groupedAt: new Date().toISOString(), groups };
+    const outPath = args["--out"] ?? ".cache/cookbook/groups.json";
+    await writeJSON(path.resolve(outPath), out);
+    console.log(`cookbook: formed ${groups.length} group(s) → ${outPath}`);
 }
 main().catch(e => { console.error(e); process.exit(1); });

--- a/packages/cookbookflow/src/05-materialize.ts
+++ b/packages/cookbookflow/src/05-materialize.ts
@@ -43,12 +43,12 @@ function render(recipe: any) {
 }
 
 async function main() {
-  const plan = JSON.parse(await fs.readFile(path.resolve(args["--plan"]), "utf-8")) as PlanFile;
-  const OUT = path.resolve(args["--out"]); await fs.mkdir(OUT, { recursive: true });
+    const plan = JSON.parse(await fs.readFile(path.resolve(args["--plan"] ?? ""), "utf-8")) as PlanFile;
+    const OUT = path.resolve(args["--out"] ?? "docs/cookbook"); await fs.mkdir(OUT, { recursive: true });
 
   let count = 0;
-  for (const [key, recs] of Object.entries(plan.groups)) {
-    for (const r of recs) {
+    for (const recs of Object.values(plan.groups)) {
+      for (const r of recs) {
       const dir = path.join(OUT, r.task);
       await fs.mkdir(dir, { recursive: true });
       const fname = `${slug(r.title)}.md`;
@@ -63,6 +63,6 @@ async function main() {
       count++;
     }
   }
-  console.log(`cookbook: wrote ${count} recipe(s) to ${args["--out"]}`);
+    console.log(`cookbook: wrote ${count} recipe(s) to ${args["--out"] ?? "docs/cookbook"}`);
 }
 main().catch(e => { console.error(e); process.exit(1); });

--- a/packages/cookbookflow/src/08-report.ts
+++ b/packages/cookbookflow/src/08-report.ts
@@ -11,12 +11,13 @@ const args = parseArgs({
 });
 
 async function main() {
-  const runs = JSON.parse(await fs.readFile(path.resolve(args["--runs"]), "utf-8")) as RunResultsFile;
-  const verify = JSON.parse(await fs.readFile(path.resolve(args["--verify"]), "utf-8")) as VerifyFile;
+    const runs = JSON.parse(await fs.readFile(path.resolve(args["--runs"] ?? ""), "utf-8")) as RunResultsFile;
+    const verify = JSON.parse(await fs.readFile(path.resolve(args["--verify"] ?? ""), "utf-8")) as VerifyFile;
 
-  await fs.mkdir(path.resolve(args["--out"]), { recursive: true });
-  const ts = new Date().toISOString().replace(/[:.]/g,"-");
-  const out = path.join(args["--out"], `cookbook-${ts}.md`);
+    const outDir = path.resolve(args["--out"] ?? "docs/agile/reports/cookbook");
+    await fs.mkdir(outDir, { recursive: true });
+    const ts = new Date().toISOString().replace(/[:.]/g, "-");
+    const out = path.join(outDir, `cookbook-${ts}.md`);
 
   const rows = runs.results.map(r => {
     const v = verify.items.find(i => i.recipePath === r.recipePath);
@@ -35,8 +36,8 @@ async function main() {
     ""
   ].join("\n");
 
-  await writeText(out, md);
-  await writeText(path.join(args["--out"], "README.md"), `# Cookbook Reports\n\n- [Latest](${path.basename(out)})\n`);
-  console.log(`cookbook: report → ${path.relative(process.cwd(), out)}`);
+    await writeText(out, md);
+    await writeText(path.join(outDir, "README.md"), `# Cookbook Reports\n\n- [Latest](${path.basename(out)})\n`);
+    console.log(`cookbook: report → ${path.relative(process.cwd(), out)}`);
 }
 main().catch(e => { console.error(e); process.exit(1); });

--- a/packages/cookbookflow/src/tests/parseArgs.test.ts
+++ b/packages/cookbookflow/src/tests/parseArgs.test.ts
@@ -1,0 +1,11 @@
+import test from 'ava';
+import { parseArgs } from '../utils.js';
+
+test('parseArgs merges defaults and argv', t => {
+  const orig = process.argv.slice();
+  process.argv = ['node', 'script', '--foo', 'bar', '--flag'];
+  const res = parseArgs({ '--foo': 'baz', '--flag': 'no' });
+  process.argv = orig;
+  t.is(res['--foo'], 'bar');
+  t.is(res['--flag'], 'true');
+});


### PR DESCRIPTION
## Summary
- harden CLI argument parsing to avoid undefined values
- safely handle optional fields across cookbookflow steps
- add parseArgs unit test

## Testing
- `pnpm --filter @promethean/cookbookflow build`
- `npx ava packages/cookbookflow/dist/tests/*.js`


------
https://chatgpt.com/codex/tasks/task_e_68b7532a816483248f05545160ecfb54