### PR TITLE
Fix Common Lisp LSP mapping and clean CodeRabbit config

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -339,9 +339,6 @@ reviews:
       # Default: true
       enabled: true
 
-      # Optional path to the SwiftLint configuration file relative to the repository. This is useful when the configuration file is named differently than the default '.swiftlint.yml' or '.swiftlint.yaml'.
-      config_file: "example-value"
-
     # PHPStan is a tool to analyze PHP code.
     # Default: {}
     phpstan:
@@ -375,9 +372,6 @@ reviews:
       # Default: true
       enabled: true
 
-      # Optional path to the golangci-lint configuration file relative to the repository. Useful when the configuration file is named differently than the default '.golangci.yml', '.golangci.yaml', '.golangci.toml', '.golangci.json'.
-      config_file: "example-value"
-
     # YAMLlint is a linter for YAML files.
     # Default: {}
     yamllint:
@@ -405,9 +399,6 @@ reviews:
       # Enable detekt - detekt is a static code analysis tool for Kotlin files. - v1.23.8
       # Default: true
       enabled: true
-
-      # Optional path to the detekt configuration file relative to the repository.
-      config_file: "example-value"
 
     # ESLint is a static code analysis tool for JavaScript files.
     # Default: {}
@@ -458,9 +449,6 @@ reviews:
       # Default: true
       enabled: true
 
-      # Optional path to the PMD configuration file relative to the repository.
-      config_file: "example-value"
-
     # Cppcheck is a static code analysis tool for the C and C++ programming languages.
     # Default: {}
     cppcheck:
@@ -476,7 +464,7 @@ reviews:
       enabled: true
 
       # Optional path to the Semgrep configuration file relative to the repository.
-      config_file: "example-value"
+      config_file: ".semgrep.yaml"
 
     # CircleCI tool is a static checker for CircleCI config files.
     # Default: {}

--- a/.emacs/layers/err-core/packages.el
+++ b/.emacs/layers/err-core/packages.el
@@ -92,15 +92,13 @@
 (defun err-core/post-init-lsp-mode ()
 
   (with-eval-after-load 'lsp-mode
+    (add-to-list 'lsp-language-id-configuration '(lisp-mode . "commonlisp"))
     (lsp-register-client
      (make-lsp-client :new-connection (lsp-stdio-connection (lambda () (list (expand-file-name "~/.roswell/bin/cl-lsp"))))
                       :activation-fn (lsp-activate-on "commonlisp")
                       :server-id 'cl-lsp))))
 
 (defun err-core/post-init-common-lisp ()
-
-  (with-eval-after-load 'lsp-mode
-    (add-to-list 'lsp-language-id-configuration '(lisp-mode . "commonlisp")))
 
   (with-eval-after-load 'lisp-mode
     (add-hook 'lisp-mode-hook #'lsp-deferred)

--- a/changelog.d/2025.09.04.21.57.28.fixed.md
+++ b/changelog.d/2025.09.04.21.57.28.fixed.md
@@ -1,0 +1,1 @@
+fix lisp-mode mapping for commonlisp LSP client and remove placeholder config_file values


### PR DESCRIPTION
## Summary
- map `lisp-mode` to `commonlisp` for CL LSP client activation
- remove placeholder `config_file` values in CodeRabbit config and point Semgrep to `.semgrep.yaml`

## Testing
- `npm test` *(fails: Object is possibly 'undefined' in packages/boardrev build)*

------
https://chatgpt.com/codex/tasks/task_e_68ba099b381c8324afbd1a7069c9c067