### PR TITLE
fix: quote git pathspecs for Windows

### DIFF
--- a/changelog.d/2025.09.03.02.29.22.fixed.md
+++ b/changelog.d/2025.09.03.02.29.22.fixed.md
@@ -1,0 +1,2 @@
+Quote git pathspecs so lint works on Windows.
+

--- a/scripts/ensure-spdx-license.mjs
+++ b/scripts/ensure-spdx-license.mjs
@@ -1,13 +1,15 @@
-import { execSync } from 'node:child_process';
+import { execFileSync } from 'node:child_process';
 import { readFileSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
 
 const checkMode = process.argv.includes('--check');
 
-const exts = ['js', 'ts', 'py'];
-
-const lsFilesCmd = "git ls-files '*.js' '*.ts' '*.py' ':!sites/**'";
-const files = execSync(lsFilesCmd).toString().trim().split('\n').filter(Boolean);
+const lsFilesArgs = ['ls-files', '*.js', '*.ts', '*.py', ':!sites/**'];
+const files = execFileSync('git', lsFilesArgs)
+  .toString()
+  .trim()
+  .split('\n')
+  .filter(Boolean);
 
 const headers = {
   js: '// SPDX-License-Identifier: GPL-3.0-only',


### PR DESCRIPTION
## Summary
- use execFileSync with arg array so git pathspecs work on Windows
- note fix in changelog

## Testing
- `node scripts/ensure-spdx-license.mjs --check` *(fails: Missing SPDX headers in packages/codex-orchestrator/src/index.d.ts, packages/codex-orchestrator/src/ollama.d.ts, packages/codex-orchestrator/src/ollama.js, packages/codex-orchestrator/src/tools.d.ts)*
- `pnpm lint` *(fails: Found a nested root configuration)*
- `pnpm test` *(fails: TypeScript error TS6231 in packages/cephalon-discord)*

------
https://chatgpt.com/codex/tasks/task_e_68b7a7dc0c4883249a229f443680dbe3