### PR TITLE
refactor: sanitize emitted property access

### DIFF
--- a/changelog.d/2025.09.03.01.39.38.fixed.md
+++ b/changelog.d/2025.09.03.01.39.38.fixed.md
@@ -1,1 +1,1 @@
-fix: ensure emitExpr returns a string and annotate parameters to avoid implicit any
+Ensure emitExpr returns a string and annotate parameters to avoid implicit any. (#665)


### PR DESCRIPTION
## Summary
- tighten string escaping and sanitize property access via `emitProp`
- guard `importNames` before binding and optimize block emission
- document fixes in changelog fragment

## Testing
- `pnpm --filter @promethean/compiler exec tsc --noEmit src/jsgen.ts`
- `pnpm --filter @promethean/compiler exec biome lint src/jsgen.ts`
- `pnpm --filter @promethean/compiler run typecheck` *(fails: TS2835 and TS7006 in other files)*

------
https://chatgpt.com/codex/tasks/task_e_68b7b88f36a48324aaee538e4b50388e