### PR TITLE
fix: resolve boardrev ts build errors

### DIFF
--- a/changelog.d/boardrev-typescript.fixed.md
+++ b/changelog.d/boardrev-typescript.fixed.md
@@ -1,0 +1,1 @@
+Fix boardrev TypeScript build errors and add basic tests.

--- a/packages/boardrev/src/02-process-prompts.ts
+++ b/packages/boardrev/src/02-process-prompts.ts
@@ -1,6 +1,5 @@
 /* eslint-disable no-console */
 import * as path from "path";
-import { promises as fs } from "fs";
 import { parseArgs, writeText, readMaybe, slug } from "./utils.js";
 import type { PromptChunk } from "./types.js";
 
@@ -11,11 +10,11 @@ const args = parseArgs({
 });
 
 async function main() {
-  const p = path.resolve(args["--process"]);
+  const p = path.resolve(args["--process"]!);
   const raw = await readMaybe(p);
   const chunks: PromptChunk[] = raw ? sliceByHeading(raw, Number(args["--min-level"])) : defaultPrompts();
-  await writeText(path.resolve(args["--out"]), JSON.stringify({ prompts: chunks }, null, 2));
-  console.log(`boardrev: prompts → ${args["--out"]} (${chunks.length})`);
+  await writeText(path.resolve(args["--out"]!), JSON.stringify({ prompts: chunks }, null, 2));
+  console.log(`boardrev: prompts → ${args["--out"]!} (${chunks.length})`);
 }
 
 function sliceByHeading(md: string, minLevel: number): PromptChunk[] {
@@ -28,11 +27,11 @@ function sliceByHeading(md: string, minLevel: number): PromptChunk[] {
   for (const line of lines) {
     const m = line.match(/^(#{1,6})\s+(.*)$/);
     if (m) {
-      const level = m[1].length;
-      if (level >= minLevel) { flush(); cur = { heading: m[2].trim(), buf: [] }; continue; }
+      const level = m[1]?.length ?? 0;
+      if (level >= minLevel) { flush(); cur = { heading: (m[2] ?? "").trim(), buf: [] }; continue; }
     }
     if (!cur) { cur = { heading: "general", buf: [] }; }
-    cur.buf.push(line);
+    cur!.buf.push(line);
   }
   flush();
   return out;

--- a/packages/boardrev/src/03-index-repo.ts
+++ b/packages/boardrev/src/03-index-repo.ts
@@ -15,7 +15,7 @@ const args = parseArgs({
 });
 
 async function main() {
-  const files = await globby(args["--globs"].split(",").map(s => s.trim()));
+  const files = await globby(args["--globs"]!.split(",").map(s => s.trim()));
   const maxB = Number(args["--max-bytes"]), maxL = Number(args["--max-lines"]);
   const index: RepoDoc[] = [];
   const embeddings: Embeddings = {};
@@ -33,12 +33,12 @@ async function main() {
     const key = d.path;
     if (!embeddings[key]) {
       const text = `PATH: ${d.path}\nKIND: ${d.kind}\n---\n${d.excerpt}`;
-      embeddings[key] = await ollamaEmbed(args["--embed-model"], text);
+      embeddings[key] = await ollamaEmbed(args["--embed-model"]!, text);
     }
   }
 
-  await writeText(path.resolve(args["--out-index"]), JSON.stringify({ docs: index }, null, 2));
-  await writeText(path.resolve(args["--out-emb"]), JSON.stringify(embeddings));
+  await writeText(path.resolve(args["--out-index"]!), JSON.stringify({ docs: index }, null, 2));
+  await writeText(path.resolve(args["--out-emb"]!), JSON.stringify(embeddings));
   console.log(`boardrev: indexed ${index.length} repo docs`);
 }
 

--- a/packages/boardrev/src/04-match-context.ts
+++ b/packages/boardrev/src/04-match-context.ts
@@ -15,11 +15,11 @@ const args = parseArgs({
 });
 
 async function main() {
-  const tasksDir = path.resolve(args["--tasks"]);
+  const tasksDir = path.resolve(args["--tasks"]!);
   const files = await listTaskFiles(tasksDir);
 
-  const index: { docs: RepoDoc[] } = JSON.parse(await fs.readFile(path.resolve(args["--index"]), "utf-8"));
-  const repoEmb: Embeddings = JSON.parse(await fs.readFile(path.resolve(args["--emb"]), "utf-8"));
+  const index: { docs: RepoDoc[] } = JSON.parse(await fs.readFile(path.resolve(args["--index"]!), "utf-8"));
+  const repoEmb: Embeddings = JSON.parse(await fs.readFile(path.resolve(args["--emb"]!), "utf-8"));
   const k = Number(args["--k"]);
 
   const out: TaskContext[] = [];
@@ -32,7 +32,7 @@ async function main() {
       `STATUS: ${gm.data?.status ?? ""}  PRIORITY: ${gm.data?.priority ?? ""}`,
       gm.content
     ].join("\n");
-    const vec = await ollamaEmbed(args["--embed-model"], text);
+    const vec = await ollamaEmbed(args["--embed-model"]!, text);
 
     const scored = index.docs.map(d => ({
       path: d.path, kind: d.kind, excerpt: d.excerpt,
@@ -42,12 +42,14 @@ async function main() {
     .sort((a,b)=>b.score-a.score)
     .slice(0, k);
 
-    const links = Array.from(raw.matchAll(/\[[^\]]*?\]\(([^)]+)\)/g)).map(m => m[1]);
+    const links = Array.from(raw.matchAll(/\[[^\]]*?\]\(([^)]+)\)/g))
+      .map(m => m[1])
+      .filter((x): x is string => Boolean(x));
 
     out.push({ taskFile: f.replace(/\\/g,"/"), hits: scored, links });
   }
 
-  await writeText(path.resolve(args["--out"]), JSON.stringify({ contexts: out }, null, 2));
+  await writeText(path.resolve(args["--out"]!), JSON.stringify({ contexts: out }, null, 2));
   console.log(`boardrev: matched context for ${out.length} task(s)`);
 }
 

--- a/packages/boardrev/src/05-evaluate.ts
+++ b/packages/boardrev/src/05-evaluate.ts
@@ -25,9 +25,8 @@ const EvalSchema = z.object({
 });
 
 async function main() {
-  const prompts: { prompts: PromptChunk[] } = JSON.parse(await fs.readFile(path.resolve(args["--prompts"]), "utf-8"));
-  const contexts: { contexts: TaskContext[] } = JSON.parse(await fs.readFile(path.resolve(args["--context"]), "utf-8"));
-  const byTask = new Map(contexts.contexts.map(c => [c.taskFile, c]));
+  const prompts: { prompts: PromptChunk[] } = JSON.parse(await fs.readFile(path.resolve(args["--prompts"]!), "utf-8"));
+  const contexts: { contexts: TaskContext[] } = JSON.parse(await fs.readFile(path.resolve(args["--context"]!), "utf-8"));
 
   const items: EvalItem[] = [];
 
@@ -59,20 +58,26 @@ async function main() {
     ].filter(Boolean).join("\n");
 
     let obj: any;
-    try { obj = await ollamaJSON(args["--model"], `SYSTEM:\n${sys}\n\nUSER:\n${user}`); }
+    try { obj = await ollamaJSON(args["--model"]!, `SYSTEM:\n${sys}\n\nUSER:\n${user}`); }
     catch { obj = { inferred_status: status, confidence: 0.5, summary: "Review failed; keep current status.", suggested_actions: ["Manually review this task."] }; }
 
     const parsed = EvalSchema.safeParse(obj);
     const clean = parsed.success ? parsed.data : { inferred_status: status, confidence: 0.5, summary: "LLM parse failed", suggested_actions: ["Manual triage required."] };
 
-    items.push({
+    const item: EvalItem = {
       taskFile: ctx.taskFile,
-      ...clean,
-      inferred_status: normStatus(clean.inferred_status)
-    });
+      inferred_status: normStatus(clean.inferred_status),
+      confidence: clean.confidence,
+      summary: clean.summary,
+      suggested_actions: clean.suggested_actions,
+      ...(clean.blockers ? { blockers: clean.blockers } : {}),
+      ...(clean.suggested_labels ? { suggested_labels: clean.suggested_labels } : {}),
+      ...(clean.suggested_assignee ? { suggested_assignee: clean.suggested_assignee } : {})
+    };
+    items.push(item);
   }
 
-  await writeText(path.resolve(args["--out"]), JSON.stringify({ evals: items }, null, 2));
+  await writeText(path.resolve(args["--out"]!), JSON.stringify({ evals: items }, null, 2));
   console.log(`boardrev: evaluated ${items.length} task(s)`);
 }
 

--- a/packages/boardrev/src/06-report.ts
+++ b/packages/boardrev/src/06-report.ts
@@ -12,10 +12,10 @@ const args = parseArgs({
 });
 
 async function main() {
-  const evals: { evals: EvalItem[] } = JSON.parse(await fs.readFile(path.resolve(args["--evals"]), "utf-8"));
-  await fs.mkdir(path.resolve(args["--outDir"]), { recursive: true });
+  const evals: { evals: EvalItem[] } = JSON.parse(await fs.readFile(path.resolve(args["--evals"]!), "utf-8"));
+  await fs.mkdir(path.resolve(args["--outDir"]!), { recursive: true });
   const ts = new Date().toISOString().replace(/[:.]/g, "-");
-  const out = path.join(args["--outDir"], `board-${ts}.md`);
+  const out = path.join(args["--outDir"]!, `board-${ts}.md`);
 
   // group by inferred status
   const groups = new Map<string, EvalItem[]>();
@@ -79,7 +79,7 @@ async function main() {
   ].join("\n");
 
   await writeText(out, md);
-  await writeText(path.join(args["--outDir"], "README.md"), `# Board Reports\n\n- [Latest](${path.basename(out)})\n`);
+  await writeText(path.join(args["--outDir"]!, "README.md"), `# Board Reports\n\n- [Latest](${path.basename(out)})\n`);
   console.log(`boardrev: wrote report → ${path.relative(process.cwd(), out)}`);
 }
 

--- a/packages/boardrev/src/utils.ts
+++ b/packages/boardrev/src/utils.ts
@@ -7,10 +7,11 @@ export const OLLAMA_URL = process.env.OLLAMA_URL ?? "http://localhost:11434";
 export function parseArgs(defaults: Record<string,string>) {
   const out = { ...defaults };
   const a = process.argv.slice(2);
-  for (let i=0;i<a.length;i++){
-    const k=a[i]; if(!k.startsWith("--")) continue;
-    const v=a[i+1] && !a[i+1].startsWith("--") ? a[++i] : "true";
-    out[k]=v;
+  for (let i = 0; i < a.length; i++) {
+    const k = a[i]!; if (!k.startsWith("--")) continue;
+    const next = a[i + 1];
+    const v = next && !next.startsWith("--") ? a[++i]! : "true";
+    out[k] = v;
   }
   return out;
 }
@@ -62,7 +63,11 @@ export async function ollamaJSON(model: string, prompt: string): Promise<any> {
 }
 
 export function cosine(a: number[], b: number[]) {
-  let dot=0, na=0, nb=0, n=Math.min(a.length,b.length);
-  for (let i=0;i<n;i++){ dot+=a[i]*b[i]; na+=a[i]*a[i]; nb+=b[i]*b[i]; }
-  return !na||!nb ? 0 : dot/(Math.sqrt(na)*Math.sqrt(nb));
+  let dot = 0, na = 0, nb = 0, n = Math.min(a.length, b.length);
+  for (let i = 0; i < n; i++) {
+    const ai = a[i]!;
+    const bi = b[i]!;
+    dot += ai * bi; na += ai * ai; nb += bi * bi;
+  }
+  return !na || !nb ? 0 : dot / (Math.sqrt(na) * Math.sqrt(nb));
 }

--- a/packages/boardrev/test/utils.test.ts
+++ b/packages/boardrev/test/utils.test.ts
@@ -1,0 +1,16 @@
+import test from "ava";
+import { parseArgs, cosine } from "../src/utils.js";
+
+test("parseArgs merges defaults and argv", t => {
+  const prev = process.argv;
+  process.argv = ["node", "script", "--foo", "bar"];
+  const args = parseArgs({ "--foo": "baz", "--a": "1" });
+  t.is(args["--foo"], "bar");
+  t.is(args["--a"], "1");
+  process.argv = prev;
+});
+
+test("cosine computes similarity", t => {
+  t.is(cosine([1, 0], [0, 1]), 0);
+  t.true(Math.abs(cosine([1, 1], [1, 1]) - 1) < 1e-9);
+});

--- a/packages/boardrev/tsconfig.json
+++ b/packages/boardrev/tsconfig.json
@@ -1,11 +1,11 @@
 {
     "extends": "../../config/tsconfig.base.json",
     "compilerOptions": {
-        "rootDir": "src",
+        "rootDir": ".",
         "outDir": "dist",
         "composite": true,
         "declaration": true
     },
-    "include": ["src/**/*"],
+    "include": ["src/**/*", "test/**/*.ts"],
     "references": []
 }


### PR DESCRIPTION
## Summary
- guard boardrev scripts against undefined CLI args and optional fields
- harden parseArgs and cosine utilities with tests

## Testing
- `pnpm -F @promethean/boardrev build`
- `pnpm exec ava packages/boardrev/dist/test/utils.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b75336816c83249ee10053c02c7b5f