### PR TITLE
chore(types): centralize markdown shims

### DIFF
--- a/changelog.d/2025.09.04.22.12.32.changed.md
+++ b/changelog.d/2025.09.04.22.12.32.changed.md
@@ -1,0 +1,1 @@
+Consolidated @promethean/markdown module declarations into shared shim file.

--- a/packages/kanban-processor/src/shims.d.ts
+++ b/packages/kanban-processor/src/shims.d.ts
@@ -1,7 +1,3 @@
 declare module '@promethean/persistence/contextStore.js';
 declare module '@promethean/persistence/dualStore.js';
 declare module '@promethean/persistence/clients.js';
-declare module '@promethean/markdown/kanban.js';
-declare module '@promethean/markdown/sync.js';
-declare module '@promethean/markdown/task.js';
-declare module '@promethean/markdown/statuses.js';

--- a/packages/kanban-processor/tsconfig.json
+++ b/packages/kanban-processor/tsconfig.json
@@ -58,6 +58,9 @@
     // Completeness
     "skipLibCheck": true
   },
-  "include": ["src/**/*.ts", "tests/**/*.ts"],
-  "exclude": ["node_modules"]
+  "include": ["src/**/*.ts", "tests/**/*.ts", "../types/shims/*.d.ts"],
+  "exclude": ["node_modules"],
+  "references": [
+    { "path": "../types" }
+  ]
 }

--- a/packages/tests/src/shims.d.ts
+++ b/packages/tests/src/shims.d.ts
@@ -1,10 +1,6 @@
 declare module '@promethean/compiler/transform/transformer.js';
 declare module '@promethean/dev/harness.js';
 declare module '@promethean/fs/fileExplorer.js';
-declare module '@promethean/markdown/kanban.js';
-declare module '@promethean/markdown/sync.js';
-declare module '@promethean/markdown/statuses.js';
-declare module '@promethean/markdown/task.js';
 declare module '@promethean/parity/normalizers.js';
 declare module '@promethean/parity/runner.js';
 declare module '@promethean/stream/title.js';

--- a/packages/tests/tsconfig.json
+++ b/packages/tests/tsconfig.json
@@ -6,7 +6,7 @@
         "composite": true,
         "declaration": true
     },
-    "include": ["src/**/*"],
+    "include": ["src/**/*", "../types/shims/*.d.ts"],
     "references": [
         {
             "path": "../compiler"
@@ -28,6 +28,9 @@
         },
         {
             "path": "../web"
+        },
+        {
+            "path": "../types"
         }
     ]
 }

--- a/packages/types/shims/markdown.d.ts
+++ b/packages/types/shims/markdown.d.ts
@@ -1,0 +1,4 @@
+declare module '@promethean/markdown/kanban.js';
+declare module '@promethean/markdown/sync.js';
+declare module '@promethean/markdown/task.js';
+declare module '@promethean/markdown/statuses.js';


### PR DESCRIPTION
## Summary
- consolidate @promethean/markdown module declarations into a shared shim
- remove markdown shim lines from kanban-processor and tests packages
- point kanban-processor and tests tsconfigs at shared markdown shim

## Testing
- `pnpm -F kanban-processor build:check`
- `pnpm -F kanban-processor test` *(fails: Cannot find module '@promethean/persistence/dist/contextStore.js')*
- `pnpm -F tests typecheck` *(fails: Cannot find name 'HeadersInit')*
- `pnpm -F tests test` *(fails: Cannot find name 'HeadersInit')*

------
https://chatgpt.com/codex/tasks/task_e_68ba0dc767fc8324a31403bbf5641140