### PR TITLE
fix: ensure piper builds and tests pass

### DIFF
--- a/changelog.d/0000.fixed.md
+++ b/changelog.d/0000.fixed.md
@@ -1,0 +1,1 @@
+fix piper package build and tests

--- a/packages/piper/package.json
+++ b/packages/piper/package.json
@@ -8,7 +8,8 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.json",
-    "prepare": "pnpm run build"
+    "prepare": "pnpm run build",
+    "test": "pnpm run build && ava --config ../../config/ava.config.mjs --no-worker-threads"
   },
   "dependencies": {
     "@promethean/piper": "link:",

--- a/packages/piper/src/runner.ts
+++ b/packages/piper/src/runner.ts
@@ -48,8 +48,16 @@ function semaphore(n: number) {
 }
 
 async function loadState(pipeline: string): Promise<State> {
-  try { return JSON.parse(await readTextMaybe(STATE_FILE(pipeline)) || "{}"); }
-  catch { return { steps: {} }; }
+  try {
+    const txt = await readTextMaybe(STATE_FILE(pipeline));
+    if (!txt) return { steps: {} };
+    const parsed = JSON.parse(txt);
+    return parsed && typeof parsed === "object" && "steps" in parsed
+      ? (parsed as State)
+      : { steps: {} };
+  } catch {
+    return { steps: {} };
+  }
 }
 
 async function saveState(pipeline: string, state: State) {


### PR DESCRIPTION
## Summary
- replace missing level-cache with simple JSON file persistence
- harden piper runner state loading
- add Ava test script with worker-thread opt-out

## Testing
- `pnpm --filter @promethean/piper test`


------
https://chatgpt.com/codex/tasks/task_e_68b76609fbc88324aa5437754e586ad7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Fixed piper package build and test execution.

- Refactor
  - Switched pipeline state persistence to a file-based cache, with no API changes.
  - Improved state loading to gracefully handle empty or invalid data.

- Tests
  - Added a test script to run build followed by AVA tests with the project config.

- Documentation
  - Updated changelog with the fix entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->