### PR TITLE
fix: expose event shim types

### DIFF
--- a/changelog.d/2025.09.04.23.33.09.fixed.md
+++ b/changelog.d/2025.09.04.23.33.09.fixed.md
@@ -1,0 +1,1 @@
+fix: expose event shim types and configure package tsconfigs to consume them via compilerOptions.types

--- a/packages/compaction/tsconfig.json
+++ b/packages/compaction/tsconfig.json
@@ -1,21 +1,19 @@
 {
-    "extends": "../../config/tsconfig.base.json",
-    "compilerOptions": {
-        "rootDir": "src",
-        "outDir": "dist",
-        "composite": true,
-        "declaration": true
-    },
-    "include": [
-        "src/**/*",
-        "node_modules/@promethean/types/shims/event.d.ts"
-    ],
-    "references": [
-        {
-            "path": "../types"
-        },
-        {
-            "path": "../event"
-        }
-    ]
+	"extends": "../../config/tsconfig.base.json",
+	"compilerOptions": {
+		"rootDir": "src",
+		"outDir": "dist",
+		"composite": true,
+		"declaration": true,
+		"types": ["node", "ava", "@promethean/types/shims/event"]
+	},
+	"include": ["src/**/*"],
+	"references": [
+		{
+			"path": "../types"
+		},
+		{
+			"path": "../event"
+		}
+	]
 }

--- a/packages/dev/tsconfig.json
+++ b/packages/dev/tsconfig.json
@@ -1,30 +1,28 @@
 {
-    "extends": "../../config/tsconfig.base.json",
-    "compilerOptions": {
-        "rootDir": "src",
-        "outDir": "dist",
-        "composite": true,
-        "declaration": true
-    },
-    "include": [
-        "src/**/*",
-        "node_modules/@promethean/types/shims/event.d.ts"
-    ],
-    "references": [
-        {
-            "path": "../types"
-        },
-        {
-            "path": "../event"
-        },
-        {
-            "path": "../examples"
-        },
-        {
-            "path": "../http"
-        },
-        {
-            "path": "../ws"
-        }
-    ]
+	"extends": "../../config/tsconfig.base.json",
+	"compilerOptions": {
+		"rootDir": "src",
+		"outDir": "dist",
+		"composite": true,
+		"declaration": true,
+		"types": ["node", "ava", "@promethean/types/shims/event"]
+	},
+	"include": ["src/**/*"],
+	"references": [
+		{
+			"path": "../types"
+		},
+		{
+			"path": "../event"
+		},
+		{
+			"path": "../examples"
+		},
+		{
+			"path": "../http"
+		},
+		{
+			"path": "../ws"
+		}
+	]
 }

--- a/packages/dlq/tsconfig.json
+++ b/packages/dlq/tsconfig.json
@@ -1,21 +1,19 @@
 {
-    "extends": "../../config/tsconfig.base.json",
-    "compilerOptions": {
-        "rootDir": "src",
-        "outDir": "dist",
-        "composite": true,
-        "declaration": true
-    },
-    "include": [
-        "src/**/*",
-        "node_modules/@promethean/types/shims/event.d.ts"
-    ],
-    "references": [
-        {
-            "path": "../types"
-        },
-        {
-            "path": "../event"
-        }
-    ]
+	"extends": "../../config/tsconfig.base.json",
+	"compilerOptions": {
+		"rootDir": "src",
+		"outDir": "dist",
+		"composite": true,
+		"declaration": true,
+		"types": ["node", "ava", "@promethean/types/shims/event"]
+	},
+	"include": ["src/**/*"],
+	"references": [
+		{
+			"path": "../types"
+		},
+		{
+			"path": "../event"
+		}
+	]
 }

