### PR TITLE
fix: pin transformer and harden whisper test

### DIFF
--- a/changelog.d/2025.09.03.02.46.14.added.md
+++ b/changelog.d/2025.09.03.02.46.14.added.md
@@ -1,1 +1,1 @@
-Add TypeScript Whisper test using @xenova/transformers and document Node ML porting strategy.
+Add a TypeScript Whisper test using @xenova/transformers and document the Node ML porting strategy.

--- a/docs/node-ml-strategy.md
+++ b/docs/node-ml-strategy.md
@@ -1,20 +1,30 @@
 # Node ML Porting Strategy
 
+#node #ml #whisper
+
 ## Node Equivalents
-- **@xenova/transformers**: JavaScript/TypeScript transformers with ONNX runtime backend. Supports models like Whisper for speech recognition.
+
+- **@xenova/transformers**: JavaScript/TypeScript transformers with ONNX Runtime backend.
+  Supports models like Whisper for speech recognition.
 - **onnxruntime-node**: Native Node.js bindings for ONNX Runtime allowing execution of ONNX models.
 
 ## Prototype
-- `scripts/whisper_test.ts` uses `@xenova/transformers` to run a tiny Whisper model. It falls back to the existing Python `scripts/whisper_test.py` via `child_process.spawn` if the Node path fails.
+
+- [[scripts/whisper_test.ts]] uses @xenova/transformers to run a tiny Whisper model.
+  It falls back to the existing Python [[scripts/whisper_test.py]] via child_process.spawn
+  if the Node path fails.
 
 ## Trade-offs
-- **Porting** keeps logic in a single runtime and simplifies deployment but may require downloading large models and can be slower.
+
+- **Porting** keeps logic in a single runtime and simplifies deployment but may require
+  downloading large models and can be slower.
 - **Wrapping** leverages mature Python ecosystems but adds process management overhead.
 
 ## Recommendations
+
 | Script | Approach |
 |-------|----------|
-| `scripts/whisper_test.py` | Ported to TypeScript with fallback to Python |
-| `scripts/tts.py` | Wrap Python – Node alternatives immature |
-| `scripts/stt.py` | Wrap Python – depends on Python-only tools |
+| scripts/whisper_test.py | Port to TypeScript with fallback to Python |
+| scripts/tts.py | Wrap Python — Node alternatives immature |
+| scripts/stt.py | Wrap Python — depends on Python-only tools |
 

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@promethean/legacy": "file:packages/legacy",
     "@promethean/piper": "file:packages/piper",
     "@types/node": "^24.3.0",
-    "@xenova/transformers": "^2.17.2",
+    "@xenova/transformers": "2.17.2",
     "adm-zip": "0.5.16",
     "dotenv": "17.2.1",
     "gray-matter": "^4.0.3",

--- a/scripts/whisper_test.ts
+++ b/scripts/whisper_test.ts
@@ -1,19 +1,29 @@
-import { pipeline } from '@xenova/transformers';
+import { pipeline, env } from '@xenova/transformers';
 import { spawn } from 'node:child_process';
+
+// Cache directory can be overridden via XENOVA_CACHE_DIR
+env.cacheDir = process.env.XENOVA_CACHE_DIR ?? '.cache/transformers';
+const PYTHON = process.env.PYTHON || (process.platform === 'win32' ? 'py' : 'python3');
 
 async function main() {
   try {
-    const asr = await pipeline('automatic-speech-recognition', 'Xenova/whisper-tiny.en');
+    const asr = await pipeline(
+      'automatic-speech-recognition',
+      'Xenova/whisper-tiny.en',
+      { quantized: true }
+    );
     const silence = new Float32Array(16000);
-    const result = await asr(silence);
+    const result = await asr(silence, { sampling_rate: 16000 });
     console.log('Transcription:', result.text);
   } catch (err) {
-    console.warn('Falling back to Python implementation due to', err);
-    const child = spawn('python3', ['scripts/whisper_test.py'], { stdio: 'inherit' });
-    child.on('close', (code) => {
-      if (code !== 0) {
-        console.error(`Python script exited with code ${code}`);
-      }
+    console.warn('JS ASR failed; falling back to Python:', (err as Error)?.message ?? err);
+    await new Promise<void>((resolve, reject) => {
+      const child = spawn(PYTHON, ['scripts/whisper_test.py'], { stdio: 'inherit' });
+      child.once('error', reject);
+      child.once('close', (code) => {
+        if (code === 0) resolve();
+        else reject(new Error(`Python script exited with code ${code}`));
+      });
     });
   }
 }


### PR DESCRIPTION
## Summary
- pin @xenova/transformers to exact version
- harden Node whisper test with cache setup, quantized model, and awaitable Python fallback
- document Node ML porting strategy with hashtags and Wikilinks

## Testing
- `pnpm lint` *(fails: nested root configuration)*
- `pnpm test` *(fails: could not resolve path in @promethean/cephalon-discord build)*
- `npx tsx scripts/whisper_test.ts` *(falls back to Python which exits with code 1 after skipping)*

------
https://chatgpt.com/codex/tasks/task_e_68b7b4b619088324abbe6083b9380bdb