### PR TITLE
feat: gate auth header on 401

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -339,9 +339,6 @@ reviews:
       # Default: true
       enabled: true
 
-      # Optional path to the SwiftLint configuration file relative to the repository. This is useful when the configuration file is named differently than the default '.swiftlint.yml' or '.swiftlint.yaml'.
-      config_file: "example-value"
-
     # PHPStan is a tool to analyze PHP code.
     # Default: {}
     phpstan:
@@ -375,9 +372,6 @@ reviews:
       # Default: true
       enabled: true
 
-      # Optional path to the golangci-lint configuration file relative to the repository. Useful when the configuration file is named differently than the default '.golangci.yml', '.golangci.yaml', '.golangci.toml', '.golangci.json'.
-      config_file: "example-value"
-
     # YAMLlint is a linter for YAML files.
     # Default: {}
     yamllint:
@@ -405,9 +399,6 @@ reviews:
       # Enable detekt - detekt is a static code analysis tool for Kotlin files. - v1.23.8
       # Default: true
       enabled: true
-
-      # Optional path to the detekt configuration file relative to the repository.
-      config_file: "example-value"
 
     # ESLint is a static code analysis tool for JavaScript files.
     # Default: {}
@@ -458,9 +449,6 @@ reviews:
       # Default: true
       enabled: true
 
-      # Optional path to the PMD configuration file relative to the repository.
-      config_file: "example-value"
-
     # Cppcheck is a static code analysis tool for the C and C++ programming languages.
     # Default: {}
     cppcheck:
@@ -474,9 +462,8 @@ reviews:
       # Enable Semgrep - Semgrep is a static analysis tool designed to scan code for security vulnerabilities and code quality issues. - Enable Semgrep integration. - v1.128.1
       # Default: true
       enabled: true
-
       # Optional path to the Semgrep configuration file relative to the repository.
-      config_file: "example-value"
+      config_file: ".semgrep.yaml"
 
     # CircleCI tool is a static checker for CircleCI config files.
     # Default: {}

--- a/infrastructure/nginx/ml.conf
+++ b/infrastructure/nginx/ml.conf
@@ -28,6 +28,9 @@ http {
 
   map $http_upgrade $connection_upgrade { default upgrade; '' close; }
 
+  # Only send WWW-Authenticate header on 401 responses
+  map $status $www_auth { 401 "X-API-Key"; default ""; }
+
   server {
     listen 80;
     server_name _;
@@ -42,7 +45,7 @@ http {
 
     # global auth gate
     if ($api_key_ok = 0) { return 401; }
-    add_header Www-Authenticate 'X-API-Key' always;
+    add_header WWW-Authenticate $www_auth always;
 
     # -------- Ollama --------
     location /ollama/ {


### PR DESCRIPTION
## Summary
- only send `WWW-Authenticate` header on 401 responses
- drop placeholder CodeRabbit `config_file` paths and point Semgrep to `.semgrep.yaml`

## Testing
- `pnpm lint` *(fails: nested root configuration)*
- `pnpm test` *(fails: @promethean/boardrev build error)*

------
https://chatgpt.com/codex/tasks/task_e_68ba09987f7c8324b02f5e52552a7476