### PR TITLE
fix: clean up buildfix TypeScript errors

### DIFF
--- a/changelog.d/0000.fixed.md
+++ b/changelog.d/0000.fixed.md
@@ -1,0 +1,1 @@
+fix: resolve TypeScript compile errors in buildfix utilities

--- a/packages/buildfix/src/01-errors.ts
+++ b/packages/buildfix/src/01-errors.ts
@@ -1,6 +1,5 @@
 /* eslint-disable no-console */
 import * as path from "path";
-import { promises as fs } from "fs";
 import { parseArgs, tsc, codeFrame, writeJSON } from "./utils.js";
 import type { ErrorList, BuildError } from "./types.js";
 
@@ -10,7 +9,7 @@ const args = parseArgs({
 });
 
 async function main() {
-  const tsconfig = path.resolve(args["--tsconfig"]);
+  const tsconfig = path.resolve(args["--tsconfig"]!);
   const { diags } = await tsc(tsconfig);
 
   const errors: BuildError[] = [];
@@ -22,7 +21,7 @@ async function main() {
   }
 
   const out: ErrorList = { createdAt: new Date().toISOString(), tsconfig, errors };
-  await writeJSON(path.resolve(args["--out"]), out);
+  await writeJSON(path.resolve(args["--out"]!), out);
   console.log(`buildfix: collected ${errors.length} error(s) → ${args["--out"]}`);
 }
 

