### PR TITLE
Dev/stealth: fix LLM MCP prefix binding

### DIFF
--- a/.emacs/layers/llm/keybindings.el
+++ b/.emacs/layers/llm/keybindings.el
@@ -1,39 +1,24 @@
+;;; keybindings.el --- llm layer keybindings -*- lexical-binding: t; -*-
+
 ;; Global LLM prefix
 (spacemacs/declare-prefix "al" "LLM")  ;; SPC a l ...
 
-;; Major-mode keys (e.g., in prog/text)
-(dolist (mode '(prog-mode text-mode org-mode markdown-mode))
-  (spacemacs/declare-prefix-for-mode mode "ml" "LLM")
-  (spacemacs/set-leader-keys-for-major-mode mode
-    "lc" 'gptel-send                    ;; send region/buffer
-    "le" 'gptel-explain                 ;; explain code/region
-    "lr" 'gptel-rewrite                 ;; rewrite selection
-    "lq" 'gptel-quick))                 ;; quick popup
+;; GPTel entrypoints
+(spacemacs/set-leader-keys
+  "alg" #'gptel                 ;; open chat buffer
+  "alq" #'gptel-quick)          ;; quick popup (optional)
 
 ;; Ellama flows (optional)
-(spacemacs/set-leader-keys
-  "ale" 'ellama)                        ;; open ellama session
+(when (fboundp 'ellama)
+  (spacemacs/set-leader-keys "ale" #'ellama)) ;; open ellama session if available
 
-;; MCP
+;; MCP under LLM prefix
 (spacemacs/declare-prefix "alm" "MCP")
 (spacemacs/set-leader-keys
-  "almc" 'mcp-connect                   ;; connect to a server
-  "almd" 'mcp-disconnect
-  "alml" 'mcp-list-tools)               ;; discover tools/resources
-(spacemacs/set-leader-keys
-  "alm" #'gptel-mcp-dispatch) ;; MCP menu inside gptel
-
-;; Also available inside gptel buffers via C-c m
-;;; keybindings.el --- llm layer keybindings  -*- lexical-binding: t; -*-
-
-;; Global LLM prefix
-(spacemacs/declare-prefix "al" "LLM")
-
-;; GPTel entrypoints
-(spacemacs/set-leader-keys
-  "alg" #'gptel                 ;; open chat buffer
-  "alq" #'gptel-quick           ;; quick popup (optional)
-  "alm" #'gptel-mcp-dispatch)   ;; MCP menu inside GPTel (Emacs 30+)
+  "almc" #'mcp-connect                   ;; connect to a server
+  "almd" #'mcp-disconnect
+  "alml" #'mcp-list-tools                ;; discover tools/resources
+  "almm" #'gptel-mcp-dispatch)           ;; MCP menu inside gptel
 
 ;; Per-major-mode bindings (prog/text/org/markdown)
 (dolist (mode '(prog-mode text-mode org-mode markdown-mode))
@@ -44,22 +29,3 @@
     "lr" #'gptel-rewrite
     "lq" #'gptel-quick))
 
-;;; keybindings.el --- llm layer keybindings  -*- lexical-binding: t; -*-
-
-;; Global LLM prefix
-(spacemacs/declare-prefix "al" "LLM")
-
-;; GPTel entrypoints
-(spacemacs/set-leader-keys
-  "alg" #'gptel                 ;; open chat buffer
-  "alq" #'gptel-quick           ;; quick popup (optional)
-  "alm" #'gptel-mcp-dispatch)   ;; MCP menu inside GPTel (Emacs 30+)
-
-;; Per-major-mode bindings (prog/text/org/markdown)
-(dolist (mode '(prog-mode text-mode org-mode markdown-mode))
-  (spacemacs/declare-prefix-for-mode mode "ml" "LLM")
-  (spacemacs/set-leader-keys-for-major-mode mode
-    "lc" #'llm/gptel-send-region-or-buffer
-    "le" #'gptel-explain
-    "lr" #'gptel-rewrite
-    "lq" #'gptel-quick))

--- a/changelog.d/2025.09.04.00.43.15.fixed.md
+++ b/changelog.d/2025.09.04.00.43.15.fixed.md
@@ -1,0 +1,1 @@
+Fix MCP dispatch binding under LLM prefix.


### PR DESCRIPTION
## Summary
- keep `alm` as MCP prefix and move dispatch to `almm`
- note LLM keybinding fix in changelog

## Testing
- `pnpm test` *(fails: Expected ',' or '}' after property value in JSON at position 243 in packages/piper/package.json)*


------
https://chatgpt.com/codex/tasks/task_e_68b8e05fbca88324b4d5abbab1cd1fd4