### PR TITLE
refactor(codemods): remove undefined canonical params

### DIFF
--- a/changelog.d/remove-canonical-params.changed.md
+++ b/changelog.d/remove-canonical-params.changed.md
@@ -1,0 +1,1 @@
+Removed placeholder params property from codemod spec canonical definitions.

--- a/packages/codemods/src/01-spec.ts
+++ b/packages/codemods/src/01-spec.ts
@@ -82,7 +82,7 @@ async function main() {
       clusterId: c.id,
       title: plan.title,
       summary: plan.summary,
-      canonical: { path: plan.canonicalPath, name: plan.canonicalName, params: undefined },
+      canonical: { path: plan.canonicalPath, name: plan.canonicalName },
       duplicates: dups.map(d => ({
         id: d.id, package: d.pkgName, file: d.fileRel, name: d.name, kind: d.kind, exported: d.exported
       }))


### PR DESCRIPTION
## Summary
- omit `params` from canonical codemod spec structure
- allow canonical parameters to be added only when discovered

## Testing
- `pnpm --filter @promethean/codemods run build` *(fails: TS errors in package)*
- `pnpm lint packages/codemods/src/01-spec.ts` *(fails: biome configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68b7533d23948324aad0f34262812b83