### PR TITLE
fix(ds): type rest parameters as arrays

### DIFF
--- a/changelog.d/2025.09.03.01.37.25.changed.md
+++ b/changelog.d/2025.09.03.01.37.25.changed.md
@@ -1,0 +1,1 @@
+Changed: updated SystemCtx iterAll signature to accept an array-typed rest parameter.

--- a/packages/ds/src/system.ts
+++ b/packages/ds/src/system.ts
@@ -1,5 +1,5 @@
 // ecs/strict-system.ts
-import type { World, Entity, ComponentType, Query } from './ecs';
+import type { World, Entity, ComponentType, Query } from './ecs.js';
 
 export type SystemSpec = {
     name: string;
@@ -18,7 +18,9 @@ export type SystemCtx = {
     setIfChanged: <T>(e: Entity, c: ComponentType<T>, v: T) => void;
     carry: <T>(e: Entity, c: ComponentType<T>) => void;
     iter: World['iter']; // base iterator (for custom modes)
-    iterAll: <T extends any[]>(...cs: { [K in keyof T]: ComponentType<T[K]> }) => IterableIterator<[Entity, ...T]>;
+    iterAll: <T extends any[]>(
+        ...cs: { [K in keyof T]: ComponentType<T[K]> }[]
+    ) => IterableIterator<[Entity, ...T]>;
     iterPacked: <T extends any[]>(opts: {
         comps: { [K in keyof T]: ComponentType<T[K]> };
         block?: number;
@@ -38,7 +40,7 @@ export function* iterAll<T extends any[]>(
 ): IterableIterator<[Entity, ...T]> {
     // single pass: pull each comp once per row
     for (const [e, get] of w.iter(q)) {
-        const tuple = comps.map((c) => get(c)) as T;
+        const tuple = comps.map((c: ComponentType<T[number]>) => get(c)) as T;
         yield [e, ...tuple];
     }
 }


### PR DESCRIPTION
## Summary
- ensure SystemCtx.iterAll uses array-typed rest parameters
- clarify generics in iterAll to avoid implicit any
- add changelog entry

## Testing
- `pnpm --filter @promethean/ds build` *(fails: Relative import paths need explicit file extensions)*
- `pnpm --filter @promethean/ds lint` *(warnings: 201 warnings found)*

------
https://chatgpt.com/codex/tasks/task_e_68b79b375b688324a1f17aa7962cef4b