### PR TITLE
Fix unlabeled blockquote fences in canvas troubleshooting doc

### DIFF
--- a/docs/Nexus/Conversations/chatgpt/2025/08/Canvas performance troubleshooting.md
+++ b/docs/Nexus/Conversations/chatgpt/2025/08/Canvas performance troubleshooting.md
@@ -76,7 +76,7 @@ Last Updated: 08/18/2025 at 3:28 PM
 >  - `about:config`: set **`gfx.webrender.software` = true** (test), then if worse, set it back and instead try **`MOZ_ENABLE_WAYLAND=1 firefox`** (if you’re on Wayland-capable stack).
 > 
 > 2) **Kill compositor interference (quick test):** 
->  ```
+>  ```text
 >  pkill picom; firefox --new-instance --ProfileManager
 >  ```
 >  Open a fresh profile → load ChatGPT → reproduce. If smooth now, picom rules or your old profile were the culprit.
@@ -89,7 +89,7 @@ Last Updated: 08/18/2025 at 3:28 PM
 > 
 > 5) **Last‑resort: isolate the heavyweight tab:** 
 >  Run Chromium just for ChatGPT UI: 
->  ```
+>  ```text
 >  chromium --user-data-dir=/tmp/chatgpt-clean --disable-extensions --disable-background-timer-throttling
 >  ```
 >  Keep everything else in Firefox.
@@ -190,7 +190,7 @@ Last Updated: 08/18/2025 at 3:28 PM
 > 
 > 3. **Limit Firefox RAM so it can’t spiral**: 
 >  - `about:config`: 
->  ```
+>  ```text
 >  browser.tabs.unloadOnLowMemory = true
 >  media.memory_cache_max_size = 65536
 >  ```
@@ -231,7 +231,7 @@ Last Updated: 08/18/2025 at 3:28 PM
 > 1. **GPU driver path** 
 >  - Both Firefox and Chrome talk to the same Mesa/Intel/AMD driver stack. If WebGL/WebGPU or heavy compositing kicks a known bug, you get a system-wide hang. 
 >  - Telltale sign: kernel log lines like 
->  ```
+>  ```text
 >  GPU HANG: ecode ...
 >  Resetting GPU
 >  ``` 
@@ -260,7 +260,7 @@ Last Updated: 08/18/2025 at 3:28 PM
 >  ``` 
 >  That way if canvas tries to balloon, kernel kills just that process, not the whole session.
 > - **Keep zram on**: 
->  ```
+>  ```text
 >  sudo apt install zram-tools
 >  ``` 
 >  (or systemd-zram-generator). This absorbs swap storms.


### PR DESCRIPTION
## Summary
- mark blockquoted code samples as `text` in Canvas performance troubleshooting guide

## Testing
- `pnpm test` *(fails: Expected ',' or '}' after property value in JSON at position 243 in packages/piper/package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b8df7ebed08324afeb434514c40f53