### PR TITLE
feat: centralize event shims

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,7 @@ evidence, and produce diffs/notes.
 - Functional preferred
 - TTD non-negotiable
 - Document-driven development
+- No relative module resolution outside of the package root. Depend on `@promethean/types` via "workspace:*".
 
 # Banned
 Under no circumstances should you introduce the following to Promethean:

--- a/packages/compaction/package.json
+++ b/packages/compaction/package.json
@@ -1,70 +1,71 @@
 {
-    "name": "@promethean/compaction",
-    "version": "0.0.1",
-    "private": true,
-    "type": "module",
-    "main": "dist/index.cjs",
-    "types": "dist/index.d.ts",
-    "exports": {
-        ".": {
-            "types": "./dist/index.d.ts",
-            "import": "./dist/index.js",
-            "require": "./dist/index.cjs"
-        },
-        "./dist/*": "./dist/*",
-        "./*": "./dist/*"
-    },
-    "files": [
-        "dist"
-    ],
-    "scripts": {
-        "build": "tsc",
-        "clean": "rimraf dist",
-        "typecheck": "tsc -p tsconfig.json --noEmit",
-        "test": "pnpm run build && ava --config ../../config/ava.config.mjs",
-        "lint": "pnpm exec biome lint .",
-        "lisp": "node dist/cli/lisp.js",
-        "coverage": "pnpm run build && c8 ava --config ../../config/ava.config.mjs",
-        "test:markdown": "pnpm run build && ava --config ../../config/ava.config.mjs dist/tests/markdown.*.test.js",
-        "format": "pnpm exec biome format --write ."
-    },
-    "module": "dist/index.js",
-    "dependencies": {
-        "@types/javascript-time-ago": "^2.5.0",
-        "@types/unist": "^3.0.3",
-        "body-parser": "^1.20.2",
-        "chromadb": "^3.0.14",
-        "duckduckgo-search": "^1.0.7",
-        "express": "^4.19.2",
-        "gray-matter": "^4.0.3",
-        "javascript-time-ago": "^2.5.11",
-        "mongodb": "^6.18.0",
-        "ollama": "^0.5.17",
-        "prom-client": "^15.1.0",
-        "remark-gfm": "^4.0.1",
-        "remark-parse": "^11.0.0",
-        "remark-stringify": "^11.0.0",
-        "sucrase": "^3.35.0",
-        "unified": "^11.0.5",
-        "unist": "^0.0.1",
-        "unist-util-to-string-with-nodes": "^0.1.1",
-        "unist-util-visit": "^5.0.0",
-        "uuid": "^11.1.0",
-        "ws": "^8.18.0",
-        "yaml": "^2.5.1",
-        "zod": "^3.23.8",
-        "@promethean/event": "workspace:*"
-    },
-    "devDependencies": {
-        "@biomejs/biome": "^2.2.2",
-        "@types/body-parser": "^1.19.5",
-        "@types/estree": "^1.0.5",
-        "@types/express": "^4.17.21",
-        "@types/node": "^20.19.11",
-        "@types/ws": "^8.5.9",
-        "acorn": "^8.15.0",
-        "rimraf": "^6.0.1",
-        "ts-node": "^10.9.2",
-        "typescript": "^5.9.2"
-    }
+	"name": "@promethean/compaction",
+	"version": "0.0.1",
+	"private": true,
+	"type": "module",
+	"main": "dist/index.cjs",
+	"types": "dist/index.d.ts",
+	"exports": {
+		".": {
+			"types": "./dist/index.d.ts",
+			"import": "./dist/index.js",
+			"require": "./dist/index.cjs"
+		},
+		"./dist/*": "./dist/*",
+		"./*": "./dist/*"
+	},
+	"files": [
+		"dist"
+	],
+	"scripts": {
+		"build": "tsc",
+		"clean": "rimraf dist",
+		"typecheck": "tsc -p tsconfig.json --noEmit",
+		"test": "pnpm run build && ava --config ../../config/ava.config.mjs",
+		"lint": "pnpm exec biome lint .",
+		"lisp": "node dist/cli/lisp.js",
+		"coverage": "pnpm run build && c8 ava --config ../../config/ava.config.mjs",
+		"test:markdown": "pnpm run build && ava --config ../../config/ava.config.mjs dist/tests/markdown.*.test.js",
+		"format": "pnpm exec biome format --write ."
+	},
+	"module": "dist/index.js",
+	"dependencies": {
+		"@types/javascript-time-ago": "^2.5.0",
+		"@types/unist": "^3.0.3",
+		"body-parser": "^1.20.2",
+		"chromadb": "^3.0.14",
+		"duckduckgo-search": "^1.0.7",
+		"express": "^4.19.2",
+		"gray-matter": "^4.0.3",
+		"javascript-time-ago": "^2.5.11",
+		"mongodb": "^6.18.0",
+		"ollama": "^0.5.17",
+		"prom-client": "^15.1.0",
+		"remark-gfm": "^4.0.1",
+		"remark-parse": "^11.0.0",
+		"remark-stringify": "^11.0.0",
+		"sucrase": "^3.35.0",
+		"unified": "^11.0.5",
+		"unist": "^0.0.1",
+		"unist-util-to-string-with-nodes": "^0.1.1",
+		"unist-util-visit": "^5.0.0",
+		"uuid": "^11.1.0",
+		"ws": "^8.18.0",
+		"yaml": "^2.5.1",
+		"zod": "^3.23.8",
+		"@promethean/event": "workspace:*",
+		"@promethean/types": "workspace:*"
+	},
+	"devDependencies": {
+		"@biomejs/biome": "^2.2.2",
+		"@types/body-parser": "^1.19.5",
+		"@types/estree": "^1.0.5",
+		"@types/express": "^4.17.21",
+		"@types/node": "^20.19.11",
+		"@types/ws": "^8.5.9",
+		"acorn": "^8.15.0",
+		"rimraf": "^6.0.1",
+		"ts-node": "^10.9.2",
+		"typescript": "^5.9.2"
+	}
 }

--- a/packages/compaction/tsconfig.json
+++ b/packages/compaction/tsconfig.json
@@ -6,8 +6,14 @@
         "composite": true,
         "declaration": true
     },
