### PR TITLE
chore: align package licenses with GPL-3.0-only

### DIFF
--- a/changelog.d/2025.09.03.01.29.14.changed.md
+++ b/changelog.d/2025.09.03.01.29.14.changed.md
@@ -1,1 +1,1 @@
-Update package licenses to GPL-3.0-only and add LICENSE.txt to: @promethean/cephalon, @promethean/discord-embedder, @kit-js/repl.
+Update package license fields to GPL-3.0-only; add LICENSE.txt to @promethean/cephalon, @promethean/discord-embedder, and @kit-js/repl.

--- a/packages/discord-embedder/LICENSE.txt
+++ b/packages/discord-embedder/LICENSE.txt
@@ -198,8 +198,7 @@ To do so, attach the following notices to the program. It is safest to attach th
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
-    the Free Software Foundation, either version 3 of the License, or
-    (at your option) any later version.
+    the Free Software Foundation, version 3.
 
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/shared/sibilant/src/node/kit-repl/LICENSE.txt
+++ b/shared/sibilant/src/node/kit-repl/LICENSE.txt
@@ -198,8 +198,7 @@ To do so, attach the following notices to the program. It is safest to attach th
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
-    the Free Software Foundation, either version 3 of the License, or
-    (at your option) any later version.
+    the Free Software Foundation, version 3.
 
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of


### PR DESCRIPTION
## Summary
- remove "or any later version" from discord-embedder and kit-repl GPL headers
- clarify changelog entry for updated package licenses

## Testing
- `pnpm --filter @promethean/cephalon test` *(fails: Cannot find module '@promethean/agent-ecs/helpers/pushVision.js')*
- `pnpm --filter @promethean/discord-embedder test` *(fails: Cannot find module '@promethean/embeddings/remote.js')*
- `pnpm --filter @kit-js/repl test` *(fails: No projects matched the filters)*

------
https://chatgpt.com/codex/tasks/task_e_68b7b85c0f488324a140520d6b84687c