### PR TITLE
fix: ensure jsgen emits string and typed params

### DIFF
--- a/changelog.d/2025.09.03.01.39.38.fixed.md
+++ b/changelog.d/2025.09.03.01.39.38.fixed.md
@@ -1,0 +1,1 @@
+fix: ensure emitExpr returns a string and annotate parameters to avoid implicit any

--- a/packages/compiler/src/jsgen.ts
+++ b/packages/compiler/src/jsgen.ts
@@ -1,64 +1,75 @@
-import type { Expr } from './ast';
+import type { Expr, Name } from "./ast";
 
 interface Options {
-    iife: boolean;
-    importNames: string[];
-    pretty: boolean;
+	iife: boolean;
+	importNames: string[];
+	pretty: boolean;
 }
 
 export function emitJS(expr: Expr, opts: Options): string {
-    const body = emitExpr(expr);
-    const imports = opts.importNames;
-    const header = imports.length ? `const { ${imports.join(', ')} } = args;` : '';
-    return `(function(args){${header}return ${body};})`;
+	const body = emitExpr(expr);
+	const imports = opts.importNames;
+	const header = imports.length
+		? `const { ${imports.join(", ")} } = args;`
+		: "";
+	return `(function(args){${header}return ${body};})`;
 }
 
 function emitExpr(e: Expr): string {
-    switch (e.kind) {
-        case 'Num':
-            return String(e.value);
-        case 'Str':
-            return JSON.stringify(e.value);
-        case 'Bool':
-            return e.value ? 'true' : 'false';
-        case 'Null':
-            return 'null';
-        case 'Var':
-            return e.name.text;
-        case 'If':
-            return `(${emitExpr(e.cond)}?${emitExpr(e.then)}:${emitExpr(e.else)})`;
-        case 'Block': {
-            const exprs = e.exprs.map(emitExpr);
-            const last = exprs.pop() ?? 'null';
-            return `(function(){${exprs.map((x) => `${x};`).join('')}return ${last};})()`;
-        }
-        case 'Let':
-            return `(function(){const ${e.name.text}=${emitExpr(e.value)};return ${emitExpr(e.body)};})()`;
-        case 'Fun':
-            return `(${e.params.map((p) => p.text).join(',')}=>${emitExpr(e.body)})`;
-        case 'Def':
-            return `function ${e.name.text}(${e.params.map((p) => p.text).join(',')}){return ${emitExpr(e.body)};}`;
-        case 'Bin':
-            return `(${emitExpr(e.left)}${e.op}${emitExpr(e.right)})`;
-        case 'Un':
-            return `(${e.op}${emitExpr(e.expr)})`;
-        case 'Call':
-            return `${emitExpr(e.callee)}(${e.args.map(emitExpr).join(',')})`;
-        case 'Class': {
-            const ctorParams = e.fields.map((f) => f.text).join(',');
-            const fieldAssign = e.fields.map((f) => `this.${f.text}=${f.text};`).join('');
-            const methods = e.methods
-                .map((m) => `${m.name.text}(${m.params.map((p) => p.text).join(',')}){return ${emitExpr(m.body)};}`)
-                .join('');
-            return `(class ${e.name.text}{constructor(${ctorParams}){${fieldAssign}}${methods}})`;
-        }
-        case 'New':
-            return `(new ${emitExpr(e.ctor)}(${e.args.map(emitExpr).join(',')}))`;
-        case 'Get':
-            return `(${emitExpr(e.obj)}.${e.prop})`;
-        case 'Set':
-            return `(${emitExpr(e.obj)}.${e.prop}=${emitExpr(e.value)})`;
-        case 'MethodCall':
-            return `${emitExpr(e.obj)}.${e.method}(${e.args.map(emitExpr).join(',')})`;
-    }
+	switch (e.kind) {
+		case "Num":
+			return String(e.value);
+		case "Str":
+			return JSON.stringify(e.value);
+		case "Bool":
+			return e.value ? "true" : "false";
+		case "Null":
+			return "null";
+		case "Var":
+			return e.name.text;
+		case "If":
+			return `(${emitExpr(e.cond)}?${emitExpr(e.then)}:${emitExpr(e.else)})`;
+		case "Block": {
+			const exprs = e.exprs.map(emitExpr);
+			const last = exprs.pop() ?? "null";
+			return `(function(){${exprs.map((x: string) => `${x};`).join("")}return ${last};})()`;
+		}
+		case "Let":
+			return `(function(){const ${e.name.text}=${emitExpr(e.value)};return ${emitExpr(e.body)};})()`;
+		case "Fun":
+			return `(${e.params.map((p: Name) => p.text).join(",")}=>${emitExpr(e.body)})`;
+		case "Def":
+			return `function ${e.name.text}(${e.params.map((p: Name) => p.text).join(",")}){return ${emitExpr(e.body)};}`;
+		case "Bin":
+			return `(${emitExpr(e.left)}${e.op}${emitExpr(e.right)})`;
+		case "Un":
+			return `(${e.op}${emitExpr(e.expr)})`;
+		case "Call":
+			return `${emitExpr(e.callee)}(${e.args.map(emitExpr).join(",")})`;
+		case "Class": {
+			const ctorParams = e.fields.map((f: Name) => f.text).join(",");
+			const fieldAssign = e.fields
+				.map((f: Name) => `this.${f.text}=${f.text};`)
+				.join("");
+			const methods = e.methods
+				.map(
+					(m: { name: Name; params: Name[]; body: Expr }) =>
+						`${m.name.text}(${m.params.map((p: Name) => p.text).join(",")}){return ${emitExpr(m.body)};}`,
+				)
+				.join("");
+			return `(class ${e.name.text}{constructor(${ctorParams}){${fieldAssign}}${methods}})`;
+		}
+		case "New":
+			return `(new ${emitExpr(e.ctor)}(${e.args.map(emitExpr).join(",")}))`;
+		case "Get":
+			return `(${emitExpr(e.obj)}.${e.prop})`;
+		case "Set":
+			return `(${emitExpr(e.obj)}.${e.prop}=${emitExpr(e.value)})`;
+		case "MethodCall":
+			return `${emitExpr(e.obj)}.${e.method}(${e.args.map(emitExpr).join(",")})`;
+		default:
+			throw new Error(
+				`Unhandled expression kind: ${(e as { kind: string }).kind}`,
+			);
+	}
 }


### PR DESCRIPTION
## Summary
- add default case in `emitExpr` to handle unknown expression kinds
- annotate arrow-function params in `jsgen` to remove implicit any
- document change in changelog

## Testing
- `pnpm --filter @promethean/compiler exec tsc --noEmit src/jsgen.ts`
- `pnpm --filter @promethean/compiler exec biome lint src/jsgen.ts`
- `pnpm --filter @promethean/compiler run typecheck` *(fails: TS2835 and TS7006 in other files)*

------
https://chatgpt.com/codex/tasks/task_e_68b79b36dcf483248affc3f899edeb8f