### PR TITLE
fix(agent-ecs): resolve build warnings

### DIFF
--- a/changelog.d/0000.fixed.md
+++ b/changelog.d/0000.fixed.md
@@ -1,0 +1,1 @@
+fix unused variable build errors in agent-ecs

--- a/packages/agent-ecs/src/agent-ecs.doublebuffer.test.ts
+++ b/packages/agent-ecs/src/agent-ecs.doublebuffer.test.ts
@@ -1,7 +1,7 @@
 import test from 'ava';
-import { createAgentWorld } from './world';
-import { enqueueUtterance } from './helpers/enqueueUtterance';
-import { OrchestratorSystem } from './systems/orchestrator';
+import { createAgentWorld } from './world.js';
+import { enqueueUtterance } from './helpers/enqueueUtterance.js';
+import { OrchestratorSystem } from './systems/orchestrator.js';
 
 function makePlayer() {
     let playing = false;

--- a/packages/agent-ecs/src/systems/voice.ts
+++ b/packages/agent-ecs/src/systems/voice.ts
@@ -1,6 +1,6 @@
 // loose typing to avoid cross-package type coupling
 import type { defineAgentComponents } from '../components';
-import { enqueueUtterance } from '../helpers/enqueueUtterance';
+import { enqueueUtterance } from '../helpers/enqueueUtterance.js';
 
 type Deps = {
     joinVoiceChannel: (opts: any) => any;
@@ -51,7 +51,7 @@ export function VoiceSystem(
             id: `${Date.now()}`,
             group: 'agent-speech',
             factory: async () => {
-                const { stream, cleanup } = await deps.tts(e.message);
+                const { stream } = await deps.tts(e.message);
                 const res = deps.createAudioResource(stream);
                 // cleanup after playback via player events if needed
                 return res;

--- a/packages/agent-ecs/src/voice.system.test.ts
+++ b/packages/agent-ecs/src/voice.system.test.ts
@@ -1,6 +1,6 @@
 import test from 'ava';
-import { createAgentWorld } from './world';
-import { VoiceSystem } from './systems/voice';
+import { createAgentWorld } from './world.js';
+import { VoiceSystem } from './systems/voice.js';
 
 function makePlayer() {
     let subscribed: any = null;
@@ -38,7 +38,7 @@ test('voice system joins and leaves', (t) => {
     const bus = makeBus();
     let destroyed = false;
     VoiceSystem(w, agent, C, bus, {
-        joinVoiceChannel: (e: any) => ({
+        joinVoiceChannel: (_e: any) => ({
             subscribe: (_p: any) => {},
             destroy: () => {
                 destroyed = true;


### PR DESCRIPTION
## Summary
- remove unused variables from SpeechArbiter, Voice, World, and tests
- add `.js` extensions for local module imports to aid ESM resolution
- document fix in changelog

## Testing
- `pnpm --filter @promethean/agent-ecs build`
- `pnpm --filter @promethean/agent-ecs test` *(fails: Cannot find module '@promethean/ds/dist/ecs.js')*
- `pnpm --filter @promethean/ds build` *(fails: TypeScript errors in @promethean/ds)*

------
https://chatgpt.com/codex/tasks/task_e_68b7533768a8832495c5fad9d4e9d326