--- a/packages/examples/tsconfig.json
+++ b/packages/examples/tsconfig.json
@@ -1,21 +1,19 @@
 {
-    "extends": "../../config/tsconfig.base.json",
-    "compilerOptions": {
-        "rootDir": "src",
-        "outDir": "dist",
-        "composite": true,
-        "declaration": true
-    },
-    "include": [
-        "src/**/*",
-        "node_modules/@promethean/types/shims/event.d.ts"
-    ],
-    "references": [
-        {
-            "path": "../types"
-        },
-        {
-            "path": "../event"
-        }
-    ]
+	"extends": "../../config/tsconfig.base.json",
+	"compilerOptions": {
+		"rootDir": "src",
+		"outDir": "dist",
+		"composite": true,
+		"declaration": true,
+		"types": ["node", "ava", "@promethean/types/shims/event"]
+	},
+	"include": ["src/**/*"],
+	"references": [
+		{
+			"path": "../types"
+		},
+		{
+			"path": "../event"
+		}
+	]
 }

--- a/packages/http/tsconfig.json
+++ b/packages/http/tsconfig.json
@@ -1,21 +1,19 @@
 {
-    "extends": "../../config/tsconfig.base.json",
-    "compilerOptions": {
-        "rootDir": "src",
-        "outDir": "dist",
-        "composite": true,
-        "declaration": true
-    },
-    "include": [
-        "src/**/*",
-        "node_modules/@promethean/types/shims/event.d.ts"
-    ],
-    "references": [
-        {
-            "path": "../types"
-        },
-        {
-            "path": "../event"
-        }
-    ]
+	"extends": "../../config/tsconfig.base.json",
+	"compilerOptions": {
+		"rootDir": "src",
+		"outDir": "dist",
+		"composite": true,
+		"declaration": true,
+		"types": ["node", "ava", "@promethean/types/shims/event"]
+	},
+	"include": ["src/**/*"],
+	"references": [
+		{
+			"path": "../types"
+		},
+		{
+			"path": "../event"
+		}
+	]
 }

--- a/packages/schema/tsconfig.json
+++ b/packages/schema/tsconfig.json
@@ -1,21 +1,19 @@
 {
-    "extends": "../../config/tsconfig.base.json",
-    "compilerOptions": {
-        "rootDir": "src",
-        "outDir": "dist",
-        "composite": true,
-        "declaration": true
-    },
-    "include": [
-        "src/**/*",
-        "node_modules/@promethean/types/shims/event.d.ts"
-    ],
-    "references": [
-        {
-            "path": "../types"
-        },
-        {
-            "path": "../event"
-        }
-    ]
+	"extends": "../../config/tsconfig.base.json",
+	"compilerOptions": {
+		"rootDir": "src",
+		"outDir": "dist",
+		"composite": true,
+		"declaration": true,
+		"types": ["node", "ava", "@promethean/types/shims/event"]
+	},
+	"include": ["src/**/*"],
+	"references": [
+		{
+			"path": "../types"
+		},
+		{
+			"path": "../event"
+		}
+	]
 }

