### PR TITLE
fix: resolve missing local imports

### DIFF
--- a/packages/discord-attachment-indexer/src/index.ts
+++ b/packages/discord-attachment-indexer/src/index.ts
@@ -1,4 +1,6 @@
-import { fileBackedRegistry, mongoForTenant, topic } from "@shared/prom-lib";
+import { fileBackedRegistry } from "../../platform/dist/provider-registry.js";
+import { mongoForTenant } from "../../effects/dist/mongo.js";
+import { topic } from "../../platform/dist/topic.js";
 
 export async function handleSocialMessageCreated(evt: any) {
   if (!evt.attachments?.length) return [];

--- a/packages/discord-gateway/src/gateway.ts
+++ b/packages/discord-gateway/src/gateway.ts
@@ -1,8 +1,6 @@
-import {
-  InMemoryEventBus,
-  topic,
-  normalizeDiscordMessage,
-} from "@shared/prom-lib";
+import { InMemoryEventBus } from "../../event/dist/memory.js";
+import { topic } from "../../platform/dist/topic.js";
+import { normalizeDiscordMessage } from "../../providers/dist/discord/normalize.js";
 
 export class GatewayPublisher {
   constructor(private bus: InMemoryEventBus) {}

--- a/packages/discord-gateway/src/index.ts
+++ b/packages/discord-gateway/src/index.ts
@@ -1,7 +1,5 @@
-import {
-  fileBackedRegistry,
-  topic, // , SocialMessageCreated, toUrn
-} from "@shared/prom-lib";
+import { fileBackedRegistry } from "../../platform/dist/provider-registry.js";
+import { topic } from "../../platform/dist/topic.js";
 
 // Stub Gateway: would connect to Discord WS, normalize MESSAGE_CREATE to SocialMessageCreated
 async function main() {

--- a/packages/discord-gateway/tests/flow.test.js
+++ b/packages/discord-gateway/tests/flow.test.js
@@ -1,5 +1,5 @@
 import test from "ava";
-import { InMemoryEventBus } from "@shared/prom-lib";
+import { InMemoryEventBus } from "../../event/dist/memory.js";
 import { GatewayPublisher } from "../src/gateway.js";
 import { handleSocialMessageCreated as indexMessage } from "../../discord-message-indexer/src/index.js";
 import { handleSocialMessageCreated as indexAttachments } from "../../discord-attachment-indexer/src/index.js";

--- a/packages/discord-gateway/tests/gateway.test.js
+++ b/packages/discord-gateway/tests/gateway.test.js
@@ -1,5 +1,5 @@
 import test from "ava";
-import { InMemoryEventBus } from "@shared/prom-lib";
+import { InMemoryEventBus } from "../../event/dist/memory.js";
 import { GatewayPublisher } from "../src/gateway.js";
 
 test("publishes raw and normalized events to bus", async (t) => {

--- a/packages/discord-message-embedder/src/index.ts
+++ b/packages/discord-message-embedder/src/index.ts
@@ -1,6 +1,6 @@
-import { fileBackedRegistry } from "@shared/prom-lib";
-import { makeChromaWrapper } from "@shared/prom-lib";
-import { makeDeterministicEmbedder } from "@shared/prom-lib";
+import { fileBackedRegistry } from "../../platform/dist/provider-registry.js";
+import { makeChromaWrapper } from "../../migrations/dist/chroma.js";
+import { makeDeterministicEmbedder } from "../../migrations/dist/embedder.js";
 
 export async function embedMessage(evt: any) {
   if (!evt.text || !evt.text.trim()) return null;

--- a/packages/discord-message-indexer/src/index.ts
+++ b/packages/discord-message-indexer/src/index.ts
@@ -1,4 +1,6 @@
-import { topic, fileBackedRegistry, mongoForTenant } from "@shared/prom-lib";
+import { topic } from "../../platform/dist/topic.js";
+import { fileBackedRegistry } from "../../platform/dist/provider-registry.js";
+import { mongoForTenant } from "../../effects/dist/mongo.js";
 
 export async function handleSocialMessageCreated(evt: any) {
   const reg = fileBackedRegistry();

--- a/packages/discord-rest/src/index.ts
+++ b/packages/discord-rest/src/index.ts
@@ -1,7 +1,5 @@
-import {
-  fileBackedRegistry,
-  topic, // , PostMessage
-} from "@shared/prom-lib";
+import { fileBackedRegistry } from "../../platform/dist/provider-registry.js";
+import { topic } from "../../platform/dist/topic.js";
 
 // Stub REST proxy: subscribes to rest.request and would call Discord REST.
 async function main() {

--- a/packages/discord-rest/src/rest.ts
+++ b/packages/discord-rest/src/rest.ts
@@ -1,5 +1,5 @@
-import { makePolicy } from "@shared/prom-lib";
-import { fileBackedRegistry } from "@shared/prom-lib";
+import { makePolicy } from "../../agent/dist/policy.js";
+import { fileBackedRegistry } from "../../platform/dist/provider-registry.js";
 
 type RestResponse = {
   ok: boolean;

--- a/packages/ds/src/bst.test.ts
+++ b/packages/ds/src/bst.test.ts
@@ -1,5 +1,5 @@
 import test from 'ava';
-import { AVLTree } from './bst';
+import { AVLTree } from './bst.js';
 
 test('AVLTree: basic operations', (t) => {
     const tree = new AVLTree<number, string>();

--- a/packages/ds/src/ecs.doublebuffer.behavior.test.ts
+++ b/packages/ds/src/ecs.doublebuffer.behavior.test.ts
@@ -1,5 +1,5 @@
 import test from 'ava';
-import { World } from './ecs';
+import { World } from './ecs.js';
 
 test('ECS double-buffer: add readable in-frame; set visible after endTick', (t) => {
     const w = new World();

--- a/packages/ds/src/ecs.prefab.test.ts
+++ b/packages/ds/src/ecs.prefab.test.ts
@@ -1,6 +1,6 @@
 import test from 'ava';
-import { World } from './ecs';
-import { makeBlueprint, spawn } from './ecs.prefab';
+import { World } from './ecs.js';
+import { makeBlueprint, spawn } from './ecs.prefab.js';
 
 test('prefab: spawns entities from blueprint with overrides', (t) => {
     const world = new World();

--- a/packages/ds/src/ecs.prefab.ts
+++ b/packages/ds/src/ecs.prefab.ts
@@ -1,6 +1,6 @@
 // shared/ts/prom-lib/ds/ecs.prefab.ts
 
-import { World, ComponentType } from './ecs';
+import { World, ComponentType } from './ecs.js';
 
 export type BlueprintStep<T = any> = {
     c: ComponentType<T>;

--- a/packages/ds/src/ecs.scheduler.test.ts
+++ b/packages/ds/src/ecs.scheduler.test.ts
@@ -1,6 +1,6 @@
 import test from 'ava';
-import { World } from './ecs';
-import { Scheduler } from './ecs.scheduler';
+import { World } from './ecs.js';
+import { Scheduler } from './ecs.scheduler.js';
 
 test('Scheduler: orders systems, respects conflicts, skips empty', async (t) => {
     const world = new World();

--- a/packages/ds/src/ecs.scheduler.ts
+++ b/packages/ds/src/ecs.scheduler.ts
@@ -1,8 +1,8 @@
 // shared/ts/prom-lib/ds/ecs.scheduler.ts
 // MIT. Zero deps (uses World from ecs.ts and Graph from graph.ts)
 
-import { World, CommandBuffer, ComponentType, Query } from './ecs';
-import { Graph } from './graph';
+import { World, CommandBuffer, ComponentType, Query } from './ecs.js';
+import { Graph } from './graph.js';
 
 export type Stage = 'startup' | 'update' | 'late' | 'render' | 'cleanup';
 export const DEFAULT_STAGE_ORDER: Stage[] = ['startup', 'update', 'late', 'render', 'cleanup'];

--- a/packages/ds/src/ecs.test.ts
+++ b/packages/ds/src/ecs.test.ts
@@ -1,5 +1,5 @@
 import test from 'ava';
-import { World } from './ecs';
+import { World } from './ecs.js';
 
 test('ecs: creates entity and iterates components', (t) => {
     const world = new World();

--- a/packages/ds/src/graph.test.ts
+++ b/packages/ds/src/graph.test.ts
@@ -1,5 +1,5 @@
 import test from 'ava';
-import { Graph } from './graph';
+import { Graph } from './graph.js';
 
 test('Graph: bfs traverses undirected graph', (t) => {
     const g = new Graph({ directed: false });

--- a/packages/ds/src/system.ts
+++ b/packages/ds/src/system.ts
@@ -1,5 +1,5 @@
 // ecs/strict-system.ts
-import type { World, Entity, ComponentType, Query } from './ecs';
+import type { World, Entity, ComponentType, Query } from './ecs.js';
 
 export type SystemSpec = {
     name: string;

--- a/packages/migrations/src/backfill.js
+++ b/packages/migrations/src/backfill.js
@@ -1,9 +1,9 @@
 #!/usr/bin/env node
 import { MongoClient } from 'mongodb';
-import { makeDeterministicEmbedder } from '@shared/prom-lib';
-import { makeChromaWrapper } from '@shared/prom-lib';
-import { makeCheckpointStore } from '@shared/prom-lib';
-import { checksumFor } from '@shared/prom-lib';
+import { makeDeterministicEmbedder } from './embedder.js';
+import { makeChromaWrapper } from './chroma.js';
+import { makeCheckpointStore } from './checkpoints.js';
+import { checksumFor } from './integrity.js';
 import fs from 'node:fs';
 import path from 'node:path';
 

--- a/packages/ws/src/server.ts
+++ b/packages/ws/src/server.ts
@@ -1,6 +1,6 @@
 import { WebSocketServer, WebSocket } from 'ws';
 // loosen typing to avoid cross-package type coupling
-import { makeConnLimiter, makeTopicLimiter } from './server.rate';
+import { makeConnLimiter, makeTopicLimiter } from './server.rate.js';
 // token bucket provided at runtime
 
 export type AuthResult = { ok: true; subScopes?: string[] } | { ok: false; code: string; msg: string };


### PR DESCRIPTION
## Summary
- resolve failing relative imports by adding explicit `.js` extensions
- replace `@shared/prom-lib` references with concrete package paths
- update migrations backfill script to use local helpers

## Testing
- `npx tsc -p tsconfig.json` (packages/ws)
- `npx tsc -p tsconfig.json` (packages/ds)
- `npx tsc -p tsconfig.json` (packages/discord-message-embedder)
- `npx tsc -p tsconfig.json` (packages/discord-attachment-indexer)
- `npx tsc -p tsconfig.json` (packages/discord-rest)
- `npx tsc -p tsconfig.json` (packages/discord-gateway)
- `npx tsc -p tsconfig.json` (packages/discord-message-indexer)
- `npx tsc -p tsconfig.json` (packages/migrations)


------
https://chatgpt.com/codex/tasks/task_e_68b79b3981f88324856aac9c8c1e224a