--- a/packages/buildfix/src/02-iterate.ts
+++ b/packages/buildfix/src/02-iterate.ts
@@ -50,17 +50,17 @@ function makeBranch(err: any) {
 }
 
 async function main() {
-  const errors = await readJSON<ErrorList>(path.resolve(args["--errors"]));
+  const errors = await readJSON<ErrorList>(path.resolve(args["--errors"]!));
   if (!errors) throw new Error("errors.json not found");
   const tsconfig = args["--tsconfig"] || errors.tsconfig;
   const onlyCode = (args["--only-code"] || "").trim();
   const onlyFile = (args["--only-file"] || "").trim();
   const maxCycles = Number(args["--max-cycles"]);
-  const OUT = path.resolve(args["--out"]);
+  const OUT = path.resolve(args["--out"]!);
 
   const useGit = args["--git"] !== "off" && (await isGitRepo());
   const commitOn = (args["--commit-on"] as "always" | "success") || "always";
-  const remote = args["--remote"];
+  const remote = args["--remote"]!;
   const push = args["--push"] === "true";
   const useGh = args["--use-gh"] === "true";
   const doRollback = args["--rollback-on-regress"] === "true";
@@ -110,7 +110,7 @@ async function main() {
       // 1) Plan
       let plan;
       try {
-        plan = await requestPlan(args["--model"], err, history);
+          plan = await requestPlan(args["--model"]!, err, history);
       } catch (e) {
         console.error(`✖ plan failed for ${err.key}:`, e);
         break;
@@ -145,7 +145,7 @@ async function main() {
           await rollbackWorktree();
           rolledBack = true;
           // recompute to keep history consistent with tree
-          const { r: re, present: rePresent } = await buildAndJudge(
+          const { r: re } = await buildAndJudge(
             tsconfig,
             err.key,
           );
@@ -191,11 +191,14 @@ async function main() {
         const sha = await commitIfChanges(title);
         if (sha) {
           att.commitSha = sha;
-          att.branch = branch;
+          if (branch) att.branch = branch;
           if (push && branch) {
-            att.pushed = await pushBranch(branch, remote);
-            if (att.pushed && useGh)
-              att.prUrl = await createPR(branch, title, bodyPath);
+            const b = branch!;
+            att.pushed = await pushBranch(b, remote);
+            if (att.pushed && useGh) {
+              const pr = await createPR(b, title, bodyPath);
+              if (pr) att.prUrl = pr;
+            }
           }
         }
       }
@@ -210,13 +213,15 @@ async function main() {
       }
     }
 
-    summary.items.push({
+    const item: Summary["items"][number] = {
       key: err.key,
       resolved,
       attempts: history.attempts.length,
-      lastSnippet: history.attempts.at(-1)?.snippetPath,
-      branch,
-    });
+    };
+    const last = history.attempts.at(-1)?.snippetPath;
+    if (last) item.lastSnippet = last;
+    if (branch) item.branch = branch;
+    summary.items.push(item);
   }
 
   await writeJSON(path.join(OUT, "summary.json"), summary);

--- a/packages/buildfix/src/03-report.ts
+++ b/packages/buildfix/src/03-report.ts
@@ -11,16 +11,16 @@ const args = parseArgs({
 });
 
 async function main() {
-  const sum = await readJSON<Summary>(path.resolve(args["--summary"]));
+  const sum = await readJSON<Summary>(path.resolve(args["--summary"]!));
   if (!sum) throw new Error("summary not found");
 
-  await fs.mkdir(path.resolve(args["--out"]), { recursive: true });
+  await fs.mkdir(path.resolve(args["--out"]!), { recursive: true });
   const ts = new Date().toISOString().replace(/[:.]/g, "-");
-  const out = path.join(args["--out"], `buildfix-${ts}.md`);
+  const out = path.join(args["--out"]!, `buildfix-${ts}.md`);
 
   const rows = await Promise.all(
     sum.items.map(async (it: { key: string; resolved: any; attempts: any }) => {
-      const hp = path.join(args["--history-root"], it.key, "history.json");
+      const hp = path.join(args["--history-root"]!, it.key, "history.json");
       const hist = await readJSON<History>(hp);
       const last = hist?.attempts.at(-1);
       return `| \`${it.key}\` | ${it.resolved ? "✅" : "❌"} | ${
@@ -44,7 +44,7 @@ async function main() {
 
   await fs.writeFile(out, md, "utf-8");
   await fs.writeFile(
-    path.join(args["--out"], "README.md"),
+    path.join(args["--out"]!, "README.md"),
     `# Buildfix Reports\n\n- [Latest](${path.basename(out)})\n`,
   );
   console.log(`buildfix: report → ${path.relative(process.cwd(), out)}`);

--- a/packages/buildfix/src/iter/dsl.ts
+++ b/packages/buildfix/src/iter/dsl.ts
@@ -25,7 +25,7 @@ export function decodeB64(s: string): string {
 }
 
 // Turn DSL ops into a safe ESM snippet.
-export async function dslToSnippet(ops: OpT[], rootDir: string): Promise<string> {
+export async function dslToSnippet(ops: OpT[]): Promise<string> {
   const hdr = `import { SyntaxKind } from "ts-morph";
 export async function apply(project){
   const by = (p)=>project.getSourceFile(p) || project.getSourceFiles().find(f=>f.getFilePath().endsWith(p));
@@ -105,7 +105,7 @@ export async function apply(project){
 export async function materializeSnippet(plan: Plan, outPath: string): Promise<void> {
   let code = "";
   if (plan.snippet_b64) code = decodeB64(plan.snippet_b64);
-  else if (plan.dsl && plan.dsl.length) code = await dslToSnippet(plan.dsl, process.cwd());
+  else if (plan.dsl && plan.dsl.length) code = await dslToSnippet(plan.dsl);
   else throw new Error("plan has neither snippet_b64 nor dsl");
   await fs.mkdir(path.dirname(outPath), { recursive: true });
   await fs.writeFile(outPath, code, "utf-8");

--- a/packages/buildfix/src/iter/eval.ts
+++ b/packages/buildfix/src/iter/eval.ts
@@ -2,8 +2,14 @@ import * as path from "path";
 import { tsc } from "../utils.js";
 
 export function errorStillPresent(diags: any[], key: string) {
-  const [code, file, lineStr] = key.split("|"); const line = Number(lineStr);
-  return diags.some(d => d.code === code && path.resolve(d.file) === path.resolve(file) && Math.abs(d.line - line) <= 2);
+  const [code, file, lineStr] = key.split("|") as [string, string, string];
+  const line = Number(lineStr);
+  return diags.some(
+    (d) =>
+      d.code === code &&
+      path.resolve(d.file) === path.resolve(file) &&
+      Math.abs(d.line - line) <= 2,
+  );
 }
 
 export async function buildAndJudge(tsconfig: string, key: string) {

--- a/packages/buildfix/src/iter/git.ts
+++ b/packages/buildfix/src/iter/git.ts
@@ -1,5 +1,3 @@
-import * as path from "path";
-import { promises as fs } from "fs";
 import { git, isGitRepo, sanitizeBranch } from "../utils.js";
 
 export async function ensureBranch(branch: string) {

--- a/packages/buildfix/src/iter/prompt.ts
+++ b/packages/buildfix/src/iter/prompt.ts
@@ -1,4 +1,3 @@
-import * as path from "path";
 import type { History } from "../types.js";
 
 export function buildPrompt(err: {file:string; line:number; col:number; code:string; message:string; frame:string; key:string}, history: History){

--- a/packages/buildfix/src/utils.ts
+++ b/packages/buildfix/src/utils.ts
@@ -1,7 +1,7 @@
 import { exec as _exec } from "child_process";
 import { promises as fs } from "fs";
 import * as path from "path";
-import { fileURLToPath, pathToFileURL } from "url";
+import { pathToFileURL } from "url";
 import { Project } from "ts-morph";
 
 export const OLLAMA_URL = process.env.OLLAMA_URL ?? "http://localhost:11434";
@@ -10,9 +10,9 @@ export function parseArgs(def: Record<string, string>) {
   const out = { ...def };
   const a = process.argv.slice(2);
   for (let i = 0; i < a.length; i++) {
-    const k = a[i];
+    const k = a[i]!;
     if (!k.startsWith("--")) continue;
-    const v = a[i + 1] && !a[i + 1].startsWith("--") ? a[++i] : "true";
+    const v = a[i + 1] !== undefined && !a[i + 1]!.startsWith("--") ? a[++i]! : "true";
     out[k] = v;
   }
   return out;
@@ -58,13 +58,13 @@ export function parseTsc(text: string) {
   }> = [];
   let m: RegExpExecArray | null;
   while ((m = re.exec(text))) {
-    items.push({
-      file: m[1],
-      line: Number(m[2]),
-      col: Number(m[3]),
-      code: m[4],
-      message: m[5].trim(),
-    });
+      items.push({
+        file: m[1]!,
+        line: Number(m[2]!),
+        col: Number(m[3]!),
+        code: m[4]!,
+        message: m[5]!.trim(),
+      });
   }
   return items;
 }


### PR DESCRIPTION
## Summary
- fix strict TypeScript issues in buildfix scripts
- harden CLI argument parsing and git helpers
- document fixes

## Testing
- `pnpm --filter @promethean/buildfix build`


------
https://chatgpt.com/codex/tasks/task_e_68b75334f8e883248c498789de396510