### PR TITLE
refactor: share ensureDir helper

### DIFF
--- a/changelog.d/2025.09.04.22.17.17.changed.md
+++ b/changelog.d/2025.09.04.22.17.17.changed.md
@@ -1,0 +1,1 @@
+Introduced shared `ensureDir` utility and refactored packages to use it.

--- a/packages/codepack/package.json
+++ b/packages/codepack/package.json
@@ -17,6 +17,7 @@
     "unified": "^11.0.4",
     "unist-util-visit": "^5.0.0",
     "yaml": "^2.5.0",
-    "zod": "^3.23.8"
+    "zod": "^3.23.8",
+    "@promethean/fs-utils": "workspace:*"
   }
 }

--- a/packages/codepack/src/utils.ts
+++ b/packages/codepack/src/utils.ts
@@ -5,6 +5,9 @@ import { unified } from "unified";
 import remarkParse from "remark-parse";
 import { visit } from "unist-util-visit";
 import * as crypto from "crypto";
+import { ensureDir } from "@promethean/fs-utils";
+
+export { ensureDir };
 
 export const OLLAMA_URL = process.env.OLLAMA_URL ?? "http://localhost:11434";
 
@@ -52,10 +55,6 @@ export function cosine(a: number[], b: number[]) {
   }
   if (!na || !nb) return 0;
   return dot / (Math.sqrt(na) * Math.sqrt(nb));
-}
-
-export async function ensureDir(p: string) {
-  await fs.mkdir(p, { recursive: true });
 }
 
 export function relPath(fromRoot: string, fileAbs: string) {

--- a/packages/fs-utils/package.json
+++ b/packages/fs-utils/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@promethean/fs-utils",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    },
+    "./ensureDir": {
+      "import": "./dist/ensureDir.js",
+      "types": "./dist/ensureDir.d.ts"
+    }
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "test": "pnpm run build && ava",
+    "clean": "rimraf dist"
+  },
+  "dependencies": {},
+  "devDependencies": {
+    "ava": "6.4.1",
+    "tsx": "4.19.2",
+    "typescript": "5.5.4",
+    "rimraf": "6.0.1"
+  }
+}

--- a/packages/fs-utils/src/ensureDir.ts
+++ b/packages/fs-utils/src/ensureDir.ts
@@ -1,0 +1,5 @@
+import { promises as fs } from 'fs';
+
+export async function ensureDir(p: string) {
+  await fs.mkdir(p, { recursive: true });
+}

--- a/packages/fs-utils/src/index.ts
+++ b/packages/fs-utils/src/index.ts
@@ -1,0 +1,1 @@
+export * from './ensureDir.js';

--- a/packages/fs-utils/src/tests/ensureDir.test.ts
+++ b/packages/fs-utils/src/tests/ensureDir.test.ts
@@ -1,0 +1,13 @@
+import test from 'ava';
+import { promises as fs } from 'fs';
+import * as path from 'path';
+import { tmpdir } from 'os';
+
+import { ensureDir } from '../ensureDir.js';
+
+test('ensureDir creates directory', async (t) => {
+  const dir = path.join(tmpdir(), 'ensure-dir-test', Date.now().toString());
+  await ensureDir(dir);
+  const stat = await fs.stat(dir);
+  t.true(stat.isDirectory());
+});

--- a/packages/fs-utils/tsconfig.json
+++ b/packages/fs-utils/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../config/tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "composite": true,
+    "declaration": true
+  },
+  "include": ["src/**/*"],
+  "references": []
+}

--- a/packages/fs/package.json
+++ b/packages/fs/package.json
@@ -53,7 +53,8 @@
         "ws": "^8.18.0",
         "yaml": "^2.5.1",
         "zod": "^3.23.8",
