### PR TITLE
fix: assert CLI arguments in verification scripts

### DIFF
--- a/changelog.d/0000.fixed.md
+++ b/changelog.d/0000.fixed.md
@@ -1,0 +1,1 @@
+Ensure required CLI arguments are asserted and default optional commands in verification scripts.

--- a/packages/codemods/src/04-verify.ts
+++ b/packages/codemods/src/04-verify.ts
@@ -1,221 +1,284 @@
 /* eslint-disable no-console */
-import { promises as fs } from "fs";
-import * as path from "path";
-import { exec } from "child_process";
+import { promises as fs } from "node:fs";
+import * as path from "node:path";
+import { exec } from "node:child_process";
 
 const args = parseArgs({
-  "--stage": "after",                           // "baseline" | "after" | any label you like
-  "--out": "docs/agile/tasks/codemods",         // markdown reports
-  "--cache": ".cache/codemods/verify",          // json snapshots
-  "--include-run-summary": ".cache/codemods/run-apply.json", // optional; produced by 03-run.ts (see patch below)
-  "--tsc": "npx tsc -p tsconfig.json --noEmit",
-  "--build": "",                                // e.g. "pnpm -w -r build"
-  "--test": "pnpm -w -r test",                  // tweak to your runner; empty string skips
-  "--timeout": "0"                              // ms; 0 = no timeout
+	"--stage": "after", // "baseline" | "after" | any label you like
+	"--out": "docs/agile/tasks/codemods", // markdown reports
+	"--cache": ".cache/codemods/verify", // json snapshots
+	"--include-run-summary": ".cache/codemods/run-apply.json", // optional; produced by 03-run.ts (see patch below)
+	"--tsc": "npx tsc -p tsconfig.json --noEmit",
+	"--build": "", // e.g. "pnpm -w -r build"
+	"--test": "pnpm -w -r test", // tweak to your runner; empty string skips
+	"--timeout": "0", // ms; 0 = no timeout
 });
 
 type StepResult = {
-  name: string;
-  cmd: string;
-  exitCode: number | null;
-  durationMs: number;
-  stdout: string;
-  stderr: string;
+	name: string;
+	cmd: string;
+	exitCode: number | null;
+	durationMs: number;
+	stdout: string;
+	stderr: string;
 };
 
 type Snapshot = {
-  stage: string;
-  startedAt: string;
-  endedAt: string;
-  steps: StepResult[];
-  runSummary?: {
-    changedByCodemod?: Record<string, string[]>; // codemodId -> [files]
-  };
+	stage: string;
+	startedAt: string;
+	endedAt: string;
+	steps: StepResult[];
+	runSummary?: {
+		changedByCodemod?: Record<string, string[]>; // codemodId -> [files]
+	};
 };
 
