### PR TITLE
fix(readmeflow): drop JSON artifacts from pipeline definitions

### DIFF
--- a/packages/readmeflow/pipelines.yml
+++ b/packages/readmeflow/pipelines.yml
@@ -2,28 +2,20 @@ pipelines:
   - name: readmes
     steps:
       - id: rm-scan
-        shell: "pnpm --filter @promethean/readmeflow rm:01-scan --root packages --out .cache/readmes/scan.json"
+        shell: "pnpm --filter @promethean/readmeflow rm:01-scan --root packages"
         inputs:
           - "packages/**/package.json"
           - "packages/**/tsconfig.json"
-        outputs:
-          - ".cache/readmes/scan.json"
 
       - id: rm-outline
         deps: ["rm-scan"]
-        shell: "pnpm --filter @promethean/readmeflow rm:02-outline --scan .cache/readmes/scan.json --out .cache/readmes/outlines.json --model qwen3:4b"
+        shell: "pnpm --filter @promethean/readmeflow rm:02-outline --model qwen3:4b"
         env:
           OLLAMA_URL: "${OLLAMA_URL}"
-        inputs:
-          - ".cache/readmes/scan.json"
-        outputs:
-          - ".cache/readmes/outlines.json"
 
       - id: rm-write
         deps: ["rm-outline"]
-        shell: "pnpm --filter @promethean/readmeflow rm:03-write --scan .cache/readmes/scan.json --outlines .cache/readmes/outlines.json --mermaid true"
-        inputs:
-          - ".cache/readmes/outlines.json"
+        shell: "pnpm --filter @promethean/readmeflow rm:03-write --mermaid true"
         outputs:
           - "packages/**/README.md"
 

--- a/pipelines.yaml
+++ b/pipelines.yaml
@@ -191,26 +191,18 @@ pipelines:
   - name: readmes
     steps:
       - id: rm-scan
-        shell: "pnpm --filter @promethean/readmeflow rm:01-scan --root packages --out .cache/readmes/scan.json"
+        shell: "pnpm --filter @promethean/readmeflow rm:01-scan --root packages"
         inputs:
           - "packages/**/package.json"
           - "packages/**/tsconfig.json"
-        outputs:
-          - ".cache/readmes/scan.json"
       - id: rm-outline
         deps: ["rm-scan"]
-        shell: "pnpm --filter @promethean/readmeflow rm:02-outline --scan .cache/readmes/scan.json --out .cache/readmes/outlines.json --model qwen3:4b"
+        shell: "pnpm --filter @promethean/readmeflow rm:02-outline --model qwen3:4b"
         env:
           OLLAMA_URL: "${OLLAMA_URL}"
-        inputs:
-          - ".cache/readmes/scan.json"
-        outputs:
-          - ".cache/readmes/outlines.json"
       - id: rm-write
         deps: ["rm-outline"]
-        shell: "pnpm --filter @promethean/readmeflow rm:03-write --scan .cache/readmes/scan.json --outlines .cache/readmes/outlines.json --mermaid true"
-        inputs:
-          - ".cache/readmes/outlines.json"
+        shell: "pnpm --filter @promethean/readmeflow rm:03-write --mermaid true"
         outputs:
           - "packages/**/README.md"
       - id: rm-verify


### PR DESCRIPTION
## Summary
- remove .cache readme JSON outputs from pipeline definitions
- adjust readmeflow steps to rely on Level cache

## Testing
- `pnpm lint pipelines.yaml packages/readmeflow/pipelines.yml` *(fails: Found a nested root configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68ba450cf67483248a26ba3d95b9bc3a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Simplified README generation pipeline by removing intermediate artifacts and chaining steps directly.
- Performance
  - Reduced I/O and dependencies between steps for faster, more reliable runs.
- Chores
  - Updated pipeline configuration to streamline execution; verification step remains unchanged.
- Documentation
  - README generation process streamlined; no changes to resulting README content.
- Notes
  - No functional changes to the product; this update improves build/process efficiency only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->