### PR TITLE
refactor: centralize ECS shim

### DIFF
--- a/changelog.d/2025.09.04.22.12.07.changed.md
+++ b/changelog.d/2025.09.04.22.12.07.changed.md
@@ -1,0 +1,1 @@
+Moved package-specific ECS shims to shared types package and updated configs.

--- a/packages/agent-ecs/src/shims.d.ts
+++ b/packages/agent-ecs/src/shims.d.ts
@@ -1,1 +1,0 @@
-declare module '@promethean/ds/ecs.js';

--- a/packages/agent-ecs/tsconfig.json
+++ b/packages/agent-ecs/tsconfig.json
@@ -6,7 +6,7 @@
         "composite": true,
         "declaration": true
     },
-    "include": ["src/**/*"],
+    "include": ["src/**/*", "../types/shims/ecs.d.ts"],
     "references": [
         {
             "path": "../ds"

--- a/packages/types/shims/ecs.d.ts
+++ b/packages/types/shims/ecs.d.ts
@@ -1,0 +1,4 @@
+// Shared ECS module shim
+// Provides global typings for the ECS implementation used across packages.
+// This shim centralizes the declaration to avoid per-package duplicates.
+declare module '@promethean/ds/ecs.js';

--- a/packages/worker/src/shims.d.ts
+++ b/packages/worker/src/shims.d.ts
@@ -1,1 +1,0 @@
-declare module '@promethean/ds/ecs.js';

--- a/packages/worker/tsconfig.json
+++ b/packages/worker/tsconfig.json
@@ -6,7 +6,7 @@
         "composite": true,
         "declaration": true
     },
-    "include": ["src/**/*"],
+    "include": ["src/**/*", "../types/shims/ecs.d.ts"],
     "references": [
         {
             "path": "../ds"


### PR DESCRIPTION
## Summary
- add shared ECS shim in types package
- reference shared ECS shim from agent-ecs and worker
- remove redundant per-package ECS shims

## Testing
- `pnpm -F types test` *(fails: Couldn't find any files to test)*
- `pnpm -F agent-ecs test` *(fails: TS6133 unused declarations)*
- `pnpm -F worker test` *(fails: several TS2532 and TS2345 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68ba0dc3936c8324832f185673f8ec02