### PR TITLE
chore: fix TypeScript builds

### DIFF
--- a/changelog.d/2025.09.03.04.08.27.fixed.md
+++ b/changelog.d/2025.09.03.04.08.27.fixed.md
@@ -1,0 +1,1 @@
+- resolve TypeScript build errors in multiple packages by fixing code and imports

--- a/packages/boardrev/src/01-ensure-fm.ts
+++ b/packages/boardrev/src/01-ensure-fm.ts
@@ -18,8 +18,7 @@ const args = parseArgs({
   "--default-status": "todo",
 });
 
-function randomUUID() {
-  // @ts-ignore
+async function randomUUID() {
   return (
     globalThis.crypto?.randomUUID?.() ?? (await import("crypto")).randomUUID()
   );
@@ -44,7 +43,7 @@ async function main() {
       inferTitle(gm.content) ??
       slug(path.basename(f, ".md")).replace(/-/g, " ");
     const payload: TaskFM = {
-      uuid: fm.uuid ?? randomUUID(),
+      uuid: fm.uuid ?? (await randomUUID()),
       title,
       status: normStatus(fm.status ?? args["--default-status"]),
       priority: (fm.priority as any) ?? args["--default-priority"],

--- a/packages/codemods/src/01-spec.ts
+++ b/packages/codemods/src/01-spec.ts
@@ -1,7 +1,7 @@
 import { promises as fs } from "fs";
 import * as path from "path";
 
-import { Project } from "ts-morph";
+import { Project, Node } from "ts-morph";
 
 import { readJSON, writeJSON } from "./utils.js";
 import type { ModSpecFile, ModSpec } from "./types.js";
@@ -100,11 +100,8 @@ async function main() {
     // const foo = (...) => {}
     const vd = sf.getVariableDeclaration(funcName);
     const init = vd?.getInitializer();
-    if (init && typeof (init as any).getParameters === "function") {
-      // arrow or function expression
-      // @ts-ignore
-      if (init.getParameters)
-        return init.getParameters().map((p: any) => p.getName());
+    if (init && (Node.isArrowFunction(init) || Node.isFunctionExpression(init))) {
+      return init.getParameters().map((p) => p.getName());
     }
     return undefined;
   }

--- a/packages/ds/src/bst.test.ts
+++ b/packages/ds/src/bst.test.ts
@@ -1,6 +1,6 @@
 import test from 'ava';
 
-import { AVLTree } from './bst';
+import { AVLTree } from './bst.js';
 
 test('AVLTree: basic operations', (t) => {
     const tree = new AVLTree<number, string>();

--- a/packages/ds/src/ecs.doublebuffer.behavior.test.ts
+++ b/packages/ds/src/ecs.doublebuffer.behavior.test.ts
@@ -1,6 +1,6 @@
 import test from 'ava';
 
-import { World } from './ecs';
+import { World } from './ecs.js';
 
 test('ECS double-buffer: add readable in-frame; set visible after endTick', (t) => {
     const w = new World();

--- a/packages/ds/src/ecs.prefab.test.ts
+++ b/packages/ds/src/ecs.prefab.test.ts
@@ -1,7 +1,7 @@
 import test from 'ava';
 
-import { World } from './ecs';
-import { makeBlueprint, spawn } from './ecs.prefab';
+import { World } from './ecs.js';
+import { makeBlueprint, spawn } from './ecs.prefab.js';
 
 test('prefab: spawns entities from blueprint with overrides', (t) => {
     const world = new World();

--- a/packages/ds/src/ecs.prefab.ts
+++ b/packages/ds/src/ecs.prefab.ts
@@ -1,6 +1,6 @@
 // shared/ts/prom-lib/ds/ecs.prefab.ts
 
-import { World, ComponentType } from './ecs';
+import { World, ComponentType } from './ecs.js';
 
 export type BlueprintStep<T = any> = {
     c: ComponentType<T>;

--- a/packages/ds/src/ecs.scheduler.test.ts
+++ b/packages/ds/src/ecs.scheduler.test.ts
@@ -1,7 +1,7 @@
 import test from 'ava';
 
-import { World } from './ecs';
-import { Scheduler } from './ecs.scheduler';
+import { World } from './ecs.js';
+import { Scheduler } from './ecs.scheduler.js';
 
 test('Scheduler: orders systems, respects conflicts, skips empty', async (t) => {
     const world = new World();

--- a/packages/ds/src/ecs.scheduler.ts
+++ b/packages/ds/src/ecs.scheduler.ts
@@ -1,8 +1,8 @@
 // shared/ts/prom-lib/ds/ecs.scheduler.ts
 // MIT. Zero deps (uses World from ecs.ts and Graph from graph.ts)
 
-import { World, CommandBuffer, ComponentType, Query } from './ecs';
-import { Graph } from './graph';
+import { World, CommandBuffer, ComponentType, Query } from './ecs.js';
+import { Graph } from './graph.js';
 
 export type Stage = 'startup' | 'update' | 'late' | 'render' | 'cleanup';
 export const DEFAULT_STAGE_ORDER: Stage[] = ['startup', 'update', 'late', 'render', 'cleanup'];

--- a/packages/ds/src/ecs.test.ts
+++ b/packages/ds/src/ecs.test.ts
@@ -1,6 +1,6 @@
 import test from 'ava';
 
-import { World } from './ecs';
+import { World } from './ecs.js';
 
 test('ecs: creates entity and iterates components', (t) => {
     const world = new World();

--- a/packages/ds/src/graph.test.ts
+++ b/packages/ds/src/graph.test.ts
@@ -1,6 +1,6 @@
 import test from 'ava';
 
-import { Graph } from './graph';
+import { Graph } from './graph.js';
 
 test('Graph: bfs traverses undirected graph', (t) => {
     const g = new Graph({ directed: false });

--- a/packages/mcp/src/stdio.ts
+++ b/packages/mcp/src/stdio.ts
@@ -3,9 +3,6 @@ import dotenv from "dotenv";
 import WebSocket, { type RawData } from "ws";
 import readline from "node:readline";
 
-import dotenv from "dotenv";
-import WebSocket from "ws";
-
 dotenv.config();
 
 const url = process.env.MCP_SERVER_URL || "ws://localhost:4410/mcp";


### PR DESCRIPTION
## Summary
- restore NodeNext module settings in shared tsconfig
- fix DS package imports for NodeNext and tighten iter helper typing
- make boardrev randomUUID async and drop loose `any` casts in codemods and ECS tests

## Testing
- `pnpm -F boardrev build`
- `pnpm -F codemods build`
- `pnpm -F ds build`
- `pnpm -F ds test`


------
https://chatgpt.com/codex/tasks/task_e_68b7be97654883249fd694e5286041e6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Packed iteration now exposes entity identifiers alongside rows and columns.
- Refactor
  - Simplified system iteration API signatures to use rest parameters and broader types for easier consumption.
- Bug Fixes
  - Resolved TypeScript build errors across multiple packages by correcting code and imports; no runtime behavior changes expected.
- Tests
  - Updated module import paths to explicit extensions; test logic unchanged.
- Chores
  - Removed duplicate imports in tooling.
  - Added a changelog entry documenting these updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->