### PR TITLE
refactor: centralize ECS shim

### DIFF
--- a/packages/AGENTS.md
+++ b/packages/AGENTS.md
@@ -1,0 +1,6 @@
+# AGENTS.md
+
+## Module Resolution
+- Do not resolve modules via relative paths outside of a package's root.
+- Shared types and shims must be provided by dependencies (e.g., `"@promethean/types": "workspace:*"`).
+- If a package needs cross-package types, add the dependency in `package.json` and reference it through normal module specifiers.

--- a/packages/agent-ecs/package.json
+++ b/packages/agent-ecs/package.json
@@ -54,7 +54,8 @@
         "yaml": "^2.5.1",
         "zod": "^3.23.8",
         "@promethean/ds": "workspace:*",
-        "@promethean/legacy": "workspace:*"
+        "@promethean/legacy": "workspace:*",
+        "@promethean/types": "workspace:*"
     },
     "devDependencies": {
         "@biomejs/biome": "^2.2.2",

--- a/packages/agent-ecs/tsconfig.json
+++ b/packages/agent-ecs/tsconfig.json
@@ -4,12 +4,16 @@
         "rootDir": "src",
         "outDir": "dist",
         "composite": true,
-        "declaration": true
+        "declaration": true,
+        "typeRoots": ["./node_modules/@types", "./node_modules/@promethean/types/shims"]
     },
-    "include": ["src/**/*", "../types/shims/ecs.d.ts"],
+    "include": ["src/**/*"],
     "references": [
         {
             "path": "../ds"
+        },
+        {
+            "path": "../types"
         }
     ]
 }

--- a/packages/worker/package.json
+++ b/packages/worker/package.json
@@ -53,7 +53,8 @@
         "ws": "^8.18.0",
         "yaml": "^2.5.1",
         "zod": "^3.23.8",
-        "@promethean/ds": "workspace:*"
+        "@promethean/ds": "workspace:*",
+        "@promethean/types": "workspace:*"
     },
     "devDependencies": {
         "@biomejs/biome": "^2.2.2",

--- a/packages/worker/tsconfig.json
+++ b/packages/worker/tsconfig.json
@@ -4,12 +4,16 @@
         "rootDir": "src",
         "outDir": "dist",
         "composite": true,
-        "declaration": true
+        "declaration": true,
+        "typeRoots": ["./node_modules/@types", "./node_modules/@promethean/types/shims"]
     },
-    "include": ["src/**/*", "../types/shims/ecs.d.ts"],
+    "include": ["src/**/*"],
     "references": [
         {
             "path": "../ds"
+        },
+        {
+            "path": "../types"
         }
     ]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -232,6 +232,9 @@ importers:
       '@promethean/legacy':
         specifier: workspace:*
         version: link:../legacy
+      '@promethean/types':
+        specifier: workspace:*
+        version: link:../types
       '@types/javascript-time-ago':
         specifier: ^2.5.0
         version: 2.5.0
@@ -5418,6 +5421,9 @@ importers:
       '@promethean/ds':
         specifier: workspace:*
         version: link:../ds
+      '@promethean/types':
+        specifier: workspace:*
+        version: link:../types
       '@types/javascript-time-ago':
         specifier: ^2.5.0
         version: 2.5.0


### PR DESCRIPTION
## Summary
- add @promethean/types dependency to agent-ecs and worker
- configure tsconfigs to load shared ECS shim via typeRoots
- document package-level rule to avoid cross-package relative paths

## Testing
- `pnpm -F types test` *(fails: Couldn’t find any files to test)*
- `pnpm -F agent-ecs test` *(fails: Cannot find type definition file for 'javascript-time-ago')*
- `pnpm -F worker test` *(fails: Cannot find type definition file for 'javascript-time-ago')*


------
https://chatgpt.com/codex/tasks/task_e_68ba195ee8e48324853d2b79cf2be033