### PR TITLE
fix: handle smartgpt-bridge log file errors

### DIFF
--- a/packages/smartgpt-bridge/src/logger.ts
+++ b/packages/smartgpt-bridge/src/logger.ts
@@ -11,7 +11,13 @@ function buildStream(): NodeJS.WritableStream {
   if (logFile) {
     try {
       fs.mkdirSync(path.dirname(logFile), { recursive: true });
-      outputs.push(fs.createWriteStream(logFile, { flags: "a" }));
+      const fileStream = fs.createWriteStream(logFile, { flags: "a" });
+      fileStream.on("error", (error) => {
+        console.error("log file stream error", error);
+        const idx = outputs.indexOf(fileStream);
+        if (idx !== -1) outputs.splice(idx, 1);
+      });
+      outputs.push(fileStream);
     } catch {
       // ignore file errors and fall back to stdout only
     }

--- a/packages/smartgpt-bridge/src/tests/unit/logger.test.ts
+++ b/packages/smartgpt-bridge/src/tests/unit/logger.test.ts
@@ -1,7 +1,9 @@
 import test from "ava";
-import fs from "node:fs/promises";
+import fs from "node:fs";
+import fsp from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { Writable } from "node:stream";
 
 function delay(ms: number) {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -13,8 +15,38 @@ test("writes logs to file when LOG_FILE is set", async (t) => {
   const { logger } = await import("../../logger.js?" + Date.now());
   logger.info("hello-file");
   await delay(20);
-  const contents = await fs.readFile(file, "utf8");
+  const contents = await fsp.readFile(file, "utf8");
   t.true(contents.includes("hello-file"));
-  await fs.unlink(file);
+  await fsp.unlink(file);
+  delete process.env.LOG_FILE;
+});
+
+test("falls back to stdout when log file stream errors", async (t) => {
+  process.env.LOG_FILE = path.join(os.tmpdir(), `smartgpt-log-${Date.now()}.log`);
+
+  const originalCreate = fs.createWriteStream;
+  fs.createWriteStream = () => {
+    const stream = new Writable({
+      write(_chunk, _enc, cb) {
+        cb();
+      },
+    });
+    setImmediate(() => stream.emit("error", new Error("disk full")));
+    return stream as unknown as fs.WriteStream;
+  };
+
+  let errorLogged = false;
+  const originalError = console.error;
+  console.error = () => {
+    errorLogged = true;
+  };
+
+  const { logger } = await import("../../logger.js?" + Date.now());
+  t.notThrows(() => logger.info("hello-error"));
+  await delay(20);
+  t.true(errorLogged);
+
+  console.error = originalError;
+  fs.createWriteStream = originalCreate;
   delete process.env.LOG_FILE;
 });


### PR DESCRIPTION
## Summary
- attach error listener to log file stream and remove stream on error
- add unit test ensuring logger falls back to stdout when file stream fails

## Testing
- `pnpm test --filter @promethean/utils`
- `pnpm test --filter @promethean/smartgpt-bridge` *(fails: Cannot find module '@promethean/utils/logger.js')*
- `pnpm exec ava packages/smartgpt-bridge/src/tests/unit/logger.test.ts --config config/ava.config.mjs` *(fails: SyntaxError: Unexpected token ':')*


------
https://chatgpt.com/codex/tasks/task_e_68ba15914d108324879aea9e63ace604