### PR TITLE
chore: add explicit types for event and mcp helpers

### DIFF
--- a/changelog.d/2025.09.03.01.40.10.fixed.md
+++ b/changelog.d/2025.09.03.01.40.10.fixed.md
@@ -1,0 +1,1 @@
+fix: add explicit parameter types and proper import extensions in event bus tests and mcp stdio

--- a/packages/event/src/example.ts
+++ b/packages/event/src/example.ts
@@ -1,4 +1,5 @@
-import { InMemoryEventBus } from './memory';
+import { InMemoryEventBus } from './memory.js';
+import type { EventRecord } from './types.js';
 
 (async () => {
     const bus = new InMemoryEventBus();
@@ -7,9 +8,9 @@ import { InMemoryEventBus } from './memory';
     await bus.subscribe(
         'heartbeat.received',
         'ops',
-        async (e) => {
+        async (_e: EventRecord) => {
             // do stuff (update process table, emit metrics, etc.)
-            // console.log("HB:", e.payload);
+            // console.log("HB:", _e.payload);
         },
         { from: 'earliest', batchSize: 100 },
     );
@@ -28,6 +29,6 @@ import { InMemoryEventBus } from './memory';
     );
 
     // Optional: read the cursor
-    const cur = await bus.getCursor('heartbeat.received', 'ops');
-    // console.log("cursor:", cur);
+    const _cur = await bus.getCursor('heartbeat.received', 'ops');
+    // console.log("cursor:", _cur);
 })();

--- a/packages/event/src/outbox.ts
+++ b/packages/event/src/outbox.ts
@@ -1,6 +1,6 @@
-import { EventBus, UUID } from './types';
+import type { EventBus, UUID } from './types.js';
 
-export interface OutboxStore<T = any> {
+export interface OutboxStore<T = unknown> {
     add(rec: { id: UUID; topic: string; payload: T; headers?: Record<string, string> }): Promise<void>;
     claimBatch(n: number): Promise<{ id: UUID; topic: string; payload: T; headers?: Record<string, string> }[]>;
     markSent(id: UUID): Promise<void>;

--- a/packages/mcp/src/stdio.ts
+++ b/packages/mcp/src/stdio.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import dotenv from 'dotenv';
-import WebSocket from 'ws';
-import readline from 'readline';
+import WebSocket, { type RawData } from 'ws';
+import readline from 'node:readline';
 
 dotenv.config();
 
@@ -14,15 +14,15 @@ const ws = new WebSocket(url, {
 
 ws.on('open', () => {
     const rl = readline.createInterface({ input: process.stdin });
-    rl.on('line', (line) => ws.send(line));
-    ws.on('message', (data) => {
-        process.stdout.write(data.toString() + '\n');
+    rl.on('line', (line: string) => ws.send(line));
+    ws.on('message', (data: RawData) => {
+        process.stdout.write(`${data.toString()}\n`);
     });
     ws.on('close', () => rl.close());
 });
 
 ws.on('close', () => process.exit(0));
-ws.on('error', (err) => {
+ws.on('error', (err: Error) => {
     console.error('WS error', err);
     process.exit(1);
 });


### PR DESCRIPTION
## Summary
- add explicit EventRecord and RawData parameter types in tests and stdio utility
- convert event package imports to `.js` extensions with type-only imports
- cover examples and outbox with stricter typings

## Testing
- `pnpm exec biome lint packages/event/src/event.bus.test.ts packages/event/src/example.ts packages/event/src/memory.ts packages/event/src/mongo.ts packages/event/src/outbox.ts packages/mcp/src/stdio.ts`
- `pnpm exec tsc -p packages/event/tsconfig.json --noEmit`
- `pnpm exec tsc -p packages/mcp/tsconfig.json --noEmit`
- `pnpm exec tsc -p packages/event/tsconfig.json && pnpm exec ava packages/event/dist/event.bus.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b79b39db6883249c8115c6730e893c