### PR TITLE
chore: remove unused Project import

### DIFF
--- a/changelog.d/0000.removed.md
+++ b/changelog.d/0000.removed.md
@@ -1,0 +1,1 @@
+Remove unused `Project` import from codemods utilities.

--- a/packages/codemods/src/utils.ts
+++ b/packages/codemods/src/utils.ts
@@ -1,6 +1,6 @@
 import { promises as fs } from "fs";
 import * as path from "path";
-import { Project, SourceFile, SyntaxKind } from "ts-morph";
+import { SourceFile, SyntaxKind } from "ts-morph";
 import { globby } from "globby";
 
 export async function readJSON<T>(p: string, fallback: T): Promise<T> {


### PR DESCRIPTION
## Summary
- drop unused `Project` import in codemods utils
- note removal in changelog

## Testing
- `pnpm lint packages/codemods/src/utils.ts` (fails: Found a nested root configuration, but there's already a root configuration.)
- `pnpm test` (fails: TypeScript build errors in `packages/boardrev`)


------
https://chatgpt.com/codex/tasks/task_e_68b75339c8a083248bbe621dd4582671