### PR TITLE
refactor codemods arg parsing

### DIFF
--- a/changelog.d/0000.changed.md
+++ b/changelog.d/0000.changed.md
@@ -1,0 +1,1 @@
+refactor: strengthen codemods arg parsing

--- a/packages/codemods/src/01-spec.ts
+++ b/packages/codemods/src/01-spec.ts
@@ -1,5 +1,4 @@
 /* eslint-disable no-console */
-import { promises as fs } from "fs";
 import * as path from "path";
 import { Project } from "ts-morph";
 import { readJSON, writeJSON } from "./utils.js";
@@ -13,14 +12,14 @@ const args = parseArgs({
   "--tsconfig": "tsconfig.json"
 });
 
-function parseArgs(defaults: Record<string,string>) {
-  const out = { ...defaults };
+function parseArgs<T extends Record<string, string>>(defaults: T): T {
+  const out: T = { ...defaults };
   const a = process.argv.slice(2);
-  for (let i=0;i<a.length;i++){
-    const k=a[i];
-    if(!k.startsWith("--")) continue;
-    const v=a[i+1] && !a[i+1].startsWith("--") ? a[++i] : "true";
-    out[k]=v;
+  for (let i = 0; i < a.length; i++) {
+    const k = a[i];
+    if (!k?.startsWith("--")) continue;
+    const v = a[i + 1] && !a[i + 1]?.startsWith("--") ? a[++i]! : "true";
+    out[k as keyof T] = v;
   }
   return out;
 }


### PR DESCRIPTION
## Summary
- remove unused fs import in codemods spec builder
- make parseArgs generic with optional guards
- document codemods arg parsing tweak

## Testing
- `pnpm lint packages/codemods/src/01-spec.ts` *(fails: Found a nested root configuration, but there's already a root configuration.)*
- `pnpm -F @promethean/codemods build` *(fails: Argument of type 'string | undefined' is not assignable to parameter of type 'string'.)*
- `pnpm test --filter @promethean/codemods` *(no output)*

------
https://chatgpt.com/codex/tasks/task_e_68b7533dcd188324a40bb9f5c491a562