### PR TITLE
fix: resolve missing local imports

### DIFF
--- a/changelog.d/2025.09.03.02.32.31.fixed.md
+++ b/changelog.d/2025.09.03.02.32.31.fixed.md
@@ -1,0 +1,1 @@
+fix: import Discord gateway dependencies via package names

--- a/packages/discord-gateway/package.json
+++ b/packages/discord-gateway/package.json
@@ -11,8 +11,8 @@
     "lint": "pnpm exec @biomejs/biome lint . || true"
   },
   "dependencies": {
-    "@promethean/platform": "workspace:*",
     "@promethean/event": "workspace:*",
+    "@promethean/platform": "workspace:*",
     "@promethean/providers": "workspace:*",
     "@types/node": "^24.3.0",
     "typescript": "^5.9.2"

--- a/packages/discord-gateway/src/gateway.ts
+++ b/packages/discord-gateway/src/gateway.ts
@@ -1,6 +1,6 @@
-import { InMemoryEventBus } from "../../event/dist/memory.js";
-import { topic } from "../../platform/dist/topic.js";
-import { normalizeDiscordMessage } from "../../providers/dist/discord/normalize.js";
+import { InMemoryEventBus } from "@promethean/event/memory.js";
+import { topic } from "@promethean/platform/topic.js";
+import { normalizeDiscordMessage } from "@promethean/providers/discord/normalize.js";
 
 export class GatewayPublisher {
   constructor(private bus: InMemoryEventBus) {}

--- a/packages/discord-gateway/src/index.ts
+++ b/packages/discord-gateway/src/index.ts
@@ -1,5 +1,5 @@
-import { fileBackedRegistry } from "../../platform/dist/provider-registry.js";
-import { topic } from "../../platform/dist/topic.js";
+import { fileBackedRegistry } from "@promethean/platform/provider-registry.js";
+import { topic } from "@promethean/platform/topic.js";
 
 // Stub Gateway: would connect to Discord WS, normalize MESSAGE_CREATE to SocialMessageCreated
 async function main() {


### PR DESCRIPTION
## Summary
- import Discord gateway helpers from package exports instead of source paths
- ensure `@promethean/event`, `@promethean/platform`, and `@promethean/providers` are declared dependencies

## Testing
- `npx tsc -p packages/discord-gateway/tsconfig.json` *(fails: TS2307 cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_68b7a63af2a88324a595ac63faf55388