### PR TITLE
fix: clean unused vars in agent-ecs

### DIFF
--- a/changelog.d/9999.fixed.md
+++ b/changelog.d/9999.fixed.md
@@ -1,0 +1,1 @@
+fix: remove unused variables in agent-ecs to resolve TypeScript build errors

--- a/packages/agent-ecs/src/systems/voice.ts
+++ b/packages/agent-ecs/src/systems/voice.ts
@@ -51,7 +51,7 @@ export function VoiceSystem(
             id: `${Date.now()}`,
             group: 'agent-speech',
             factory: async () => {
-                const { stream, cleanup } = await deps.tts(e.message);
+                const { stream } = await deps.tts(e.message);
                 const res = deps.createAudioResource(stream);
                 // cleanup after playback via player events if needed
                 return res;

--- a/packages/agent-ecs/src/voice.system.test.ts
+++ b/packages/agent-ecs/src/voice.system.test.ts
@@ -38,7 +38,7 @@ test('voice system joins and leaves', (t) => {
     const bus = makeBus();
     let destroyed = false;
     VoiceSystem(w, agent, C, bus, {
-        joinVoiceChannel: (e: any) => ({
+        joinVoiceChannel: () => ({
             subscribe: (_p: any) => {},
             destroy: () => {
                 destroyed = true;

--- a/packages/agent-ecs/src/world.ts
+++ b/packages/agent-ecs/src/world.ts
@@ -1,28 +1,8 @@
-import { World, Entity } from '@promethean/ds/ecs.js';
+import { World } from '@promethean/ds/ecs.js';
 import { defineAgentComponents } from './components';
 import { VADUpdateSystem } from './systems/vad';
 import { TurnDetectionSystem } from './systems/turn';
 import { SpeechArbiterSystem } from './systems/speechArbiter';
-// ecs/carry.ts
-
-// Carry a *subset* of components for all entities that have them in the current buffer.
-// This avoids needing a "query all" and keeps it cheap enough for now.
-function carryForTick(
-    w: any,
-    components: Array<any>, // component defs (e.g., C.Turn, C.PlaybackQ, etc.)
-) {
-    for (const Comp of components) {
-        // Query "all entities that have this Comp"
-        const q = w.makeQuery({ all: [Comp] });
-        for (const [eid, get] of w.iter(q)) {
-            const cur = get(Comp); // reads from current buffer
-            if (cur !== undefined && cur !== null) {
-                // write-through into next buffer unchanged
-                (w as any).set(eid as any, Comp, cur);
-            }
-        }
-    }
-}
 
 export function createAgentWorld(audioPlayer: any) {
     const w = new World();
@@ -53,19 +33,6 @@ export function createAgentWorld(audioPlayer: any) {
 
     async function tick(dtMs = 50) {
         const cmd = w.beginTick();
-
-        // 1) Carry: snapshot current → next so reads don't vanish when turn bumps
-        // carryForTick(w, [
-        //     C.Turn,
-        //     C.Policy,
-        //     C.PlaybackQ,
-        //     C.Utterance,
-        //     C.AudioRes,
-        //     C.AudioRef,
-        //     C.VAD,
-        //     C.RawVAD,
-        //     C.TranscriptFinal
-        // ]);
 
         for (const s of systems) await s(dtMs);
 


### PR DESCRIPTION
## Summary
- remove unused variables and helper from speech arbiter
- simplify voice system TTS handling
- drop dead code from world and clean voice tests

## Testing
- `pnpm --filter @promethean/agent-ecs build`
- `NODE_OPTIONS=--experimental-specifier-resolution=node pnpm --filter @promethean/agent-ecs test` *(fails: Cannot find module '@promethean/ds/dist/ecs.js')*

------
https://chatgpt.com/codex/tasks/task_e_68b7533f25c08324bb102dcf930039ed