-    "include": ["src/**/*", "../types/shims/event.d.ts"],
+    "include": [
+        "src/**/*",
+        "node_modules/@promethean/types/shims/event.d.ts"
+    ],
     "references": [
+        {
+            "path": "../types"
+        },
         {
             "path": "../event"
         }

--- a/packages/dev/package.json
+++ b/packages/dev/package.json
@@ -1,73 +1,74 @@
 {
-    "name": "@promethean/dev",
-    "version": "0.0.1",
-    "private": true,
-    "type": "module",
-    "main": "dist/index.cjs",
-    "types": "dist/index.d.ts",
-    "exports": {
-        ".": {
-            "types": "./dist/index.d.ts",
-            "import": "./dist/index.js",
-            "require": "./dist/index.cjs"
-        },
-        "./dist/*": "./dist/*",
-        "./*": "./dist/*"
-    },
-    "files": [
-        "dist"
-    ],
-    "scripts": {
-        "build": "tsc",
-        "clean": "rimraf dist",
-        "typecheck": "tsc -p tsconfig.json --noEmit",
-        "test": "pnpm run build && ava --config ../../config/ava.config.mjs",
-        "lint": "pnpm exec biome lint .",
-        "lisp": "node dist/cli/lisp.js",
-        "coverage": "pnpm run build && c8 ava --config ../../config/ava.config.mjs",
-        "test:markdown": "pnpm run build && ava --config ../../config/ava.config.mjs dist/tests/markdown.*.test.js",
-        "format": "pnpm exec biome format --write ."
-    },
-    "module": "dist/index.js",
-    "dependencies": {
-        "@types/javascript-time-ago": "^2.5.0",
-        "@types/unist": "^3.0.3",
-        "body-parser": "^1.20.2",
-        "chromadb": "^3.0.14",
-        "duckduckgo-search": "^1.0.7",
-        "express": "^4.19.2",
-        "gray-matter": "^4.0.3",
-        "javascript-time-ago": "^2.5.11",
-        "mongodb": "^6.18.0",
-        "ollama": "^0.5.17",
-        "prom-client": "^15.1.0",
-        "remark-gfm": "^4.0.1",
-        "remark-parse": "^11.0.0",
-        "remark-stringify": "^11.0.0",
-        "sucrase": "^3.35.0",
-        "unified": "^11.0.5",
-        "unist": "^0.0.1",
-        "unist-util-to-string-with-nodes": "^0.1.1",
-        "unist-util-visit": "^5.0.0",
-        "uuid": "^11.1.0",
-        "ws": "^8.18.0",
-        "yaml": "^2.5.1",
-        "zod": "^3.23.8",
-        "@promethean/event": "workspace:*",
-        "@promethean/examples": "workspace:*",
-        "@promethean/http": "workspace:*",
-        "@promethean/ws": "workspace:*"
-    },
-    "devDependencies": {
-        "@biomejs/biome": "^2.2.2",
-        "@types/body-parser": "^1.19.5",
-        "@types/estree": "^1.0.5",
-        "@types/express": "^4.17.21",
-        "@types/node": "^20.19.11",
-        "@types/ws": "^8.5.9",
-        "acorn": "^8.15.0",
-        "rimraf": "^6.0.1",
-        "ts-node": "^10.9.2",
-        "typescript": "^5.9.2"
-    }
+	"name": "@promethean/dev",
+	"version": "0.0.1",
+	"private": true,
+	"type": "module",
+	"main": "dist/index.cjs",
+	"types": "dist/index.d.ts",
+	"exports": {
+		".": {
+			"types": "./dist/index.d.ts",
+			"import": "./dist/index.js",
+			"require": "./dist/index.cjs"
+		},
+		"./dist/*": "./dist/*",
+		"./*": "./dist/*"
+	},
+	"files": [
+		"dist"
+	],
+	"scripts": {
+		"build": "tsc",
+		"clean": "rimraf dist",
+		"typecheck": "tsc -p tsconfig.json --noEmit",
+		"test": "pnpm run build && ava --config ../../config/ava.config.mjs",
+		"lint": "pnpm exec biome lint .",
+		"lisp": "node dist/cli/lisp.js",
+		"coverage": "pnpm run build && c8 ava --config ../../config/ava.config.mjs",
+		"test:markdown": "pnpm run build && ava --config ../../config/ava.config.mjs dist/tests/markdown.*.test.js",
+		"format": "pnpm exec biome format --write ."
+	},
+	"module": "dist/index.js",
+	"dependencies": {
+		"@types/javascript-time-ago": "^2.5.0",
+		"@types/unist": "^3.0.3",
+		"body-parser": "^1.20.2",
+		"chromadb": "^3.0.14",
+		"duckduckgo-search": "^1.0.7",
+		"express": "^4.19.2",
+		"gray-matter": "^4.0.3",
+		"javascript-time-ago": "^2.5.11",
+		"mongodb": "^6.18.0",
+		"ollama": "^0.5.17",
+		"prom-client": "^15.1.0",
+		"remark-gfm": "^4.0.1",
+		"remark-parse": "^11.0.0",
+		"remark-stringify": "^11.0.0",
+		"sucrase": "^3.35.0",
+		"unified": "^11.0.5",
+		"unist": "^0.0.1",
+		"unist-util-to-string-with-nodes": "^0.1.1",
+		"unist-util-visit": "^5.0.0",
+		"uuid": "^11.1.0",
+		"ws": "^8.18.0",
+		"yaml": "^2.5.1",
+		"zod": "^3.23.8",
+		"@promethean/event": "workspace:*",
+		"@promethean/examples": "workspace:*",
+		"@promethean/http": "workspace:*",
+		"@promethean/ws": "workspace:*",
+		"@promethean/types": "workspace:*"
+	},
+	"devDependencies": {
+		"@biomejs/biome": "^2.2.2",
+		"@types/body-parser": "^1.19.5",
+		"@types/estree": "^1.0.5",
+		"@types/express": "^4.17.21",
+		"@types/node": "^20.19.11",
+		"@types/ws": "^8.5.9",
+		"acorn": "^8.15.0",
+		"rimraf": "^6.0.1",
+		"ts-node": "^10.9.2",
+		"typescript": "^5.9.2"
+	}
 }

--- a/packages/dev/tsconfig.json
+++ b/packages/dev/tsconfig.json
@@ -6,8 +6,14 @@
         "composite": true,
         "declaration": true
     },
