### PR TITLE
Use level-cache for readmeflow

### DIFF
--- a/packages/AGENTS.md
+++ b/packages/AGENTS.md
@@ -1,0 +1,5 @@
+# AGENTS.md
+
+- Avoid writing JSON files for cache or temp data.
+- Prefer key-value caches such as `@promethean/level-cache`.
+- Conventionally, store readmeflow data under `.cache/readmes`.

--- a/packages/readmeflow/package.json
+++ b/packages/readmeflow/package.json
@@ -1,30 +1,38 @@
 {
- "name": "@promethean/readmeflow",
- "version": "0.1.0",
- "private": true,
- "type": "module",
- "bin": {
-  "readmeflow-scan": "dist/01-scan.js",
-  "readmeflow-outline": "dist/02-outline.js",
-  "readmeflow-write": "dist/03-write.js",
-  "readmeflow-verify": "dist/04-verify.js"
- },
- "scripts": {
-  "build": "tsc -p tsconfig.json",
-  "rm:01-scan": "tsx src/01-scan.ts",
-  "rm:02-outline": "tsx src/02-outline.ts",
-  "rm:03-write": "tsx src/03-write.ts",
-  "rm:04-verify": "tsx src/04-verify.ts",
-  "rm:all": "pnpm rm:01-scan && pnpm rm:02-outline && pnpm rm:03-write && pnpm rm:04-verify"
- },
- "dependencies": {
-  "globby": "^14.0.2",
-  "gray-matter": "^4.0.3",
-  "yaml": "^2.5.0",
-  "zod": "^3.23.8"
- },
- "devDependencies": {
-  "tsx": "^4.19.2",
-  "typescript": "^5.5.4"
- }
+	"name": "@promethean/readmeflow",
+	"version": "0.1.0",
+	"private": true,
+	"type": "module",
+	"bin": {
+		"readmeflow-scan": "dist/01-scan.js",
+		"readmeflow-outline": "dist/02-outline.js",
+		"readmeflow-write": "dist/03-write.js",
+		"readmeflow-verify": "dist/04-verify.js"
+	},
+	"scripts": {
+		"build": "tsc -p tsconfig.json",
+		"test": "pnpm build && ava",
+		"typecheck": "tsc -p tsconfig.json --noEmit",
+		"clean": "rimraf dist",
+		"coverage": "c8 pnpm test",
+		"lint": "biome lint .",
+		"format": "biome format .",
+		"rm:01-scan": "tsx src/01-scan.ts",
+		"rm:02-outline": "tsx src/02-outline.ts",
+		"rm:03-write": "tsx src/03-write.ts",
+		"rm:04-verify": "tsx src/04-verify.ts",
+		"rm:all": "pnpm rm:01-scan && pnpm rm:02-outline && pnpm rm:03-write && pnpm rm:04-verify"
+	},
+	"dependencies": {
+		"@promethean/level-cache": "workspace:*",
+		"globby": "^14.0.2",
+		"gray-matter": "^4.0.3",
+		"yaml": "^2.5.0",
+		"zod": "^3.23.8"
+	},
+	"devDependencies": {
+		"rimraf": "^6.0.0",
+		"tsx": "^4.19.2",
+		"typescript": "^5.9.2"
+	}
 }

--- a/packages/readmeflow/src/01-scan.ts
+++ b/packages/readmeflow/src/01-scan.ts
@@ -1,82 +1,91 @@
-import { promises as fs } from "fs";
-import * as path from "path";
+import { promises as fs } from "node:fs";
+import * as path from "node:path";
 
