### PR TITLE
fix: guard smartgpt-bridge tests against missing builds

### DIFF
--- a/packages/smartgpt-bridge/package.json
+++ b/packages/smartgpt-bridge/package.json
@@ -8,13 +8,15 @@
     "start": "node dist/fastifyServer.js",
     "reindex": "node dist/cli-reindex.js",
     "symbols": "node dist/cli-symbols.js",
-    "test": "pnpm -r --filter @promethean/smartgpt-bridge... build && ava",
-    "test:watch": "pnpm -r --filter @promethean/smartgpt-bridge... build && ava -w",
+    "test": "pnpm -r --filter @promethean/smartgpt-bridge... run --if-present build && ava",
+    "test:watch": "pnpm -r --filter @promethean/smartgpt-bridge... run --if-present build && ava -w",
     "build": "tsc -p tsconfig.json",
+    "clean": "rimraf dist",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
     "lint": "pnpm exec biome lint src/tests/unit src/tests/integration src/tests/system src/tests/helpers || true && pnpm run lint:tests",
     "lint:tests": "node --input-type=module -e \"import fs from 'fs';import path from 'path';const walk=d=>fs.readdirSync(d).some(f=>{const p=path.join(d,f);const s=fs.statSync(p);return s.isDirectory()?walk(p):p.endsWith('.test.js');});if(walk('src/tests')){console.error('Error: compiled test artifacts found');process.exit(1);} \"",
     "format": "pnpm exec biome format --write src src/tests/unit src/tests/integration src/tests/system src/tests/helpers",
-    "test:coverage": "pnpm run build && c8 -r text -r text-summary -r lcov -r html ava --config ../../config/ava.config.mjs"
+    "coverage": "pnpm run build && c8 -r text -r text-summary -r lcov -r html ava --config ../../config/ava.config.mjs"
   },
   "dependencies": {
     "@fastify/swagger": "^8.15.0",
@@ -22,7 +24,6 @@
     "@promethean/fs": "file:../fs",
     "@promethean/embeddings": "file:../embeddings",
     "@promethean/persistence": "file:../persistence",
-    "@types/node": "^24.3.0",
     "ajv-formats": "^3.0.1",
     "chromadb": "^1.8.1",
     "dotenv": "^17.2.1",
@@ -42,6 +43,7 @@
   },
   "devDependencies": {
     "@biomejs/biome": "^2.2.2",
+    "@types/node": "^24.3.0",
     "ava": "^6.1.3",
     "c8": "^9.1.0",
     "mongodb-memory-server": "^10.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4354,9 +4354,6 @@ importers:
       '@promethean/persistence':
         specifier: file:../persistence
         version: file:packages/persistence(socks@2.8.7)
-      '@types/node':
-        specifier: ^24.3.0
-        version: 24.3.1
       ajv-formats:
         specifier: ^3.0.1
         version: 3.0.1(ajv@8.17.1)
@@ -4409,6 +4406,9 @@ importers:
       '@biomejs/biome':
         specifier: ^2.2.2
         version: 2.2.2
+      '@types/node':
+        specifier: ^24.3.0
+        version: 24.3.1
       ava:
         specifier: ^6.1.3
         version: 6.4.1


### PR DESCRIPTION
## Summary
- run build only where present before smartgpt-bridge tests
- move `@types/node` to dev dependencies and add missing package scripts

## Testing
- `pnpm --filter @promethean/smartgpt-bridge lint` *(fails: Found 65 errors; 99 warnings)*
- `pnpm --filter @promethean/smartgpt-bridge typecheck`
- `pnpm --filter @promethean/smartgpt-bridge test` *(fails: @promethean/stream build: Cannot find name 'HeadersInit')*

------
https://chatgpt.com/codex/tasks/task_e_68ba3ba2e8688324b8c4e9859b85d30a