--- a/packages/timetravel/tsconfig.json
+++ b/packages/timetravel/tsconfig.json
@@ -1,21 +1,19 @@
 {
-    "extends": "../../config/tsconfig.base.json",
-    "compilerOptions": {
-        "rootDir": "src",
-        "outDir": "dist",
-        "composite": true,
-        "declaration": true
-    },
-    "include": [
-        "src/**/*",
-        "node_modules/@promethean/types/shims/event.d.ts"
-    ],
-    "references": [
-        {
-            "path": "../types"
-        },
-        {
-            "path": "../event"
-        }
-    ]
+	"extends": "../../config/tsconfig.base.json",
+	"compilerOptions": {
+		"rootDir": "src",
+		"outDir": "dist",
+		"composite": true,
+		"declaration": true,
+		"types": ["node", "ava", "@promethean/types/shims/event"]
+	},
+	"include": ["src/**/*"],
+	"references": [
+		{
+			"path": "../types"
+		},
+		{
+			"path": "../event"
+		}
+	]
 }

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,69 +1,71 @@
 {
-    "name": "@promethean/types",
-    "version": "0.0.1",
-    "private": true,
-    "type": "module",
-    "main": "dist/index.cjs",
-    "types": "dist/index.d.ts",
-    "exports": {
-        ".": {
-            "types": "./dist/index.d.ts",
-            "import": "./dist/index.js",
-            "require": "./dist/index.cjs"
-        },
-        "./dist/*": "./dist/*",
-        "./*": "./dist/*"
-    },
-    "files": [
-        "dist"
-    ],
-    "scripts": {
-        "build": "tsc",
-        "clean": "rimraf dist",
-        "typecheck": "tsc -p tsconfig.json --noEmit",
-        "test": "pnpm run build && ava --config ../../config/ava.config.mjs",
-        "lint": "pnpm exec biome lint .",
-        "lisp": "node dist/cli/lisp.js",
-        "coverage": "pnpm run build && c8 ava --config ../../config/ava.config.mjs",
-        "test:markdown": "pnpm run build && ava --config ../../config/ava.config.mjs dist/tests/markdown.*.test.js",
-        "format": "pnpm exec biome format --write ."
-    },
-    "module": "dist/index.js",
-    "dependencies": {
-        "@types/javascript-time-ago": "^2.5.0",
-        "@types/unist": "^3.0.3",
-        "body-parser": "^1.20.2",
-        "chromadb": "^3.0.14",
-        "duckduckgo-search": "^1.0.7",
-        "express": "^4.19.2",
-        "gray-matter": "^4.0.3",
-        "javascript-time-ago": "^2.5.11",
-        "mongodb": "^6.18.0",
-        "ollama": "^0.5.17",
-        "prom-client": "^15.1.0",
-        "remark-gfm": "^4.0.1",
-        "remark-parse": "^11.0.0",
-        "remark-stringify": "^11.0.0",
-        "sucrase": "^3.35.0",
-        "unified": "^11.0.5",
-        "unist": "^0.0.1",
-        "unist-util-to-string-with-nodes": "^0.1.1",
-        "unist-util-visit": "^5.0.0",
-        "uuid": "^11.1.0",
-        "ws": "^8.18.0",
-        "yaml": "^2.5.1",
-        "zod": "^3.23.8"
-    },
-    "devDependencies": {
-        "@biomejs/biome": "^2.2.2",
-        "@types/body-parser": "^1.19.5",
-        "@types/estree": "^1.0.5",
-        "@types/express": "^4.17.21",
-        "@types/node": "^20.19.11",
-        "@types/ws": "^8.5.9",
-        "acorn": "^8.15.0",
-        "rimraf": "^6.0.1",
-        "ts-node": "^10.9.2",
-        "typescript": "^5.9.2"
-    }
+	"name": "@promethean/types",
+	"version": "0.0.1",
+	"private": true,
+	"type": "module",
+	"main": "dist/index.cjs",
+	"types": "dist/index.d.ts",
+	"exports": {
+		".": {
+			"types": "./dist/index.d.ts",
+			"import": "./dist/index.js",
+			"require": "./dist/index.cjs"
+		},
+		"./shims/*": "./shims/*",
+		"./dist/*": "./dist/*",
+		"./*": "./dist/*"
+	},
+	"files": [
+		"dist",
+		"shims"
+	],
+	"scripts": {
+		"build": "tsc",
+		"clean": "rimraf dist",
+		"typecheck": "tsc -p tsconfig.json --noEmit",
+		"test": "pnpm run build && ava --config ../../config/ava.config.mjs",
+		"lint": "pnpm exec biome lint .",
+		"lisp": "node dist/cli/lisp.js",
+		"coverage": "pnpm run build && c8 ava --config ../../config/ava.config.mjs",
+		"test:markdown": "pnpm run build && ava --config ../../config/ava.config.mjs dist/tests/markdown.*.test.js",
+		"format": "pnpm exec biome format --write ."
+	},
+	"module": "dist/index.js",
+	"dependencies": {
+		"@types/javascript-time-ago": "^2.5.0",
+		"@types/unist": "^3.0.3",
+		"body-parser": "^1.20.2",
+		"chromadb": "^3.0.14",
+		"duckduckgo-search": "^1.0.7",
+		"express": "^4.19.2",
+		"gray-matter": "^4.0.3",
+		"javascript-time-ago": "^2.5.11",
+		"mongodb": "^6.18.0",
+		"ollama": "^0.5.17",
+		"prom-client": "^15.1.0",
+		"remark-gfm": "^4.0.1",
+		"remark-parse": "^11.0.0",
+		"remark-stringify": "^11.0.0",
+		"sucrase": "^3.35.0",
+		"unified": "^11.0.5",
+		"unist": "^0.0.1",
+		"unist-util-to-string-with-nodes": "^0.1.1",
+		"unist-util-visit": "^5.0.0",
+		"uuid": "^11.1.0",
+		"ws": "^8.18.0",
+		"yaml": "^2.5.1",
+		"zod": "^3.23.8"
+	},
+	"devDependencies": {
+		"@biomejs/biome": "^2.2.2",
+		"@types/body-parser": "^1.19.5",
+		"@types/estree": "^1.0.5",
+		"@types/express": "^4.17.21",
+		"@types/node": "^20.19.11",
+		"@types/ws": "^8.5.9",
+		"acorn": "^8.15.0",
+		"rimraf": "^6.0.1",
+		"ts-node": "^10.9.2",
+		"typescript": "^5.9.2"
+	}
 }

