### PR TITLE
Dev/stealth: fix OVMS port clash and clean up lint config placeholders

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -339,9 +339,6 @@ reviews:
       # Default: true
       enabled: true
 
-      # Optional path to the SwiftLint configuration file relative to the repository. This is useful when the configuration file is named differently than the default '.swiftlint.yml' or '.swiftlint.yaml'.
-      config_file: "example-value"
-
     # PHPStan is a tool to analyze PHP code.
     # Default: {}
     phpstan:
@@ -375,9 +372,6 @@ reviews:
       # Default: true
       enabled: true
 
-      # Optional path to the golangci-lint configuration file relative to the repository. Useful when the configuration file is named differently than the default '.golangci.yml', '.golangci.yaml', '.golangci.toml', '.golangci.json'.
-      config_file: "example-value"
-
     # YAMLlint is a linter for YAML files.
     # Default: {}
     yamllint:
@@ -405,9 +399,6 @@ reviews:
       # Enable detekt - detekt is a static code analysis tool for Kotlin files. - v1.23.8
       # Default: true
       enabled: true
-
-      # Optional path to the detekt configuration file relative to the repository.
-      config_file: "example-value"
 
     # ESLint is a static code analysis tool for JavaScript files.
     # Default: {}
@@ -458,9 +449,6 @@ reviews:
       # Default: true
       enabled: true
 
-      # Optional path to the PMD configuration file relative to the repository.
-      config_file: "example-value"
-
     # Cppcheck is a static code analysis tool for the C and C++ programming languages.
     # Default: {}
     cppcheck:
@@ -474,9 +462,6 @@ reviews:
       # Enable Semgrep - Semgrep is a static analysis tool designed to scan code for security vulnerabilities and code quality issues. - Enable Semgrep integration. - v1.128.1
       # Default: true
       enabled: true
-
-      # Optional path to the Semgrep configuration file relative to the repository.
-      config_file: "example-value"
 
     # CircleCI tool is a static checker for CircleCI config files.
     # Default: {}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -154,7 +154,10 @@ services:
   # ---------- OVMS (Intel iGPU/NPU) ----------
   ovms-npu:
     image: ${OVMS_IMAGE:-openvino/model_server:2025.2.1}
-    command: --config_path /config/config.json --rest_port 9000 --port 9000
+    command: --config_path /config/config.json --rest_port 9090 --port 9000
+    ports:
+      - "9000:9000" # gRPC
+      - "9090:9090" # REST
     volumes:
       - ./infra/ovms/config.json:/config/config.json:ro
       - ./models/ov:/opt/models:ro


### PR DESCRIPTION
## Summary
- use distinct REST/gRPC ports for OVMS and expose 9000/9090
- drop placeholder `config_file` entries for linters in `.coderabbit.yaml`

## Testing
- `pnpm test` *(fails: Object is possibly 'undefined' in packages/boardrev)*

------
https://chatgpt.com/codex/tasks/task_e_68ba099d4f54832496a1cb2c3ce4c1a0