-import { parseArgs, readMaybe, writeJSON } from "./utils.js";
+import { parseArgs, readMaybe } from "./utils.js";
+import { openLevelCache } from "@promethean/level-cache";
 import type { PkgInfo, ScanOut } from "./types.js";
 
 const args = parseArgs({
-  "--root": "packages",
-  "--out": ".cache/readmes/scan.json",
+	"--root": "packages",
+	"--cache": ".cache/readmes",
 });
 
 async function main() {
-  const ROOT = path.resolve(args["--root"]!);
-  const dirs = (await fs.readdir(ROOT, { withFileTypes: true }))
-    .filter((e) => e.isDirectory())
-    .map((e) => e.name);
+	const ROOT = path.resolve(args["--root"]);
+	const dirs = (await fs.readdir(ROOT, { withFileTypes: true }))
+		.filter((e) => e.isDirectory())
+		.map((e) => e.name);
 
-  const pkgMap = new Map<string, PkgInfo>();
-  for (const d of dirs) {
-    const dir = path.join(ROOT, d);
-    const pj = path.join(dir, "package.json");
-    try {
-      const json = JSON.parse(await fs.readFile(pj, "utf-8"));
-      const name = json.name ?? d;
-      const maybeReadme = await readMaybe(path.join(dir, "README.md"));
-      const info: PkgInfo = {
-        name,
-        version: json.version ?? "0.0.0",
-        dir,
-        description: json.description,
-        bin: json.bin,
-        scripts: json.scripts,
-        dependencies: json.dependencies,
-        devDependencies: json.devDependencies,
-        peerDependencies: json.peerDependencies,
-        workspaceDeps: [],
-        hasTsConfig: !!(await readMaybe(path.join(dir, "tsconfig.json"))),
-        ...(maybeReadme !== undefined ? { readme: maybeReadme } : {}),
-      };
-      pkgMap.set(name, info);
-    } catch {
-      /* skip */
-    }
-  }
+	const pkgMap = new Map<string, PkgInfo>();
+	for (const d of dirs) {
+		const dir = path.join(ROOT, d);
+		const pj = path.join(dir, "package.json");
+		try {
+			const json = JSON.parse(await fs.readFile(pj, "utf-8"));
+			const name = json.name ?? d;
+			const maybeReadme = await readMaybe(path.join(dir, "README.md"));
+			const info: PkgInfo = {
+				name,
+				version: json.version ?? "0.0.0",
+				dir,
+				description: json.description,
+				bin: json.bin,
+				scripts: json.scripts,
+				dependencies: json.dependencies,
+				devDependencies: json.devDependencies,
+				peerDependencies: json.peerDependencies,
+				workspaceDeps: [],
+				hasTsConfig: !!(await readMaybe(
+					path.join(dir, "tsconfig.json"),
+				)),
+				...(maybeReadme !== undefined ? { readme: maybeReadme } : {}),
+			};
+			pkgMap.set(name, info);
+		} catch {
+			/* skip */
+		}
+	}
 
-  // compute workspace internal deps
-  for (const info of pkgMap.values()) {
-    const all = {
-      ...(info.dependencies ?? {}),
-      ...(info.devDependencies ?? {}),
-      ...(info.peerDependencies ?? {}),
-    };
-    const internal = Object.keys(all).filter((n) => pkgMap.has(n));
-    info.workspaceDeps = internal;
-  }
+	// compute workspace internal deps
+	for (const info of pkgMap.values()) {
+		const all = {
+			...(info.dependencies ?? {}),
+			...(info.devDependencies ?? {}),
+			...(info.peerDependencies ?? {}),
+		};
+		const internal = Object.keys(all).filter((n) => pkgMap.has(n));
+		info.workspaceDeps = internal;
+	}
 
-  // mermaid graph (packages and internal deps)
-  const lines: string[] = ["flowchart LR"];
-  for (const [name, info] of pkgMap) {
-    const id = name.replace(/[^a-zA-Z0-9]/g, "_");
-    lines.push(`  ${id}["${name}\\n${info.version}"]`);
-  }
-  for (const [name, info] of pkgMap) {
-    const from = name.replace(/[^a-zA-Z0-9]/g, "_");
-    for (const dep of info.workspaceDeps) {
-      const to = dep.replace(/[^a-zA-Z0-9]/g, "_");
-      lines.push(`  ${from} --> ${to}`);
-    }
-  }
+	// mermaid graph (packages and internal deps)
+	const lines: string[] = ["flowchart LR"];
+	for (const [name, info] of pkgMap) {
+		const id = name.replace(/[^a-zA-Z0-9]/g, "_");
+		lines.push(`  ${id}["${name}\\n${info.version}"]`);
+	}
+	for (const [name, info] of pkgMap) {
+		const from = name.replace(/[^a-zA-Z0-9]/g, "_");
+		for (const dep of info.workspaceDeps) {
+			const to = dep.replace(/[^a-zA-Z0-9]/g, "_");
+			lines.push(`  ${from} --> ${to}`);
+		}
+	}
 
-  const out: ScanOut = {
-    createdAt: new Date().toISOString(),
-    packages: Array.from(pkgMap.values()),
-    graphMermaid: lines.join("\n"),
-  };
-  await writeJSON(path.resolve(args["--out"]!), out);
-  console.log(`readmeflow: scanned ${pkgMap.size} packages → ${args["--out"]}`);
+	const out: ScanOut = {
+		createdAt: new Date().toISOString(),
+		packages: Array.from(pkgMap.values()),
+		graphMermaid: lines.join("\n"),
+	};
+	const cache = await openLevelCache<ScanOut>({
+		path: path.resolve(args["--cache"]),
+	});
+	await cache.set("scan", out);
+	await cache.close();
+	console.log(
+		`readmeflow: scanned ${pkgMap.size} packages → ${args["--cache"]}`,
+	);
 }
 main().catch((e) => {
-  console.error(e);
-  process.exit(1);
+	console.error(e);
+	process.exit(1);
 });

