### PR TITLE
Add SPDX license headers and enforcement script

### DIFF
--- a/docs/agile/tasks/clearly-standardize-data-models.md
+++ b/docs/agile/tasks/clearly-standardize-data-models.md
@@ -49,8 +49,4 @@ Nothing
 - [kanban](kanban.md)
 
 #framework-core #Ready
-<<<<<<< HEAD:docs/agile/tasks/clearly-standardize-data-models.md
 #ready
-=======
-
->>>>>>> origin/dev/yoga:docs/agile/tasks/clearly standardize data models.md

--- a/docs/agile/tasks/codex-action-build-file-contextualizer..md
+++ b/docs/agile/tasks/codex-action-build-file-contextualizer..md
@@ -19,9 +19,5 @@ You might find [this] useful while working on this task
 
 ## Comments
 
-<<<<<<< HEAD:docs/agile/tasks/codex-action-build-file-contextualizer..md
 Useful for agents to engage in append only conversations about this task.
 #archive
-=======
-Useful for agents to engage in append only conversations about this task.
->>>>>>> origin/dev/yoga:docs/agile/tasks/consolidate all configs into ` config` as `.edn` files.md

--- a/docs/agile/tasks/connect-bluesky.md
+++ b/docs/agile/tasks/connect-bluesky.md
@@ -51,7 +51,4 @@ You might find [Bluesky API docs](https://docs.bsky.app/docs/api) useful while w
 Useful for agents to engage in append only conversations about this task.
 
 #Ready
-<<<<<<< HEAD:docs/agile/tasks/connect-bluesky.md
 #ready
-=======
->>>>>>> origin/dev/yoga:docs/agile/tasks/connect bluesky.md

--- a/docs/agile/tasks/connect-reddit.md
+++ b/docs/agile/tasks/connect-reddit.md
@@ -71,7 +71,4 @@ Useful for agents to engage in append only conversations about this task.
 No blockers.
 
 #Ready
-<<<<<<< HEAD:docs/agile/tasks/connect-reddit.md
 #ready
-=======
->>>>>>> origin/dev/yoga:docs/agile/tasks/connect reddit.md

--- a/docs/agile/tasks/connect-wikipedia.md
+++ b/docs/agile/tasks/connect-wikipedia.md
@@ -71,7 +71,4 @@ Useful for agents to engage in append only conversations about this task.
 No blockers.
 
 #Ready
-<<<<<<< HEAD:docs/agile/tasks/connect-wikipedia.md
 #ready
-=======
->>>>>>> origin/dev/yoga:docs/agile/tasks/connect wikipedia.md

--- a/docs/agile/tasks/context-service.md
+++ b/docs/agile/tasks/context-service.md
@@ -19,9 +19,5 @@ You might find [this] useful while working on this task
 
 ## Comments
 
-<<<<<<< HEAD:docs/agile/tasks/context-service.md
 Useful for agents to engage in append only conversations about this task.
 #ready
-=======
-Useful for agents to engage in append only conversations about this task.
->>>>>>> origin/dev/yoga:docs/agile/tasks/flatten sibilant src folders.md

--- a/docs/agile/tasks/convert-current-services-to-packages--then-redefine-the-services-using-config-files.md
+++ b/docs/agile/tasks/convert-current-services-to-packages--then-redefine-the-services-using-config-files.md
@@ -54,8 +54,4 @@ Nothing
 - [kanban](kanban.md)
 
 #framework-core #Ready
-<<<<<<< HEAD:docs/agile/tasks/convert-current-services-to-packages--then-redefine-the-services-using-config-files.md
 #ready
-=======
-
->>>>>>> origin/dev/yoga:docs/agile/tasks/convert current services to packages, then redefine the services using config files.md

--- a/docs/agile/tasks/convert-smartgpt-bridge-to-ts.md
+++ b/docs/agile/tasks/convert-smartgpt-bridge-to-ts.md
@@ -19,9 +19,5 @@ You might find [this] useful while working on this task
 
 ## Comments
 
-<<<<<<< HEAD:docs/agile/tasks/convert-smartgpt-bridge-to-ts.md
 Useful for agents to engage in append only conversations about this task.
 #ready
-=======
-Useful for agents to engage in append only conversations about this task.
->>>>>>> origin/dev/yoga:docs/agile/tasks/convert smartgpt bridge to ts.md

--- a/docs/agile/tasks/create_vault-config_obsidian_with_kanban_and_minimal_vault_setup_1_md_md.md
+++ b/docs/agile/tasks/create_vault-config_obsidian_with_kanban_and_minimal_vault_setup_1_md_md.md
@@ -1,56 +1,33 @@
 ## 🛠️ Task: Create vault-config .obsidian with Kanban and minimal vault setup
 
-<<<<<<< HEAD
 Provide a shareable `.obsidian` folder that new contributors can copy to get the
 same Kanban board and plugin configuration. Keep the config minimal so it works
 across different operating systems.
-=======
-Provide a small example of an Obsidian configuration so contributors can quickly
-spin up the same vault environment. The config should enable the Kanban plugin
-and include a `README` explaining how to copy the folder into `.obsidian/`.
->>>>>>> main
 
 ---
 
 ## 🎯 Goals
 
-<<<<<<< HEAD
 - Include the Kanban plugin as the only required community plugin
 - Document how to copy the config into a fresh clone
 - Ensure markdown files render correctly on GitHub without extra plugins
-=======
-- Supply a ready-to-copy `.obsidian` folder under `vault-config/`.
-- Document how to copy the folder and what plugins are enabled.
-- Keep the configuration minimal so personal settings remain local.
->>>>>>> main
 
 ---
 
 ## 📦 Requirements
-<<<<<<< HEAD
 
 - [ ] Store config under `vault-config/.obsidian/`
 - [ ] Include `config` and `community-plugins.json`
 - [ ] Mention the setup command in `vault-config/README.md`
 - [ ] Keep plugin list short (kanban only by default)
-=======
-- [ ] Include `config` file with Kanban plugin enabled.
-- [ ] Provide `community-plugins.json` listing `obsidian-kanban` only.
-- [ ] Write `vault-config/README.md` instructions on usage.
->>>>>>> main
 
 ---
 
 ## 📋 Subtasks
-<<<<<<< HEAD
 
 - [ ] Verify `.obsidian/config` enables Kanban view
 - [ ] Add usage notes to `docs/vault-config-readme.md`
 - [ ] Link this task from the main README onboarding section
-=======
-- [ ] Verify the folder works by opening the vault locally.
-- [ ] Add a note in `README.md` referencing the config.
->>>>>>> main
 
 ---
 

--- a/docs/agile/tasks/discord_image_awareness_md_md.md
+++ b/docs/agile/tasks/discord_image_awareness_md_md.md
@@ -60,8 +60,4 @@ This allows the “Duck” to have **visual memory** tied to conversational cont
 - Tests or documentation are missing; acceptance criteria not fully met.
 - Story Points: 5
 
-<<<<<<< HEAD
 #ready
-=======
-#in-progress
->>>>>>> origin/dev/yoga

--- a/docs/agile/tasks/ensure-openapi-specs-are-automaticly-updated-when-an-endpoint-is-changed.md
+++ b/docs/agile/tasks/ensure-openapi-specs-are-automaticly-updated-when-an-endpoint-is-changed.md
@@ -41,9 +41,5 @@ Nothing
 
 ## 🔍 Relevant Links
 
-<<<<<<< HEAD:docs/agile/tasks/ensure-openapi-specs-are-automaticly-updated-when-an-endpoint-is-changed.md
 - [[kanban]]
 #done
-=======
-- [[kanban.md]]
->>>>>>> origin/dev/yoga:docs/agile/tasks/Ensure openapi specs are automaticly updated when an endpoint is changed.md

--- a/docs/agile/tasks/evaluate_and_reward_flow_satisfaction.md
+++ b/docs/agile/tasks/evaluate_and_reward_flow_satisfaction.md
@@ -59,7 +59,4 @@ Generated from [../unique/2025.07.28.18.07.20.md](../unique/2025.07.28.18.07.20.
 - Should user feedback be captured explicitly or inferred from message content?
 - Do we need real-time updates to the reward signal or batched summaries?
 #IceBox
-<<<<<<< HEAD
 #rejected
-=======
->>>>>>> origin/dev/yoga

--- a/docs/agile/tasks/find-music-that-triggered-copyright-mute-on-twitch-for-analysis-incoming.md
+++ b/docs/agile/tasks/find-music-that-triggered-copyright-mute-on-twitch-for-analysis-incoming.md
@@ -40,9 +40,5 @@ Nothing
 
 ## 🔍 Relevant Links
 
-<<<<<<< HEAD:docs/agile/tasks/find-music-that-triggered-copyright-mute-on-twitch-for-analysis-incoming.md
 - [[kanban]]
 #rejected
-=======
-- [[kanban.md]]
->>>>>>> origin/dev/yoga:docs/agile/tasks/Find music that triggered copyright mute on twitch for analysis incoming.md

--- a/docs/agile/tasks/fully-convert-js-ts-projects-to-pnpm-incoming.md
+++ b/docs/agile/tasks/fully-convert-js-ts-projects-to-pnpm-incoming.md
@@ -41,9 +41,5 @@ Nothing
 
 ## 🔍 Relevant Links
 
-<<<<<<< HEAD:docs/agile/tasks/fully-convert-js-ts-projects-to-pnpm-incoming.md
 - [[kanban]]
 #archive
-=======
-- [[kanban.md]]
->>>>>>> origin/dev/yoga:docs/agile/tasks/Fully convert js ts projects to pnpm incoming.md

--- a/docs/agile/tasks/gather_baseline_emotion_metrics_for_eidolon_field_1_md.md
+++ b/docs/agile/tasks/gather_baseline_emotion_metrics_for_eidolon_field_1_md.md
@@ -30,16 +30,9 @@ this baseline to detect deviations and compute rewards.
 
 ## 📋 Subtasks
 
-<<<<<<< HEAD
 - [ ] Run initial collection using current Eidolon service (or mock data)
 - [ ] Export cleaned results to `data/eidolon/baseline.csv`
 - [ ] Update doc `eidolon-field-math.md` with methodology and assumptions
-=======
-- [ ] Run the collection script on a local machine
-- [ ] Verify the CSV contains timestamped vectors with eight fields
-- [ ] Update doc `eidolon-field-math.md` with sampling methodology
-- [ ] Commit the CSV and report under `data/eidolon/`
->>>>>>> main
 
 ---
 
@@ -69,7 +62,4 @@ Nothing
 - What instrumentation already exists in Eidolon for metric export?
 - How much historical data is needed for a meaningful baseline?
 #IceBox
-<<<<<<< HEAD
 #rejected
-=======
->>>>>>> origin/dev/yoga

--- a/docs/agile/tasks/gather_open_questions_about_system_direction_md_md.md
+++ b/docs/agile/tasks/gather_open_questions_about_system_direction_md_md.md
@@ -37,7 +37,4 @@ Nothing
 ## 🔍 Relevant Links
 - [kanban](../boards/kanban.md)
 #IceBox
-<<<<<<< HEAD
 #ice-box
-=======
->>>>>>> origin/dev/yoga

--- a/docs/agile/tasks/integrate_synthesis-agent_pass_on_unique_to_produce_draft_docs_1_md.md
+++ b/docs/agile/tasks/integrate_synthesis-agent_pass_on_unique_to_produce_draft_docs_1_md.md
@@ -49,7 +49,4 @@ Nothing
 - [process](process.md)
 - [kanban](../boards/kanban.md)
 #IceBox
-<<<<<<< HEAD
 #ready
-=======
->>>>>>> origin/dev/yoga

--- a/docs/agile/tasks/llm-service-must-accept-tool-calls.md
+++ b/docs/agile/tasks/llm-service-must-accept-tool-calls.md
@@ -50,8 +50,4 @@ Nothing
 - [kanban](kanban.md)
 
 #framework-core #Ready
-<<<<<<< HEAD:docs/agile/tasks/llm-service-must-accept-tool-calls.md
 #ready
-=======
-
->>>>>>> origin/dev/yoga:docs/agile/tasks/LLM service must accept tool calls.md

--- a/docs/agile/tasks/llm-service-must-allow-streamed-responses.md
+++ b/docs/agile/tasks/llm-service-must-allow-streamed-responses.md
@@ -30,7 +30,4 @@ Useful for agents to engage in append only conversations about this task.
 - Estimate: 5
 - Assumptions: Underlying LLM and transport layer support streaming responses.
 - Dependencies: Streaming protocol implementation and client compatibility.
-<<<<<<< HEAD:docs/agile/tasks/llm-service-must-allow-streamed-responses.md
 #ready
-=======
->>>>>>> origin/dev/yoga:docs/agile/tasks/LLM service must allow streamed responses.md

--- a/docs/agile/tasks/make-the-system-hashtag-aware.md
+++ b/docs/agile/tasks/make-the-system-hashtag-aware.md
@@ -30,7 +30,4 @@ Useful for agents to engage in append only conversations about this task.
 - Estimate: 3
 - Assumptions: A consistent hashtag taxonomy is available.
 - Dependencies: Vault graph service and parsing hooks.
-<<<<<<< HEAD:docs/agile/tasks/make-the-system-hashtag-aware.md
 #ready
-=======
->>>>>>> origin/dev/yoga:docs/agile/tasks/Make the system hashtag aware.md

--- a/docs/agile/tasks/replace-all-python-properly-with-hy-incoming.md
+++ b/docs/agile/tasks/replace-all-python-properly-with-hy-incoming.md
@@ -237,8 +237,4 @@ Append-only thread for agents. Note blockers, weird Hy interop, or macro decisio
 
 \#tags #promethean #hy #lisp #python #build #ci #git #precommit #policy #docs
 
-<<<<<<< HEAD:docs/agile/tasks/replace-all-python-properly-with-hy-incoming.md
 #archive
-=======
-#in-progress
->>>>>>> origin/dev/yoga:docs/agile/tasks/Replace all python properly with hy incoming.md

--- a/docs/agile/tasks/run_model_bakeoff_md.md
+++ b/docs/agile/tasks/run_model_bakeoff_md.md
@@ -46,7 +46,4 @@ Nothing
 ## 🔍 Relevant Links
 - [kanban](../boards/kanban.md)
 #IceBox
-<<<<<<< HEAD
 #ready
-=======
->>>>>>> origin/dev/yoga

--- a/docs/agile/tasks/set-up-new-user-roles-and-policies-for-the-systems.md
+++ b/docs/agile/tasks/set-up-new-user-roles-and-policies-for-the-systems.md
@@ -35,7 +35,4 @@ Useful for agents to engage in append only conversations about this task.
 - Estimate: 5
 - Assumptions: Existing auth framework can be extended for granular roles.
 - Dependencies: Permission schema design and configuration interface.
-<<<<<<< HEAD:docs/agile/tasks/set-up-new-user-roles-and-policies-for-the-systems.md
 #ready
-=======
->>>>>>> origin/dev/yoga:docs/agile/tasks/Set up new user roles and policies for the systems.md

--- a/docs/agile/tasks/snapshot_prompts_specs_to_repo.md
+++ b/docs/agile/tasks/snapshot_prompts_specs_to_repo.md
@@ -31,7 +31,4 @@ Capture existing prompt and specification documents into the repository so they 
 - [kanban](../boards/kanban.md)
 
 #IceBox
-<<<<<<< HEAD
 #ready
-=======
->>>>>>> origin/dev/yoga

--- a/docs/agile/tasks/tool_chain_management_system_md_md.md
+++ b/docs/agile/tasks/tool_chain_management_system_md_md.md
@@ -16,14 +16,8 @@ Placeholder task stub generated from kanban board.
 
 ---
 
-<<<<<<< HEAD
 ### **Related Tasks**  
 - [[integrate-sonarqube-into-devops]] (if SonarQube integration is part of this tool chain).  
-=======
-## 📋 Subtasks
-
-- [ ] Outline steps to implement.
->>>>>>> origin/dev/yoga
 
 ---
 
@@ -35,19 +29,5 @@ Placeholder task stub generated from kanban board.
 
 ## ⛓️ Blocked By
 
-<<<<<<< HEAD
 Let me know if you need further details or adjustments!
-=======
-Nothing
-
-## ⛓️ Blocks
-
-Nothing
-
----
-
-## 🔍 Relevant Links
-
-- [kanban](../boards/kanban.md)
->>>>>>> origin/dev/yoga
 #ice-box

--- a/docs/agile/tasks/update_makefile_to_have_commands_specific_for_agents_md.md
+++ b/docs/agile/tasks/update_makefile_to_have_commands_specific_for_agents_md.md
@@ -52,7 +52,4 @@ Nothing
 
 
 #devops #Ready
-<<<<<<< HEAD
 #ready
-=======
->>>>>>> origin/dev/yoga

--- a/packages/codex-orchestrator/src/index.d.ts
+++ b/packages/codex-orchestrator/src/index.d.ts
@@ -1,2 +1,3 @@
+// SPDX-License-Identifier: GPL-3.0-only
 export {};
 //# sourceMappingURL=index.d.ts.map

--- a/packages/codex-orchestrator/src/ollama.d.ts
+++ b/packages/codex-orchestrator/src/ollama.d.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-only
 type Msg = {
     role: "system" | "user" | "assistant";
     content: string;

--- a/packages/codex-orchestrator/src/ollama.js
+++ b/packages/codex-orchestrator/src/ollama.js
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-only
 export async function chat({ model, messages, options = {}, }) {
     const host = process.env.OLLAMA_HOST || "http://localhost:11434";
     const res = await fetch(`${host}/api/chat`, {

--- a/packages/codex-orchestrator/src/tools.d.ts
+++ b/packages/codex-orchestrator/src/tools.d.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-only
 export declare function readFileSafe(p: string): Promise<string>;
 export declare function summarize(s: string, maxLen?: number): string;
 export declare function ripgrep(cwd: string, query: string): Promise<string>;


### PR DESCRIPTION
## Summary
- resolve merge conflicts in Agile task docs
- add SPDX headers to Codex orchestrator sources

## Testing
- `node scripts/ensure-spdx-license.mjs --check`
- `pnpm lint` *(fails: nested root configuration)*
- `pnpm test` *(fails: TypeScript build errors in packages/compiler)*

------
https://chatgpt.com/codex/tasks/task_e_68b7bad7cf548324b7cdd55b6070b3ea