--- a/packages/ws/tsconfig.json
+++ b/packages/ws/tsconfig.json
@@ -1,24 +1,22 @@
 {
-    "extends": "../../config/tsconfig.base.json",
-    "compilerOptions": {
-        "rootDir": "src",
-        "outDir": "dist",
-        "composite": true,
-        "declaration": true
-    },
-    "include": [
-        "src/**/*",
-        "node_modules/@promethean/types/shims/event.d.ts"
-    ],
-    "references": [
-        {
-            "path": "../types"
-        },
-        {
-            "path": "../event"
-        },
-        {
-            "path": "../rate"
-        }
-    ]
+	"extends": "../../config/tsconfig.base.json",
+	"compilerOptions": {
+		"rootDir": "src",
+		"outDir": "dist",
+		"composite": true,
+		"declaration": true,
+		"types": ["node", "ava", "@promethean/types/shims/event"]
+	},
+	"include": ["src/**/*"],
+	"references": [
+		{
+			"path": "../types"
+		},
+		{
+			"path": "../event"
+		},
+		{
+			"path": "../rate"
+		}
+	]
 }


### PR DESCRIPTION
## Summary
- expose `@promethean/types` shims via package exports and files list
- load event shim declarations with `compilerOptions.types` in package `tsconfig`

## Testing
- `pnpm --filter @promethean/types test` *(fails: Couldn’t find any files to test)*
- `pnpm --filter @promethean/compaction test` *(fails: Cannot find type definition file '@promethean/types/shims/event')*
- `pnpm --filter @promethean/dev test` *(fails: Cannot find type definition file '@promethean/types/shims/event')*
- `pnpm --filter @promethean/dlq test` *(fails: Cannot find type definition file '@promethean/types/shims/event')*
- `pnpm --filter @promethean/examples test` *(fails: Cannot find type definition file '@promethean/types/shims/event')*
- `pnpm --filter @promethean/http test` *(fails: Cannot find type definition file '@promethean/types/shims/event')*
- `pnpm --filter @promethean/schema test` *(fails: Cannot find type definition file '@promethean/types/shims/event')*
- `pnpm --filter @promethean/timetravel test` *(fails: Cannot find type definition file '@promethean/types/shims/event')*
- `pnpm --filter @promethean/ws test` *(fails: Cannot find type definition file '@promethean/types/shims/event')*


------
https://chatgpt.com/codex/tasks/task_e_68ba212ac99483248b3bcd9d6c42232c