--- a/packages/readmeflow/src/02-outline.ts
+++ b/packages/readmeflow/src/02-outline.ts
@@ -1,122 +1,126 @@
-import * as path from "path";
-import { promises as fs } from "fs";
+import * as path from "node:path";
 
 import { z } from "zod";
 
-import { parseArgs, ollamaJSON, writeJSON } from "./utils.js";
+import { parseArgs, ollamaJSON } from "./utils.js";
+import { openLevelCache } from "@promethean/level-cache";
 import type { ScanOut, Outline, OutlinesFile } from "./types.js";
 
 const args = parseArgs({
-  "--scan": ".cache/readmes/scan.json",
-  "--out": ".cache/readmes/outlines.json",
-  "--model": "qwen3:4b",
+	"--cache": ".cache/readmes",
+	"--model": "qwen3:4b",
 });
 
 const OutlineSchema = z.object({
-  title: z.string().min(1),
-  tagline: z.string().min(1),
-  includeTOC: z.boolean().optional().default(true),
-  sections: z
-    .array(z.object({ heading: z.string().min(1), body: z.string().min(1) }))
-    .min(3),
-  badges: z.array(z.string()).optional(),
+	title: z.string().min(1),
+	tagline: z.string().min(1),
+	includeTOC: z.boolean().optional().default(true),
+	sections: z
+		.array(
+			z.object({ heading: z.string().min(1), body: z.string().min(1) }),
+		)
+		.min(3),
+	badges: z.array(z.string()).optional(),
 });
 
 async function main() {
-  const scan = JSON.parse(
-    await fs.readFile(path.resolve(args["--scan"]!), "utf-8"),
-  ) as ScanOut;
-  const outlines: Record<string, Outline> = {};
+	const cache = await openLevelCache<ScanOut | OutlinesFile>({
+		path: path.resolve(args["--cache"]),
+	});
+	const scan = (await cache.get("scan")) as ScanOut;
+	let outlines: Record<string, Outline> = {};
 
-  for (const pkg of scan.packages) {
-    const sys = [
-      "You write tight, practical READMEs for dev tools. Use short sections and code blocks when useful.",
-      "Return ONLY JSON: { title, tagline, includeTOC?, sections:[{heading, body}], badges?[] }",
-      "Prefer concise install, quickstart, CLI/API usage, configuration, and troubleshooting.",
-    ].join("\n");
+	for (const pkg of scan.packages) {
+		const sys = [
+			"You write tight, practical READMEs for dev tools. Use short sections and code blocks when useful.",
+			"Return ONLY JSON: { title, tagline, includeTOC?, sections:[{heading, body}], badges?[] }",
+			"Prefer concise install, quickstart, CLI/API usage, configuration, and troubleshooting.",
+		].join("\n");
 
-    const user = [
-      `PACKAGE: ${pkg.name} v${pkg.version}`,
-      `DESC: ${pkg.description ?? "(none)"}`,
-      `HAS_TS: ${pkg.hasTsConfig}`,
-      `BIN: ${Object.keys(pkg.bin ?? {}).join(", ") || "(none)"}`,
-      `SCRIPTS: ${
-        Object.keys(pkg.scripts ?? {})
-          .slice(0, 8)
-          .join(", ") || "(none)"
-      }`,
-      `INTERNAL_DEPS: ${pkg.workspaceDeps.join(", ") || "(none)"}`,
-      "",
-      "If the package is a CLI, include a 'Commands' section with examples.",
-      "If it's a library, include a 'Quickstart' import/usage snippet.",
-      "If the repo uses Piper pipelines, mention how to run the relevant pipeline.",
-    ].join("\n");
+		const user = [
+			`PACKAGE: ${pkg.name} v${pkg.version}`,
+			`DESC: ${pkg.description ?? "(none)"}`,
+			`HAS_TS: ${pkg.hasTsConfig}`,
+			`BIN: ${Object.keys(pkg.bin ?? {}).join(", ") || "(none)"}`,
+			`SCRIPTS: ${
+				Object.keys(pkg.scripts ?? {})
+					.slice(0, 8)
+					.join(", ") || "(none)"
+			}`,
+			`INTERNAL_DEPS: ${pkg.workspaceDeps.join(", ") || "(none)"}`,
+			"",
+			"If the package is a CLI, include a 'Commands' section with examples.",
+			"If it's a library, include a 'Quickstart' import/usage snippet.",
+			"If the repo uses Piper pipelines, mention how to run the relevant pipeline.",
+		].join("\n");
 
-    let obj: any;
-    try {
-      obj = await ollamaJSON(
-        args["--model"]!,
-        `SYSTEM:\n${sys}\n\nUSER:\n${user}`,
-      );
-    } catch {
-      obj = {
-        title: pkg.name,
-        tagline: pkg.description ?? "",
-        includeTOC: true,
-        sections: [
-          {
-            heading: "Install",
-            body: "```bash\npnpm -w add -D " + pkg.name + "\n```",
-          },
-          { heading: "Quickstart", body: "```ts\n// usage example\n```" },
-          {
-            heading: "Commands",
-            body:
-              Object.keys(pkg.scripts ?? {})
-                .map((k) => `- \`${k}\``)
-                .join("\n") || "N/A",
-          },
-        ],
-      };
-    }
-    const parsed = OutlineSchema.safeParse(obj);
-    const outlineRaw = parsed.success
-      ? parsed.data
-      : {
-          title: pkg.name,
-          tagline: pkg.description ?? "",
-          includeTOC: true,
-          sections: [
-            { heading: "Install", body: "pnpm add " + pkg.name },
-            { heading: "Usage", body: "(coming soon)" },
-            { heading: "License", body: "MIT" },
-          ],
-        };
+		let obj: unknown;
+		try {
+			obj = await ollamaJSON(
+				args["--model"],
+				`SYSTEM:\n${sys}\n\nUSER:\n${user}`,
+			);
+		} catch {
+			obj = {
+				title: pkg.name,
+				tagline: pkg.description ?? "",
+				includeTOC: true,
+				sections: [
+					{
+						heading: "Install",
+						body: `\`\`\`bash\npnpm -w add -D ${pkg.name}\n\`\`\``,
+					},
+					{
+						heading: "Quickstart",
+						body: "```ts\n// usage example\n```",
+					},
+					{
+						heading: "Commands",
+						body:
+							Object.keys(pkg.scripts ?? {})
+								.map((k) => `- \`${k}\``)
+								.join("\n") || "N/A",
+					},
+				],
+			};
+		}
+		const parsed = OutlineSchema.safeParse(obj);
+		const outlineRaw = parsed.success
+			? parsed.data
+			: {
+					title: pkg.name,
+					tagline: pkg.description ?? "",
+					includeTOC: true,
+					sections: [
+						{ heading: "Install", body: `pnpm add ${pkg.name}` },
+						{ heading: "Usage", body: "(coming soon)" },
+						{ heading: "License", body: "MIT" },
+					],
+				};
 
-    const outline: Outline = {
-      name: pkg.name,
-      title: outlineRaw.title,
-      tagline: outlineRaw.tagline,
-      includeTOC: outlineRaw.includeTOC ?? true,
-      sections: outlineRaw.sections,
-      ...(Array.isArray((outlineRaw as any).badges) &&
-      (outlineRaw as any).badges.length
-        ? { badges: (outlineRaw as any).badges as string[] }
-        : {}),
-    };
+		// eslint-disable-next-line functional/prefer-immutable-types
+		const outline: Outline = {
+			name: pkg.name,
+			title: outlineRaw.title,
+			tagline: outlineRaw.tagline,
+			includeTOC: outlineRaw.includeTOC,
+			sections: outlineRaw.sections,
+			...(outlineRaw.badges?.length ? { badges: outlineRaw.badges } : {}),
+		};
 
-    outlines[pkg.name] = outline;
-  }
-
-  const out: OutlinesFile = { plannedAt: new Date().toISOString(), outlines };
-  await writeJSON(path.resolve(args["--out"]!), out);
-  console.log(
-    `readmeflow: outlined ${Object.keys(outlines).length} README(s) → ${
-      args["--out"]
-    }`,
-  );
+		outlines = { ...outlines, [pkg.name]: outline };
+	}
+	// eslint-disable-next-line functional/prefer-immutable-types
+	const out: OutlinesFile = { plannedAt: new Date().toISOString(), outlines };
+	await cache.set("outlines", out);
+	await cache.close();
+	console.log(
+		`readmeflow: outlined ${Object.keys(outlines).length} README(s) → ${
+			args["--cache"]
+		}`,
+	);
 }
 main().catch((e) => {
-  console.error(e);
-  process.exit(1);
+	console.error(e);
+	process.exit(1);
 });

