### PR TITLE
test: centralize sleep helper for tests

### DIFF
--- a/changelog.d/2025.09.05.05.05.05.changed.md
+++ b/changelog.d/2025.09.05.05.05.05.changed.md
@@ -1,0 +1,1 @@
+- exposed sleep helper for tests and discouraged direct setTimeout-based sleeps

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -79,4 +79,22 @@ export default [
       ],
     },
   },
+  {
+    files: [
+      "**/*.test.{ts,tsx,js}",
+      "**/*.spec.{ts,tsx,js}",
+      "**/tests/**/*.{ts,tsx,js}",
+    ],
+    rules: {
+      "no-restricted-syntax": [
+        "error",
+        {
+          selector:
+            "CallExpression[callee.name='setTimeout'][arguments.0.type='Identifier']",
+          message:
+            "Use sleep from @promethean/test-utils instead of setTimeout for sleeps in tests.",
+        },
+      ],
+    },
+  },
 ];

--- a/packages/agent-ecs/src/agent-ecs.doublebuffer.test.ts
+++ b/packages/agent-ecs/src/agent-ecs.doublebuffer.test.ts
@@ -1,4 +1,7 @@
 import test from 'ava';
+
+import { sleep } from '@promethean/test-utils/sleep';
+
 import { createAgentWorld } from './world.js';
 import { enqueueUtterance } from './helpers/enqueueUtterance.js';
 import { OrchestratorSystem } from './systems/orchestrator.js';