-    "include": ["src/**/*", "../types/shims/event.d.ts"],
+    "include": [
+        "src/**/*",
+        "node_modules/@promethean/types/shims/event.d.ts"
+    ],
     "references": [
+        {
+            "path": "../types"
+        },
         {
             "path": "../event"
         },

--- a/packages/dlq/package.json
+++ b/packages/dlq/package.json
@@ -1,70 +1,71 @@
 {
-    "name": "@promethean/dlq",
-    "version": "0.0.1",
-    "private": true,
-    "type": "module",
-    "main": "dist/index.cjs",
-    "types": "dist/index.d.ts",
-    "exports": {
-        ".": {
-            "types": "./dist/index.d.ts",
-            "import": "./dist/index.js",
-            "require": "./dist/index.cjs"
-        },
-        "./dist/*": "./dist/*",
-        "./*": "./dist/*"
-    },
-    "files": [
-        "dist"
-    ],
-    "scripts": {
-        "build": "tsc",
-        "clean": "rimraf dist",
-        "typecheck": "tsc -p tsconfig.json --noEmit",
-        "test": "pnpm run build && ava --config ../../config/ava.config.mjs",
-        "lint": "pnpm exec biome lint .",
-        "lisp": "node dist/cli/lisp.js",
-        "coverage": "pnpm run build && c8 ava --config ../../config/ava.config.mjs",
-        "test:markdown": "pnpm run build && ava --config ../../config/ava.config.mjs dist/tests/markdown.*.test.js",
-        "format": "pnpm exec biome format --write ."
-    },
-    "module": "dist/index.js",
-    "dependencies": {
-        "@types/javascript-time-ago": "^2.5.0",
-        "@types/unist": "^3.0.3",
-        "body-parser": "^1.20.2",
-        "chromadb": "^3.0.14",
-        "duckduckgo-search": "^1.0.7",
-        "express": "^4.19.2",
-        "gray-matter": "^4.0.3",
-        "javascript-time-ago": "^2.5.11",
-        "mongodb": "^6.18.0",
-        "ollama": "^0.5.17",
-        "prom-client": "^15.1.0",
-        "remark-gfm": "^4.0.1",
-        "remark-parse": "^11.0.0",
-        "remark-stringify": "^11.0.0",
-        "sucrase": "^3.35.0",
-        "unified": "^11.0.5",
-        "unist": "^0.0.1",
-        "unist-util-to-string-with-nodes": "^0.1.1",
-        "unist-util-visit": "^5.0.0",
-        "uuid": "^11.1.0",
-        "ws": "^8.18.0",
-        "yaml": "^2.5.1",
-        "zod": "^3.23.8",
-        "@promethean/event": "workspace:*"
-    },
-    "devDependencies": {
-        "@biomejs/biome": "^2.2.2",
-        "@types/body-parser": "^1.19.5",
-        "@types/estree": "^1.0.5",
-        "@types/express": "^4.17.21",
-        "@types/node": "^20.19.11",
-        "@types/ws": "^8.5.9",
-        "acorn": "^8.15.0",
-        "rimraf": "^6.0.1",
-        "ts-node": "^10.9.2",
-        "typescript": "^5.9.2"
-    }
+	"name": "@promethean/dlq",
+	"version": "0.0.1",
+	"private": true,
+	"type": "module",
+	"main": "dist/index.cjs",
+	"types": "dist/index.d.ts",
+	"exports": {
+		".": {
+			"types": "./dist/index.d.ts",
+			"import": "./dist/index.js",
+			"require": "./dist/index.cjs"
+		},
+		"./dist/*": "./dist/*",
+		"./*": "./dist/*"
+	},
+	"files": [
+		"dist"
+	],
+	"scripts": {
+		"build": "tsc",
+		"clean": "rimraf dist",
+		"typecheck": "tsc -p tsconfig.json --noEmit",
+		"test": "pnpm run build && ava --config ../../config/ava.config.mjs",
+		"lint": "pnpm exec biome lint .",
+		"lisp": "node dist/cli/lisp.js",
+		"coverage": "pnpm run build && c8 ava --config ../../config/ava.config.mjs",
+		"test:markdown": "pnpm run build && ava --config ../../config/ava.config.mjs dist/tests/markdown.*.test.js",
+		"format": "pnpm exec biome format --write ."
+	},
+	"module": "dist/index.js",
+	"dependencies": {
+		"@types/javascript-time-ago": "^2.5.0",
+		"@types/unist": "^3.0.3",
+		"body-parser": "^1.20.2",
+		"chromadb": "^3.0.14",
+		"duckduckgo-search": "^1.0.7",
+		"express": "^4.19.2",
+		"gray-matter": "^4.0.3",
+		"javascript-time-ago": "^2.5.11",
+		"mongodb": "^6.18.0",
+		"ollama": "^0.5.17",
+		"prom-client": "^15.1.0",
+		"remark-gfm": "^4.0.1",
+		"remark-parse": "^11.0.0",
+		"remark-stringify": "^11.0.0",
+		"sucrase": "^3.35.0",
+		"unified": "^11.0.5",
+		"unist": "^0.0.1",
+		"unist-util-to-string-with-nodes": "^0.1.1",
+		"unist-util-visit": "^5.0.0",
+		"uuid": "^11.1.0",
+		"ws": "^8.18.0",
+		"yaml": "^2.5.1",
+		"zod": "^3.23.8",
+		"@promethean/event": "workspace:*",
+		"@promethean/types": "workspace:*"
+	},
+	"devDependencies": {
+		"@biomejs/biome": "^2.2.2",
+		"@types/body-parser": "^1.19.5",
+		"@types/estree": "^1.0.5",
+		"@types/express": "^4.17.21",
+		"@types/node": "^20.19.11",
+		"@types/ws": "^8.5.9",
+		"acorn": "^8.15.0",
+		"rimraf": "^6.0.1",
+		"ts-node": "^10.9.2",
+		"typescript": "^5.9.2"
+	}
 }

--- a/packages/dlq/tsconfig.json
+++ b/packages/dlq/tsconfig.json
@@ -6,8 +6,14 @@
         "composite": true,
         "declaration": true
     },