--- a/packages/readmeflow/src/03-write.ts
+++ b/packages/readmeflow/src/03-write.ts
@@ -1,81 +1,83 @@
-import * as path from "path";
-import { promises as fs } from "fs";
+import * as path from "node:path";
 
 import matter from "gray-matter";
 
 import { parseArgs, writeText, readMaybe } from "./utils.js";
-import type { ScanOut, OutlinesFile } from "./types.js";
+import { openLevelCache } from "@promethean/level-cache";
+import type { ScanOut, OutlinesFile, Outline } from "./types.js";
 
 const args = parseArgs({
-  "--scan": ".cache/readmes/scan.json",
-  "--outlines": ".cache/readmes/outlines.json",
-  "--mermaid": "true",
+	"--cache": ".cache/readmes",
+	"--mermaid": "true",
 });
 
 const START = "<!-- READMEFLOW:BEGIN -->";
 const END = "<!-- READMEFLOW:END -->";
 
 function stripGenerated(text: string) {
-  const si = text.indexOf(START),
-    ei = text.indexOf(END);
-  if (si >= 0 && ei > si) return (text.slice(0, si).trimEnd() + "\n").trimEnd();
-  return text.trimEnd();
+	const si = text.indexOf(START),
+		ei = text.indexOf(END);
+	if (si >= 0 && ei > si) return `${text.slice(0, si).trimEnd()}\n`.trimEnd();
+	return text.trimEnd();
 }
 
