### PR TITLE
feat: add image link generator

### DIFF
--- a/changelog.d/2025.09.04.00.44.15.added.md
+++ b/changelog.d/2025.09.04.00.44.15.added.md
@@ -1,0 +1,1 @@
+Added image link generator package for repairing broken Markdown/Org image links with generated placeholders.

--- a/docs/image-link-generator.md
+++ b/docs/image-link-generator.md
@@ -1,0 +1,3 @@
+# Image Link Generator
+
+Scans Markdown and Org documents for broken image links and uses small text-to-image models to generate placeholder images.

--- a/packages/image-link-generator/package.json
+++ b/packages/image-link-generator/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "@promethean/image-link-generator",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "main": "dist/index.cjs",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    },
+    "./dist/*": "./dist/*",
+    "./*": "./dist/*"
+  },
+  "files": ["dist"],
+  "scripts": {
+    "build": "tsc",
+    "clean": "rimraf dist",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "test": "pnpm run build && ava --config ../../config/ava.config.mjs",
+    "lint": "pnpm exec biome lint .",
+    "coverage": "pnpm run build && c8 ava --config ../../config/ava.config.mjs",
+    "format": "pnpm exec biome format --write ."
+  },
+  "module": "dist/index.js",
+  "dependencies": {
+    "@xenova/transformers": "^2.17.2"
+  },
+  "devDependencies": {
+    "@biomejs/biome": "^2.2.2",
+    "@types/node": "^20.19.11",
+    "ava": "^6.4.1",
+    "c8": "^10.1.3",
+    "rimraf": "^6.0.1",
+    "ts-node": "^10.9.2",
+    "typescript": "^5.9.2"
+  }
+}

--- a/packages/image-link-generator/src/index.ts
+++ b/packages/image-link-generator/src/index.ts
@@ -1,0 +1,102 @@
+import type { Dirent } from "node:fs";
+import { readdir, readFile, stat } from "node:fs/promises";
+import path from "node:path";
+
+export interface BrokenImageLink {
+	readonly file: string;
+	readonly url: string;
+	readonly alt: string;
+}
+
+async function pathExists(p: string): Promise<boolean> {
+	try {
+		await stat(p);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+async function walk(dir: string, acc: string[]): Promise<void> {
+	const entries = (await readdir(dir, { withFileTypes: true })) as Dirent[];
+	await Promise.all(
+		entries.map(async (entry) => {
+			const resolved = path.join(dir, entry.name);
+			if (entry.isDirectory()) {
+				await walk(resolved, acc);
+			} else if (
+				entry.isFile() &&
+				(entry.name.endsWith(".md") || entry.name.endsWith(".org"))
+			) {
+				acc.push(resolved);
+			}
+		}),
+	);
+}
+
+export async function findBrokenImageLinks(
+	root: string,
+): Promise<BrokenImageLink[]> {
+	const files: string[] = [];
+	await walk(root, files);
+	const results: BrokenImageLink[] = [];
+	for (const file of files) {
+		const content = await readFile(file, "utf8");
+		// markdown ![alt](url)
+		const mdRegex = /!\[(.*?)\]\((.*?)\)/g;
+		let match: RegExpExecArray | null;
+		while ((match = mdRegex.exec(content)) !== null) {
+			const alt = match[1] ?? "";
+			const url = match[2]!;
+			const imgPath = path.resolve(path.dirname(file), url);
+			if (!(await pathExists(imgPath))) {
+				results.push({ file, url, alt });
+			}
+		}
+		// org [[file:img.png][alt]] or [[img.png]]
+		const orgRegex = /\[\[(?:file:)?([^\]\[]+?)\](?:\[([^\]]*?)\])?\]/g;
+		while ((match = orgRegex.exec(content)) !== null) {
+			const url = match[1]!;
+			const alt = match[2] ?? "";
+			const imgPath = path.resolve(path.dirname(file), url);
+			if (!(await pathExists(imgPath))) {
+				results.push({ file, url, alt });
+			}
+		}
+	}
+	return results;
+}
+
+export type ImageGenerator = (
+	prompt: string,
+	outputPath: string,
+) => Promise<void>;
+
+export async function defaultImageGenerator(
+	prompt: string,
+	outputPath: string,
+): Promise<void> {
+	const { pipeline } = await import("@xenova/transformers");
+	const pipe: any = await pipeline(
+		"text-to-image" as any,
+		"stabilityai/stable-diffusion-2-1-base" as any,
+	);
+	const result: any = await pipe(prompt);
+	// transformers.js Image type supports .save()
+	await result.images[0].save(outputPath);
+}
+
+export async function fixBrokenImageLinks(
+	root: string,
+	generator: ImageGenerator = defaultImageGenerator,
+): Promise<BrokenImageLink[]> {
+	const links = await findBrokenImageLinks(root);
+	await Promise.all(
+		links.map(async (link) => {
+			const output = path.resolve(path.dirname(link.file), link.url);
+			const prompt = link.alt || "placeholder image";
+			await generator(prompt, output);
+		}),
+	);
+	return links;
+}

--- a/packages/image-link-generator/tests/index.test.ts
+++ b/packages/image-link-generator/tests/index.test.ts
@@ -1,0 +1,33 @@
+import test from "ava";
+import { mkdtemp, writeFile, stat } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { findBrokenImageLinks, fixBrokenImageLinks } from "../src/index.js";
+
+test("finds broken markdown and org image links", async (t) => {
+	const dir = await mkdtemp(path.join(os.tmpdir(), "img-test-"));
+	await writeFile(path.join(dir, "doc.md"), "![cat](cat.png)");
+	await writeFile(path.join(dir, "doc.org"), "[[file:dog.png][dog]]");
+	const links = await findBrokenImageLinks(dir);
+	t.deepEqual(links.map((l) => l.url).sort(), ["cat.png", "dog.png"]);
+});
+
+test("fixBrokenImageLinks generates files using provided generator", async (t) => {
+	const dir = await mkdtemp(path.join(os.tmpdir(), "img-test-"));
+	await writeFile(path.join(dir, "doc.md"), "![cat](cat.png)");
+	const generated: string[] = [];
+	const generator = async (
+		_prompt: string,
+		outPath: string,
+	): Promise<void> => {
+		generated.push(outPath);
+		await writeFile(outPath, "fake-image");
+	};
+	const links = await fixBrokenImageLinks(dir, generator);
+	t.is(links.length, 1);
+	const fileExists = await stat(path.join(dir, "cat.png"))
+		.then(() => true)
+		.catch(() => false);
+	t.true(fileExists);
+	t.deepEqual(generated, [path.join(dir, "cat.png")]);
+});

--- a/packages/image-link-generator/tsconfig.json
+++ b/packages/image-link-generator/tsconfig.json
@@ -1,0 +1,12 @@
+{
+	"extends": "../../config/tsconfig.base.json",
+	"compilerOptions": {
+		"rootDir": ".",
+		"outDir": "dist",
+		"composite": true,
+		"declaration": true,
+		"lib": ["ES2022", "DOM"],
+		"skipLibCheck": true
+	},
+	"include": ["src/**/*", "tests/**/*"]
+}


### PR DESCRIPTION
## Summary
- add `@promethean/image-link-generator` for scanning docs and generating missing images
- document image link generator package
- note addition in changelog

## Testing
- `pnpm exec tsc -p packages/image-link-generator/tsconfig.json`
- `pnpm exec ava packages/image-link-generator/dist/tests/index.test.js --config config/ava.config.mjs`


------
https://chatgpt.com/codex/tasks/task_e_68b8dede29fc832497ca0fcbea5c28b6