-    "include": ["src/**/*", "../types/shims/event.d.ts"],
+    "include": [
+        "src/**/*",
+        "node_modules/@promethean/types/shims/event.d.ts"
+    ],
     "references": [
+        {
+            "path": "../types"
+        },
         {
             "path": "../event"
         }

--- a/packages/examples/package.json
+++ b/packages/examples/package.json
@@ -1,70 +1,71 @@
 {
-    "name": "@promethean/examples",
-    "version": "0.0.1",
-    "private": true,
-    "type": "module",
-    "main": "dist/index.cjs",
-    "types": "dist/index.d.ts",
-    "exports": {
-        ".": {
-            "types": "./dist/index.d.ts",
-            "import": "./dist/index.js",
-            "require": "./dist/index.cjs"
-        },
-        "./dist/*": "./dist/*",
-        "./*": "./dist/*"
-    },
-    "files": [
-        "dist"
-    ],
-    "scripts": {
-        "build": "tsc",
-        "clean": "rimraf dist",
-        "typecheck": "tsc -p tsconfig.json --noEmit",
-        "test": "pnpm run build && ava --config ../../config/ava.config.mjs",
-        "lint": "pnpm exec biome lint .",
-        "lisp": "node dist/cli/lisp.js",
-        "coverage": "pnpm run build && c8 ava --config ../../config/ava.config.mjs",
-        "test:markdown": "pnpm run build && ava --config ../../config/ava.config.mjs dist/tests/markdown.*.test.js",
-        "format": "pnpm exec biome format --write ."
-    },
-    "module": "dist/index.js",
-    "dependencies": {
-        "@types/javascript-time-ago": "^2.5.0",
-        "@types/unist": "^3.0.3",
-        "body-parser": "^1.20.2",
-        "chromadb": "^3.0.14",
-        "duckduckgo-search": "^1.0.7",
-        "express": "^4.19.2",
-        "gray-matter": "^4.0.3",
-        "javascript-time-ago": "^2.5.11",
-        "mongodb": "^6.18.0",
-        "ollama": "^0.5.17",
-        "prom-client": "^15.1.0",
-        "remark-gfm": "^4.0.1",
-        "remark-parse": "^11.0.0",
-        "remark-stringify": "^11.0.0",
-        "sucrase": "^3.35.0",
-        "unified": "^11.0.5",
-        "unist": "^0.0.1",
-        "unist-util-to-string-with-nodes": "^0.1.1",
-        "unist-util-visit": "^5.0.0",
-        "uuid": "^11.1.0",
-        "ws": "^8.18.0",
-        "yaml": "^2.5.1",
-        "zod": "^3.23.8",
-        "@promethean/event": "workspace:*"
-    },
-    "devDependencies": {
-        "@biomejs/biome": "^2.2.2",
-        "@types/body-parser": "^1.19.5",
-        "@types/estree": "^1.0.5",
-        "@types/express": "^4.17.21",
-        "@types/node": "^20.19.11",
-        "@types/ws": "^8.5.9",
-        "acorn": "^8.15.0",
-        "rimraf": "^6.0.1",
-        "ts-node": "^10.9.2",
-        "typescript": "^5.9.2"
-    }
+	"name": "@promethean/examples",
+	"version": "0.0.1",
+	"private": true,
+	"type": "module",
+	"main": "dist/index.cjs",
+	"types": "dist/index.d.ts",
+	"exports": {
+		".": {
+			"types": "./dist/index.d.ts",
+			"import": "./dist/index.js",
+			"require": "./dist/index.cjs"
+		},
+		"./dist/*": "./dist/*",
+		"./*": "./dist/*"
+	},
+	"files": [
+		"dist"
+	],
+	"scripts": {
+		"build": "tsc",
+		"clean": "rimraf dist",
+		"typecheck": "tsc -p tsconfig.json --noEmit",
+		"test": "pnpm run build && ava --config ../../config/ava.config.mjs",
+		"lint": "pnpm exec biome lint .",
+		"lisp": "node dist/cli/lisp.js",
+		"coverage": "pnpm run build && c8 ava --config ../../config/ava.config.mjs",
+		"test:markdown": "pnpm run build && ava --config ../../config/ava.config.mjs dist/tests/markdown.*.test.js",
+		"format": "pnpm exec biome format --write ."
+	},
+	"module": "dist/index.js",
+	"dependencies": {
+		"@types/javascript-time-ago": "^2.5.0",
+		"@types/unist": "^3.0.3",
+		"body-parser": "^1.20.2",
+		"chromadb": "^3.0.14",
+		"duckduckgo-search": "^1.0.7",
+		"express": "^4.19.2",
+		"gray-matter": "^4.0.3",
+		"javascript-time-ago": "^2.5.11",
+		"mongodb": "^6.18.0",
+		"ollama": "^0.5.17",
+		"prom-client": "^15.1.0",
+		"remark-gfm": "^4.0.1",
+		"remark-parse": "^11.0.0",
+		"remark-stringify": "^11.0.0",
+		"sucrase": "^3.35.0",
+		"unified": "^11.0.5",
+		"unist": "^0.0.1",
+		"unist-util-to-string-with-nodes": "^0.1.1",
+		"unist-util-visit": "^5.0.0",
+		"uuid": "^11.1.0",
+		"ws": "^8.18.0",
+		"yaml": "^2.5.1",
+		"zod": "^3.23.8",
+		"@promethean/event": "workspace:*",
+		"@promethean/types": "workspace:*"
+	},
+	"devDependencies": {
+		"@biomejs/biome": "^2.2.2",
+		"@types/body-parser": "^1.19.5",
+		"@types/estree": "^1.0.5",
+		"@types/express": "^4.17.21",
+		"@types/node": "^20.19.11",
+		"@types/ws": "^8.5.9",
+		"acorn": "^8.15.0",
+		"rimraf": "^6.0.1",
+		"ts-node": "^10.9.2",
+		"typescript": "^5.9.2"
+	}
 }

--- a/packages/examples/tsconfig.json
+++ b/packages/examples/tsconfig.json
@@ -6,8 +6,14 @@
         "composite": true,
         "declaration": true
     },