-function makeReadme(_pkg: any, outline: any, mermaid?: string) {
-  const toc = outline.includeTOC ? "[TOC]\n\n" : "";
-  const sec = outline.sections
-    .map((s: any) => `## ${s.heading}\n\n${s.body}\n`)
-    .join("\n");
-  const badges = (outline.badges ?? []).join(" ");
-  const diag = mermaid
-    ? `\n### Package graph\n\n\`\`\`mermaid\n${mermaid}\n\`\`\`\n`
-    : "";
+function makeReadme(_pkg: unknown, outline: Outline, mermaid?: string) {
+	const toc = outline.includeTOC ? "[TOC]\n\n" : "";
+	const sec = outline.sections
+		.map((s) => `## ${s.heading}\n\n${s.body}\n`)
+		.join("\n");
+	const badges = (outline.badges ?? []).join(" ");
+	const diag = mermaid
+		? `\n### Package graph\n\n\`\`\`mermaid\n${mermaid}\n\`\`\`\n`
+		: "";
 
-  return [
-    START,
-    `# ${outline.title}`,
-    badges ? `\n${badges}\n` : "",
-    `${outline.tagline}\n`,
-    toc,
-    sec,
-    diag,
-    END,
-    "",
-  ].join("\n");
+	return [
+		START,
+		`# ${outline.title}`,
+		badges ? `\n${badges}\n` : "",
+		`${outline.tagline}\n`,
+		toc,
+		sec,
+		diag,
+		END,
+		"",
+	].join("\n");
 }
 
 async function main() {
-  const scan = JSON.parse(
-    await fs.readFile(path.resolve(args["--scan"]!), "utf-8"),
-  ) as ScanOut;
-  const outlines = JSON.parse(
-    await fs.readFile(path.resolve(args["--outlines"]!), "utf-8"),
-  ) as OutlinesFile;
+	const cache = await openLevelCache<ScanOut | OutlinesFile>({
+		path: path.resolve(args["--cache"]),
+	});
+	const scan = (await cache.get("scan")) as ScanOut;
+	const outlines = (await cache.get("outlines")) as OutlinesFile;
 
-  for (const pkg of scan.packages) {
-    const out = outlines.outlines[pkg.name];
-    if (!out) continue;
+	for (const pkg of scan.packages) {
+		const out = outlines.outlines[pkg.name];
+		if (!out) continue;
 
-    const readmePath = path.join(pkg.dir, "README.md");
-    const existing = await readMaybe(readmePath);
-    const gm = existing ? matter(existing) : { content: "", data: {} as any };
+		const readmePath = path.join(pkg.dir, "README.md");
+		const existing = await readMaybe(readmePath);
+		const gm = existing
+			? matter(existing)
+			: { content: "", data: {} as Record<string, unknown> };
 
-    const content =
-      (stripGenerated(gm.content) ? stripGenerated(gm.content) + "\n\n" : "") +
-      makeReadme(
-        pkg,
-        out,
-        args["--mermaid"] === "true" ? scan.graphMermaid : undefined,
-      );
+		const stripped = stripGenerated(gm.content);
+		const content =
+			(stripped ? `${stripped}\n\n` : "") +
+			makeReadme(
+				pkg,
+				out,
+				args["--mermaid"] === "true" ? scan.graphMermaid : undefined,
+			);
 
-    const fm = { ...(gm as any).data };
-    const final = matter.stringify(content, fm, { language: "yaml" });
-    await writeText(readmePath, final);
-  }
-  console.log(`readmeflow: wrote ${scan.packages.length} README(s)`);
+		const fm = { ...gm.data };
+		const final = matter.stringify(content, fm, { language: "yaml" });
+		await writeText(readmePath, final);
+	}
+	await cache.close();
+	console.log(`readmeflow: wrote ${scan.packages.length} README(s)`);
 }
 main().catch((e) => {
-  console.error(e);
-  process.exit(1);
+	console.error(e);
+	process.exit(1);
 });

--- a/packages/readmeflow/src/04-verify.ts
+++ b/packages/readmeflow/src/04-verify.ts
@@ -1,81 +1,83 @@
-import * as path from "path";
-import { promises as fs } from "fs";
+import * as path from "node:path";
+import { promises as fs } from "node:fs";
 
 import { parseArgs, writeText } from "./utils.js";
 import type { VerifyReport } from "./types.js";
 
 const args = parseArgs({
-  "--root": "packages",
-  "--out": "docs/agile/reports/readmes",
-  "--max": "200",
+	"--root": "packages",
+	"--out": "docs/agile/reports/readmes",
+	"--max": "200",
 });
 
 async function main() {
-  const pkgs = await fs
-    .readdir(path.resolve(args["--root"]!), { withFileTypes: true })
-    .then((ents) =>
-      ents
-        .filter((e) => e.isDirectory())
-        .map((e) => path.join(args["--root"]!, e.name)),
-    );
-  const results: VerifyReport["results"] = [];
+	const pkgs = await fs
+		.readdir(path.resolve(args["--root"]), { withFileTypes: true })
+		.then((ents) =>
+			ents
+				.filter((e) => e.isDirectory())
+				.map((e) => path.join(args["--root"], e.name)),
+		);
+	const results: VerifyReport["results"] = [];
 
-  for (const dir of pkgs) {
-    const readme = path.join(dir, "README.md");
-    try {
-      await fs.access(readme);
-    } catch {
-      continue;
-    }
-    const raw = await fs.readFile(readme, "utf-8");
-    const links: string[] = Array.from(raw.matchAll(/\[[^\]]+?\]\(([^)]+)\)/g))
-      .map((m) => m[1])
-      .filter((h): h is string => typeof h === "string")
-      .filter((h) => !h.startsWith("http"));
-    const broken: string[] = [];
-    const max = Number(args["--max"]!);
-    for (let i = 0; i < Math.min(links.length, max); i++) {
-      const href: string = links[i]!;
-      const segment: string = href.split("#").at(0) ?? "";
-      const target = path.resolve(dir as string, segment as string);
-      try {
-        await fs.access(target);
-      } catch {
-        broken.push(href);
-      }
-    }
-    if (broken.length) results.push({ pkg: dir.split("/").pop()!, broken });
-  }
+	for (const dir of pkgs) {
+		const readme = path.join(dir, "README.md");
+		try {
+			await fs.access(readme);
+		} catch {
+			continue;
+		}
+		const raw = await fs.readFile(readme, "utf-8");
+		const links: string[] = Array.from(
+			raw.matchAll(/\[[^\]]+?\]\(([^)]+)\)/g),
+		)
+			.map((m) => m[1])
+			.filter((h): h is string => typeof h === "string")
+			.filter((h) => !h.startsWith("http"));
+		const broken: string[] = [];
+		const max = Number(args["--max"]);
+		const limited = links.slice(0, Math.min(links.length, max));
+		for (const href of limited) {
+			const segment: string = href.split("#").at(0) ?? "";
+			const target = path.resolve(dir as string, segment as string);
+			try {
+				await fs.access(target);
+			} catch {
+				broken.push(href);
+			}
+		}
+		if (broken.length) results.push({ pkg: path.basename(dir), broken });
+	}
 
