### PR TITLE
refactor: remove unused fs import

### DIFF
--- a/changelog.d/0000.removed.md
+++ b/changelog.d/0000.removed.md
@@ -1,0 +1,1 @@
+remove unused fs import in codemods spec

--- a/packages/codemods/src/01-spec.ts
+++ b/packages/codemods/src/01-spec.ts
@@ -1,5 +1,4 @@
 /* eslint-disable no-console */
-import { promises as fs } from "fs";
 import * as path from "path";
 import { Project } from "ts-morph";
 import { readJSON, writeJSON } from "./utils.js";


### PR DESCRIPTION
## Summary
- remove unused `fs` import from codemods spec
- document removal in changelog

## Testing
- `pnpm exec biome lint packages/codemods/src/01-spec.ts`
- `pnpm run test --filter @promethean/codemods` *(fails: @promethean/boardrev build: `tsc -p tsconfig.json`)*

------
https://chatgpt.com/codex/tasks/task_e_68b753382f648324a8e77d203dee385e