-    "include": ["src/**/*", "../types/shims/event.d.ts"],
+    "include": [
+        "src/**/*",
+        "node_modules/@promethean/types/shims/event.d.ts"
+    ],
     "references": [
+        {
+            "path": "../types"
+        },
         {
             "path": "../event"
         }

--- a/packages/http/package.json
+++ b/packages/http/package.json
@@ -1,70 +1,71 @@
 {
-    "name": "@promethean/http",
-    "version": "0.0.1",
-    "private": true,
-    "type": "module",
-    "main": "dist/index.cjs",
-    "types": "dist/index.d.ts",
-    "exports": {
-        ".": {
-            "types": "./dist/index.d.ts",
-            "import": "./dist/index.js",
-            "require": "./dist/index.cjs"
-        },
-        "./dist/*": "./dist/*",
-        "./*": "./dist/*"
-    },
-    "files": [
-        "dist"
-    ],
-    "scripts": {
-        "build": "tsc",
-        "clean": "rimraf dist",
-        "typecheck": "tsc -p tsconfig.json --noEmit",
-        "test": "pnpm run build && ava --config ../../config/ava.config.mjs",
-        "lint": "pnpm exec biome lint .",
-        "lisp": "node dist/cli/lisp.js",
-        "coverage": "pnpm run build && c8 ava --config ../../config/ava.config.mjs",
-        "test:markdown": "pnpm run build && ava --config ../../config/ava.config.mjs dist/tests/markdown.*.test.js",
-        "format": "pnpm exec biome format --write ."
-    },
-    "module": "dist/index.js",
-    "dependencies": {
-        "@types/javascript-time-ago": "^2.5.0",
-        "@types/unist": "^3.0.3",
-        "body-parser": "^1.20.2",
-        "chromadb": "^3.0.14",
-        "duckduckgo-search": "^1.0.7",
-        "express": "^4.19.2",
-        "gray-matter": "^4.0.3",
-        "javascript-time-ago": "^2.5.11",
-        "mongodb": "^6.18.0",
-        "ollama": "^0.5.17",
-        "prom-client": "^15.1.0",
-        "remark-gfm": "^4.0.1",
-        "remark-parse": "^11.0.0",
-        "remark-stringify": "^11.0.0",
-        "sucrase": "^3.35.0",
-        "unified": "^11.0.5",
-        "unist": "^0.0.1",
-        "unist-util-to-string-with-nodes": "^0.1.1",
-        "unist-util-visit": "^5.0.0",
-        "uuid": "^11.1.0",
-        "ws": "^8.18.0",
-        "yaml": "^2.5.1",
-        "zod": "^3.23.8",
-        "@promethean/event": "workspace:*"
-    },
-    "devDependencies": {
-        "@biomejs/biome": "^2.2.2",
-        "@types/body-parser": "^1.19.5",
-        "@types/estree": "^1.0.5",
-        "@types/express": "^4.17.21",
-        "@types/node": "^20.19.11",
-        "@types/ws": "^8.5.9",
-        "acorn": "^8.15.0",
-        "rimraf": "^6.0.1",
-        "ts-node": "^10.9.2",
-        "typescript": "^5.9.2"
-    }
+	"name": "@promethean/http",
+	"version": "0.0.1",
+	"private": true,
+	"type": "module",
+	"main": "dist/index.cjs",
+	"types": "dist/index.d.ts",
+	"exports": {
+		".": {
+			"types": "./dist/index.d.ts",
+			"import": "./dist/index.js",
+			"require": "./dist/index.cjs"
+		},
+		"./dist/*": "./dist/*",
+		"./*": "./dist/*"
+	},
+	"files": [
+		"dist"
+	],
+	"scripts": {
+		"build": "tsc",
+		"clean": "rimraf dist",
+		"typecheck": "tsc -p tsconfig.json --noEmit",
+		"test": "pnpm run build && ava --config ../../config/ava.config.mjs",
+		"lint": "pnpm exec biome lint .",
+		"lisp": "node dist/cli/lisp.js",
+		"coverage": "pnpm run build && c8 ava --config ../../config/ava.config.mjs",
+		"test:markdown": "pnpm run build && ava --config ../../config/ava.config.mjs dist/tests/markdown.*.test.js",
+		"format": "pnpm exec biome format --write ."
+	},
+	"module": "dist/index.js",
+	"dependencies": {
+		"@types/javascript-time-ago": "^2.5.0",
+		"@types/unist": "^3.0.3",
+		"body-parser": "^1.20.2",
+		"chromadb": "^3.0.14",
+		"duckduckgo-search": "^1.0.7",
+		"express": "^4.19.2",
+		"gray-matter": "^4.0.3",
+		"javascript-time-ago": "^2.5.11",
+		"mongodb": "^6.18.0",
+		"ollama": "^0.5.17",
+		"prom-client": "^15.1.0",
+		"remark-gfm": "^4.0.1",
+		"remark-parse": "^11.0.0",
+		"remark-stringify": "^11.0.0",
+		"sucrase": "^3.35.0",
+		"unified": "^11.0.5",
+		"unist": "^0.0.1",
+		"unist-util-to-string-with-nodes": "^0.1.1",
+		"unist-util-visit": "^5.0.0",
+		"uuid": "^11.1.0",
+		"ws": "^8.18.0",
+		"yaml": "^2.5.1",
+		"zod": "^3.23.8",
+		"@promethean/event": "workspace:*",
+		"@promethean/types": "workspace:*"
+	},
+	"devDependencies": {
+		"@biomejs/biome": "^2.2.2",
+		"@types/body-parser": "^1.19.5",
+		"@types/estree": "^1.0.5",
+		"@types/express": "^4.17.21",
+		"@types/node": "^20.19.11",
+		"@types/ws": "^8.5.9",
+		"acorn": "^8.15.0",
+		"rimraf": "^6.0.1",
+		"ts-node": "^10.9.2",
+		"typescript": "^5.9.2"
+	}
 }

--- a/packages/http/tsconfig.json
+++ b/packages/http/tsconfig.json
@@ -6,8 +6,14 @@
         "composite": true,
         "declaration": true
     },
