### PR TITLE
docs: disable markdownlint rules in Canvas troubleshooting note

### DIFF
--- a/changelog.d/2025.09.04.00.46.01.fixed.md
+++ b/changelog.d/2025.09.04.00.46.01.fixed.md
@@ -1,0 +1,1 @@
+Silence markdownlint MD024/MD029 warnings in Canvas performance troubleshooting note.

--- a/docs/Nexus/Conversations/chatgpt/2025/08/Canvas performance troubleshooting.md
+++ b/docs/Nexus/Conversations/chatgpt/2025/08/Canvas performance troubleshooting.md
@@ -10,6 +10,7 @@ chat_url: "https://chat.openai.com/c/68a38690-27f0-8333-8319-d7deec3076a9"
 tags: [canvas, performance, troubleshooting, chatgpt, browsers]
 doc_kind: "conversation-transcript"
 ---
+<!-- markdownlint-disable MD024 MD029 -->
 
 # Title: Canvas performance troubleshooting
 


### PR DESCRIPTION
## Summary
- silence markdownlint MD024/MD029 warnings for Canvas performance troubleshooting note
- log change in changelog fragment

## Testing
- `npx markdownlint-cli2 docs/Nexus/Conversations/chatgpt/2025/08/Canvas\ performance\ troubleshooting.md`

------
https://chatgpt.com/codex/tasks/task_e_68b8e025e0848324a6fc0357273fe798