### PR TITLE
feat(scripts): add lint tasks script

### DIFF
--- a/changelog.d/2025.09.03.02.45.16.added.md
+++ b/changelog.d/2025.09.03.02.45.16.added.md
@@ -1,0 +1,1 @@
+Added lint-tasks TypeScript script and configuration.

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "doc:05-footers": "tsx packages/docops/src/05-footers.ts --dir docs/unique --anchor-style block",
     "doc:06-rename": "tsx packages/docops/src/06-rename.ts --dir docs/unique",
     "doc:all": "pnpm doc:01-frontmatter && pnpm doc:02-embed && pnpm doc:03-query && pnpm doc:04-relate && pnpm doc:05-footers && pnpm doc:06-rename",
+    "script:lint-tasks": "tsx --tsconfig tsconfig.scripts.json scripts/lint_tasks.ts",
     "postinstall": "pnpm --filter @promethean/piper^... run build && pnpm --filter @promethean/piper run build"
   },
   "bin": {

--- a/scripts/lint_tasks.ts
+++ b/scripts/lint_tasks.ts
@@ -1,0 +1,54 @@
+import { readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const REQUIRED_SECTIONS = ["Description", "Goals", "Requirements", "Subtasks"];
+const STATUS_TAGS = ["#IceBox", "#Accepted", "#Ready", "#Todo", "#InProgress", "#Done"];
+
+function escapeRegExp(input: string): string {
+  return input.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function checkFile(path: string): string[] | null {
+  const text = readFileSync(path, "utf8");
+  const errors: string[] = [];
+
+  for (const section of REQUIRED_SECTIONS) {
+    const pattern = new RegExp(`^#+\\s*${escapeRegExp(section)}`, "im");
+    if (!pattern.test(text)) {
+      errors.push(`Missing section: ${section}`);
+    }
+  }
+
+  if (!STATUS_TAGS.some((tag) => text.includes(tag))) {
+    errors.push("Missing status hashtag");
+  }
+
+  return errors.length ? errors : null;
+}
+
+export function main(): void {
+  const directory = process.argv[2] ?? "docs/agile/tasks";
+  const files = readdirSync(directory).filter((f) => f.endsWith(".md")).sort();
+  const failures: Array<{ path: string; errors: string[] }> = [];
+
+  for (const file of files) {
+    const filePath = join(directory, file);
+    const result = checkFile(filePath);
+    if (result) failures.push({ path: filePath, errors: result });
+  }
+
+  if (failures.length) {
+    for (const { path, errors } of failures) {
+      for (const err of errors) {
+        console.log(`${path}: ${err}`);
+      }
+    }
+    process.exit(1);
+  }
+
+  console.log("All task files have required sections and status hashtags.");
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/tsconfig.scripts.json
+++ b/tsconfig.scripts.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.base.json",
+  "include": ["scripts/**/*.ts"]
+}


### PR DESCRIPTION
## Summary
- add TypeScript lint_tasks script and tsconfig
- expose script via `script:lint-tasks` package.json command

## Testing
- `pnpm exec biome lint --config-path=biome.json scripts/lint_tasks.ts` *(fails: Found a nested root configuration)*
- `pytest tests/scripts/test_lint_tasks.py -q`
- `pnpm script:lint-tasks "$tmpdir"`


------
https://chatgpt.com/codex/tasks/task_e_68b7ab5bdf808324a7bff1c69155a256