### PR TITLE
fix: add .js extensions to relative imports

### DIFF
--- a/changelog.d/2025.09.03.01.40.35.fixed.md
+++ b/changelog.d/2025.09.03.01.40.35.fixed.md
@@ -1,0 +1,1 @@
+Fixed missing `.js` extensions in package imports to resolve TS2835 build errors.

--- a/packages/agent-ecs/src/adapters/example-hooks.ts
+++ b/packages/agent-ecs/src/adapters/example-hooks.ts
@@ -1,4 +1,4 @@
-import { enqueueUtterance } from '../helpers/enqueueUtterance';
+import { enqueueUtterance } from '../helpers/enqueueUtterance.js';
 
 export function wireAdapters(
     world: ReturnType<typeof import('../world').createAgentWorld>,

--- a/packages/agent-ecs/src/agent-ecs.doublebuffer.test.ts
+++ b/packages/agent-ecs/src/agent-ecs.doublebuffer.test.ts
@@ -1,7 +1,7 @@
 import test from 'ava';
-import { createAgentWorld } from './world';
-import { enqueueUtterance } from './helpers/enqueueUtterance';
-import { OrchestratorSystem } from './systems/orchestrator';
+import { createAgentWorld } from './world.js';
+import { enqueueUtterance } from './helpers/enqueueUtterance.js';
+import { OrchestratorSystem } from './systems/orchestrator.js';
 
 function makePlayer() {
     let playing = false;

--- a/packages/agent-ecs/src/helpers/enqueueUtterance.ts
+++ b/packages/agent-ecs/src/helpers/enqueueUtterance.ts
@@ -1,5 +1,5 @@
 // loose typing
-import type { defineAgentComponents } from '../components';
+import type { defineAgentComponents } from '../components.js';
 
 export function enqueueUtterance(
     w: any,

--- a/packages/agent-ecs/src/helpers/pushVision.ts
+++ b/packages/agent-ecs/src/helpers/pushVision.ts
@@ -1,5 +1,5 @@
 // loose typing
-import type { defineAgentComponents } from '../components';
+import type { defineAgentComponents } from '../components.js';
 
 export function pushVisionFrame(
     w: any,

--- a/packages/agent-ecs/src/systems/orchestrator.ts
+++ b/packages/agent-ecs/src/systems/orchestrator.ts
@@ -1,4 +1,4 @@
-import type { AgentBus } from '../bus';
+import type { AgentBus } from '../bus.js';
 
 export function OrchestratorSystem(
     w: any,

--- a/packages/agent-ecs/src/systems/speechArbiter.ts
+++ b/packages/agent-ecs/src/systems/speechArbiter.ts
@@ -1,5 +1,5 @@
 // loose typing to avoid cross-package type coupling
-import type { defineAgentComponents } from '../components';
+import type { defineAgentComponents } from '../components.js';
 
 // If the user keeps speaking for at least this long while we're paused,
 // escalate to a hard stop of the current utterance.

--- a/packages/agent-ecs/src/systems/turn.ts
+++ b/packages/agent-ecs/src/systems/turn.ts
@@ -1,4 +1,4 @@
-import type { defineAgentComponents } from '../components';
+import type { defineAgentComponents } from '../components.js';
 
 export function TurnDetectionSystem(w: any, C: ReturnType<typeof import('../components').defineAgentComponents>) {
     const { Turn, VAD, TranscriptFinal } = C as ReturnType<typeof defineAgentComponents>;

--- a/packages/agent-ecs/src/systems/voice.ts
+++ b/packages/agent-ecs/src/systems/voice.ts
@@ -1,6 +1,6 @@
 // loose typing to avoid cross-package type coupling
-import type { defineAgentComponents } from '../components';
-import { enqueueUtterance } from '../helpers/enqueueUtterance';
+import type { defineAgentComponents } from '../components.js';
+import { enqueueUtterance } from '../helpers/enqueueUtterance.js';
 
 type Deps = {
     joinVoiceChannel: (opts: any) => any;

--- a/packages/agent-ecs/src/voice.system.test.ts
+++ b/packages/agent-ecs/src/voice.system.test.ts
@@ -1,6 +1,6 @@
 import test from 'ava';
-import { createAgentWorld } from './world';
-import { VoiceSystem } from './systems/voice';
+import { createAgentWorld } from './world.js';
+import { VoiceSystem } from './systems/voice.js';
 
 function makePlayer() {
     let subscribed: any = null;

--- a/packages/agent-ecs/src/world.ts
+++ b/packages/agent-ecs/src/world.ts
@@ -1,8 +1,8 @@
 import { World, Entity } from '@promethean/ds/ecs.js';
-import { defineAgentComponents } from './components';
-import { VADUpdateSystem } from './systems/vad';
-import { TurnDetectionSystem } from './systems/turn';
-import { SpeechArbiterSystem } from './systems/speechArbiter';
+import { defineAgentComponents } from './components.js';
+import { VADUpdateSystem } from './systems/vad.js';
+import { TurnDetectionSystem } from './systems/turn.js';
+import { SpeechArbiterSystem } from './systems/speechArbiter.js';
 // ecs/carry.ts
 
 // Carry a *subset* of components for all entities that have them in the current buffer.

--- a/packages/compiler/src/ast.ts
+++ b/packages/compiler/src/ast.ts
@@ -1,4 +1,4 @@
-import type { Span } from './common';
+import type { Span } from './common.js';
 
 export type Name = { kind: 'Name'; text: string; span: Span };
 

--- a/packages/compiler/src/compiler.test.ts
+++ b/packages/compiler/src/compiler.test.ts
@@ -1,5 +1,5 @@
 import test from 'ava';
-import { compileAndRun } from './driver';
+import { compileAndRun } from './driver.js';
 
 test('compiler: compiles and runs basic program', (t) => {
     const src = 'let x = 2 + 3 in if x > 3 then x*10 else 0';

--- a/packages/compiler/src/driver.ts
+++ b/packages/compiler/src/driver.ts
@@ -1,6 +1,6 @@
-import { parse } from './parser';
-import { lower } from './lower';
-import { compileToBytecode, runBytecode } from './vm';
+import { parse } from './parser.js';
+import { lower } from './lower.js';
+import { compileToBytecode, runBytecode } from './vm.js';
 
 export function compileAndRun(src: string) {
     const ast = parse(src);

--- a/packages/compiler/src/jsgen.ts
+++ b/packages/compiler/src/jsgen.ts
@@ -1,4 +1,4 @@
-import type { Expr } from './ast';
+import type { Expr } from './ast.js';
 
 interface Options {
     iife: boolean;

--- a/packages/compiler/src/lexer.ts
+++ b/packages/compiler/src/lexer.ts
@@ -1,4 +1,4 @@
-import { Span } from './common';
+import { Span } from './common.js';
 
 export type TokKind = 'id' | 'num' | 'str' | 'op' | 'punct' | 'kw' | 'eof';
 

--- a/packages/compiler/src/lisp/driver.test.ts
+++ b/packages/compiler/src/lisp/driver.test.ts
@@ -1,5 +1,5 @@
 import test from 'ava';
-import { runLisp } from './driver';
+import { runLisp } from './driver.js';
 
 test('lisp: basic arithmetic', (t) => {
     t.is(runLisp('(+ 2 40)'), 42);

--- a/packages/compiler/src/lisp/driver.ts
+++ b/packages/compiler/src/lisp/driver.ts
@@ -1,9 +1,9 @@
 // @ts-nocheck
-import { read } from './reader';
-import { macroexpandAll } from './expand';
-import { toExpr } from './to-expr';
-import { sym, isList } from './syntax';
-import { emitJS } from '../jsgen';
+import { read } from './reader.js';
+import { macroexpandAll } from './expand.js';
+import { toExpr } from './to-expr.js';
+import { sym, isList } from './syntax.js';
+import { emitJS } from '../jsgen.js';
 
 export function compileLispToJS(src: string, { pretty = false, importNames = [] as string[] } = {}) {
     const forms = read(src);

--- a/packages/compiler/src/lisp/expand.ts
+++ b/packages/compiler/src/lisp/expand.ts
@@ -1,5 +1,5 @@
-import { S, List, Sym, isList, isSym, list, sym } from './syntax';
-import { MacroEnv, installCoreMacros } from './macros';
+import { S, List, Sym, isList, isSym, list, sym } from './syntax.js';
+import { MacroEnv, installCoreMacros } from './macros.js';
 
 export function macroexpandAll(forms: S[], user?: (m: MacroEnv) => void): S[] {
     const M = new MacroEnv();

--- a/packages/compiler/src/lisp/js-ast2lisp.ts
+++ b/packages/compiler/src/lisp/js-ast2lisp.ts
@@ -1,5 +1,5 @@
 import type * as EST from 'estree';
-import { S, Sym, Num, Str, Bool, Nil, List, sym, num, str, bool, list, nil } from './syntax';
+import { S, Sym, Num, Str, Bool, Nil, List, sym, num, str, bool, list, nil } from './syntax.js';
 
 export interface Js2LispOptions {
     // When true, try to fold "let v; v = EXPR;" into one (let ((v EXPR)) ...)

--- a/packages/compiler/src/lisp/js2lisp.ts
+++ b/packages/compiler/src/lisp/js2lisp.ts
@@ -1,5 +1,5 @@
-import { estreeProgramToLisp, type Js2LispOptions } from './js-ast2lisp';
-import { printS } from './print';
+import { estreeProgramToLisp, type Js2LispOptions } from './js-ast2lisp.js';
+import { printS } from './print.js';
 
 export async function jsToLisp(src: string, opts: Js2LispOptions & { tryAcorn?: boolean } = {}) {
     let Program: any = null;

--- a/packages/compiler/src/lisp/macros.ts
+++ b/packages/compiler/src/lisp/macros.ts
@@ -1,5 +1,5 @@
-import { S, List, Sym, list, sym, isList, isSym, gensym } from './syntax';
-import { qq } from './qq';
+import { S, List, Sym, list, sym, isList, isSym, gensym } from './syntax.js';
+import { qq } from './qq.js';
 
 export type MacroFn = (form: List, expand: (x: S) => S) => S;
 export class MacroEnv {

--- a/packages/compiler/src/lisp/print.ts
+++ b/packages/compiler/src/lisp/print.ts
@@ -1,4 +1,4 @@
-import { S } from './syntax';
+import { S } from './syntax.js';
 
 export interface PrintOptions {
     indent?: number;

--- a/packages/compiler/src/lisp/qq.ts
+++ b/packages/compiler/src/lisp/qq.ts
@@ -1,4 +1,4 @@
-import { S, List, Sym, Nil, isList, isSym, list, sym, nil } from './syntax';
+import { S, List, Sym, Nil, isList, isSym, list, sym, nil } from './syntax.js';
 
 export function qq(expr: S, env: Record<string, S>): S {
     // (quasiquote x) expands with , and ,@ substitutions from env

--- a/packages/compiler/src/lisp/reader.ts
+++ b/packages/compiler/src/lisp/reader.ts
@@ -1,4 +1,4 @@
-import { Span, S, Sym, List, Nil, num, str, bool, sym, list, nil } from './syntax';
+import { Span, S, Sym, List, Nil, num, str, bool, sym, list, nil } from './syntax.js';
 
 type Tok =
     | { k: 'id'; s: string; sp: Span }

--- a/packages/compiler/src/lisp/to-expr.ts
+++ b/packages/compiler/src/lisp/to-expr.ts
@@ -1,6 +1,6 @@
-import type { Expr } from '../ast';
-import { name as mkName } from '../ast';
-import { S, List, Sym, Num, Str, Bool, Nil, isList, isSym, list, sym } from './syntax';
+import type { Expr } from '../ast.js';
+import { name as mkName } from '../ast.js';
+import { S, List, Sym, Num, Str, Bool, Nil, isList, isSym, list, sym } from './syntax.js';
 
 export function toExpr(x: S): Expr {
     switch (x.t) {

--- a/packages/compiler/src/lisp/ts2lisp.test.ts
+++ b/packages/compiler/src/lisp/ts2lisp.test.ts
@@ -1,5 +1,5 @@
 import test from 'ava';
-import { tsToLisp } from './ts2lisp';
+import { tsToLisp } from './ts2lisp.js';
 
 test('transpiles TypeScript to Lisp', async (t) => {
     const src = 'const x: number = 1 + 2;';

--- a/packages/compiler/src/lisp/ts2lisp.ts
+++ b/packages/compiler/src/lisp/ts2lisp.ts
@@ -1,4 +1,4 @@
-import { jsToLisp } from './js2lisp';
+import { jsToLisp } from './js2lisp.js';
 
 export interface TsToLispOptions {
     // Names treated as globals -> (js/global "Name"), e.g., ["document","window","Image"]

--- a/packages/compiler/src/lower.ts
+++ b/packages/compiler/src/lower.ts
@@ -1,5 +1,5 @@
-import type { Expr } from './ast';
-import { gensym, type Module, type Fun, type Stmt, type Sym, type Rhs, type Val } from './ir';
+import type { Expr } from './ast.js';
+import { gensym, type Module, type Fun, type Stmt, type Sym, type Rhs, type Val } from './ir.js';
 
 export function lower(ast: Expr): Module {
     const env: Map<string, Sym> = new Map();

--- a/packages/compiler/src/parser.ts
+++ b/packages/compiler/src/parser.ts
@@ -1,8 +1,8 @@
-import { Diag, assert } from './common';
-import type { Tok } from './lexer';
-import { lex } from './lexer';
-import type { Expr, Name } from './ast';
-import { name as mkName } from './ast';
+import { Diag, assert } from './common.js';
+import type { Tok } from './lexer.js';
+import { lex } from './lexer.js';
+import type { Expr, Name } from './ast.js';
+import { name as mkName } from './ast.js';
 
 type Nud = () => Expr;
 type Led = (left: Expr) => Expr;

--- a/packages/compiler/src/vm.ts
+++ b/packages/compiler/src/vm.ts
@@ -1,4 +1,4 @@
-import type { Module, Fun, Stmt, Rhs } from './ir';
+import type { Module, Fun, Stmt, Rhs } from './ir.js';
 
 export type OpCode =
     | ['LIT', number | string | boolean | null]

--- a/packages/dlq/src/replay.ts
+++ b/packages/dlq/src/replay.ts
@@ -1,5 +1,5 @@
 // Loosen types to decouple cross-package declarations at build time
-import { dlqTopic } from './types';
+import { dlqTopic } from './types.js';
 
 export async function replayDLQ(
     store: any,

--- a/packages/dlq/src/subscribe.ts
+++ b/packages/dlq/src/subscribe.ts
@@ -1,5 +1,5 @@
 // Using loose typing to avoid cross-package type coupling at build time
-import { dlqTopic } from './types';
+import { dlqTopic } from './types.js';
 
 export function withDLQ(bus: any, { maxAttempts = 5, group }: { maxAttempts?: number; group: string }) {
     return async function subscribeWithDLQ(topic: string, handler: (e: any) => Promise<void>, opts: any = {}) {

--- a/packages/docops/src/01-frontmatter.ts
+++ b/packages/docops/src/01-frontmatter.ts
@@ -2,8 +2,8 @@ import { promises as fs } from "fs";
 import * as path from "path";
 import matter from "gray-matter";
 import { z } from "zod";
-import { parseArgs, listFilesRec, randomUUID } from "./utils";
-import type { Front } from "./types";
+import { parseArgs, listFilesRec, randomUUID } from "./utils.js";
+import type { Front } from "./types.js";
 
 const OLLAMA_URL = process.env.OLLAMA_URL ?? "http://localhost:11434";
 

--- a/packages/docops/src/02-embed.ts
+++ b/packages/docops/src/02-embed.ts
@@ -7,8 +7,8 @@ import {
   writeJSON,
   readJSON,
   parseMarkdownChunks,
-} from "./utils";
-import type { Chunk, Front } from "./types";
+} from "./utils.js";
+import type { Chunk, Front } from "./types.js";
 
 const OLLAMA_URL = process.env.OLLAMA_URL ?? "http://localhost:11434";
 

--- a/packages/docops/src/03-query.ts
+++ b/packages/docops/src/03-query.ts
@@ -1,5 +1,5 @@
-import { parseArgs, cosine, writeJSON, readJSON } from "./utils";
-import type { Chunk, QueryHit } from "./types";
+import { parseArgs, cosine, writeJSON, readJSON } from "./utils.js";
+import type { Chunk, QueryHit } from "./types.js";
 import * as path from "path";
 
 const args = parseArgs({

--- a/packages/docops/src/04-relations.ts
+++ b/packages/docops/src/04-relations.ts
@@ -1,8 +1,8 @@
 import { promises as fs } from "fs";
 import * as path from "path";
 import matter from "gray-matter";
-import { parseArgs, readJSON } from "./utils";
-import type { Chunk, Front, QueryHit } from "./types";
+import { parseArgs, readJSON } from "./utils.js";
+import type { Chunk, Front, QueryHit } from "./types.js";
 
 const args = parseArgs({
   "--docs-dir": "docs/unique",

--- a/packages/docops/src/05-footers.ts
+++ b/packages/docops/src/05-footers.ts
@@ -1,8 +1,8 @@
 import { promises as fs } from "fs";
 import * as path from "path";
 import matter from "gray-matter";
-import { parseArgs, readJSON, stripGeneratedSections, relMdLink, anchorId, injectAnchors } from "./utils";
-import type { Front } from "./types";
+import { parseArgs, readJSON, stripGeneratedSections, relMdLink, anchorId, injectAnchors } from "./utils.js";
+import type { Front } from "./types.js";
 
 const args = parseArgs({
   "--dir": "docs/unique",

--- a/packages/docops/src/06-filename.ts
+++ b/packages/docops/src/06-filename.ts
@@ -1,8 +1,8 @@
 import { promises as fs } from "fs";
 import * as path from "path";
 import matter from "gray-matter";
-import { parseArgs, slugify, extnamePrefer } from "./utils";
-import type { Front } from "./types";
+import { parseArgs, slugify, extnamePrefer } from "./utils.js";
+import type { Front } from "./types.js";
 
 const args = parseArgs({ "--dir": "docs/unique", "--dry-run": "false" });
 const ROOT = path.resolve(args["--dir"]);

--- a/packages/docops/src/lib/chroma.ts
+++ b/packages/docops/src/lib/chroma.ts
@@ -1,5 +1,5 @@
 // Lightweight helpers to get a Chroma collection with Ollama embedding function
-import { OLLAMA_URL } from "../utils";
+import { OLLAMA_URL } from "../utils.js";
 
 export async function getChromaCollection(opts: {
   collection: string;

--- a/packages/docops/src/utils.ts
+++ b/packages/docops/src/utils.ts
@@ -5,7 +5,7 @@ import { unified } from "unified";
 import remarkParse from "remark-parse";
 import { visit } from "unist-util-visit";
 import * as yaml from "yaml";
-import type { Chunk, Front } from "./types";
+import type { Chunk, Front } from "./types.js";
 
 export const OLLAMA_URL = process.env.OLLAMA_URL ?? "http://localhost:11434";
 

--- a/packages/ds/src/bst.test.ts
+++ b/packages/ds/src/bst.test.ts
@@ -1,5 +1,5 @@
 import test from 'ava';
-import { AVLTree } from './bst';
+import { AVLTree } from './bst.js';
 
 test('AVLTree: basic operations', (t) => {
     const tree = new AVLTree<number, string>();

--- a/packages/ds/src/ecs.doublebuffer.behavior.test.ts
+++ b/packages/ds/src/ecs.doublebuffer.behavior.test.ts
@@ -1,5 +1,5 @@
 import test from 'ava';
-import { World } from './ecs';
+import { World } from './ecs.js';
 
 test('ECS double-buffer: add readable in-frame; set visible after endTick', (t) => {
     const w = new World();

--- a/packages/ds/src/ecs.prefab.test.ts
+++ b/packages/ds/src/ecs.prefab.test.ts
@@ -1,6 +1,6 @@
 import test from 'ava';
-import { World } from './ecs';
-import { makeBlueprint, spawn } from './ecs.prefab';
+import { World } from './ecs.js';
+import { makeBlueprint, spawn } from './ecs.prefab.js';
 
 test('prefab: spawns entities from blueprint with overrides', (t) => {
     const world = new World();

--- a/packages/ds/src/ecs.prefab.ts
+++ b/packages/ds/src/ecs.prefab.ts
@@ -1,6 +1,6 @@
 // shared/ts/prom-lib/ds/ecs.prefab.ts
 
-import { World, ComponentType } from './ecs';
+import { World, ComponentType } from './ecs.js';
 
 export type BlueprintStep<T = any> = {
     c: ComponentType<T>;

--- a/packages/ds/src/ecs.scheduler.test.ts
+++ b/packages/ds/src/ecs.scheduler.test.ts
@@ -1,6 +1,6 @@
 import test from 'ava';
-import { World } from './ecs';
-import { Scheduler } from './ecs.scheduler';
+import { World } from './ecs.js';
+import { Scheduler } from './ecs.scheduler.js';
 
 test('Scheduler: orders systems, respects conflicts, skips empty', async (t) => {
     const world = new World();

--- a/packages/ds/src/ecs.scheduler.ts
+++ b/packages/ds/src/ecs.scheduler.ts
@@ -1,8 +1,8 @@
 // shared/ts/prom-lib/ds/ecs.scheduler.ts
 // MIT. Zero deps (uses World from ecs.ts and Graph from graph.ts)
 
-import { World, CommandBuffer, ComponentType, Query } from './ecs';
-import { Graph } from './graph';
+import { World, CommandBuffer, ComponentType, Query } from './ecs.js';
+import { Graph } from './graph.js';
 
 export type Stage = 'startup' | 'update' | 'late' | 'render' | 'cleanup';
 export const DEFAULT_STAGE_ORDER: Stage[] = ['startup', 'update', 'late', 'render', 'cleanup'];

--- a/packages/ds/src/ecs.test.ts
+++ b/packages/ds/src/ecs.test.ts
@@ -1,5 +1,5 @@
 import test from 'ava';
-import { World } from './ecs';
+import { World } from './ecs.js';
 
 test('ecs: creates entity and iterates components', (t) => {
     const world = new World();

--- a/packages/ds/src/graph.test.ts
+++ b/packages/ds/src/graph.test.ts
@@ -1,5 +1,5 @@
 import test from 'ava';
-import { Graph } from './graph';
+import { Graph } from './graph.js';
 
 test('Graph: bfs traverses undirected graph', (t) => {
     const g = new Graph({ directed: false });

--- a/packages/ds/src/system.ts
+++ b/packages/ds/src/system.ts
@@ -1,5 +1,5 @@
 // ecs/strict-system.ts
-import type { World, Entity, ComponentType, Query } from './ecs';
+import type { World, Entity, ComponentType, Query } from './ecs.js';
 
 export type SystemSpec = {
     name: string;

--- a/packages/event/src/event.bus.test.ts
+++ b/packages/event/src/event.bus.test.ts
@@ -1,5 +1,5 @@
 import test from 'ava';
-import { InMemoryEventBus } from './memory';
+import { InMemoryEventBus } from './memory.js';
 
 test('event bus: publish/subscribe earliest', async (t) => {
     const bus = new InMemoryEventBus();

--- a/packages/event/src/example.ts
+++ b/packages/event/src/example.ts
@@ -1,4 +1,4 @@
-import { InMemoryEventBus } from './memory';
+import { InMemoryEventBus } from './memory.js';
 
 (async () => {
     const bus = new InMemoryEventBus();

--- a/packages/event/src/memory.ts
+++ b/packages/event/src/memory.ts
@@ -10,7 +10,7 @@ import {
     CursorStore,
     Ack,
     UUID,
-} from './types';
+} from './types.js';
 
 type GroupKey = string; // `${topic}::${group}`
 const gkey = (t: string, g: string) => `${t}::${g}`;

--- a/packages/event/src/mongo.ts
+++ b/packages/event/src/mongo.ts
@@ -1,6 +1,6 @@
 import { Collection, Db } from 'mongodb';
-import { EventBus, EventRecord, EventStore, CursorStore, PublishOptions, CursorPosition, Ack, UUID } from './types';
-import { InMemoryEventBus } from './memory';
+import { EventBus, EventRecord, EventStore, CursorStore, PublishOptions, CursorPosition, Ack, UUID } from './types.js';
+import { InMemoryEventBus } from './memory.js';
 
 export class MongoEventStore implements EventStore {
     private coll: Collection<EventRecord>;

--- a/packages/event/src/outbox.ts
+++ b/packages/event/src/outbox.ts
@@ -1,4 +1,4 @@
-import { EventBus, UUID } from './types';
+import { EventBus, UUID } from './types.js';
 
 export interface OutboxStore<T = any> {
     add(rec: { id: UUID; topic: string; payload: T; headers?: Record<string, string> }): Promise<void>;

--- a/packages/examples/src/process/projector.ts
+++ b/packages/examples/src/process/projector.ts
@@ -1,6 +1,6 @@
 // loosen typing to avoid cross-package type coupling
 import { Topics } from '@promethean/event/topics.js';
-import { HeartbeatPayload, ProcessState } from './types';
+import { HeartbeatPayload, ProcessState } from './types.js';
 
 const STALE_MS = 15_000;
 

--- a/packages/intention/src/boot-local.ts
+++ b/packages/intention/src/boot-local.ts
@@ -1,8 +1,8 @@
 import { promises as fs } from 'node:fs';
-import { RouterLLM } from './router';
-import { FileCacheLLM } from './cache';
-import { OllamaLLM } from './ollama';
-import { OpenAICompatLLM } from './openai_compat';
+import { RouterLLM } from './router.js';
+import { FileCacheLLM } from './cache.js';
+import { OllamaLLM } from './ollama.js';
+import { OpenAICompatLLM } from './openai_compat.js';
 
 interface Cfg {
     cacheDir?: string;

--- a/packages/intention/src/cache.ts
+++ b/packages/intention/src/cache.ts
@@ -1,7 +1,7 @@
 import { createHash } from 'node:crypto';
 import { promises as fs } from 'node:fs';
 import * as path from 'node:path';
-import type { LLM } from './llm';
+import type { LLM } from './llm.js';
 
 export class FileCacheLLM implements LLM {
     constructor(

--- a/packages/intention/src/ollama.ts
+++ b/packages/intention/src/ollama.ts
@@ -1,4 +1,4 @@
-import type { LLM } from './llm';
+import type { LLM } from './llm.js';
 
 type OllamaOpts = {
     model: string;

--- a/packages/intention/src/openai_compat.ts
+++ b/packages/intention/src/openai_compat.ts
@@ -1,4 +1,4 @@
-import type { LLM } from './llm';
+import type { LLM } from './llm.js';
 
 export class OpenAICompatLLM implements LLM {
     constructor(

--- a/packages/intention/src/router.ts
+++ b/packages/intention/src/router.ts
@@ -1,4 +1,4 @@
-import type { LLM } from './llm';
+import type { LLM } from './llm.js';
 
 export class RouterLLM implements LLM {
     constructor(private providers: LLM[]) {}

--- a/packages/parity/src/runner.ts
+++ b/packages/parity/src/runner.ts
@@ -1,4 +1,4 @@
-import { normalizeChat, normalizeEmbed, normalizeError, normalizeStream } from './normalizers';
+import { normalizeChat, normalizeEmbed, normalizeError, normalizeStream } from './normalizers.js';
 
 export interface ParityClients {
     broker: {

--- a/packages/schema/src/dualwrite.ts
+++ b/packages/schema/src/dualwrite.ts
@@ -1,5 +1,5 @@
 // loosen typing to avoid cross-package type coupling
-import { SchemaRegistry } from './registry';
+import { SchemaRegistry } from './registry.js';
 
 export function withDualWrite(bus: any, reg: SchemaRegistry): any {
     return {

--- a/packages/schema/src/normalize.ts
+++ b/packages/schema/src/normalize.ts
@@ -1,6 +1,6 @@
 // loosen typing to avoid cross-package type coupling
-import { SchemaRegistry } from './registry';
-import { UpcastChain } from './upcast';
+import { SchemaRegistry } from './registry.js';
+import { UpcastChain } from './upcast.js';
 
 export async function subscribeNormalized(
     bus: any,

--- a/packages/schema/src/topics.ts
+++ b/packages/schema/src/topics.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { SchemaRegistry } from './registry';
+import { SchemaRegistry } from './registry.js';
 
 export const reg = new SchemaRegistry();
 

--- a/packages/schema/src/upcast.ts
+++ b/packages/schema/src/upcast.ts
@@ -1,5 +1,5 @@
 // loosen typing to avoid cross-package type coupling
-import { SchemaRegistry } from './registry';
+import { SchemaRegistry } from './registry.js';
 
 export type Upcaster = (e: any) => any;
 

--- a/packages/timetravel/src/examples.ts
+++ b/packages/timetravel/src/examples.ts
@@ -1,4 +1,4 @@
-import { reconstructAt } from './reconstruct';
+import { reconstructAt } from './reconstruct.js';
 // loosen typing to avoid cross-package type coupling
 
 export async function processAt(store: any, processId: string, atTs: number) {

--- a/packages/voice/src/index.d.ts
+++ b/packages/voice/src/index.d.ts
@@ -1,6 +1,6 @@
 import express from "express";
 import { Client } from "discord.js";
-import { VoiceSession } from "./voice-session";
+import { VoiceSession } from "./voice-session.js";
 export declare function createVoiceService(token?: string): {
   app: express.Application;
   client: Client<boolean>;

--- a/packages/voice/src/index.js
+++ b/packages/voice/src/index.js
@@ -1,6 +1,6 @@
 import express from "express";
 import { Client, GatewayIntentBits } from "discord.js";
-import { VoiceSession } from "./voice-session";
+import { VoiceSession } from "./voice-session.js";
 import { HeartbeatClient } from "../../../../shared/js/heartbeat/index.js";
 export function createVoiceService(token = process.env.DISCORD_TOKEN || "") {
   if (!token) {

--- a/packages/voice/src/index.ts
+++ b/packages/voice/src/index.ts
@@ -1,6 +1,6 @@
 import express, { Application } from "express";
 import { Client, GatewayIntentBits, User } from "discord.js";
-import { VoiceSession } from "./voice-session";
+import { VoiceSession } from "./voice-session.js";
 import { HeartbeatClient } from "@promethean/legacy/heartbeat/index.js";
 
 export function createVoiceService(

--- a/packages/voice/src/speaker.d.ts
+++ b/packages/voice/src/speaker.d.ts
@@ -1,9 +1,9 @@
 import { PassThrough } from "node:stream";
-import { Transcriber } from "./transcriber";
+import { Transcriber } from "./transcriber.js";
 import { AudioReceiveStream } from "@discordjs/voice";
 import { User } from "discord.js";
 import EventEmitter from "node:events";
-import { VoiceRecorder } from "./voice-recorder";
+import { VoiceRecorder } from "./voice-recorder.js";
 export type SpeakerOptions = {
   user: User;
   transcriber: Transcriber;

--- a/packages/voice/src/speaker.ts
+++ b/packages/voice/src/speaker.ts
@@ -4,13 +4,13 @@
 // import { once } from 'node:events';
 import * as prism from "prism-media";
 import { PassThrough } from "node:stream";
-import { Transcriber } from "./transcriber";
+import { Transcriber } from "./transcriber.js";
 import { AudioReceiveStream } from "@discordjs/voice";
 import { User } from "discord.js";
 
 import { Transform, TransformCallback } from "node:stream";
 import EventEmitter from "node:events";
-import { VoiceRecorder } from "./voice-recorder";
+import { VoiceRecorder } from "./voice-recorder.js";
 
 class OpusSilenceFilter extends Transform {
   override _transform(

--- a/packages/voice/src/transcriber.d.ts
+++ b/packages/voice/src/transcriber.d.ts
@@ -2,7 +2,7 @@ import { User } from "discord.js";
 import EventEmitter from "node:events";
 import http, { RequestOptions } from "node:http";
 import { PassThrough } from "node:stream";
-import { Speaker } from "./speaker";
+import { Speaker } from "./speaker.js";
 export type TranscriberOptions = {
   hostname: string;
   port: number;

--- a/packages/voice/src/transcriber.ts
+++ b/packages/voice/src/transcriber.ts
@@ -2,7 +2,7 @@ import { User } from "discord.js";
 import EventEmitter from "node:events";
 import http, { RequestOptions } from "node:http";
 import { PassThrough } from "node:stream";
-import { Speaker } from "./speaker";
+import { Speaker } from "./speaker.js";
 
 export type TranscriberOptions = {
   hostname: string;

--- a/packages/voice/src/voice-session.d.ts
+++ b/packages/voice/src/voice-session.d.ts
@@ -1,10 +1,10 @@
 import { VoiceConnection } from "@discordjs/voice";
 import * as discord from "discord.js";
-import { Speaker } from "./speaker";
+import { Speaker } from "./speaker.js";
 import { UUID } from "crypto";
-import { Transcriber } from "./transcriber";
-import { VoiceRecorder } from "./voice-recorder";
-import { VoiceSynth } from "./voice-synth";
+import { Transcriber } from "./transcriber.js";
+import { VoiceRecorder } from "./voice-recorder.js";
+import { VoiceSynth } from "./voice-synth.js";
 import EventEmitter from "events";
 /**
    Handles all things voice. Emits an event when a user begins speaking, and when they stop speaking

--- a/packages/voice/src/voice-session.js
+++ b/packages/voice/src/voice-session.js
@@ -7,12 +7,12 @@ import {
   getVoiceConnection,
   joinVoiceChannel,
 } from "@discordjs/voice";
-import { Speaker } from "./speaker";
-// import {Transcript} from "./transcript"
+import { Speaker } from "./speaker.js";
+// import {Transcript} from "./transcript.js"
 import { randomUUID } from "crypto";
-import { Transcriber } from "./transcriber";
-import { VoiceRecorder } from "./voice-recorder";
-import { VoiceSynth } from "./voice-synth";
+import { Transcriber } from "./transcriber.js";
+import { VoiceRecorder } from "./voice-recorder.js";
+import { VoiceSynth } from "./voice-synth.js";
 import EventEmitter from "events";
 export class VoiceSession extends EventEmitter {
   id;

--- a/packages/voice/src/voice-session.ts
+++ b/packages/voice/src/voice-session.ts
@@ -9,12 +9,12 @@ import {
   joinVoiceChannel,
 } from "@discordjs/voice";
 import * as discord from "discord.js";
-import { Speaker } from "./speaker";
-// import {Transcript} from "./transcript"
+import { Speaker } from "./speaker.js";
+// import {Transcript} from "./transcript.js"
 import { randomUUID, UUID } from "crypto";
-import { Transcriber } from "./transcriber";
-import { VoiceRecorder } from "./voice-recorder";
-import { VoiceSynth } from "./voice-synth";
+import { Transcriber } from "./transcriber.js";
+import { VoiceRecorder } from "./voice-recorder.js";
+import { VoiceSynth } from "./voice-synth.js";
 import EventEmitter from "events";
 /**
    Handles all things voice. Emits an event when a user begins speaking, and when they stop speaking

--- a/packages/worker/src/zero/snapshot.test.ts
+++ b/packages/worker/src/zero/snapshot.test.ts
@@ -1,6 +1,6 @@
 import test from 'ava';
-import { buildSnapshot, commitSnapshot, type WorldLike, type ComponentRef } from './snapshot';
-import { markChanged } from './layout';
+import { buildSnapshot, commitSnapshot, type WorldLike, type ComponentRef } from './snapshot.js';
+import { markChanged } from './layout.js';
 
 class MockWorld implements WorldLike {
     comps = new Map<number, Map<number, any>>();

--- a/packages/worker/src/zero/snapshot.ts
+++ b/packages/worker/src/zero/snapshot.ts
@@ -1,5 +1,5 @@
 // loosen typing to avoid cross-package type coupling
-import { CompLayout, Snap, allocColumns, canUseSAB, isChanged } from './layout';
+import { CompLayout, Snap, allocColumns, canUseSAB, isChanged } from './layout.js';
 type Transferable = ArrayBuffer | SharedArrayBuffer;
 
 export type ComponentRef = any;

--- a/packages/worker/src/zero/struct.test.ts
+++ b/packages/worker/src/zero/struct.test.ts
@@ -1,7 +1,7 @@
 // @ts-nocheck
 import test from 'ava';
-import { S, compileStruct } from './struct';
-import type { Infer } from './struct';
+import { S, compileStruct } from './struct.js';
+import type { Infer } from './struct.js';
 
 const Position = S.struct({ x: S.f32(), y: S.f32() });
 type Position = Infer<typeof Position>;


### PR DESCRIPTION
## Summary
- add explicit `.js` extensions to relative imports across packages
- document fix for TS2835 build errors

## Testing
- `pnpm lint` *(fails: Found a nested root configuration, but there's already a root configuration)*
- `pnpm -r run build` *(fails: Could not resolve the path '' in @promethean/cephalon-discord)*
- `pnpm --filter ./packages/compiler run build`
- `pnpm --filter ./packages/dlq run build`
- `pnpm --filter ./packages/ds run build`
- `pnpm --filter ./packages/event run build`
- `pnpm --filter ./packages/examples run build`
- `pnpm --filter ./packages/intention run build`
- `pnpm --filter ./packages/parity run build`
- `pnpm --filter ./packages/schema run build`
- `pnpm --filter ./packages/timetravel run build`
- `pnpm --filter ./packages/voice run build`
- `pnpm --filter ./packages/worker run build`
- `pnpm test` *(fails: Could not resolve the path '' in @promethean/cephalon-discord)*

------
https://chatgpt.com/codex/tasks/task_e_68b79b35e02c832499a3e2ecb278d404