-        "@promethean/stream": "workspace:*"
+        "@promethean/stream": "workspace:*",
+        "@promethean/fs-utils": "workspace:*"
     },
     "devDependencies": {
         "@biomejs/biome": "^2.2.2",

--- a/packages/fs/src/mirrorTransform.ts
+++ b/packages/fs/src/mirrorTransform.ts
@@ -4,6 +4,7 @@ import * as path from 'path';
 import { Readable, Transform, Writable } from 'stream';
 import { pipeline as _pipeline } from 'stream/promises';
 
+import { ensureDir } from '@promethean/fs-utils';
 import { streamTreeConcurrent, StreamEvent, StreamNode } from './streamTreeGeneratorsConcurrent.js';
 
 type OverwriteMode = 'always' | 'if-newer' | 'never';
@@ -68,8 +69,6 @@ export type PlannedOp =
     | { kind: 'skip'; src: string; dst: string; reason: string }
     | { kind: 'symlink'; src: string; dst: string; target: string }
     | { kind: 'error'; at: string; error: string };
-
-const ensureDir = async (p: string) => fs.mkdir(p, { recursive: true });
 
 const defaultMapPath = (info: FileInfo) => path.join(info.dstRoot, info.relPath);
 

--- a/packages/piper/package.json
+++ b/packages/piper/package.json
@@ -22,7 +22,8 @@
     "globby": "14.0.2",
     "yaml": "2.5.0",
     "zod": "3.23.8",
-    "@promethean/level-cache": "workspace:*"
+    "@promethean/level-cache": "workspace:*",
+    "@promethean/fs-utils": "workspace:*"
   },
   "devDependencies": {
     "ava": "6.4.1",

--- a/packages/piper/src/fsutils.ts
+++ b/packages/piper/src/fsutils.ts
@@ -3,12 +3,11 @@ import * as path from "path";
 import { spawn } from "child_process";
 
 import { globby } from "globby";
+import { ensureDir } from "@promethean/fs-utils";
 
 import { PiperStep } from "./types.js";
 
-export async function ensureDir(p: string) {
-  await fs.mkdir(p, { recursive: true });
-}
+export { ensureDir };
 
 export async function readTextMaybe(p: string) {
   try {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -816,6 +816,9 @@ importers:
 
   packages/codepack:
     dependencies:
+      '@promethean/fs-utils':
+        specifier: workspace:*
+        version: link:../fs-utils
       gray-matter:
         specifier: ^4.0.3
         version: 4.0.3
@@ -2272,6 +2275,9 @@ importers:
 
   packages/fs:
     dependencies:
+      '@promethean/fs-utils':
+        specifier: workspace:*
+        version: link:../fs-utils
       '@promethean/stream':
         specifier: workspace:*
         version: link:../stream
@@ -2375,6 +2381,21 @@ importers:
       typescript:
         specifier: ^5.9.2
         version: 5.9.2
+
+  packages/fs-utils:
+    devDependencies:
+      ava:
+        specifier: 6.4.1
+        version: 6.4.1
+      rimraf:
+        specifier: 6.0.1
+        version: 6.0.1
+      tsx:
+        specifier: 4.19.2
+        version: 4.19.2
+      typescript:
+        specifier: 5.5.4
+        version: 5.5.4
 
   packages/hf-http:
     dependencies:
@@ -3721,6 +3742,9 @@ importers:
 
   packages/piper:
     dependencies:
+      '@promethean/fs-utils':
+        specifier: workspace:*
+        version: link:../fs-utils
       '@promethean/level-cache':
         specifier: workspace:*
         version: link:../level-cache
@@ -13775,6 +13799,7 @@ snapshots:
 
   '@promethean/fs@file:packages/fs(socks@2.8.7)':
     dependencies:
+      '@promethean/fs-utils': link:packages/fs-utils
       '@promethean/stream': link:packages/stream
       '@types/javascript-time-ago': 2.5.0
       '@types/unist': 3.0.3
@@ -13893,6 +13918,7 @@ snapshots:
 
   '@promethean/piper@file:packages/piper':
     dependencies:
+      '@promethean/fs-utils': link:packages/fs-utils
       '@promethean/level-cache': link:packages/level-cache
       chokidar: 3.6.0
       globby: 14.0.2


### PR DESCRIPTION
## Summary
- add @promethean/fs-utils package with shared ensureDir helper
- use shared ensureDir in fs, codepack, and piper packages
- remove duplicate ensureDir implementations

## Testing
- `pnpm -F @promethean/fs-utils test`
- `pnpm -F @promethean/fs test` *(fails: TS errors in existing sources)*
- `pnpm -F @promethean/codepack run test` *(no test script)*
- `pnpm -F @promethean/piper test`


------
https://chatgpt.com/codex/tasks/task_e_68ba0dc8adc8832490d10ca30cd10572