### PR TITLE
fix: restore smartgpt-bridge log file

### DIFF
--- a/changelog.d/2025.09.04.22.34.30.fixed.md
+++ b/changelog.d/2025.09.04.22.34.30.fixed.md
@@ -1,0 +1,1 @@
+- restore `LOG_FILE` support in `smartgpt-bridge` logger to keep audit logs persisted

--- a/packages/smartgpt-bridge/src/logger.ts
+++ b/packages/smartgpt-bridge/src/logger.ts
@@ -1,3 +1,30 @@
+import fs from "node:fs";
+import path from "node:path";
+import { Writable } from "node:stream";
+
 import { createLogger } from "@promethean/utils/logger.js";
 
-export const logger = createLogger({ service: "smartgpt-bridge" });
+function buildStream(): NodeJS.WritableStream {
+  const outputs: NodeJS.WritableStream[] = [process.stdout];
+  const logFile = process.env.LOG_FILE;
+
+  if (logFile) {
+    try {
+      fs.mkdirSync(path.dirname(logFile), { recursive: true });
+      outputs.push(fs.createWriteStream(logFile, { flags: "a" }));
+    } catch {
+      // ignore file errors and fall back to stdout only
+    }
+  }
+
+  if (outputs.length === 1) return outputs[0]!;
+
+  return new Writable({
+    write(chunk, _enc, cb) {
+      for (const out of outputs) out.write(chunk);
+      cb();
+    },
+  });
+}
+
+export const logger = createLogger({ service: "smartgpt-bridge", stream: buildStream() });

--- a/packages/smartgpt-bridge/src/tests/unit/logger.test.ts
+++ b/packages/smartgpt-bridge/src/tests/unit/logger.test.ts
@@ -1,0 +1,20 @@
+import test from "ava";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+function delay(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+test("writes logs to file when LOG_FILE is set", async (t) => {
+  const file = path.join(os.tmpdir(), `smartgpt-log-${Date.now()}.log`);
+  process.env.LOG_FILE = file;
+  const { logger } = await import("../../logger.js?" + Date.now());
+  logger.info("hello-file");
+  await delay(20);
+  const contents = await fs.readFile(file, "utf8");
+  t.true(contents.includes("hello-file"));
+  await fs.unlink(file);
+  delete process.env.LOG_FILE;
+});


### PR DESCRIPTION
## Summary
- reintroduce `LOG_FILE` handling so smartgpt-bridge writes to file and stdout
- add unit test covering file logging
- document fix in changelog

## Testing
- `pnpm test --filter @promethean/utils`
- `pnpm test --filter @promethean/smartgpt-bridge` *(fails: Cannot find module '@promethean/embeddings/dist/remote.js')*
- `pnpm exec ava packages/smartgpt-bridge/dist/tests/unit/logger.test.js --config config/ava.config.mjs`


------
https://chatgpt.com/codex/tasks/task_e_68ba13a19e0c83249e208d3eb7ddb391