-    "include": ["src/**/*", "../types/shims/event.d.ts"],
+    "include": [
+        "src/**/*",
+        "node_modules/@promethean/types/shims/event.d.ts"
+    ],
     "references": [
+        {
+            "path": "../types"
+        },
         {
             "path": "../event"
         }

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -1,70 +1,71 @@
 {
-    "name": "@promethean/schema",
-    "version": "0.0.1",
-    "private": true,
-    "type": "module",
-    "main": "dist/index.cjs",
-    "types": "dist/index.d.ts",
-    "exports": {
-        ".": {
-            "types": "./dist/index.d.ts",
-            "import": "./dist/index.js",
-            "require": "./dist/index.cjs"
-        },
-        "./dist/*": "./dist/*",
-        "./*": "./dist/*"
-    },
-    "files": [
-        "dist"
-    ],
-    "scripts": {
-        "build": "tsc",
-        "clean": "rimraf dist",
-        "typecheck": "tsc -p tsconfig.json --noEmit",
-        "test": "pnpm run build && ava --config ../../config/ava.config.mjs",
-        "lint": "pnpm exec biome lint .",
-        "lisp": "node dist/cli/lisp.js",
-        "coverage": "pnpm run build && c8 ava --config ../../config/ava.config.mjs",
-        "test:markdown": "pnpm run build && ava --config ../../config/ava.config.mjs dist/tests/markdown.*.test.js",
-        "format": "pnpm exec biome format --write ."
-    },
-    "module": "dist/index.js",
-    "dependencies": {
-        "@types/javascript-time-ago": "^2.5.0",
-        "@types/unist": "^3.0.3",
-        "body-parser": "^1.20.2",
-        "chromadb": "^3.0.14",
-        "duckduckgo-search": "^1.0.7",
-        "express": "^4.19.2",
-        "gray-matter": "^4.0.3",
-        "javascript-time-ago": "^2.5.11",
-        "mongodb": "^6.18.0",
-        "ollama": "^0.5.17",
-        "prom-client": "^15.1.0",
-        "remark-gfm": "^4.0.1",
-        "remark-parse": "^11.0.0",
-        "remark-stringify": "^11.0.0",
-        "sucrase": "^3.35.0",
-        "unified": "^11.0.5",
-        "unist": "^0.0.1",
-        "unist-util-to-string-with-nodes": "^0.1.1",
-        "unist-util-visit": "^5.0.0",
-        "uuid": "^11.1.0",
-        "ws": "^8.18.0",
-        "yaml": "^2.5.1",
-        "zod": "^3.23.8",
-        "@promethean/event": "workspace:*"
-    },
-    "devDependencies": {
-        "@biomejs/biome": "^2.2.2",
-        "@types/body-parser": "^1.19.5",
-        "@types/estree": "^1.0.5",
-        "@types/express": "^4.17.21",
-        "@types/node": "^20.19.11",
-        "@types/ws": "^8.5.9",
-        "acorn": "^8.15.0",
-        "rimraf": "^6.0.1",
-        "ts-node": "^10.9.2",
-        "typescript": "^5.9.2"
-    }
+	"name": "@promethean/schema",
+	"version": "0.0.1",
+	"private": true,
+	"type": "module",
+	"main": "dist/index.cjs",
+	"types": "dist/index.d.ts",
+	"exports": {
+		".": {
+			"types": "./dist/index.d.ts",
+			"import": "./dist/index.js",
+			"require": "./dist/index.cjs"
+		},
+		"./dist/*": "./dist/*",
+		"./*": "./dist/*"
+	},
+	"files": [
+		"dist"
+	],
+	"scripts": {
+		"build": "tsc",
+		"clean": "rimraf dist",
+		"typecheck": "tsc -p tsconfig.json --noEmit",
+		"test": "pnpm run build && ava --config ../../config/ava.config.mjs",
+		"lint": "pnpm exec biome lint .",
+		"lisp": "node dist/cli/lisp.js",
+		"coverage": "pnpm run build && c8 ava --config ../../config/ava.config.mjs",
+		"test:markdown": "pnpm run build && ava --config ../../config/ava.config.mjs dist/tests/markdown.*.test.js",
+		"format": "pnpm exec biome format --write ."
+	},
+	"module": "dist/index.js",
+	"dependencies": {
+		"@types/javascript-time-ago": "^2.5.0",
+		"@types/unist": "^3.0.3",
+		"body-parser": "^1.20.2",
+		"chromadb": "^3.0.14",
+		"duckduckgo-search": "^1.0.7",
+		"express": "^4.19.2",
+		"gray-matter": "^4.0.3",
+		"javascript-time-ago": "^2.5.11",
+		"mongodb": "^6.18.0",
+		"ollama": "^0.5.17",
+		"prom-client": "^15.1.0",
+		"remark-gfm": "^4.0.1",
+		"remark-parse": "^11.0.0",
+		"remark-stringify": "^11.0.0",
+		"sucrase": "^3.35.0",
+		"unified": "^11.0.5",
+		"unist": "^0.0.1",
+		"unist-util-to-string-with-nodes": "^0.1.1",
+		"unist-util-visit": "^5.0.0",
+		"uuid": "^11.1.0",
+		"ws": "^8.18.0",
+		"yaml": "^2.5.1",
+		"zod": "^3.23.8",
+		"@promethean/event": "workspace:*",
+		"@promethean/types": "workspace:*"
+	},
+	"devDependencies": {
+		"@biomejs/biome": "^2.2.2",
+		"@types/body-parser": "^1.19.5",
+		"@types/estree": "^1.0.5",
+		"@types/express": "^4.17.21",
+		"@types/node": "^20.19.11",
+		"@types/ws": "^8.5.9",
+		"acorn": "^8.15.0",
+		"rimraf": "^6.0.1",
+		"ts-node": "^10.9.2",
+		"typescript": "^5.9.2"
+	}
 }

--- a/packages/schema/tsconfig.json
+++ b/packages/schema/tsconfig.json
@@ -6,8 +6,14 @@
         "composite": true,
         "declaration": true
     },
