### PR TITLE
test: strengthen normalize and document ava config

### DIFF
--- a/packages/nitpack/tests/normalize.test.ts
+++ b/packages/nitpack/tests/normalize.test.ts
@@ -6,7 +6,8 @@ test("normalize strips code fences and paths", (t) => {
     'Please add .js suffix in imports from "./foo" in packages/x/src/a.ts:12.```ts\nimport x from "./bar"\n```',
   ];
   const got = normalizeComments(input);
-  t.true(got[0]?.includes(".js suffix") || true);
+  t.is(got.length, 1);
+  t.true(got[0]?.includes(".js suffix"));
   t.false(got[0]?.includes("```"));
   t.false(/packages\/x\/src\/a\.ts/.test(got[0] ?? ""));
 });

--- a/packages/piper/ava.config.mjs
+++ b/packages/piper/ava.config.mjs
@@ -2,5 +2,6 @@ import base from "../../config/ava.config.mjs";
 
 export default {
   ...base,
+  // Disable worker threads for CI stability.
   workerThreads: false,
 };


### PR DESCRIPTION
## Summary
- ensure normalize test asserts length and .js suffix
- explain workerThreads setting in Piper AVA config

## Testing
- `pnpm -F @promethean/nitpack test`
- `pnpm -F @promethean/piper test`


------
https://chatgpt.com/codex/tasks/task_e_68b9c9f4fda883249fc2838abe04cd9a