### PR TITLE
fix: build-based AVA tests and pin dependencies

### DIFF
--- a/packages/agent/ava.config.mjs
+++ b/packages/agent/ava.config.mjs
@@ -1,1 +1,1 @@
-export { default } from '../../../config/ava.config.mjs';
+export { default } from '../../config/ava.config.mjs';

--- a/packages/nitpack/ava.config.mjs
+++ b/packages/nitpack/ava.config.mjs
@@ -1,7 +1,3 @@
-export default {
-  files: ["tests/**/*.ts"],
-  extensions: {
-    ts: "module",
-  },
-  nodeArguments: ["--loader=tsx"],
-};
+import base from "../../config/ava.config.mjs";
+
+export default base;

--- a/packages/nitpack/package.json
+++ b/packages/nitpack/package.json
@@ -9,15 +9,16 @@
   },
   "scripts": {
     "start": "tsx src/index.ts",
-    "test": "ava"
+    "build": "tsc -p tsconfig.json",
+    "test": "pnpm build && ava"
   },
   "dependencies": {
-    "globby": "^14.0.2",
-    "zod": "^3.23.8"
+    "globby": "14.0.2",
+    "zod": "3.23.8"
   },
   "devDependencies": {
-    "ava": "^6.1.3",
-    "tsx": "^4.7.0",
-    "typescript": "^5.5.4"
+    "ava": "6.1.3",
+    "tsx": "4.7.0",
+    "typescript": "5.5.4"
   }
 }

--- a/packages/nitpack/tsconfig.json
+++ b/packages/nitpack/tsconfig.json
@@ -1,5 +1,4 @@
 {
-  "extends": null,
   "compilerOptions": {
     "target": "ES2022",
     "lib": ["ES2022"],
@@ -7,11 +6,14 @@
     "moduleResolution": "NodeNext",
     "moduleDetection": "force",
     "strict": true,
+    "verbatimModuleSyntax": true,
     "noUncheckedIndexedAccess": true,
     "resolveJsonModule": true,
     "skipLibCheck": true,
     "allowJs": false,
-    "composite": false
+    "composite": false,
+    "rootDir": ".",
+    "outDir": "dist"
   },
   "include": ["src", "tests"]
 }

--- a/packages/piper/ava.config.mjs
+++ b/packages/piper/ava.config.mjs
@@ -1,1 +1,6 @@
-export { default } from "../../../config/ava.config.mjs";
+import base from "../../config/ava.config.mjs";
+
+export default {
+  ...base,
+  workerThreads: false,
+};

--- a/packages/piper/package.json
+++ b/packages/piper/package.json
@@ -18,15 +18,15 @@
     }
   },
   "dependencies": {
-    "chokidar": "^3.6.0",
-    "globby": "^14.0.2",
-    "yaml": "^2.5.0",
-    "zod": "^3.23.8",
+    "chokidar": "3.6.0",
+    "globby": "14.0.2",
+    "yaml": "2.5.0",
+    "zod": "3.23.8",
     "@promethean/level-cache": "workspace:*"
   },
   "devDependencies": {
-    "ava": "^6.4.1",
-    "tsx": "^4.19.2",
-    "typescript": "^5.5.4"
+    "ava": "6.4.1",
+    "tsx": "4.19.2",
+    "typescript": "5.5.4"
   }
 }


### PR DESCRIPTION
## Summary
- correct AVA config paths and disable worker threads for Piper tests
- pin dependencies and switch Piper and Nitpack tests to build-then-run AVA
- compile Nitpack sources to dist with updated tsconfig and centralized AVA config

## Testing
- `pnpm -F @promethean/piper test`
- `pnpm -F @promethean/nitpack test`


------
https://chatgpt.com/codex/tasks/task_e_68b9b95fc9b88324a598e9bc5db6a8b2