### PR TITLE
fix: harden cookbookflow argument handling

### DIFF
--- a/changelog.d/0000.fixed.md
+++ b/changelog.d/0000.fixed.md
@@ -1,0 +1,1 @@
+fix cookbookflow build errors by ensuring argument parsing returns strings and by checking for undefined values

--- a/packages/cookbookflow/src/01-scan.ts
+++ b/packages/cookbookflow/src/01-scan.ts
@@ -9,15 +9,15 @@ const args = parseArgs({
   "--roots": "docs examples packages",
   "--out": ".cache/cookbook/blocks.json",
   "--max-context": "12"
-});
+} as const);
 
 function* mdCodeBlocks(md: string): Generator<{lang:string, code:string, header:string}> {
-  const fence = /```(\w+)?[^\n]*\n([\s\S]*?)```/g;
-  let m; while ( (m = fence.exec(md)) ) {
-    const before = md.slice(0, m.index);
-    const header = (before.match(/(?:^|\n)#{1,6}\s+[^\n]+$/m)?.[0] ?? "").trim();
-    yield { lang: (m[1]||"").toLowerCase(), code: m[2], header };
-  }
+    const fence = /```(\w+)?[^\n]*\n([\s\S]*?)```/g;
+    let m; while ( (m = fence.exec(md)) ) {
+      const before = md.slice(0, m.index);
+      const header = (before.match(/(?:^|\n)#{1,6}\s+[^\n]+$/m)?.[0] ?? "").trim();
+      yield { lang: (m[1] || "").toLowerCase(), code: m[2] ?? "", header };
+    }
 }
 
 async function main() {

--- a/packages/cookbookflow/src/02-embed-classify.ts
+++ b/packages/cookbookflow/src/02-embed-classify.ts
@@ -9,7 +9,7 @@ const args = parseArgs({
   "--out": ".cache/cookbook/classes.json",
   "--embed-model": "nomic-embed-text:latest",
   "--llm": "qwen3:4b"
-});
+} as const);
 
 async function main() {
   const scan = JSON.parse(await fs.readFile(path.resolve(args["--in"]), "utf-8")) as ScanOutput;

--- a/packages/cookbookflow/src/03-group.ts
+++ b/packages/cookbookflow/src/03-group.ts
@@ -9,7 +9,7 @@ const args = parseArgs({
   "--out": ".cache/cookbook/groups.json",
   "--min-sim": "0.82",
   "--max-size": "12"
-});
+} as const);
 
 async function main() {
   const cf = JSON.parse(await fs.readFile(path.resolve(args["--in"]), "utf-8")) as ClassesFile;
@@ -21,7 +21,7 @@ async function main() {
 
   for (const id of ids) {
     if (seen.has(id)) continue;
-    const seed = cf.classes[id];
+    const seed = cf.classes[id]!;
     const key = `${seed.task}|${seed.runtime}|${seed.language}`;
     const centroid = cf.embeddings[id];
     const members = [id];
@@ -29,15 +29,16 @@ async function main() {
     // greedy nearest neighbors within same key
     for (const other of ids) {
       if (id === other || seen.has(other)) continue;
-      const c = cf.classes[other];
-      if (`${c.task}|${c.runtime}|${c.language}` !== key) continue;
-      const sim = cosine(centroid, cf.embeddings[other] || []);
+        const c = cf.classes[other]!;
+        if (`${c.task}|${c.runtime}|${c.language}` !== key) continue;
+        const sim = cosine(centroid ?? [], cf.embeddings[other] ?? []);
       if (sim >= minSim) members.push(other);
       if (members.length >= maxSize) break;
     }
 
     members.forEach(m => seen.add(m));
-    groups.push({ key, blockIds: members, centroid });
+    const g: Group = centroid ? { key, blockIds: members, centroid } : { key, blockIds: members };
+    groups.push(g);
   }
 
   const out: GroupsFile = { groupedAt: new Date().toISOString(), groups };

--- a/packages/cookbookflow/src/04-plan.ts
+++ b/packages/cookbookflow/src/04-plan.ts
@@ -11,7 +11,7 @@ const args = parseArgs({
   "--groups": ".cache/cookbook/groups.json",
   "--out": ".cache/cookbook/plan.json",
   "--llm": "qwen3:4b"
-});
+} as const);
 
 const RecipeSchema = z.object({
   title: z.string().min(1),
@@ -36,8 +36,9 @@ async function main() {
   const outGroups: Record<string, PlanRecipe[]> = {};
 
   for (const g of groups.groups) {
-    const sample = byId.get(g.blockIds[0])!;
-    const meta = classes.classes[g.blockIds[0]];
+    const firstId = g.blockIds[0]!;
+    const sample = byId.get(firstId)!;
+    const meta = classes.classes[firstId]!;
     const sys = [
       "You produce runnable, task-oriented cookbook recipes.",
       "Return ONLY JSON with keys:",

--- a/packages/cookbookflow/src/05-materialize.ts
+++ b/packages/cookbookflow/src/05-materialize.ts
@@ -8,7 +8,7 @@ import type { PlanFile } from "./types.js";
 const args = parseArgs({
   "--plan": ".cache/cookbook/plan.json",
   "--out": "docs/cookbook"
-});
+} as const);
 
 const START="<!-- COOKBOOK:BEGIN -->";
 const END="<!-- COOKBOOK:END -->";
@@ -47,7 +47,7 @@ async function main() {
   const OUT = path.resolve(args["--out"]); await fs.mkdir(OUT, { recursive: true });
 
   let count = 0;
-  for (const [key, recs] of Object.entries(plan.groups)) {
+  for (const recs of Object.values(plan.groups)) {
     for (const r of recs) {
       const dir = path.join(OUT, r.task);
       await fs.mkdir(dir, { recursive: true });

--- a/packages/cookbookflow/src/06-exec.ts
+++ b/packages/cookbookflow/src/06-exec.ts
@@ -10,7 +10,7 @@ const args = parseArgs({
   "--root": "docs/cookbook",
   "--out": ".cache/cookbook/run-results.json",
   "--timeout": "0"
-});
+} as const);
 
 async function main() {
   const files = await globby([`${args["--root"].replace(/\\/g,"/")}/**/*.md`]);
@@ -25,8 +25,8 @@ async function main() {
     const m = body.match(/```(\w+)?[^\n]*\n([\s\S]*?)```/);
     if (!m) { results.push({ recipePath: f, ok: false, stdoutPreview: "", stderrPreview: "no code block found", exitCode: null }); continue; }
 
-    const lang = (m[1]||"").toLowerCase();
-    const code = m[2];
+      const lang = (m[1]||"").toLowerCase();
+      const code = m[2] ?? "";
 
     // crude sandbox: create a temp dir under .cache/cookbook/run/<slug>
     const runDir = path.join(".cache/cookbook/run", path.basename(f, ".md"));

--- a/packages/cookbookflow/src/07-verify.ts
+++ b/packages/cookbookflow/src/07-verify.ts
@@ -28,7 +28,10 @@ async function main() {
       await fs.writeFile(r.recipePath, final, "utf-8");
     }
 
-    items.push({ recipePath: r.recipePath, expected, actual, ok: !!actual && !!expected && expected === actual && r.ok });
+    const item: VerifyItem = { recipePath: r.recipePath, ok: !!actual && !!expected && expected === actual && r.ok };
+    if (expected !== undefined) item.expected = expected;
+    if (actual !== undefined) item.actual = actual;
+    items.push(item);
   }
 
   const out: VerifyFile = { verifiedAt: new Date().toISOString(), items };

--- a/packages/cookbookflow/src/08-report.ts
+++ b/packages/cookbookflow/src/08-report.ts
@@ -8,7 +8,7 @@ const args = parseArgs({
   "--runs": ".cache/cookbook/run-results.json",
   "--verify": ".cache/cookbook/verify.json",
   "--out": "docs/agile/reports/cookbook"
-});
+} as const);
 
 async function main() {
   const runs = JSON.parse(await fs.readFile(path.resolve(args["--runs"]), "utf-8")) as RunResultsFile;

--- a/packages/cookbookflow/src/utils.ts
+++ b/packages/cookbookflow/src/utils.ts
@@ -4,11 +4,19 @@ import { exec as _exec } from "child_process";
 
 export const OLLAMA_URL = process.env.OLLAMA_URL ?? "http://localhost:11434";
 
-export function parseArgs(def: Record<string, string>) {
-  const out = { ...def }; const a = process.argv.slice(2);
-  for (let i=0;i<a.length;i++){ const k=a[i]; if(!k.startsWith("--")) continue;
-    const v=a[i+1] && !a[i+1].startsWith("--") ? a[++i] : "true"; out[k]=v; }
-  return out;
+export function parseArgs<T extends Record<string, string>>(def: T): T {
+  const out: Record<string, string> = { ...def };
+  const a = process.argv.slice(2);
+  for (let i = 0; i < a.length; i++) {
+    const k = a[i]!;
+    if (!k.startsWith("--")) continue;
+    const next = a[i + 1];
+    const hasVal = next !== undefined && !next.startsWith("--");
+    const v = hasVal ? next! : "true";
+    if (hasVal) i++;
+    out[k] = v;
+  }
+  return out as T;
 }
 export async function readMaybe(p: string) { try { return await fs.readFile(p, "utf-8"); } catch { return undefined; } }
 export async function writeJSON(p: string, data: any) { await fs.mkdir(path.dirname(p), { recursive: true }); await fs.writeFile(p, JSON.stringify(data, null, 2), "utf-8"); }
@@ -38,7 +46,18 @@ export async function ollamaJSON(model: string, prompt: string): Promise<any> {
   const raw = typeof response === "string" ? response : JSON.stringify(response);
   return JSON.parse(String(raw).replace(/```json\s*/g,"").replace(/```\s*$/g,"").trim());
 }
-export function cosine(a: number[], b: number[]) { let dot=0, na=0, nb=0, n=Math.min(a.length,b.length); for (let i=0;i<n;i++){ dot+=a[i]*b[i]; na+=a[i]*a[i]; nb+=b[i]*b[i]; } return !na||!nb?0:dot/(Math.sqrt(na)*Math.sqrt(nb)); }
+export function cosine(a: number[], b: number[]) {
+  let dot = 0, na = 0, nb = 0;
+  const n = Math.min(a.length, b.length);
+  for (let i = 0; i < n; i++) {
+    const ai = a[i]!;
+    const bi = b[i]!;
+    dot += ai * bi;
+    na += ai * ai;
+    nb += bi * bi;
+  }
+  return !na || !nb ? 0 : dot / (Math.sqrt(na) * Math.sqrt(nb));
+}
 
 export async function execShell(cmd: string, cwd: string) {
   return new Promise<{ code: number|null; stdout: string; stderr: string }>((resolve) => {


### PR DESCRIPTION
## Summary
- type-safe CLI parser and cosine calc in cookbookflow utils
- guard against undefined values across cookbookflow scripts
- add changelog fragment

## Testing
- `pnpm --filter @promethean/cookbookflow build`
- `pnpm --filter @promethean/cookbookflow test` *(no tests found)*
- `pnpm test` *(fails: @promethean/boardrev build: tsc errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b7533fef28832496c242eea5bc1410