### PR TITLE
fix: correct ml nginx mount paths

### DIFF
--- a/changelog.d/2025.09.04.21.54.09.fixed.md
+++ b/changelog.d/2025.09.04.21.54.09.fixed.md
@@ -1,0 +1,1 @@
+Correct ML compose nginx mount paths and add placeholder secrets.

--- a/infrastructure/compose/ml.yaml
+++ b/infrastructure/compose/ml.yaml
@@ -17,7 +17,7 @@ services:
     container_name: edge
     ports: ["80:80"]
     volumes:
-      - ../nginx/nginx.conf:/etc/nginx/nginx.conf:ro
+      - ../nginx/ml.conf:/etc/nginx/nginx.conf:ro
       - ../nginx/secrets:/etc/nginx/secrets:ro
     networks: [prom-net]
     restart: unless-stopped

--- a/infrastructure/nginx/secrets/.gitignore
+++ b/infrastructure/nginx/secrets/.gitignore
@@ -1,0 +1,3 @@
+# Ignore secret files except placeholder map
+*
+!api_keys.map

--- a/infrastructure/nginx/secrets/api_keys.map
+++ b/infrastructure/nginx/secrets/api_keys.map
@@ -1,0 +1,3 @@
+# Format: "api_key" value; one per line
+# Example:
+# "demo-key" 1;


### PR DESCRIPTION
## Summary
- mount existing `ml.conf` in ML compose
- add placeholder `api_keys.map` and ignore real secrets

## Testing
- `npm test` *(fails: @promethean/boardrev build: Object is possibly 'undefined')*

------
https://chatgpt.com/codex/tasks/task_e_68ba0998ed148324a0c5302a6af61ca4