### PR TITLE
fix: resolve missing local imports

### DIFF
--- a/packages/discord-attachment-indexer/src/index.ts
+++ b/packages/discord-attachment-indexer/src/index.ts
@@ -1,6 +1,6 @@
-import { fileBackedRegistry } from "../../platform/dist/provider-registry.js";
-import { mongoForTenant } from "../../effects/dist/mongo.js";
-import { topic } from "../../platform/dist/topic.js";
+import { fileBackedRegistry } from "@promethean/platform/provider-registry.js";
+import { mongoForTenant } from "@promethean/effects/mongo.js";
+import { topic } from "@promethean/platform/topic.js";
 
 export async function handleSocialMessageCreated(evt: any) {
   if (!evt.attachments?.length) return [];

--- a/packages/discord-gateway/tests/flow.test.js
+++ b/packages/discord-gateway/tests/flow.test.js
@@ -1,10 +1,10 @@
 import test from "ava";
-import { InMemoryEventBus } from "../../event/dist/memory.js";
+import { InMemoryEventBus } from "@promethean/event/memory.js";
 import { GatewayPublisher } from "../src/gateway.js";
-import { handleSocialMessageCreated as indexMessage } from "../../discord-message-indexer/src/index.js";
-import { handleSocialMessageCreated as indexAttachments } from "../../discord-attachment-indexer/src/index.js";
-import { embedMessage } from "../../discord-message-embedder/src/index.js";
-import { embedAttachments } from "../../attachment-embedder/src/index.js";
+import { handleSocialMessageCreated as indexMessage } from "@promethean/discord-message-indexer/src/index.js";
+import { handleSocialMessageCreated as indexAttachments } from "@promethean/discord-attachment-indexer/src/index.js";
+import { embedMessage } from "@promethean/discord-message-embedder/src/index.js";
+import { embedAttachments } from "@promethean/attachment-embedder/src/index.js";
 
 test("end-to-end: raw -> normalized -> index + embed", async (t) => {
   process.env.DISCORD_TOKEN_DUCK = "x";

--- a/packages/discord-gateway/tests/gateway.test.js
+++ b/packages/discord-gateway/tests/gateway.test.js
@@ -1,5 +1,5 @@
 import test from "ava";
-import { InMemoryEventBus } from "../../event/dist/memory.js";
+import { InMemoryEventBus } from "@promethean/event/memory.js";
 import { GatewayPublisher } from "../src/gateway.js";
 
 test("publishes raw and normalized events to bus", async (t) => {

--- a/packages/discord-message-embedder/package.json
+++ b/packages/discord-message-embedder/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@promethean/migrations": "workspace:*",
+    "@promethean/platform": "workspace:*",
     "@types/node": "^24.3.0",
     "typescript": "^5.9.2"
   },

--- a/packages/discord-message-embedder/src/index.ts
+++ b/packages/discord-message-embedder/src/index.ts
@@ -1,6 +1,6 @@
-import { fileBackedRegistry } from "../../platform/dist/provider-registry.js";
-import { makeChromaWrapper } from "../../migrations/dist/chroma.js";
-import { makeDeterministicEmbedder } from "../../migrations/dist/embedder.js";
+import { fileBackedRegistry } from "@promethean/platform/provider-registry.js";
+import { makeChromaWrapper } from "@promethean/migrations/chroma.js";
+import { makeDeterministicEmbedder } from "@promethean/migrations/embedder.js";
 
 export async function embedMessage(evt: any) {
   if (!evt.text || !evt.text.trim()) return null;

--- a/packages/discord-message-indexer/src/index.ts
+++ b/packages/discord-message-indexer/src/index.ts
@@ -1,6 +1,6 @@
-import { topic } from "../../platform/dist/topic.js";
-import { fileBackedRegistry } from "../../platform/dist/provider-registry.js";
-import { mongoForTenant } from "../../effects/dist/mongo.js";
+import { topic } from "@promethean/platform/topic.js";
+import { fileBackedRegistry } from "@promethean/platform/provider-registry.js";
+import { mongoForTenant } from "@promethean/effects/mongo.js";
 
 export async function handleSocialMessageCreated(evt: any) {
   const reg = fileBackedRegistry();

--- a/packages/discord-rest/src/index.ts
+++ b/packages/discord-rest/src/index.ts
@@ -1,5 +1,5 @@
-import { fileBackedRegistry } from "../../platform/dist/provider-registry.js";
-import { topic } from "../../platform/dist/topic.js";
+import { fileBackedRegistry } from "@promethean/platform/provider-registry.js";
+import { topic } from "@promethean/platform/topic.js";
 
 // Stub REST proxy: subscribes to rest.request and would call Discord REST.
 async function main() {

--- a/packages/discord-rest/src/rest.ts
+++ b/packages/discord-rest/src/rest.ts
@@ -1,5 +1,5 @@
-import { makePolicy } from "../../agent/dist/policy.js";
-import { fileBackedRegistry } from "../../platform/dist/provider-registry.js";
+import { makePolicy } from "@promethean/agent/policy.js";
+import { fileBackedRegistry } from "@promethean/platform/provider-registry.js";
 
 type RestResponse = {
   ok: boolean;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1442,6 +1442,9 @@ importers:
       '@promethean/migrations':
         specifier: workspace:*
         version: link:../migrations
+      '@promethean/platform':
+        specifier: workspace:*
+        version: link:../platform
       '@types/node':
         specifier: ^24.3.0
         version: 24.3.0
@@ -14014,7 +14017,7 @@ snapshots:
 
   axios@1.11.0:
     dependencies:
-      follow-redirects: 1.15.11(debug@4.3.7)
+      follow-redirects: 1.15.11(debug@4.4.1)
       form-data: 4.0.4
       proxy-from-env: 1.1.0
     transitivePeerDependencies:
@@ -16085,7 +16088,7 @@ snapshots:
   http-proxy@1.18.1:
     dependencies:
       eventemitter3: 4.0.7
-      follow-redirects: 1.15.11(debug@4.3.7)
+      follow-redirects: 1.15.11(debug@4.4.1)
       requires-port: 1.0.0
     transitivePeerDependencies:
       - debug


### PR DESCRIPTION
## Summary
- replace cross-package relative imports with scoped package references
- add missing `@promethean/platform` dependency for Discord message embedder

## Testing
- `npx tsc -p packages/discord-attachment-indexer/tsconfig.json`
- `npx tsc -p packages/discord-gateway/tsconfig.json`
- `npx tsc -p packages/discord-message-embedder/tsconfig.json`
- `npx tsc -p packages/discord-message-indexer/tsconfig.json`
- `npx tsc -p packages/discord-rest/tsconfig.json`


------
https://chatgpt.com/codex/tasks/task_e_68b7b3952004832482b3d935d59c25f2