### PR TITLE
dev/stealth: document disabled worker threads for Piper tests

### DIFF
--- a/packages/piper/ava.config.mjs
+++ b/packages/piper/ava.config.mjs
@@ -2,5 +2,6 @@ import base from "../../config/ava.config.mjs";
 
 export default {
   ...base,
+  // Disable worker threads for CI stability.
   workerThreads: false,
 };


### PR DESCRIPTION
## Summary
- explain why Piper's AVA config disables worker threads

## Testing
- `pnpm -F @promethean/piper test`
- `pnpm -F @promethean/nitpack test`


------
https://chatgpt.com/codex/tasks/task_e_68b9c98743b88324907dab9f9435b1fd