-    "include": ["src/**/*", "../types/shims/event.d.ts"],
+    "include": [
+        "src/**/*",
+        "node_modules/@promethean/types/shims/event.d.ts"
+    ],
     "references": [
+        {
+            "path": "../types"
+        },
         {
             "path": "../event"
         }

--- a/packages/timetravel/package.json
+++ b/packages/timetravel/package.json
@@ -1,70 +1,71 @@
 {
-    "name": "@promethean/timetravel",
-    "version": "0.0.1",
-    "private": true,
-    "type": "module",
-    "main": "dist/index.cjs",
-    "types": "dist/index.d.ts",
-    "exports": {
-        ".": {
-            "types": "./dist/index.d.ts",
-            "import": "./dist/index.js",
-            "require": "./dist/index.cjs"
-        },
-        "./dist/*": "./dist/*",
-        "./*": "./dist/*"
-    },
-    "files": [
-        "dist"
-    ],
-    "scripts": {
-        "build": "tsc",
-        "clean": "rimraf dist",
-        "typecheck": "tsc -p tsconfig.json --noEmit",
-        "test": "pnpm run build && ava --config ../../config/ava.config.mjs",
-        "lint": "pnpm exec biome lint .",
-        "lisp": "node dist/cli/lisp.js",
-        "coverage": "pnpm run build && c8 ava --config ../../config/ava.config.mjs",
-        "test:markdown": "pnpm run build && ava --config ../../config/ava.config.mjs dist/tests/markdown.*.test.js",
-        "format": "pnpm exec biome format --write ."
-    },
-    "module": "dist/index.js",
-    "dependencies": {
-        "@types/javascript-time-ago": "^2.5.0",
-        "@types/unist": "^3.0.3",
-        "body-parser": "^1.20.2",
-        "chromadb": "^3.0.14",
-        "duckduckgo-search": "^1.0.7",
-        "express": "^4.19.2",
-        "gray-matter": "^4.0.3",
-        "javascript-time-ago": "^2.5.11",
-        "mongodb": "^6.18.0",
-        "ollama": "^0.5.17",
-        "prom-client": "^15.1.0",
-        "remark-gfm": "^4.0.1",
-        "remark-parse": "^11.0.0",
-        "remark-stringify": "^11.0.0",
-        "sucrase": "^3.35.0",
-        "unified": "^11.0.5",
-        "unist": "^0.0.1",
-        "unist-util-to-string-with-nodes": "^0.1.1",
-        "unist-util-visit": "^5.0.0",
-        "uuid": "^11.1.0",
-        "ws": "^8.18.0",
-        "yaml": "^2.5.1",
-        "zod": "^3.23.8",
-        "@promethean/event": "workspace:*"
-    },
-    "devDependencies": {
-        "@biomejs/biome": "^2.2.2",
-        "@types/body-parser": "^1.19.5",
-        "@types/estree": "^1.0.5",
-        "@types/express": "^4.17.21",
-        "@types/node": "^20.19.11",
-        "@types/ws": "^8.5.9",
-        "acorn": "^8.15.0",
-        "rimraf": "^6.0.1",
-        "ts-node": "^10.9.2",
-        "typescript": "^5.9.2"
-    }
+	"name": "@promethean/timetravel",
+	"version": "0.0.1",
+	"private": true,
+	"type": "module",
+	"main": "dist/index.cjs",
+	"types": "dist/index.d.ts",
+	"exports": {
+		".": {
+			"types": "./dist/index.d.ts",
+			"import": "./dist/index.js",
+			"require": "./dist/index.cjs"
+		},
+		"./dist/*": "./dist/*",
+		"./*": "./dist/*"
+	},
+	"files": [
+		"dist"
+	],
+	"scripts": {
+		"build": "tsc",
+		"clean": "rimraf dist",
+		"typecheck": "tsc -p tsconfig.json --noEmit",
+		"test": "pnpm run build && ava --config ../../config/ava.config.mjs",
+		"lint": "pnpm exec biome lint .",
+		"lisp": "node dist/cli/lisp.js",
+		"coverage": "pnpm run build && c8 ava --config ../../config/ava.config.mjs",
+		"test:markdown": "pnpm run build && ava --config ../../config/ava.config.mjs dist/tests/markdown.*.test.js",
+		"format": "pnpm exec biome format --write ."
+	},
+	"module": "dist/index.js",
+	"dependencies": {
+		"@types/javascript-time-ago": "^2.5.0",
+		"@types/unist": "^3.0.3",
+		"body-parser": "^1.20.2",
+		"chromadb": "^3.0.14",
+		"duckduckgo-search": "^1.0.7",
+		"express": "^4.19.2",
+		"gray-matter": "^4.0.3",
+		"javascript-time-ago": "^2.5.11",
+		"mongodb": "^6.18.0",
+		"ollama": "^0.5.17",
+		"prom-client": "^15.1.0",
+		"remark-gfm": "^4.0.1",
+		"remark-parse": "^11.0.0",
+		"remark-stringify": "^11.0.0",
+		"sucrase": "^3.35.0",
+		"unified": "^11.0.5",
+		"unist": "^0.0.1",
+		"unist-util-to-string-with-nodes": "^0.1.1",
+		"unist-util-visit": "^5.0.0",
+		"uuid": "^11.1.0",
+		"ws": "^8.18.0",
+		"yaml": "^2.5.1",
+		"zod": "^3.23.8",
+		"@promethean/event": "workspace:*",
+		"@promethean/types": "workspace:*"
+	},
+	"devDependencies": {
+		"@biomejs/biome": "^2.2.2",
+		"@types/body-parser": "^1.19.5",
+		"@types/estree": "^1.0.5",
+		"@types/express": "^4.17.21",
+		"@types/node": "^20.19.11",
+		"@types/ws": "^8.5.9",
+		"acorn": "^8.15.0",
+		"rimraf": "^6.0.1",
+		"ts-node": "^10.9.2",
+		"typescript": "^5.9.2"
+	}
 }

--- a/packages/timetravel/tsconfig.json
+++ b/packages/timetravel/tsconfig.json
@@ -6,8 +6,14 @@
         "composite": true,
         "declaration": true
     },
-    "include": ["src/**/*", "../types/shims/event.d.ts"],
+    "include": [
+        "src/**/*",
+        "node_modules/@promethean/types/shims/event.d.ts"
+    ],
     "references": [
+        {
+            "path": "../types"
+        },
         {
             "path": "../event"
         }

--- a/packages/ws/package.json
+++ b/packages/ws/package.json
@@ -1,71 +1,72 @@
 {
-    "name": "@promethean/ws",
-    "version": "0.0.1",
-    "private": true,
-    "type": "module",
-    "main": "dist/index.cjs",
-    "types": "dist/index.d.ts",
-    "exports": {
-        ".": {
-            "types": "./dist/index.d.ts",
-            "import": "./dist/index.js",
-            "require": "./dist/index.cjs"
-        },
-        "./dist/*": "./dist/*",
-        "./*": "./dist/*"
-    },
-    "files": [
-        "dist"
-    ],
-    "scripts": {
-        "build": "tsc",
-        "clean": "rimraf dist",
-        "typecheck": "tsc -p tsconfig.json --noEmit",
-        "test": "pnpm run build && ava --config ../../config/ava.config.mjs",
-        "lint": "pnpm exec biome lint .",
-        "lisp": "node dist/cli/lisp.js",
-        "coverage": "pnpm run build && c8 ava --config ../../config/ava.config.mjs",
-        "test:markdown": "pnpm run build && ava --config ../../config/ava.config.mjs dist/tests/markdown.*.test.js",
-        "format": "pnpm exec biome format --write ."
-    },
-    "module": "dist/index.js",
-    "dependencies": {
-        "@types/javascript-time-ago": "^2.5.0",
-        "@types/unist": "^3.0.3",
-        "body-parser": "^1.20.2",
-        "chromadb": "^3.0.14",
-        "duckduckgo-search": "^1.0.7",
-        "express": "^4.19.2",
-        "gray-matter": "^4.0.3",
-        "javascript-time-ago": "^2.5.11",
-        "mongodb": "^6.18.0",
-        "ollama": "^0.5.17",
-        "prom-client": "^15.1.0",
-        "remark-gfm": "^4.0.1",
-        "remark-parse": "^11.0.0",
-        "remark-stringify": "^11.0.0",
-        "sucrase": "^3.35.0",
-        "unified": "^11.0.5",
-        "unist": "^0.0.1",
-        "unist-util-to-string-with-nodes": "^0.1.1",
-        "unist-util-visit": "^5.0.0",
-        "uuid": "^11.1.0",
-        "ws": "^8.18.0",
-        "yaml": "^2.5.1",
-        "zod": "^3.23.8",
-        "@promethean/event": "workspace:*",
-        "@promethean/rate": "workspace:*"
-    },
-    "devDependencies": {
-        "@biomejs/biome": "^2.2.2",
-        "@types/body-parser": "^1.19.5",
-        "@types/estree": "^1.0.5",
-        "@types/express": "^4.17.21",
-        "@types/node": "^20.19.11",
-        "@types/ws": "^8.5.9",
-        "acorn": "^8.15.0",
-        "rimraf": "^6.0.1",
-        "ts-node": "^10.9.2",
-        "typescript": "^5.9.2"
-    }
+	"name": "@promethean/ws",
+	"version": "0.0.1",
+	"private": true,
+	"type": "module",
+	"main": "dist/index.cjs",
+	"types": "dist/index.d.ts",
+	"exports": {
+		".": {
+			"types": "./dist/index.d.ts",
+			"import": "./dist/index.js",
+			"require": "./dist/index.cjs"
+		},
+		"./dist/*": "./dist/*",
+		"./*": "./dist/*"
+	},
+	"files": [
+		"dist"
+	],
+	"scripts": {
+		"build": "tsc",
+		"clean": "rimraf dist",
+		"typecheck": "tsc -p tsconfig.json --noEmit",
+		"test": "pnpm run build && ava --config ../../config/ava.config.mjs",
+		"lint": "pnpm exec biome lint .",
+		"lisp": "node dist/cli/lisp.js",
+		"coverage": "pnpm run build && c8 ava --config ../../config/ava.config.mjs",
+		"test:markdown": "pnpm run build && ava --config ../../config/ava.config.mjs dist/tests/markdown.*.test.js",
+		"format": "pnpm exec biome format --write ."
+	},
+	"module": "dist/index.js",
+	"dependencies": {
+		"@types/javascript-time-ago": "^2.5.0",
+		"@types/unist": "^3.0.3",
+		"body-parser": "^1.20.2",
+		"chromadb": "^3.0.14",
+		"duckduckgo-search": "^1.0.7",
+		"express": "^4.19.2",
+		"gray-matter": "^4.0.3",
+		"javascript-time-ago": "^2.5.11",
+		"mongodb": "^6.18.0",
+		"ollama": "^0.5.17",
+		"prom-client": "^15.1.0",
+		"remark-gfm": "^4.0.1",
+		"remark-parse": "^11.0.0",
+		"remark-stringify": "^11.0.0",
+		"sucrase": "^3.35.0",
+		"unified": "^11.0.5",
+		"unist": "^0.0.1",
+		"unist-util-to-string-with-nodes": "^0.1.1",
+		"unist-util-visit": "^5.0.0",
+		"uuid": "^11.1.0",
+		"ws": "^8.18.0",
+		"yaml": "^2.5.1",
+		"zod": "^3.23.8",
+		"@promethean/event": "workspace:*",
+		"@promethean/rate": "workspace:*",
+		"@promethean/types": "workspace:*"
+	},
+	"devDependencies": {
+		"@biomejs/biome": "^2.2.2",
+		"@types/body-parser": "^1.19.5",
+		"@types/estree": "^1.0.5",
+		"@types/express": "^4.17.21",
+		"@types/node": "^20.19.11",
+		"@types/ws": "^8.5.9",
+		"acorn": "^8.15.0",
+		"rimraf": "^6.0.1",
+		"ts-node": "^10.9.2",
+		"typescript": "^5.9.2"
+	}
 }

--- a/packages/ws/tsconfig.json
+++ b/packages/ws/tsconfig.json
@@ -6,8 +6,14 @@
         "composite": true,
         "declaration": true
     },