-  const ts = new Date().toISOString().replace(/[:.]/g, "-");
-  const md = [
-    "# README link check",
-    "",
-    results.length
-      ? results
-          .map(
-            (r) =>
-              `- **${r.pkg}**:\n${r.broken.map((b) => `  - ${b}`).join("\n")}`,
-          )
-          .join("\n")
-      : "_No broken relative links found._",
-    "",
-  ].join("\n");
+	const ts = new Date().toISOString().replace(/[:.]/g, "-");
+	const md = [
+		"# README link check",
+		"",
+		results.length
+			? results
+					.map(
+						(r) =>
+							`- **${r.pkg}**:\n${r.broken.map((b) => `  - ${b}`).join("\n")}`,
+					)
+					.join("\n")
+			: "_No broken relative links found._",
+		"",
+	].join("\n");
 
-  await fs.mkdir(path.resolve(args["--out"]!), { recursive: true });
-  await writeText(path.join(args["--out"]!, `readmes-${ts}.md`), md);
-  await writeText(
-    path.join(args["--out"]!, `README.md`),
-    `# Readme Reports\n\n- [Latest](readmes-${ts}.md)\n`,
-  );
-  console.log(
-    `readmeflow: verify report → ${path.join(
-      args["--out"]!,
-      `readmes-${ts}.md`,
-    )}`,
-  );
+	await fs.mkdir(path.resolve(args["--out"]), { recursive: true });
+	await writeText(path.join(args["--out"], `readmes-${ts}.md`), md);
+	await writeText(
+		path.join(args["--out"], `README.md`),
+		`# Readme Reports\n\n- [Latest](readmes-${ts}.md)\n`,
+	);
+	console.log(
+		`readmeflow: verify report → ${path.join(
+			args["--out"],
+			`readmes-${ts}.md`,
+		)}`,
+	);
 }
 main().catch((e) => {
-  console.error(e);
-  process.exit(1);
+	console.error(e);
+	process.exit(1);
 });