-function parseArgs(defaults: Record<string,string>) {
-  const out = { ...defaults };
-  const a = process.argv.slice(2);
-  for (let i=0;i<a.length;i++){
-    const k=a[i];
-    if(!k.startsWith("--")) continue;
-    const v=a[i+1] && !a[i+1].startsWith("--") ? a[++i] : "true";
-    out[k]=v;
-  }
-  return out;
+function parseArgs(defaults: Record<string, string>) {
+	const out = { ...defaults };
+	const a = process.argv.slice(2);
+	for (let i = 0; i < a.length; i++) {
+		const k = a[i];
+		if (!k.startsWith("--")) continue;
+		const v = a[i + 1] && !a[i + 1].startsWith("--") ? a[++i] : "true";
+		out[k] = v;
+	}
+	return out;
 }
 
-async function runCmd(name: string, cmd: string, timeoutMs: number): Promise<StepResult> {
-  const started = Date.now();
-  const res: StepResult = { name, cmd, exitCode: null, durationMs: 0, stdout: "", stderr: "" };
-  if (!cmd.trim()) return { ...res, durationMs: 0, exitCode: 0 };
-  return new Promise((resolve) => {
-    (exec as any)(
-      cmd,
-      ({ maxBuffer: 1024 * 1024 * 64, timeout: timeoutMs > 0 ? timeoutMs : undefined } as any),
-      (err: any, stdout: string, stderr: string) => {
-        const ended = Date.now();
-        resolve({
-          name,
-          cmd,
-          exitCode: err ? (typeof err.code === 'number' ? err.code : 1) : 0,
-          durationMs: ended - started,
-          stdout: String(stdout ?? ''),
-          stderr: String(stderr ?? ''),
-        });
-      },
-    );
-  });
+async function runCmd(
+	name: string,
+	cmd: string,
+	timeoutMs: number,
+): Promise<StepResult> {
+	const started = Date.now();
+	const res: StepResult = {
+		name,
+		cmd,
+		exitCode: null,
+		durationMs: 0,
+		stdout: "",
+		stderr: "",
+	};
+	if (!cmd.trim()) return { ...res, durationMs: 0, exitCode: 0 };
+	return new Promise((resolve) => {
+		(exec as any)(
+			cmd,
+			{
+				maxBuffer: 1024 * 1024 * 64,
+				timeout: timeoutMs > 0 ? timeoutMs : undefined,
+			} as any,
+			(err: any, stdout: string, stderr: string) => {
+				const ended = Date.now();
+				resolve({
+					name,
+					cmd,
+					exitCode: err
+						? typeof err.code === "number"
+							? err.code
+							: 1
+						: 0,
+					durationMs: ended - started,
+					stdout: String(stdout ?? ""),
+					stderr: String(stderr ?? ""),
+				});
+			},
+		);
+	});
 }
 
 function mdEscape(s: string) {
-  return s.replace(/</g, "&lt;").replace(/>/g, "&gt;");
+	return s.replace(/</g, "&lt;").replace(/>/g, "&gt;");
 }
 
 async function readMaybe(p: string) {
-  try { return await fs.readFile(p, "utf-8"); } catch { return undefined; }
+	try {
+		return await fs.readFile(p, "utf-8");
+	} catch {
+		return undefined;
+	}
 }
 
 async function main() {
-  const STAGE = args["--stage"];
-  const OUT_DIR = path.resolve(args["--out"]);
-  const CACHE_DIR = path.resolve(args["--cache"]);
-  const SUMMARY_PATH = path.resolve(args["--include-run-summary"]);
-  const TIMEOUT = Number(args["--timeout"]) || 0;
+	const STAGE = args["--stage"]!;
+	const OUT_ARG = args["--out"]!;
+	const OUT_DIR = path.resolve(OUT_ARG);
+	const CACHE_ARG = args["--cache"]!;
+	const CACHE_DIR = path.resolve(CACHE_ARG);
+	const SUMMARY_ARG = args["--include-run-summary"]!;
+	const SUMMARY_PATH = path.resolve(SUMMARY_ARG);
+	const TSC_CMD = args["--tsc"]!;
+	const BUILD_CMD = args["--build"] ?? "";
+	const TEST_CMD = args["--test"] ?? "";
+	const TIMEOUT = Number(args["--timeout"] ?? "0") || 0;
 
-  await fs.mkdir(OUT_DIR, { recursive: true });
-  await fs.mkdir(CACHE_DIR, { recursive: true });
+	await fs.mkdir(OUT_DIR, { recursive: true });
+	await fs.mkdir(CACHE_DIR, { recursive: true });
 
-  // optional: bring in changed files from 03-run (json)
-  let runSummary: Snapshot["runSummary"] | undefined = undefined;
-  try {
-    const raw = await readMaybe(SUMMARY_PATH);
-    if (raw) runSummary = JSON.parse(raw);
-  } catch { /* ignore */ }
+	// optional: bring in changed files from 03-run (json)
+	let runSummary: Snapshot["runSummary"] | undefined;
+	try {
+		const raw = await readMaybe(SUMMARY_PATH);
+		if (raw) runSummary = JSON.parse(raw);
+	} catch {
+		/* ignore */
+	}
 
-  const steps: StepResult[] = [];
-  const startedAt = new Date().toISOString();
+	const steps: StepResult[] = [];
+	const startedAt = new Date().toISOString();
 
-  steps.push(await runCmd("tsc", args["--tsc"], TIMEOUT));
-  if (args["--build"].trim()) steps.push(await runCmd("build", args["--build"], TIMEOUT));
-  if (args["--test"].trim()) steps.push(await runCmd("test", args["--test"], TIMEOUT));
+	steps.push(await runCmd("tsc", TSC_CMD, TIMEOUT));
+	if (BUILD_CMD.trim()) steps.push(await runCmd("build", BUILD_CMD, TIMEOUT));
+	if (TEST_CMD.trim()) steps.push(await runCmd("test", TEST_CMD, TIMEOUT));
 
-  const endedAt = new Date().toISOString();
-  const snap: Snapshot = { stage: STAGE, startedAt, endedAt, steps, runSummary };
+	const endedAt = new Date().toISOString();
+	const snap: Snapshot = {
+		stage: STAGE,
+		startedAt,
+		endedAt,
+		steps,
+		runSummary,
+	};
 
-  // write cache
-  const cacheFile = path.join(CACHE_DIR, `${STAGE}.json`);
-  await fs.writeFile(cacheFile, JSON.stringify(snap, null, 2), "utf-8");
+	// write cache
+	const cacheFile = path.join(CACHE_DIR, `${STAGE}.json`);
+	await fs.writeFile(cacheFile, JSON.stringify(snap, null, 2), "utf-8");
 
-  // write stage report
-  const report = renderStageMarkdown(snap);
-  await fs.writeFile(path.join(OUT_DIR, `verify-${STAGE}.md`), report, "utf-8");
+	// write stage report
+	const report = renderStageMarkdown(snap);
+	await fs.writeFile(
+		path.join(OUT_DIR, `verify-${STAGE}.md`),
+		report,
+		"utf-8",
+	);
 
-  // if baseline exists and this is a comparison stage, emit VERIFY.md
-  const baselineFile = path.join(CACHE_DIR, `baseline.json`);
-  const baseRaw = await readMaybe(baselineFile);
-  if (baseRaw && STAGE !== "baseline") {
-    const base: Snapshot = JSON.parse(baseRaw);
-    const delta = renderDeltaMarkdown(base, snap);
-    await fs.writeFile(path.join(OUT_DIR, `VERIFY.md`), delta, "utf-8");
-  }
+	// if baseline exists and this is a comparison stage, emit VERIFY.md
+	const baselineFile = path.join(CACHE_DIR, `baseline.json`);
+	const baseRaw = await readMaybe(baselineFile);
+	if (baseRaw && STAGE !== "baseline") {
+		const base: Snapshot = JSON.parse(baseRaw);
+		const delta = renderDeltaMarkdown(base, snap);
+		await fs.writeFile(path.join(OUT_DIR, `VERIFY.md`), delta, "utf-8");
+	}
 
-  // pretty console
-  const summaryLine = steps.map(s => `${s.name}:${s.exitCode===0 ? "OK" : "FAIL"}(${s.durationMs}ms)`).join("  ");
-  const failed = steps.filter(s => s.exitCode !== 0).map(s => s.name);
-  console.log(`verify[${STAGE}] — ${summaryLine} ${failed.length ? ` ❌ ${failed.join(",")}` : " ✅"}`);
+	// pretty console
+	const summaryLine = steps
+		.map(
+			(s) =>
+				`${s.name}:${s.exitCode === 0 ? "OK" : "FAIL"}(${s.durationMs}ms)`,
+		)
+		.join("  ");
+	const failed = steps.filter((s) => s.exitCode !== 0).map((s) => s.name);
+	console.log(
+		`verify[${STAGE}] — ${summaryLine} ${failed.length ? ` ❌ ${failed.join(",")}` : " ✅"}`,
+	);
 }
 
 function renderStageMarkdown(s: Snapshot): string {
-  const lines: string[] = [
-    `# Verification — ${s.stage}`,
-    "",
-    `Started: ${s.startedAt}`,
-    `Ended:   ${s.endedAt}`,
-    "",
-    "## Results",
-    "",
-    "| Step | Exit | Duration (ms) |",
-    "|---|:---:|---:|",
-    ...s.steps.map(st => `| ${st.name} | ${st.exitCode ?? "_"} | ${st.durationMs} |`),
-    "",
-  ];
+	const lines: string[] = [
+		`# Verification — ${s.stage}`,
+		"",
+		`Started: ${s.startedAt}`,
+		`Ended:   ${s.endedAt}`,
+		"",
+		"## Results",
+		"",
+		"| Step | Exit | Duration (ms) |",
+		"|---|:---:|---:|",
+		...s.steps.map(
+			(st) => `| ${st.name} | ${st.exitCode ?? "_"} | ${st.durationMs} |`,
+		),
+		"",
+	];
 
-  if (s.runSummary?.changedByCodemod) {
-    const all = s.runSummary.changedByCodemod;
-    lines.push("## Files changed by codemod run", "");
-    for (const [id, files] of Object.entries(all)) {
-      lines.push(`- **${id}** (${files.length})`, ...files.map(f => `  - \`${f}\``), "");
-    }
-  }
+	if (s.runSummary?.changedByCodemod) {
+		const all = s.runSummary.changedByCodemod;
+		lines.push("## Files changed by codemod run", "");
+		for (const [id, files] of Object.entries(all)) {
+			lines.push(
+				`- **${id}** (${files.length})`,
+				...files.map((f) => `  - \`${f}\``),
+				"",
+			);
+		}
+	}
 
-  for (const st of s.steps) {
-    lines.push(
-      `### ${st.name}`,
-      "",
-      `**Command:** \`${mdEscape(st.cmd)}\`  `,
-      `**Exit:** ${st.exitCode}  `,
-      `**Duration:** ${st.durationMs} ms`,
-      "",
-      "<details><summary>stdout</summary>",
-      "",
-      "```text",
-      st.stdout.trimEnd(),
-      "```",
-      "",
-      "</details>",
-      "",
-      "<details><summary>stderr</summary>",
-      "",
-      "```text",
-      st.stderr.trimEnd(),
-      "```",
-      "",
-      "</details>",
-      ""
-    );
-  }
-  return lines.join("\n");
+	for (const st of s.steps) {
+		lines.push(
+			`### ${st.name}`,
+			"",
+			`**Command:** \`${mdEscape(st.cmd)}\`  `,
+			`**Exit:** ${st.exitCode}  `,
+			`**Duration:** ${st.durationMs} ms`,
+			"",
+			"<details><summary>stdout</summary>",
+			"",
+			"```text",
+			st.stdout.trimEnd(),
+			"```",
+			"",
+			"</details>",
+			"",
+			"<details><summary>stderr</summary>",
+			"",
+			"```text",
+			st.stderr.trimEnd(),
+			"```",
+			"",
+			"</details>",
+			"",
+		);
+	}
+	return lines.join("\n");
 }
 
 function renderDeltaMarkdown(base: Snapshot, cur: Snapshot): string {
-  const lines: string[] = [
-    "# Verification delta",
-    "",
-    `Baseline: **${base.stage}** (${base.startedAt})`,
-    `Current:  **${cur.stage}** (${cur.startedAt})`,
-    "",
-    "## Step status comparison",
-    "",
-    "| Step | Baseline | Current |",
-    "|---|:---:|:---:|",
-    ...mergeByName(base.steps, cur.steps).map(([b, c]) =>
-      `| ${b?.name ?? c?.name ?? "?"} | ${fmtExit(b?.exitCode)} | ${fmtExit(c?.exitCode)} |`
-    ),
-    "",
-    "## Duration change (ms)",
-    "",
-    "| Step | Baseline | Current | Δ |",
-    "|---|---:|---:|---:|",
-    ...mergeByName(base.steps, cur.steps).map(([b, c]) => {
-      const bd = b?.durationMs ?? 0, cd = c?.durationMs ?? 0;
-      const d = cd - bd;
-      return `| ${b?.name ?? c?.name ?? "?"} | ${bd} | ${cd} | ${d} |`;
-    }),
-    ""
-  ];
+	const lines: string[] = [
+		"# Verification delta",
+		"",
+		`Baseline: **${base.stage}** (${base.startedAt})`,
+		`Current:  **${cur.stage}** (${cur.startedAt})`,
+		"",
+		"## Step status comparison",
+		"",
+		"| Step | Baseline | Current |",
+		"|---|:---:|:---:|",
+		...mergeByName(base.steps, cur.steps).map(
+			([b, c]) =>
+				`| ${b?.name ?? c?.name ?? "?"} | ${fmtExit(b?.exitCode)} | ${fmtExit(c?.exitCode)} |`,
+		),
+		"",
+		"## Duration change (ms)",
+		"",
+		"| Step | Baseline | Current | Δ |",
+		"|---|---:|---:|---:|",
+		...mergeByName(base.steps, cur.steps).map(([b, c]) => {
+			const bd = b?.durationMs ?? 0,
+				cd = c?.durationMs ?? 0;
+			const d = cd - bd;
+			return `| ${b?.name ?? c?.name ?? "?"} | ${bd} | ${cd} | ${d} |`;
+		}),
+		"",
+	];
 
-  return lines.join("\n");
+	return lines.join("\n");
 }
 
 function mergeByName(a: StepResult[], b: StepResult[]) {
-  const names = new Set<string>([...a.map(s => s.name), ...b.map(s => s.name)]);
-  const out: Array<[StepResult | undefined, StepResult | undefined]> = [];
-  for (const n of Array.from(names)) {
-    out.push([a.find(s => s.name === n), b.find(s => s.name === n)]);
-  }
-  return out;
+	const names = new Set<string>([
+		...a.map((s) => s.name),
+		...b.map((s) => s.name),
+	]);
+	const out: Array<[StepResult | undefined, StepResult | undefined]> = [];
+	for (const n of Array.from(names)) {
+		out.push([a.find((s) => s.name === n), b.find((s) => s.name === n)]);
+	}
+	return out;
 }
-function fmtExit(x?: number | null) { return x === 0 ? "OK" : (x == null ? "_" : `FAIL(${x})`); }
+function fmtExit(x?: number | null) {
+	return x === 0 ? "OK" : x == null ? "_" : `FAIL(${x})`;
+}
 
-main().catch(e => { console.error(e); process.exit(1); });
+main().catch((e) => {
+	console.error(e);
+	process.exit(1);
+});

--- a/packages/readmeflow/src/04-verify.ts
+++ b/packages/readmeflow/src/04-verify.ts
@@ -1,43 +1,78 @@
 /* eslint-disable no-console */
-import * as path from "path";
-import { promises as fs } from "fs";
+import * as path from "node:path";
+import { promises as fs } from "node:fs";
 import { parseArgs, writeText } from "./utils.js";
 import type { VerifyReport } from "./types.js";
 
 const args = parseArgs({
-  "--root": "packages",
-  "--out": "docs/agile/reports/readmes",
-  "--max": "200"
+	"--root": "packages",
+	"--out": "docs/agile/reports/readmes",
+	"--max": "200",
 });
 
 async function main() {
-  const pkgs = await fs.readdir(path.resolve(args["--root"]), { withFileTypes: true }).then(ents => ents.filter(e => e.isDirectory()).map(e => path.join(args["--root"], e.name)));
-  const results: VerifyReport["results"] = [];
+	const ROOT_DIR = args["--root"]!;
+	const OUT_DIR = args["--out"]!;
+	const MAX = Number(args["--max"]!);
 
-  for (const dir of pkgs) {
-    const readme = path.join(dir, "README.md");
-    try { await fs.access(readme); } catch { continue; }
-    const raw = await fs.readFile(readme, "utf-8");
-    const links = Array.from(raw.matchAll(/\[[^\]]+?\]\(([^)]+)\)/g)).map(m => m[1]).filter(h => !h.startsWith("http"));
-    const broken: string[] = [];
-    for (const href of links.slice(0, Number(args["--max"]))) {
-      const target = path.resolve(dir, href.split("#")[0]);
-      try { await fs.access(target); } catch { broken.push(href); }
-    }
-    if (broken.length) results.push({ pkg: dir.split("/").pop()!, broken });
-  }
+	const pkgs = await fs
+		.readdir(path.resolve(ROOT_DIR), { withFileTypes: true })
+		.then((ents) =>
+			ents
+				.filter((e) => e.isDirectory())
+				.map((e) => path.join(ROOT_DIR, e.name)),
+		);
+	const results: VerifyReport["results"] = [];
 
-  const ts = new Date().toISOString().replace(/[:.]/g,"-");
-  const md = [
-    "# README link check",
-    "",
-    results.length ? results.map(r => `- **${r.pkg}**:\n${r.broken.map(b => `  - ${b}`).join("\n")}`).join("\n") : "_No broken relative links found._",
-    ""
-  ].join("\n");
+	for (const dir of pkgs) {
+		const readme = path.join(dir, "README.md");
+		try {
+			await fs.access(readme);
+		} catch {
+			continue;
+		}
+		const raw = await fs.readFile(readme, "utf-8");
+		const links = Array.from(raw.matchAll(/\[[^\]]+?\]\(([^)]+)\)/g))
+			.map((m) => m[1])
+			.filter((h) => !h.startsWith("http"));
+		const broken: string[] = [];
+		for (const href of links.slice(0, MAX)) {
+			const target = path.resolve(dir, href.split("#")[0]);
+			try {
+				await fs.access(target);
+			} catch {
+				broken.push(href);
+			}
+		}
+		if (broken.length) results.push({ pkg: dir.split("/").pop()!, broken });
+	}
 
