### PR TITLE
refactor: centralize persistence shim

### DIFF
--- a/config/tsconfig.base.json
+++ b/config/tsconfig.base.json
@@ -27,12 +27,8 @@
     "forceConsistentCasingInFileNames": true,
     "isolatedModules": true,
     "experimentalDecorators": true,
-    "lib": ["ESNext", "esnext.disposable"],
     "target": "ESNext",
     "useDefineForClassFields": true,
-    "paths": {
-      "@shared/ts/*": ["../shared/ts/dist/*"]
-    },
     "lib": ["ES2022", "esnext.disposable"]
   },
   "types": ["node", "ava"],

--- a/packages/discord-embedder/package.json
+++ b/packages/discord-embedder/package.json
@@ -29,8 +29,8 @@
   "dependencies": {
     "@discordjs/voice": "^0.18.0",
     "@promethean/legacy": "workspace:*",
-    "@promethean/embeddings": "file:../embeddings",
-    "@promethean/persistence": "file:../persistence",
+    "@promethean/embeddings": "workspace:*",
+    "@promethean/persistence": "workspace:*",
     "chromadb": "^3.0.9",
     "discord.js": "^14.17.3",
     "dotenv": "^17.2.0",
@@ -46,6 +46,7 @@
   "devDependencies": {
     "@types/node": "^22.17.2",
     "@types/ws": "^8.5.12",
+    "@promethean/types": "workspace:*",
     "ava": "^6.4.1",
     "c8": "^9.1.0",
     "@biomejs/biome": "^2.1.4",

--- a/packages/discord-embedder/tsconfig.json
+++ b/packages/discord-embedder/tsconfig.json
@@ -1,38 +1,17 @@
 {
-  "extends": "../../config/tsconfig.service.json",
+  "extends": "../../config/tsconfig.base.json",
   "compilerOptions": {
-    "outDir": "dist",
     "rootDir": "src",
-    "module": "ESNext",
-    "moduleResolution": "Bundler",
-    "baseUrl": ".",
-    "paths": {
-      "@shared/js/*": [
-        "../../js/*"
-      ],
-      "@promethean/persistence": [
-        "../persistence/dist/index"
-      ],
-      "@promethean/persistence/*": [
-        "../persistence/dist/*"
-      ],
-      "@promethean/embeddings": [
-        "../embeddings/dist/index"
-      ],
-      "@promethean/embeddings/*": [
-        "../embeddings/dist/*"
-      ]
-    },
-    "allowArbitraryExtensions": true,
-    "types": [
-      "node"
-    ]
+    "outDir": "dist",
+    "composite": true,
+    "declaration": true
   },
   "include": [
-    "src/**/*.ts",
-    "../types/shims/persistence.d.ts"
+    "src/**/*",
+    "node_modules/@promethean/types/shims/persistence.d.ts"
   ],
-  "exclude": [
-    "node_modules"
+  "references": [
+    { "path": "../embeddings" },
+    { "path": "../persistence" }
   ]
 }

--- a/packages/markdown-graph/package.json
+++ b/packages/markdown-graph/package.json
@@ -14,7 +14,7 @@
     "start:dev": "node --loader ts-node/esm src/index.ts"
   },
   "dependencies": {
-    "@promethean/persistence": "file:../persistence",
+    "@promethean/persistence": "workspace:*",
     "@types/body-parser": "^1.19.5",
     "body-parser": "^1.20.3",
     "express": "^4.21.2"
@@ -23,7 +23,8 @@
     "@types/express": "^4.17.21",
     "@types/node": "^22.17.2",
     "@types/supertest": "^2.0.13",
-    "@promethean/test-utils": "file:../test-utils",
+    "@promethean/test-utils": "workspace:*",
+    "@promethean/types": "workspace:*",
     "ava": "^6.4.1",
     "c8": "^9.1.0",
     "eslint": "^8.57.0",

--- a/packages/markdown-graph/tsconfig.json
+++ b/packages/markdown-graph/tsconfig.json
@@ -1,55 +1,17 @@
 {
-  "$schema": "https://json.schemastore.org/tsconfig.json",
-  "extends": "../../config/tsconfig.service.json",
+  "extends": "../../config/tsconfig.base.json",
   "compilerOptions": {
-    "allowUnreachableCode": false,
-    "allowUnusedLabels": false,
-    "exactOptionalPropertyTypes": true,
-    "noFallthroughCasesInSwitch": true,
-    "noImplicitOverride": true,
-    "noImplicitReturns": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "strict": true,
-    "module": "ESNext",
-    "moduleResolution": "Bundler",
-    "baseUrl": ".",
-    "paths": {
-      "@shared/ts/*": [
-        "../../../shared/ts/dist/*"
-      ],
-      "@promethean/test-utils": [
-        "../test-utils/dist/index"
-      ],
-      "@promethean/test-utils/*": [
-        "../test-utils/dist/*"
-      ]
-    },
-    "resolveJsonModule": true,
-    "resolvePackageJsonExports": true,
-    "resolvePackageJsonImports": true,
-    "declaration": true,
-    "declarationMap": true,
+    "rootDir": "src",
     "outDir": "dist",
-    "sourceMap": true,
-    "allowSyntheticDefaultImports": true,
-    "esModuleInterop": false,
-    "forceConsistentCasingInFileNames": true,
-    "isolatedModules": true,
-    "lib": [
-      "ESNext"
-    ],
-    "target": "ESNext",
-    "useDefineForClassFields": true,
-    "skipLibCheck": true
+    "composite": true,
+    "declaration": true
   },
   "include": [
-    "src/**/*.ts",
-    "src/**/*.d.ts",
-    "tests/**/*.ts",
-    "../types/shims/persistence.d.ts"
+    "src/**/*",
+    "node_modules/@promethean/types/shims/persistence.d.ts"
   ],
-  "exclude": [
-    "node_modules"
+  "references": [
+    { "path": "../persistence" },
+    { "path": "../test-utils" }
   ]
 }

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -12,10 +12,12 @@
             "require": "./dist/index.cjs"
         },
         "./dist/*": "./dist/*",
+        "./shims/*": "./shims/*",
         "./*": "./dist/*"
     },
     "files": [
-        "dist"
+        "dist",
+        "shims"
     ],
     "scripts": {
         "build": "tsc",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1388,14 +1388,14 @@ importers:
         specifier: ^0.18.0
         version: 0.18.0(@discordjs/opus@0.10.0)
       '@promethean/embeddings':
-        specifier: file:../embeddings
-        version: file:packages/embeddings(socks@2.8.7)
+        specifier: workspace:*
+        version: link:../embeddings
       '@promethean/legacy':
         specifier: workspace:*
         version: link:../legacy
       '@promethean/persistence':
-        specifier: file:../persistence
-        version: file:packages/persistence(socks@2.8.7)
+        specifier: workspace:*
+        version: link:../persistence
       chromadb:
         specifier: ^3.0.9
         version: 3.0.14
@@ -1433,6 +1433,9 @@ importers:
       '@biomejs/biome':
         specifier: ^2.1.4
         version: 2.2.2
+      '@promethean/types':
+        specifier: workspace:*
+        version: link:../types
       '@types/node':
         specifier: ^22.17.2
         version: 22.18.1
@@ -3078,8 +3081,8 @@ importers:
   packages/markdown-graph:
     dependencies:
       '@promethean/persistence':
-        specifier: file:../persistence
-        version: file:packages/persistence(socks@2.8.7)
+        specifier: workspace:*
+        version: link:../persistence
       '@types/body-parser':
         specifier: ^1.19.5
         version: 1.19.6
@@ -3091,8 +3094,11 @@ importers:
         version: 4.21.2
     devDependencies:
       '@promethean/test-utils':
-        specifier: file:../test-utils
-        version: file:packages/test-utils(socks@2.8.7)
+        specifier: workspace:*
+        version: link:../test-utils
+      '@promethean/types':
+        specifier: workspace:*
+        version: link:../types
       '@types/express':
         specifier: ^4.17.21
         version: 4.17.23


### PR DESCRIPTION
## Summary
- extend package tsconfigs from shared base and pull persistence shim from `@promethean/types`
- switch local deps to `workspace:*` and export persistence shim from types package

## Testing
- `pnpm -F @promethean/types test` (fails: Couldn’t find any files to test)
- `pnpm -F @promethean/discord-embedder test` (fails: Cannot find module '@promethean/persistence')
- `pnpm -F @promethean/markdown-graph test` (fails: Cannot find module '@promethean/persistence')


------
https://chatgpt.com/codex/tasks/task_e_68ba1a4226348324ba1d60c8bc401409