--- a/packages/readmeflow/src/tests/cache.test.ts
+++ b/packages/readmeflow/src/tests/cache.test.ts
@@ -1,0 +1,16 @@
+import test from "ava";
+import * as path from "node:path";
+import { promises as fs } from "node:fs";
+import { openLevelCache } from "@promethean/level-cache";
+
+const TMP = path.join(".cache", "readmeflow-test");
+
+test("level cache read/write", async (t) => {
+	const cache = await openLevelCache<{ msg: string }>({ path: TMP });
+	await cache.set("greeting", { msg: "hi" });
+	const val = await cache.get("greeting");
+	t.deepEqual(val, { msg: "hi" });
+	await cache.del("greeting");
+	await cache.close();
+	await fs.rm(TMP, { recursive: true, force: true });
+});

--- a/packages/readmeflow/src/utils.ts
+++ b/packages/readmeflow/src/utils.ts
@@ -1,73 +1,69 @@
-import { promises as fs } from "fs";
-import * as path from "path";
+import { promises as fs } from "node:fs";
+import * as path from "node:path";
 
 export const OLLAMA_URL = process.env.OLLAMA_URL ?? "http://localhost:11434";
 
-export function parseArgs<T extends Record<string, string>>(defaults: T): T {
-  const out = { ...defaults } as T;
-  const a = process.argv.slice(2);
-  for (let i = 0; i < a.length; i++) {
-    const k = a[i];
-    if (!k) continue;
-    if (!k.startsWith("--")) continue;
-    const next = a[i + 1];
-    let v: string;
-    if (typeof next === "string" && !next.startsWith("--")) {
-      i++;
-      v = next;
-    } else {
-      v = "true";
-    }
-    (out as Record<string, string>)[k] = v;
-  }
-  return out;
+export function parseArgs<T extends Record<string, string>>(
+	defaults: Readonly<T>,
+): Readonly<T> {
+	const pairs = process.argv
+		.slice(2)
+		.reduce<ReadonlyArray<[string, string]>>((acc, cur, idx, arr) => {
+			if (!cur.startsWith("--")) return acc;
+			const next = arr[idx + 1];
+			const value =
+				typeof next === "string" && !next.startsWith("--")
+					? next
+					: "true";
+			return acc.concat([[cur, value]]);
+		}, []);
+	return { ...defaults, ...Object.fromEntries(pairs) } as Readonly<T>;
 }
 
-export async function readMaybe(p: string) {
-  try {
-    return await fs.readFile(p, "utf-8");
-  } catch {
-    return undefined;
-  }
+export async function readMaybe(p: string): Promise<string | undefined> {
+	try {
+		return await fs.readFile(p, "utf-8");
+	} catch {
+		return undefined;
+	}
 }
-export async function writeJSON(p: string, data: any) {
-  await fs.mkdir(path.dirname(p), { recursive: true });
-  await fs.writeFile(p, JSON.stringify(data, null, 2), "utf-8");
-}
-export async function writeText(p: string, s: string) {
-  await fs.mkdir(path.dirname(p), { recursive: true });
-  await fs.writeFile(p, s, "utf-8");
+export async function writeText(p: string, s: string): Promise<void> {
+	await fs.mkdir(path.dirname(p), { recursive: true });
+	await fs.writeFile(p, s, "utf-8");
 }
 
-export function slug(s: string) {
-  return s
-    .trim()
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, "-")
-    .replace(/^-+|-+$/g, "");
+export function slug(s: string): string {
+	return s
+		.trim()
+		.toLowerCase()
+		.replace(/[^a-z0-9]+/g, "-")
+		.replace(/^-+|-+$/g, "");
 }
 
-export async function ollamaJSON(model: string, prompt: string): Promise<any> {
-  const res = await fetch(`${OLLAMA_URL}/api/generate`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({
-      model,
-      prompt,
-      stream: false,
-      options: { temperature: 0 },
-      format: "json",
-    }),
-  });
-  if (!res.ok) throw new Error(`ollama ${res.status}`);
-  const data: unknown = await res.json();
-  const response = (data as any)?.response;
-  const raw =
-    typeof response === "string" ? response : JSON.stringify(response);
-  return JSON.parse(
-    String(raw)
-      .replace(/```json\s*/g, "")
-      .replace(/```\s*$/g, "")
-      .trim(),
-  );
+export async function ollamaJSON(
+	model: string,
+	prompt: string,
+): Promise<unknown> {
+	const res = await fetch(`${OLLAMA_URL}/api/generate`, {
+		method: "POST",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify({
+			model,
+			prompt,
+			stream: false,
+			options: { temperature: 0 },
+			format: "json",
+		}),
+	});
+	if (!res.ok) throw new Error(`ollama ${res.status}`);
+	const data: unknown = await res.json();
+	const response = (data as { response?: unknown } | undefined)?.response;
+	const raw =
+		typeof response === "string" ? response : JSON.stringify(response);
+	return JSON.parse(
+		String(raw)
+			.replace(/```json\s*/g, "")
+			.replace(/```\s*$/g, "")
+			.trim(),
+	) as unknown;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4167,6 +4167,9 @@ importers:
 
   packages/readmeflow:
     dependencies:
+      '@promethean/level-cache':
+        specifier: workspace:*
+        version: link:../level-cache
       globby:
         specifier: ^14.0.2
         version: 14.0.2
@@ -4180,11 +4183,14 @@ importers:
         specifier: ^3.23.8
         version: 3.25.76
     devDependencies:
+      rimraf:
+        specifier: ^6.0.0
+        version: 6.0.1
       tsx:
         specifier: ^4.19.2
         version: 4.20.3
       typescript:
-        specifier: ^5.5.4
+        specifier: ^5.9.2
         version: 5.9.2
 
   packages/schema:
@@ -15058,7 +15064,7 @@ snapshots:
 
   axios@1.11.0:
     dependencies:
-      follow-redirects: 1.15.11(debug@4.3.7)
+      follow-redirects: 1.15.11(debug@4.4.1)
       form-data: 4.0.4
       proxy-from-env: 1.1.0
     transitivePeerDependencies:
@@ -17324,7 +17330,7 @@ snapshots:
   http-proxy@1.18.1:
     dependencies:
       eventemitter3: 4.0.7
-      follow-redirects: 1.15.11(debug@4.3.7)
+      follow-redirects: 1.15.11(debug@4.4.1)
       requires-port: 1.0.0
     transitivePeerDependencies:
       - debug


### PR DESCRIPTION
## Summary
- replace JSON scan/outlines files with `@promethean/level-cache`
- document cache convention in `packages/AGENTS.md`
- add basic cache read/write test and package scripts

## Testing
- `pnpm --filter @promethean/readmeflow lint`
- `pnpm --filter @promethean/readmeflow test`


------
https://chatgpt.com/codex/tasks/task_e_68ba352b0288832486453e410d4a5a7a