@@ -64,7 +67,7 @@ test('agent-ecs: arbiter picks audio and marks playing', async (t) => {
     // run systems once: arbiter should pick and call play
     await tick(0);
     // allow async factory microtask to resolve and invoke player.play
-    await new Promise((r) => setTimeout(r, 0));
+    await sleep(0);
 
     pq = w.get(agent, C.PlaybackQ)!;
     t.deepEqual(pq.items, []); // dequeued

--- a/packages/cephalon/src/tests/desktop_channel.test.ts
+++ b/packages/cephalon/src/tests/desktop_channel.test.ts
@@ -1,5 +1,6 @@
 import test from "ava";
 
+import { sleep } from "@promethean/test-utils/sleep";
 import { DesktopCaptureManager } from "../desktop/desktopLoop.js";
 
 // Ensure desktop captures are sent to configured channel
@@ -20,7 +21,7 @@ test("uploads desktop captures to configured channel", async (t) => {
   } as any);
   manager.step = 0;
   const run = manager.start();
-  await new Promise((res) => setTimeout(res, 10));
+  await sleep(10);
   manager.stop();
   await run;
   t.truthy(sent);

--- a/packages/cephalon/src/tests/messageThrottler.test.ts
+++ b/packages/cephalon/src/tests/messageThrottler.test.ts
@@ -3,6 +3,8 @@ import { fileURLToPath } from "url";
 
 import test from "ava";
 
+import { sleep } from "@promethean/test-utils/sleep";
+
 import { AIAgent } from "../agent.js";
 import type { Bot } from "../bot.js";
 // avoid compile-time coupling to ContextStore type
@@ -30,7 +32,7 @@ test.skip("throttles tick interval based on messages", async (t) => {
   for (let i = 0; i < 5; i++) {
     client.publish("test", {});
   }
-  await new Promise((r) => setTimeout(r, 1100));
+  await sleep(1100);
   client.publish("test", {});
   t.true((agent as any).tickInterval > 100);
 
@@ -39,7 +41,7 @@ test.skip("throttles tick interval based on messages", async (t) => {
   if (broker)
     await Promise.race([
       stopBroker(broker),
-      new Promise((resolve) => setTimeout(resolve, 1000)),
+      sleep(1000),
     ]);
   if ((agent as any).audioPlayer?.stop) (agent as any).audioPlayer.stop(true);
 });

--- a/packages/cephalon/src/tests/speechCoordinator.test.ts
+++ b/packages/cephalon/src/tests/speechCoordinator.test.ts
@@ -2,6 +2,8 @@ import EventEmitter from "events";
 
 import test from "ava";
 
+import { sleep } from "@promethean/test-utils/sleep";
+
 import {
   SpeechArbiter,
   TurnManager,
@@ -42,7 +44,7 @@ test("arbiter drops stale utterances", async (t) => {
   };
   arb.enqueue(oldU);
   arb.enqueue(newU);
-  await new Promise((r) => setTimeout(r, 10));
+  await sleep(10);
   t.deepEqual(played, ["new"]);
 });
 
@@ -70,6 +72,6 @@ test("arbiter prioritizes higher priority", async (t) => {
   };
   arb.enqueue(low);
   arb.enqueue(high);
-  await new Promise((r) => setTimeout(r, 10));
+  await sleep(10);
   t.deepEqual(played, ["high"]);
 });

--- a/packages/event/src/event.bus.test.ts
+++ b/packages/event/src/event.bus.test.ts
@@ -1,4 +1,7 @@
 import test from 'ava';
+
+import { sleep } from '@promethean/test-utils/sleep';
+
 import { InMemoryEventBus } from './memory.js';
 import type { EventRecord } from './types.js';
 
@@ -18,7 +21,7 @@ test('event bus: publish/subscribe earliest', async (t) => {
     await bus.publish('t.a', 'one');
     await bus.publish('t.a', 'two');
 
-    await new Promise((r) => setTimeout(r, 50));
+    await sleep(50);
     t.deepEqual(seen, ['one', 'two']);
 
     const cur = await bus.getCursor('t.a', 'g1');
@@ -41,7 +44,7 @@ test('event bus: nack leaves cursor and retries', async (t) => {
     );
 
     await bus.publish('t.b', 'x');
-    await new Promise((r) => setTimeout(r, 80));
+    await sleep(80);
     t.true(attempts >= 2);
     await unsub();
 });
@@ -60,7 +63,7 @@ test('event bus: manual ack requires explicit ack', async (t) => {
     );
 
     await bus.publish('t.c', 'one');
-    await new Promise((r) => setTimeout(r, 50));
+    await sleep(50);
 
     let cur = await bus.getCursor('t.c', 'g1');
     t.is(cur?.lastId, undefined);

--- a/packages/file-watcher/src/tests/events.test.ts
+++ b/packages/file-watcher/src/tests/events.test.ts
@@ -1,7 +1,11 @@
-import test from "ava";
 import { mkdtempSync, writeFileSync, promises as fs } from "fs";
-import { join } from "path";
 import { tmpdir } from "os";
+import { join } from "path";
+
+import test from "ava";
+
+import { sleep } from "@promethean/test-utils/sleep";
+
 import { startFileWatcher } from "../index.js";
 const EVENTS = {
   board: "file-watcher-board-change",
@@ -24,7 +28,7 @@ test("emits board change events", async (t) => {
     publish: (type, payload) => events.push({ type, payload }),
   });
   await fs.writeFile(boardPath, "changed");
-  await new Promise((r) => setTimeout(r, 200));
+  await sleep(200);
   (await watcher).close();
   t.true(events.some((e) => e.type === EVENTS.board));
 });
@@ -43,12 +47,12 @@ test("emits task add and change events", async (t) => {
     repoRoot: root,
     publish: (type, payload) => events.push({ type, payload }),
   });
-  await new Promise((r) => setTimeout(r, 200));
+  await sleep(200);
   const taskFile = join(tasksDir, "task.md");
   await fs.writeFile(taskFile, "foo");
-  await new Promise((r) => setTimeout(r, 300));
+  await sleep(300);
   await fs.appendFile(taskFile, "bar");
-  await new Promise((r) => setTimeout(r, 300));
+  await sleep(300);
   (await watcher).close();
   t.true(events.some((e) => e.type === EVENTS.add));
 });

--- a/packages/file-watcher/src/tests/repo-watcher.test.ts
+++ b/packages/file-watcher/src/tests/repo-watcher.test.ts
@@ -1,4 +1,7 @@
 import test from "ava";
+
+import { sleep } from "@promethean/test-utils/sleep";
+
 import { createRepoWatcher } from "../repo-watcher.js";
 
 test("repo watcher posts index/remove for non-ignored files", async (t) => {
@@ -22,11 +25,11 @@ test("repo watcher posts index/remove for non-ignored files", async (t) => {
   });
   // Directly invoke internal handle to avoid FS noise
   await (watcher as any)._handle("change", "src/example.ts");
-  await new Promise((r) => setTimeout(r, 10));
+  await sleep(10);
   await (watcher as any)._handle("change", "src/example.ts"); // coalesce by debounce
   await (watcher as any)._handle("unlink", "src/old.ts");
   await (watcher as any)._handle("change", "node_modules/ignore.js");
-  await new Promise((r) => setTimeout(r, 80)); // wait > debounce to flush
+  await sleep(80); // wait > debounce to flush
 
   const indexCalls = calls.filter(
     (c) => c.url.endsWith("/indexer/index") && c.body.path === "src/example.ts",

--- a/packages/level-cache/src/tests/cache.test.ts
+++ b/packages/level-cache/src/tests/cache.test.ts
@@ -1,7 +1,11 @@
-import test from "ava";
-import { openLevelCache } from "../index.js";
 import { rmSync, mkdirSync } from "node:fs";
 import { join } from "node:path";
+
+import test from "ava";
+
+import { sleep } from "@promethean/test-utils/sleep";
+
+import { openLevelCache } from "../index.js";
 
 const TMP_ROOT = ".cache/tests-level";
 
@@ -12,9 +16,6 @@ function tmpPath(name: string): string {
   } catch {}
   return p;
 }
-
-const sleep = (ms: number): Promise<void> =>
-  new Promise((r) => setTimeout(r, ms));
 
 test("set/get/has basic", async (t) => {
   const path = tmpPath("basic");

--- a/packages/mcp/test/router.spec.ts
+++ b/packages/mcp/test/router.spec.ts
@@ -6,6 +6,8 @@ import { EventEmitter } from "events";
 import WebSocket, { WebSocketServer } from "ws";
 import test from "ava";
 
+import { sleep } from "@promethean/test-utils/sleep";
+
 import { attachRouter } from "../src/router.js";
 import { createWsServer } from "../src/wsListener.js";
 
@@ -38,7 +40,7 @@ test("attachRouter emits progress, result, error and cleans up on close", async 
   bridgeSocket.send(
     JSON.stringify({ kind: "tool.error", id: "3", error: "boom" }),
   );
-  await new Promise((res) => setTimeout(res, 10));
+  await sleep(10);
 
   t.deepEqual(ws.sent[0], {
     jsonrpc: "2.0",

--- a/packages/mcp/test/stdio.spec.ts
+++ b/packages/mcp/test/stdio.spec.ts
@@ -5,6 +5,8 @@ import { spawn } from "child_process";
 import { WebSocketServer } from "ws";
 import test from "ava";
 
+import { sleep } from "@promethean/test-utils/sleep";
+
 test.skip("forwards stdin lines to websocket and prints responses", async (t) => {
   const wss = new WebSocketServer({ port: 0 });
   const messages: string[] = [];
@@ -25,7 +27,7 @@ test.skip("forwards stdin lines to websocket and prints responses", async (t) =>
 
   await once(wss, "connection");
   proc.stdin.write('{"jsonrpc":"2.0","id":1,"method":"ping"}\n');
-  await new Promise((r) => setTimeout(r, 200));
+  await sleep(200);
 
   for (const client of wss.clients) client.close();
   const code = await new Promise<number>((res) =>

--- a/packages/rate/src/limiter.test.ts
+++ b/packages/rate/src/limiter.test.ts
@@ -1,5 +1,7 @@
 import test from 'ava';
 
+import { sleep } from '@promethean/test-utils/sleep';
+
 import { TokenBucket } from './limiter.js';
 
 // ensure TokenBucket enforces capacity and returns deficit
@@ -16,6 +18,6 @@ test('TokenBucket refills over time', async (t) => {
     const bucket = new TokenBucket({ capacity: 1, refillPerSec: 1 });
     t.true(bucket.tryConsume());
     t.false(bucket.tryConsume());
-    await new Promise((r) => setTimeout(r, 1100));
+    await sleep(1100);
     t.true(bucket.tryConsume());
 });

--- a/packages/smartgpt-bridge/src/tests/integration/indexer.incremental.test.ts
+++ b/packages/smartgpt-bridge/src/tests/integration/indexer.incremental.test.ts
@@ -4,6 +4,8 @@ import path from "node:path";
 
 import test from "ava";
 
+import { sleep } from "@promethean/test-utils/sleep";
+
 import {
   setChromaClient,
   setEmbeddingFactory,
@@ -12,15 +14,11 @@ import {
 } from "../../indexer.js";
 import { loadBootstrapState } from "../../indexerState.js";
 
-function delay(ms) {
-  return new Promise((r) => setTimeout(r, ms));
-}
-
 async function waitIdle(timeoutMs = 5000) {
   const start = Date.now();
   while (indexerManager.isBusy()) {
     if (Date.now() - start > timeoutMs) throw new Error("waitIdle timeout");
-    await delay(10);
+    await sleep(10);
   }
 }
 

--- a/packages/smartgpt-bridge/src/tests/system/agent.supervisor.test.ts
+++ b/packages/smartgpt-bridge/src/tests/system/agent.supervisor.test.ts
@@ -2,6 +2,8 @@
 import test from "ava";
 import sinon from "sinon";
 
+import { sleep } from "@promethean/test-utils/sleep";
+
 import { mockSpawnFactory } from "../helpers/mockSpawn.js";
 import { createSupervisor } from "../../agent.js";
 
@@ -21,7 +23,7 @@ test("agent supervisor: guard pause, resume, then exit", async (t) => {
 
   const { id } = sup.start({ prompt: "noop" });
   // Give script a tick to deliver events
-  await new Promise((r) => setTimeout(r, 0));
+  await sleep(0);
 
   const st1 = sup.status(id);
   t.truthy(st1);
@@ -43,7 +45,7 @@ test("agent supervisor: guard pause, resume, then exit", async (t) => {
     killImpl: mockKill,
   });
   const { id: id2 } = sup2.start({ prompt: "noop" });
-  await new Promise((r) => setTimeout(r, 0));
+  await sleep(0);
   const st3 = sup2.status(id2);
   t.true(st3.exited === true || st3.exited === false); // existence check; exited may be set after tick
 });

--- a/packages/smartgpt-bridge/src/tests/unit/logger.test.ts
+++ b/packages/smartgpt-bridge/src/tests/unit/logger.test.ts
@@ -1,20 +1,19 @@
-import test from "ava";
 import fs from "node:fs";
 import fsp from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { Writable } from "node:stream";
 
-function delay(ms: number) {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}
+import test from "ava";
+
+import { sleep } from "@promethean/test-utils/sleep";
 
 test("writes logs to file when LOG_FILE is set", async (t) => {
   const file = path.join(os.tmpdir(), `smartgpt-log-${Date.now()}.log`);
   process.env.LOG_FILE = file;
   const { logger } = await import("../../logger.js?" + Date.now());
   logger.info("hello-file");
-  await delay(20);
+  await sleep(20);
   const contents = await fsp.readFile(file, "utf8");
   t.true(contents.includes("hello-file"));
   await fsp.unlink(file);
@@ -43,7 +42,7 @@ test("falls back to stdout when log file stream errors", async (t) => {
 
   const { logger } = await import("../../logger.js?" + Date.now());
   t.notThrows(() => logger.info("hello-error"));
-  await delay(20);
+  await sleep(20);
   t.true(errorLogged);
 
   console.error = originalError;

--- a/packages/test-utils/src/sleep.ts
+++ b/packages/test-utils/src/sleep.ts
@@ -1,0 +1,5 @@
+export function sleep(ms: number): Promise<void> {
+    return new Promise((resolve) => {
+        setTimeout(resolve, ms);
+    });
+}

--- a/packages/tests/src/dev.harness.int.test.ts
+++ b/packages/tests/src/dev.harness.int.test.ts
@@ -1,4 +1,6 @@
 import test from 'ava';
+
+import { sleep } from '@promethean/test-utils/sleep';
 import { startHarness } from '@promethean/dev/harness.js';
 
 test('harness end-to-end', async (t) => {
@@ -16,7 +18,7 @@ test('harness end-to-end', async (t) => {
         cpu_pct: 1,
         mem_mb: 2,
     });
-    await new Promise((r) => setTimeout(r, 200));
+    await sleep(200);
 
     // ensure projector emitted process.state
     const events = await h.bus.store.scan('process.state', { ts: 0 });

--- a/packages/tests/src/stream-title.test.ts
+++ b/packages/tests/src/stream-title.test.ts
@@ -2,6 +2,8 @@ import { EventEmitter } from 'node:events';
 
 import test from 'ava';
 import ollama, { type Message } from 'ollama';
+
+import { sleep } from '@promethean/test-utils/sleep';
 import {
     generateTwitchStreamTitle,
     generateAndStoreTitle,
@@ -81,7 +83,7 @@ test('watchContextAndGenerate reacts to context event', async (t) => {
 
     watchContextAndGenerate(emitter, source, store);
     emitter.emit('context');
-    await new Promise((r) => setTimeout(r, 0));
+    await sleep(0);
 
     t.deepEqual(store.titles, ['Fastest RPG Runs!']);
 

--- a/tests/brokerClient.integration.test.js
+++ b/tests/brokerClient.integration.test.js
@@ -1,6 +1,8 @@
 // integration: exercises real ws server
 import test from "ava";
 import { WebSocketServer } from "ws";
+
+import { sleep } from "@promethean/test-utils/sleep";
 import { BrokerClient } from "@shared/js/brokerClient.js";
 
 test.serial("BrokerClient sends messages and handles callbacks", async (t) => {
@@ -40,10 +42,10 @@ test.serial("BrokerClient sends messages and handles callbacks", async (t) => {
   client.ack("t1");
   client.heartbeat();
 
-  await new Promise((resolve) => setTimeout(resolve, 50));
+  await sleep(50);
 
   client.unsubscribe("foo");
-  await new Promise((r) => setTimeout(r, 10));
+  await sleep(10);
 
   t.is(eventData, 42);
   t.deepEqual(task, { id: "t1" });
@@ -85,11 +87,11 @@ test.serial("BrokerClient reconnects and flushes queue", async (t) => {
   await client.connect();
 
   // Connection will close shortly; queue a message while disconnected
-  await new Promise((r) => setTimeout(r, 50));
+  await sleep(50);
   client.publish("after", { a: 1 });
 
   // Wait for reconnection and message flush
-  await new Promise((r) => setTimeout(r, 1500));
+  await sleep(1500);
 
   t.true(
     received.some((m) => m.action === "publish" && m.message.payload.a === 1),

--- a/tests/brokerClient.tasks.unit.test.js
+++ b/tests/brokerClient.tasks.unit.test.js
@@ -1,4 +1,6 @@
 import test from 'ava';
+
+import { sleep } from '@promethean/test-utils/sleep';
 import { BrokerClient } from '@shared/js/brokerClient.js';
 import { getMemoryBroker, resetMemoryBroker } from '@shared/ts/dist/test-utils/broker.js';
 
@@ -22,7 +24,7 @@ test('memory broker: ready assigns enqueued task to worker', async (t) => {
   await prod.connect();
   prod.enqueue('jobs', { x: 1 });
 
-  await new Promise((r) => setTimeout(r, 10));
+  await sleep(10);
   t.truthy(assigned);
   t.is(assigned.payload.x, 1);
 

--- a/tests/brokerClient.unit.test.js
+++ b/tests/brokerClient.unit.test.js
@@ -1,4 +1,6 @@
 import test from "ava";
+
+import { sleep } from "@promethean/test-utils/sleep";
 import { BrokerClient } from "@shared/js/brokerClient.js";
 
 test("memory broker: publish delivers to subscribers and unsubscribe stops it", async (t) => {
@@ -12,12 +14,12 @@ test("memory broker: publish delivers to subscribers and unsubscribe stops it", 
 
   pub.publish("foo", { a: 1 });
   pub.publish("foo", { a: 2 });
-  await new Promise((r) => setTimeout(r, 10));
+  await sleep(10);
   t.deepEqual(seen, [{ a: 1 }, { a: 2 }]);
 
   sub.unsubscribe("foo");
   pub.publish("foo", { a: 3 });
-  await new Promise((r) => setTimeout(r, 10));
+  await sleep(10);
   t.deepEqual(seen, [{ a: 1 }, { a: 2 }]);
 
   sub.disconnect();

--- a/tests/queueManager.test.js
+++ b/tests/queueManager.test.js
@@ -1,4 +1,6 @@
 import test from 'ava';
+
+import { sleep } from '@promethean/test-utils/sleep';
 import { queueManager } from '../shared/js/queueManager.js';
 
 function createWS() {
@@ -75,7 +77,7 @@ test.serial('heartbeat updates lastSeen', async (t) => {
     queueManager.ready(ws, workerId, queue);
     const before = queueManager.getState().workers[workerId].lastSeen;
 
-    await new Promise((r) => setTimeout(r, 10));
+    await sleep(10);
     queueManager.heartbeat(workerId);
     const after = queueManager.getState().workers[workerId].lastSeen;
 
@@ -93,7 +95,7 @@ test.serial('expired workers are cleaned up and tasks requeued', async (t) => {
     queueManager.ready(ws, workerId, queue);
     queueManager.enqueue(queue, { value: 3 });
 
-    await new Promise((r) => setTimeout(r, 40));
+    await sleep(40);
 
     const state = queueManager.getState();
     t.is(state.workers[workerId], undefined);
@@ -125,7 +127,7 @@ test.serial('task timeout requeues and logs', async (t) => {
     const task = queueManager.enqueue(queue, { value: 3 });
 
     t.is(ws.messages.length, 1);
-    await new Promise((r) => setTimeout(r, 40));
+    await sleep(40);
 
     const state = queueManager.getState();
     t.is(state.queues[queue], 1);
@@ -155,10 +157,10 @@ test.serial('rate limit delays dispatch', async (t) => {
     const start = Date.now();
     t.true(queueManager.acknowledge(workerId, msg1.task.id));
     queueManager.ready(ws, workerId, queue);
-    await new Promise((r) => setTimeout(r, 10));
+    await sleep(10);
     t.is(ws.messages.length, 1);
 
-    await new Promise((r) => setTimeout(r, 60));
+    await sleep(60);
     t.is(ws.messages.length, 2);
     const msg2 = JSON.parse(ws.messages[1]);
     t.is(msg2.task.id, second.id);

--- a/tests/tokenBucket.test.js
+++ b/tests/tokenBucket.test.js
@@ -1,5 +1,7 @@
 
 import test from 'ava';
+
+import { sleep } from '@promethean/test-utils/sleep';
 import { TokenBucket } from '../shared/ts/dist/rate/limiter.js';
 
 test('TokenBucket limits and refills', async (t) => {
@@ -9,6 +11,6 @@ test('TokenBucket limits and refills', async (t) => {
     t.false(bucket.tryConsume());
     const deficit = bucket.deficit();
     t.true(deficit > 0);
-    await new Promise((r) => setTimeout(r, 1100));
+    await sleep(1100);
     t.true(bucket.tryConsume());
 });


### PR DESCRIPTION
## Summary
- add `sleep` utility in `@promethean/test-utils`
- swap ad-hoc `setTimeout` promises in tests for shared helper
- lint: forbid direct `setTimeout` sleeps in test files

## Testing
- `pnpm test` *(fails: packages/boardrev build: src/03-index-repo.ts(20,30): error TS2532: Object is possibly 'undefined')*


------
https://chatgpt.com/codex/tasks/task_e_68ba6e54097c832494c1ea831d3ecab8