### PR TITLE
feat: centralize event shims

### DIFF
--- a/changelog.d/2025.09.04.22.15.38.changed.md
+++ b/changelog.d/2025.09.04.22.15.38.changed.md
@@ -1,0 +1,2 @@
+- centralize event module declarations into shared types file
+- remove redundant package-level shims

--- a/packages/compaction/src/shims.d.ts
+++ b/packages/compaction/src/shims.d.ts
@@ -1,2 +1,0 @@
-declare module '@promethean/event/mongo.js';
-declare module '@promethean/event/types.js';

--- a/packages/compaction/tsconfig.json
+++ b/packages/compaction/tsconfig.json
@@ -6,7 +6,7 @@
         "composite": true,
         "declaration": true
     },
-    "include": ["src/**/*"],
+    "include": ["src/**/*", "../types/shims/event.d.ts"],
     "references": [
         {
             "path": "../event"

--- a/packages/dev/src/shims.d.ts
+++ b/packages/dev/src/shims.d.ts
@@ -1,2 +1,1 @@
-declare module '@promethean/event/memory.js';
 declare module '@promethean/ws/server.js';

--- a/packages/dev/tsconfig.json
+++ b/packages/dev/tsconfig.json
@@ -6,7 +6,7 @@
         "composite": true,
         "declaration": true
     },
-    "include": ["src/**/*"],
+    "include": ["src/**/*", "../types/shims/event.d.ts"],
     "references": [
         {
             "path": "../event"

--- a/packages/dlq/src/shims.d.ts
+++ b/packages/dlq/src/shims.d.ts
@@ -1,2 +1,0 @@
-declare module '@promethean/event/mongo.js';
-declare module '@promethean/event/types.js';

--- a/packages/dlq/tsconfig.json
+++ b/packages/dlq/tsconfig.json
@@ -6,7 +6,7 @@
         "composite": true,
         "declaration": true
     },
-    "include": ["src/**/*"],
+    "include": ["src/**/*", "../types/shims/event.d.ts"],
     "references": [
         {
             "path": "../event"

--- a/packages/examples/tsconfig.json
+++ b/packages/examples/tsconfig.json
@@ -6,7 +6,7 @@
         "composite": true,
         "declaration": true
     },
-    "include": ["src/**/*"],
+    "include": ["src/**/*", "../types/shims/event.d.ts"],
     "references": [
         {
             "path": "../event"

--- a/packages/http/src/shims.d.ts
+++ b/packages/http/src/shims.d.ts
@@ -1,2 +1,0 @@
-declare module '@promethean/event/types.js';
-declare module '@promethean/event/mongo.js';

--- a/packages/http/tsconfig.json
+++ b/packages/http/tsconfig.json
@@ -6,7 +6,7 @@
         "composite": true,
         "declaration": true
     },
-    "include": ["src/**/*"],
+    "include": ["src/**/*", "../types/shims/event.d.ts"],
     "references": [
         {
             "path": "../event"

--- a/packages/schema/src/shims.d.ts
+++ b/packages/schema/src/shims.d.ts
@@ -1,1 +1,0 @@
-declare module '@promethean/event/types.js';

--- a/packages/schema/tsconfig.json
+++ b/packages/schema/tsconfig.json
@@ -6,7 +6,7 @@
         "composite": true,
         "declaration": true
     },
-    "include": ["src/**/*"],
+    "include": ["src/**/*", "../types/shims/event.d.ts"],
     "references": [
         {
             "path": "../event"

--- a/packages/timetravel/src/shims.d.ts
+++ b/packages/timetravel/src/shims.d.ts
@@ -1,2 +1,0 @@
-declare module '@promethean/event/mongo.js';
-declare module '@promethean/event/types.js';

--- a/packages/timetravel/tsconfig.json
+++ b/packages/timetravel/tsconfig.json
@@ -6,7 +6,7 @@
         "composite": true,
         "declaration": true
     },
-    "include": ["src/**/*"],
+    "include": ["src/**/*", "../types/shims/event.d.ts"],
     "references": [
         {
             "path": "../event"

--- a/packages/types/shims/event.d.ts
+++ b/packages/types/shims/event.d.ts
@@ -1,2 +1,4 @@
 declare module '@promethean/event/types.js';
+declare module '@promethean/event/mongo.js';
 declare module '@promethean/event/topics.js';
+declare module '@promethean/event/memory.js';

--- a/packages/ws/src/shims.d.ts
+++ b/packages/ws/src/shims.d.ts
@@ -1,2 +1,1 @@
 declare module '@promethean/rate/limiter.js';
-declare module '@promethean/event/types.js';

--- a/packages/ws/tsconfig.json
+++ b/packages/ws/tsconfig.json
@@ -6,7 +6,7 @@
         "composite": true,
         "declaration": true
     },
-    "include": ["src/**/*"],
+    "include": ["src/**/*", "../types/shims/event.d.ts"],
     "references": [
         {
             "path": "../event"


### PR DESCRIPTION
## Summary
- centralize event module declarations in `packages/types/shims/event.d.ts`
- drop package-level event shims and point tsconfigs to the shared file

## Testing
- `pnpm --filter compaction test` *(fails: Couldn't find any files to test)*
- `pnpm --filter dev test` *(fails: Couldn't find any files to test)*
- `pnpm --filter dlq test` *(fails: Couldn't find any files to test)*
- `pnpm --filter examples test` *(fails: TypeScript errors)*
- `pnpm --filter http test` *(fails: TypeScript errors)*
- `pnpm --filter schema test` *(fails: TypeScript errors)*
- `pnpm --filter timetravel test` *(fails: Couldn't find any files to test)*
- `pnpm --filter ws test` *(fails: TypeScript errors)*
- `pnpm --filter types test` *(fails: Couldn't find any files to test)*

------
https://chatgpt.com/codex/tasks/task_e_68ba0dc28a888324bb9188ddec1376e5