-  await fs.mkdir(path.resolve(args["--out"]), { recursive: true });
-  await writeText(path.join(args["--out"], `readmes-${ts}.md`), md);
-  await writeText(path.join(args["--out"], `README.md`), `# Readme Reports\n\n- [Latest](readmes-${ts}.md)\n`);
-  console.log(`readmeflow: verify report → ${path.join(args["--out"], `readmes-${ts}.md`)}`);
+	const ts = new Date().toISOString().replace(/[:.]/g, "-");
+	const md = [
+		"# README link check",
+		"",
+		results.length
+			? results
+					.map(
+						(r) =>
+							`- **${r.pkg}**:\n${r.broken.map((b) => `  - ${b}`).join("\n")}`,
+					)
+					.join("\n")
+			: "_No broken relative links found._",
+		"",
+	].join("\n");
+
+	await fs.mkdir(path.resolve(OUT_DIR), { recursive: true });
+	await writeText(path.join(OUT_DIR, `readmes-${ts}.md`), md);
+	await writeText(
+		path.join(OUT_DIR, `README.md`),
+		`# Readme Reports\n\n- [Latest](readmes-${ts}.md)\n`,
+	);
+	console.log(
+		`readmeflow: verify report → ${path.join(OUT_DIR, `readmes-${ts}.md`)}`,
+	);
 }
-main().catch(e => { console.error(e); process.exit(1); });
+main().catch((e) => {
+	console.error(e);
+	process.exit(1);
+});


### PR DESCRIPTION
## Summary
- assert required CLI arguments in codemods and readmeflow verify scripts
- default optional build/test commands to empty strings before execution
- document change

## Testing
- `pnpm exec biome lint packages/codemods/src/04-verify.ts packages/readmeflow/src/04-verify.ts`
- `pnpm test` *(fails: packages/boardrev build: Argument of type 'string | undefined' is not assignable)*

------
https://chatgpt.com/codex/tasks/task_e_68b755e802148324979902db431fd92e