### PR TITLE
chore: remove placeholder tool config paths

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -340,7 +340,6 @@ reviews:
       enabled: true
 
       # Optional path to the SwiftLint configuration file relative to the repository. This is useful when the configuration file is named differently than the default '.swiftlint.yml' or '.swiftlint.yaml'.
-      config_file: "example-value"
 
     # PHPStan is a tool to analyze PHP code.
     # Default: {}
@@ -376,7 +375,6 @@ reviews:
       enabled: true
 
       # Optional path to the golangci-lint configuration file relative to the repository. Useful when the configuration file is named differently than the default '.golangci.yml', '.golangci.yaml', '.golangci.toml', '.golangci.json'.
-      config_file: "example-value"
 
     # YAMLlint is a linter for YAML files.
     # Default: {}
@@ -407,7 +405,6 @@ reviews:
       enabled: true
 
       # Optional path to the detekt configuration file relative to the repository.
-      config_file: "example-value"
 
     # ESLint is a static code analysis tool for JavaScript files.
     # Default: {}
@@ -459,7 +456,6 @@ reviews:
       enabled: true
 
       # Optional path to the PMD configuration file relative to the repository.
-      config_file: "example-value"
 
     # Cppcheck is a static code analysis tool for the C and C++ programming languages.
     # Default: {}
@@ -475,8 +471,8 @@ reviews:
       # Default: true
       enabled: true
 
-      # Optional path to the Semgrep configuration file relative to the repository.
-      config_file: "example-value"
+    # Optional path to the Semgrep configuration file relative to the repository.
+    config_file: ".semgrep.yaml"
 
     # CircleCI tool is a static checker for CircleCI config files.
     # Default: {}

--- a/changelog.d/2025.09.04.21.44.00.fixed.md
+++ b/changelog.d/2025.09.04.21.44.00.fixed.md
@@ -1,0 +1,1 @@
+fix: remove placeholder lint config paths in CodeRabbit config


### PR DESCRIPTION
## Summary
- remove placeholder `config_file` entries in CodeRabbit config
- point Semgrep to `.semgrep.yaml`

## Testing
- `pre-commit run --files .coderabbit.yaml changelog.d/2025.09.04.21.44.00.fixed.md`


------
https://chatgpt.com/codex/tasks/task_e_68ba06bce54883249dc68b0600ac0824