### PR TITLE
chore: centralize persistence shims

### DIFF
--- a/changelog.d/2025.09.04.22.12.36.changed.md
+++ b/changelog.d/2025.09.04.22.12.36.changed.md
@@ -1,0 +1,1 @@
+refactor: centralize persistence module shims into shared declaration file

--- a/packages/cephalon/src/shims.d.ts
+++ b/packages/cephalon/src/shims.d.ts
@@ -1,5 +1,3 @@
-declare module '@promethean/persistence/contextStore.js';
-declare module '@promethean/persistence/dualStore.js';
 declare module '@promethean/persistence/maintenance.js';
 declare module '@promethean/agent-ecs/systems/orchestrator.js';
 declare module '@promethean/llm/tools.js';

--- a/packages/cephalon/tsconfig.json
+++ b/packages/cephalon/tsconfig.json
@@ -5,16 +5,37 @@
     "rootDir": "src",
     "baseUrl": ".",
     "paths": {
-      "@shared/js/*": ["../../js/*"],
-      "@promethean/persistence": ["../persistence/dist/index"],
-      "@promethean/persistence/*": ["../persistence/dist/*"],
-      "@promethean/agent-ecs": ["../agent-ecs/dist/index"],
-      "@promethean/agent-ecs/*": ["../agent-ecs/dist/*"],
-      "@promethean/llm": ["../llm/dist/index"],
-      "@promethean/llm/*": ["../llm/dist/*"]
+      "@shared/js/*": [
+        "../../js/*"
+      ],
+      "@promethean/persistence": [
+        "../persistence/dist/index"
+      ],
+      "@promethean/persistence/*": [
+        "../persistence/dist/*"
+      ],
+      "@promethean/agent-ecs": [
+        "../agent-ecs/dist/index"
+      ],
+      "@promethean/agent-ecs/*": [
+        "../agent-ecs/dist/*"
+      ],
+      "@promethean/llm": [
+        "../llm/dist/index"
+      ],
+      "@promethean/llm/*": [
+        "../llm/dist/*"
+      ]
     },
-    "types": ["node"]
+    "types": [
+      "node"
+    ]
   },
-  "include": ["src/**/*"],
-  "exclude": ["dist"]
+  "include": [
+    "src/**/*",
+    "../types/shims/persistence.d.ts"
+  ],
+  "exclude": [
+    "dist"
+  ]
 }

--- a/packages/kanban-processor/src/shims.d.ts
+++ b/packages/kanban-processor/src/shims.d.ts
@@ -1,6 +1,3 @@
-declare module '@promethean/persistence/contextStore.js';
-declare module '@promethean/persistence/dualStore.js';
-declare module '@promethean/persistence/clients.js';
 declare module '@promethean/markdown/kanban.js';
 declare module '@promethean/markdown/sync.js';
 declare module '@promethean/markdown/task.js';

--- a/packages/kanban-processor/tsconfig.json
+++ b/packages/kanban-processor/tsconfig.json
@@ -58,6 +58,6 @@
     // Completeness
     "skipLibCheck": true
   },
-  "include": ["src/**/*.ts", "tests/**/*.ts"],
+  "include": ["src/**/*.ts", "tests/**/*.ts", "../types/shims/persistence.d.ts"],
   "exclude": ["node_modules"]
 }

--- a/packages/test-utils/src/shims.d.ts
+++ b/packages/test-utils/src/shims.d.ts
@@ -1,1 +1,0 @@
-declare module '@promethean/persistence/clients.js';

--- a/packages/test-utils/tsconfig.json
+++ b/packages/test-utils/tsconfig.json
@@ -1,15 +1,18 @@
 {
-    "extends": "../../config/tsconfig.base.json",
-    "compilerOptions": {
-        "rootDir": "src",
-        "outDir": "dist",
-        "composite": true,
-        "declaration": true
-    },
-    "include": ["src/**/*"],
-    "references": [
-        {
-            "path": "../persistence"
-        }
-    ]
+  "extends": "../../config/tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "composite": true,
+    "declaration": true
+  },
+  "include": [
+    "src/**/*",
+    "../types/shims/persistence.d.ts"
+  ],
+  "references": [
+    {
+      "path": "../persistence"
+    }
+  ]
 }

--- a/packages/types/shims/persistence.d.ts
+++ b/packages/types/shims/persistence.d.ts
@@ -1,0 +1,3 @@
+declare module '@promethean/persistence/contextStore.js';
+declare module '@promethean/persistence/dualStore.js';
+declare module '@promethean/persistence/clients.js';


### PR DESCRIPTION
## Summary
- centralize contextStore/dualStore/clients persistence shims into shared file
- update cephalon, kanban-processor, and test-utils tsconfigs to reference shared shim

## Testing
- `pnpm --filter @promethean/types build`
- `pnpm --filter @promethean/kanban-processor build`
- `pnpm --filter @promethean/test-utils build`
- `pnpm --filter @promethean/cephalon build` *(fails: Cannot find module '@promethean/agent-ecs/helpers/pushVision.js')*
- `pnpm --filter @promethean/kanban-processor test` *(fails: Cannot find module '@promethean/persistence/dist/contextStore.js')*
- `pnpm --filter @promethean/test-utils test` *(fails: Couldn’t find any files to test)*

------
https://chatgpt.com/codex/tasks/task_e_68ba0dc61298832493789b1ff416997a