-    "include": ["src/**/*", "../types/shims/event.d.ts"],
+    "include": [
+        "src/**/*",
+        "node_modules/@promethean/types/shims/event.d.ts"
+    ],
     "references": [
+        {
+            "path": "../types"
+        },
         {
             "path": "../event"
         },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -916,6 +916,9 @@ importers:
       '@promethean/event':
         specifier: workspace:*
         version: link:../event
+      '@promethean/types':
+        specifier: workspace:*
+        version: link:../types
       '@types/javascript-time-ago':
         specifier: ^2.5.0
         version: 2.5.0
@@ -1259,6 +1262,9 @@ importers:
       '@promethean/ws':
         specifier: workspace:*
         version: link:../ws
+      '@promethean/types':
+        specifier: workspace:*
+        version: link:../types
       '@types/javascript-time-ago':
         specifier: ^2.5.0
         version: 2.5.0
@@ -1548,6 +1554,9 @@ importers:
       '@promethean/event':
         specifier: workspace:*
         version: link:../event
+      '@promethean/types':
+        specifier: workspace:*
+        version: link:../types
       '@types/javascript-time-ago':
         specifier: ^2.5.0
         version: 2.5.0
@@ -2117,6 +2126,9 @@ importers:
       '@promethean/event':
         specifier: workspace:*
         version: link:../event
+      '@promethean/types':
+        specifier: workspace:*
+        version: link:../types
       '@types/javascript-time-ago':
         specifier: ^2.5.0
         version: 2.5.0
@@ -2487,6 +2499,9 @@ importers:
       '@promethean/event':
         specifier: workspace:*
         version: link:../event
+      '@promethean/types':
+        specifier: workspace:*
+        version: link:../types
       '@types/javascript-time-ago':
         specifier: ^2.5.0
         version: 2.5.0
@@ -4192,6 +4207,9 @@ importers:
       '@promethean/event':
         specifier: workspace:*
         version: link:../event
+      '@promethean/types':
+        specifier: workspace:*
+        version: link:../types
       '@types/javascript-time-ago':
         specifier: ^2.5.0
         version: 2.5.0
@@ -4932,6 +4950,9 @@ importers:
       '@promethean/event':
         specifier: workspace:*
         version: link:../event
+      '@promethean/types':
+        specifier: workspace:*
+        version: link:../types
       '@types/javascript-time-ago':
         specifier: ^2.5.0
         version: 2.5.0
@@ -5527,6 +5548,9 @@ importers:
       '@promethean/rate':
         specifier: workspace:*
         version: link:../rate
+      '@promethean/types':
+        specifier: workspace:*
+        version: link:../types
       '@types/javascript-time-ago':
         specifier: ^2.5.0
         version: 2.5.0


### PR DESCRIPTION
## Summary
- enforce shared `@promethean/types` dependency for event shims
- document rule against cross-package relative module resolution

## Testing
- `pnpm --filter @promethean/compaction test` *(fails: Couldn’t find any files to test)*
- `pnpm --filter @promethean/dev test` *(fails: Cannot find module '@promethean/event/memory.js')*
- `pnpm --filter @promethean/dlq test` *(fails: Couldn’t find any files to test)*
- `pnpm --filter @promethean/examples test` *(fails: Cannot find module '@promethean/event/topics.js')*
- `pnpm --filter @promethean/http test` *(fails: Not all code paths return a value)*
- `pnpm --filter @promethean/schema test` *(fails: TypeScript errors)*
- `pnpm --filter @promethean/timetravel test` *(fails: Couldn’t find any files to test)*
- `pnpm --filter @promethean/ws test` *(fails: TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_68ba178beaf883248c4fd048f08907b9