### PR TITLE
fix: add .js extensions to type imports

### DIFF
--- a/packages/agent-ecs/src/adapters/example-hooks.ts
+++ b/packages/agent-ecs/src/adapters/example-hooks.ts
@@ -1,7 +1,7 @@
 import { enqueueUtterance } from '../helpers/enqueueUtterance.js';
 
 export function wireAdapters(
-    world: ReturnType<typeof import('../world').createAgentWorld>,
+    world: ReturnType<typeof import('../world.js').createAgentWorld>,
     deps: {
         tts: { synth: (text: string) => Promise<any> }; // returns AudioResource-compatible stream
     },

--- a/packages/agent-ecs/src/helpers/enqueueUtterance.ts
+++ b/packages/agent-ecs/src/helpers/enqueueUtterance.ts
@@ -4,7 +4,7 @@ import type { defineAgentComponents } from '../components.js';
 export function enqueueUtterance(
     w: any,
     agent: any,
-    C: ReturnType<typeof import('../components').defineAgentComponents>,
+    C: ReturnType<typeof import('../components.js').defineAgentComponents>,
     rawOpts: {
         id?: string;
         priority?: number;

--- a/packages/agent-ecs/src/helpers/pushVision.ts
+++ b/packages/agent-ecs/src/helpers/pushVision.ts
@@ -4,7 +4,7 @@ import type { defineAgentComponents } from '../components.js';
 export function pushVisionFrame(
     w: any,
     agent: any,
-    C: ReturnType<typeof import('../components').defineAgentComponents>,
+    C: ReturnType<typeof import('../components.js').defineAgentComponents>,
     ref: {
         type: 'url' | 'blob' | 'attachment';
         url?: string;

--- a/packages/agent-ecs/src/systems/speechArbiter.ts
+++ b/packages/agent-ecs/src/systems/speechArbiter.ts
@@ -7,7 +7,7 @@ const STOP_AFTER_MS = 1000; // tune: 700–1200ms feels natural
 
 type BargeState = { speakingSince: number | null; paused: boolean };
 
-export function SpeechArbiterSystem(w: any, C: ReturnType<typeof import('../components').defineAgentComponents>) {
+export function SpeechArbiterSystem(w: any, C: ReturnType<typeof import('../components.js').defineAgentComponents>) {
     const { Turn, PlaybackQ, AudioRef, Utterance, AudioRes, VAD, Policy } = C as ReturnType<
         typeof defineAgentComponents
     >;

--- a/packages/agent-ecs/src/systems/turn.ts
+++ b/packages/agent-ecs/src/systems/turn.ts
@@ -1,6 +1,6 @@
 import type { defineAgentComponents } from '../components.js';
 
-export function TurnDetectionSystem(w: any, C: ReturnType<typeof import('../components').defineAgentComponents>) {
+export function TurnDetectionSystem(w: any, C: ReturnType<typeof import('../components.js').defineAgentComponents>) {
     const { Turn, VAD, TranscriptFinal } = C as ReturnType<typeof defineAgentComponents>;
     const qVad = w.makeQuery({ all: [Turn, VAD] });
     const qFinal = w.makeQuery({


### PR DESCRIPTION
## Summary
- add `.js` extensions to type-only dynamic imports in agent-ecs
- merge latest `main`

## Testing
- `pnpm lint` *(fails: Found a nested root configuration, but there's already a root configuration)*
- `pnpm --filter ./packages/agent-ecs run build`
- `pnpm test` *(fails: packages/contracts build: Failed)*

------
https://chatgpt.com/codex/tasks/task_e_68b7d586161c8324b2cb8495d37c75d7