### PR TITLE
test: declare test-utils dependency for sleep helper

### DIFF
--- a/changelog.d/2025.09.05.05.05.05.changed.md
+++ b/changelog.d/2025.09.05.05.05.05.changed.md
@@ -1,1 +1,1 @@
-- exposed sleep helper for tests and discouraged direct setTimeout-based sleeps
+- Expose a sleep helper for tests; discourage direct setTimeout-based sleeps.

--- a/config/tsconfig.base.json
+++ b/config/tsconfig.base.json
@@ -31,7 +31,9 @@
     "target": "esnext",
     "useDefineForClassFields": true,
     "paths": {
-      "@shared/ts/*": ["../shared/ts/dist/*"]
+      "@shared/ts/*": ["../shared/ts/dist/*"],
+      "@promethean/test-utils/*": ["../packages/test-utils/dist/*"],
+      "@promethean/test-utils/sleep": ["../packages/test-utils/dist/sleep"]
     },
     "types": ["node", "ava"]
   },

--- a/package.json
+++ b/package.json
@@ -74,7 +74,8 @@
     "ts-node": "10.9.2",
     "tsx": "4.20.3",
     "typescript": "5.9.2",
-    "typescript-eslint": "8.42.0"
+    "typescript-eslint": "8.42.0",
+    "@promethean/test-utils": "workspace:*"
   },
   "license": "GPL-3.0-only",
   "volta": {

--- a/packages/agent-ecs/package.json
+++ b/packages/agent-ecs/package.json
@@ -65,6 +65,7 @@
         "acorn": "^8.15.0",
         "rimraf": "^6.0.1",
         "ts-node": "^10.9.2",
-        "typescript": "5.9.2"
+        "typescript": "5.9.2",
+        "@promethean/test-utils": "workspace:*"
     }
 }

--- a/packages/boardrev/src/03-index-repo.ts
+++ b/packages/boardrev/src/03-index-repo.ts
@@ -17,9 +17,9 @@ const args = parseArgs({
 });
 
 async function main() {
-  const files = await globby(args["--globs"].split(",").map((s) => s.trim()));
-  const maxB = Number(args["--max-bytes"]),
-    maxL = Number(args["--max-lines"]);
+  const files = await globby(args["--globs"]!.split(",").map((s) => s.trim()));
+  const maxB = Number(args["--max-bytes"]!),
+    maxL = Number(args["--max-lines"]!);
   const index: RepoDoc[] = [];
   const embeddings: Embeddings = {};
 

--- a/packages/cephalon/package.json
+++ b/packages/cephalon/package.json
@@ -57,16 +57,17 @@
     "@promethean/embeddings": "file:../embeddings",
     "@promethean/utils": "workspace:*"
   },
-  "devDependencies": {
-    "@biomejs/biome": "^2.2.2",
-    "@types/node": "^22.17.2",
-    "@types/ws": "^8.5.12",
-    "ava": "^6.4.1",
-    "c8": "^9.1.0",
-    "rewrite-imports": "^3.0.0",
-    "rimraf": "^6.0.1",
-    "source-map-support": "^0.5.21",
-    "ts-node": "^10.9.2",
-    "typescript": "5.9.2"
-  }
+    "devDependencies": {
+        "@biomejs/biome": "^2.2.2",
+        "@types/node": "^22.17.2",
+        "@types/ws": "^8.5.12",
+        "ava": "^6.4.1",
+        "c8": "^9.1.0",
+        "rewrite-imports": "^3.0.0",
+        "rimraf": "^6.0.1",
+        "source-map-support": "^0.5.21",
+        "ts-node": "^10.9.2",
+        "typescript": "5.9.2",
+        "@promethean/test-utils": "workspace:*"
+    }
 }

--- a/packages/event/package.json
+++ b/packages/event/package.json
@@ -64,6 +64,7 @@
     "acorn": "^8.15.0",
     "rimraf": "^6.0.1",
     "ts-node": "^10.9.2",
-    "typescript": "5.9.2"
+    "typescript": "5.9.2",
+    "@promethean/test-utils": "workspace:*"
   }
 }

--- a/packages/file-watcher/package.json
+++ b/packages/file-watcher/package.json
@@ -33,6 +33,6 @@
     "ts-node": "^10.9.2",
     "typescript": "5.9.2",
     "@promethean/utils": "workspace:*",
-    "@promethean/test-utils": "file:../test-utils"
+    "@promethean/test-utils": "workspace:*"
   }
 }

--- a/packages/level-cache/package.json
+++ b/packages/level-cache/package.json
@@ -24,6 +24,7 @@
   },
   "devDependencies": {
     "rimraf": "^6.0.0",
-    "typescript": "5.9.2"
+    "typescript": "5.9.2",
+    "@promethean/test-utils": "workspace:*"
   }
 }

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -30,6 +30,7 @@
     "c8": "^10.1.3",
     "eslint": "^9.33.0",
     "tsx": "^4.20.3",
-    "typescript": "5.9.2"
+    "typescript": "5.9.2",
+    "@promethean/test-utils": "workspace:*"
   }
 }

--- a/packages/rate/package.json
+++ b/packages/rate/package.json
@@ -64,6 +64,7 @@
     "acorn": "^8.15.0",
     "rimraf": "^6.0.1",
     "ts-node": "^10.9.2",
-    "typescript": "5.9.2"
+    "typescript": "5.9.2",
+    "@promethean/test-utils": "workspace:*"
   }
 }

--- a/packages/smartgpt-bridge/package.json
+++ b/packages/smartgpt-bridge/package.json
@@ -50,6 +50,7 @@
     "mongodb-memory-server": "^10.2.0",
     "sinon": "^17.0.1",
     "ts-node": "^10.9.2",
-    "tsx": "^4.19.0"
+    "tsx": "^4.19.0",
+    "@promethean/test-utils": "workspace:*"
   }
 }

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -11,6 +11,10 @@
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
     },
+    "./sleep": {
+      "types": "./dist/sleep.d.ts",
+      "import": "./dist/sleep.js"
+    },
     "./dist/*": "./dist/*",
     "./*": "./dist/*"
   },

--- a/packages/test-utils/src/sleep.ts
+++ b/packages/test-utils/src/sleep.ts
@@ -1,5 +1,7 @@
 export function sleep(ms: number): Promise<void> {
     return new Promise((resolve) => {
-        setTimeout(resolve, ms);
+        const id = setTimeout(resolve, Math.max(0, ms | 0));
+        // In Node, allow the event loop to exit naturally.
+        (id as any).unref?.();
     });
 }

--- a/packages/tests/package.json
+++ b/packages/tests/package.json
@@ -71,6 +71,7 @@
     "acorn": "^8.15.0",
     "rimraf": "^6.0.1",
     "ts-node": "^10.9.2",
-    "typescript": "5.9.2"
+    "typescript": "5.9.2",
+    "@promethean/test-utils": "workspace:*"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,6 +63,9 @@ importers:
       '@biomejs/biome':
         specifier: ^2.2.2
         version: 2.2.2
+      '@promethean/test-utils':
+        specifier: workspace:*
+        version: link:packages/test-utils
       '@types/jest':
         specifier: 30.0.0
         version: 30.0.0
@@ -232,9 +235,6 @@ importers:
       '@promethean/legacy':
         specifier: workspace:*
         version: link:../legacy
-      '@promethean/utils':
-        specifier: workspace:*
-        version: link:../utils
       '@types/javascript-time-ago':
         specifier: ^2.5.0
         version: 2.5.0
@@ -308,6 +308,9 @@ importers:
       '@biomejs/biome':
         specifier: ^2.2.2
         version: 2.2.2
+      '@promethean/test-utils':
+        specifier: workspace:*
+        version: link:../test-utils
       '@types/body-parser':
         specifier: ^1.19.5
         version: 1.19.6
@@ -542,6 +545,9 @@ importers:
       '@biomejs/biome':
         specifier: ^2.2.2
         version: 2.2.2
+      '@promethean/test-utils':
+        specifier: workspace:*
+        version: link:../test-utils
       '@types/node':
         specifier: ^22.17.2
         version: 22.18.1
@@ -894,7 +900,7 @@ importers:
         version: 8.57.1
       eslint-config-neon:
         specifier: ^0.1.62
-        version: 0.1.62(eslint@8.57.1)(svelte@3.59.2)(typescript@5.9.2)
+        version: 0.1.62(eslint@8.57.1)(svelte@3.59.2)(typescript@5.7.3)
       prettier:
         specifier: ^3.4.2
         version: 3.6.2
@@ -903,10 +909,10 @@ importers:
         version: 7.1.4
       ts-node:
         specifier: ^10.9.2
-        version: 10.9.2(@types/node@22.18.1)(typescript@5.9.2)
+        version: 10.9.2(@types/node@22.18.1)(typescript@5.7.3)
       typescript:
-        specifier: 5.9.2
-        version: 5.9.2
+        specifier: 5.7.3
+        version: 5.7.3
 
   packages/codex-orchestrator:
     dependencies:
@@ -928,9 +934,6 @@ importers:
       '@promethean/event':
         specifier: workspace:*
         version: link:../event
-      '@promethean/utils':
-        specifier: workspace:*
-        version: link:../utils
       '@types/javascript-time-ago':
         specifier: ^2.5.0
         version: 2.5.0
@@ -2099,6 +2102,9 @@ importers:
       '@biomejs/biome':
         specifier: ^2.2.2
         version: 2.2.2
+      '@promethean/test-utils':
+        specifier: workspace:*
+        version: link:../test-utils
       '@types/body-parser':
         specifier: ^1.19.5
         version: 1.19.6
@@ -2255,8 +2261,8 @@ importers:
         version: 8.18.3
     devDependencies:
       '@promethean/test-utils':
-        specifier: file:../test-utils
-        version: file:packages/test-utils(socks@2.8.7)
+        specifier: workspace:*
+        version: link:../test-utils
       '@promethean/utils':
         specifier: workspace:*
         version: link:../utils
@@ -2290,9 +2296,6 @@ importers:
 
   packages/fs:
     dependencies:
-      '@promethean/fs-utils':
-        specifier: workspace:*
-        version: link:../fs-utils
       '@promethean/stream':
         specifier: workspace:*
         version: link:../stream
@@ -2323,9 +2326,6 @@ importers:
       mongodb:
         specifier: ^6.18.0
         version: 6.18.0(socks@2.8.7)
-      ollama:
-        specifier: ^0.5.17
-        version: 0.5.17
       prom-client:
         specifier: ^15.1.0
         version: 15.1.3
@@ -2871,6 +2871,9 @@ importers:
         specifier: ^9.0.0
         version: 9.0.0
     devDependencies:
+      '@promethean/test-utils':
+        specifier: workspace:*
+        version: link:../test-utils
       rimraf:
         specifier: ^6.0.0
         version: 6.0.1
@@ -3187,6 +3190,9 @@ importers:
         specifier: ^3.23.3
         version: 3.24.6(zod@3.25.76)
     devDependencies:
+      '@promethean/test-utils':
+        specifier: workspace:*
+        version: link:../test-utils
       '@types/uuid':
         specifier: ^9.0.7
         version: 9.0.8
@@ -4176,6 +4182,9 @@ importers:
       '@biomejs/biome':
         specifier: ^2.2.2
         version: 2.2.2
+      '@promethean/test-utils':
+        specifier: workspace:*
+        version: link:../test-utils
       '@types/body-parser':
         specifier: ^1.19.5
         version: 1.19.6
@@ -4229,7 +4238,7 @@ importers:
         specifier: ^4.19.2
         version: 4.20.3
       typescript:
-        specifier: 5.9.2
+        specifier: ^5.9.2
         version: 5.9.2
 
   packages/schema:
@@ -4402,9 +4411,6 @@ importers:
       '@promethean/utils':
         specifier: workspace:*
         version: link:../utils
-      '@types/node':
-        specifier: ^24.3.0
-        version: 24.3.1
       ajv-formats:
         specifier: ^3.0.1
         version: 3.0.1(ajv@8.17.1)
@@ -4448,7 +4454,7 @@ importers:
         specifier: ^1.0.0
         version: 1.0.0
       typescript:
-        specifier: 5.9.2
+        specifier: ^5.9.2
         version: 5.9.2
       uuid:
         specifier: ^9.0.1
@@ -4457,6 +4463,9 @@ importers:
       '@biomejs/biome':
         specifier: ^2.2.2
         version: 2.2.2
+      '@promethean/test-utils':
+        specifier: workspace:*
+        version: link:../test-utils
       '@types/node':
         specifier: ^24.3.0
         version: 24.3.1
@@ -4953,6 +4962,9 @@ importers:
       '@biomejs/biome':
         specifier: ^2.2.2
         version: 2.2.2
+      '@promethean/test-utils':
+        specifier: workspace:*
+        version: link:../test-utils
       '@types/body-parser':
         specifier: ^1.19.5
         version: 1.19.6
@@ -12164,6 +12176,16 @@ packages:
       eslint: ^8.57.0 || ^9.0.0
       typescript: '>=4.8.4 <6.0.0'
 
+  typescript@5.5.4:
+    resolution: {integrity: sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  typescript@5.7.3:
+    resolution: {integrity: sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
   typescript@5.9.2:
     resolution: {integrity: sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==}
     engines: {node: '>=14.17'}
@@ -12555,6 +12577,19 @@ snapshots:
 
   '@angular-eslint/bundled-angular-compiler@17.5.3': {}
 
+  '@angular-eslint/eslint-plugin-template@17.5.3(eslint@8.57.1)(typescript@5.7.3)':
+    dependencies:
+      '@angular-eslint/bundled-angular-compiler': 17.5.3
+      '@angular-eslint/utils': 17.5.3(eslint@8.57.1)(typescript@5.7.3)
+      '@typescript-eslint/type-utils': 7.11.0(eslint@8.57.1)(typescript@5.7.3)
+      '@typescript-eslint/utils': 7.11.0(eslint@8.57.1)(typescript@5.7.3)
+      aria-query: 5.3.0
+      axobject-query: 4.0.0
+      eslint: 8.57.1
+      typescript: 5.7.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@angular-eslint/eslint-plugin-template@17.5.3(eslint@8.57.1)(typescript@5.9.2)':
     dependencies:
       '@angular-eslint/bundled-angular-compiler': 17.5.3
@@ -12568,6 +12603,16 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@angular-eslint/eslint-plugin@17.5.3(eslint@8.57.1)(typescript@5.7.3)':
+    dependencies:
+      '@angular-eslint/bundled-angular-compiler': 17.5.3
+      '@angular-eslint/utils': 17.5.3(eslint@8.57.1)(typescript@5.7.3)
+      '@typescript-eslint/utils': 7.11.0(eslint@8.57.1)(typescript@5.7.3)
+      eslint: 8.57.1
+      typescript: 5.7.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@angular-eslint/eslint-plugin@17.5.3(eslint@8.57.1)(typescript@5.9.2)':
     dependencies:
       '@angular-eslint/bundled-angular-compiler': 17.5.3
@@ -12578,12 +12623,28 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@angular-eslint/template-parser@17.5.3(eslint@8.57.1)(typescript@5.7.3)':
+    dependencies:
+      '@angular-eslint/bundled-angular-compiler': 17.5.3
+      eslint: 8.57.1
+      eslint-scope: 8.4.0
+      typescript: 5.7.3
+
   '@angular-eslint/template-parser@17.5.3(eslint@8.57.1)(typescript@5.9.2)':
     dependencies:
       '@angular-eslint/bundled-angular-compiler': 17.5.3
       eslint: 8.57.1
       eslint-scope: 8.4.0
       typescript: 5.9.2
+
+  '@angular-eslint/utils@17.5.3(eslint@8.57.1)(typescript@5.7.3)':
+    dependencies:
+      '@angular-eslint/bundled-angular-compiler': 17.5.3
+      '@typescript-eslint/utils': 7.11.0(eslint@8.57.1)(typescript@5.7.3)
+      eslint: 8.57.1
+      typescript: 5.7.3
+    transitivePeerDependencies:
+      - supports-color
 
   '@angular-eslint/utils@17.5.3(eslint@8.57.1)(typescript@5.9.2)':
     dependencies:
@@ -13837,7 +13898,6 @@ snapshots:
 
   '@promethean/fs@file:packages/fs(socks@2.8.7)':
     dependencies:
-      '@promethean/fs-utils': link:packages/fs-utils
       '@promethean/stream': link:packages/stream
       '@types/javascript-time-ago': 2.5.0
       '@types/unist': 3.0.3
@@ -13848,7 +13908,6 @@ snapshots:
       gray-matter: 4.0.3
       javascript-time-ago: 2.5.11
       mongodb: 6.18.0(socks@2.8.7)
-      ollama: 0.5.17
       prom-client: 15.1.3
       remark-gfm: 4.0.1
       remark-parse: 11.0.0
@@ -14341,6 +14400,24 @@ snapshots:
       '@types/node': 24.3.1
     optional: true
 
+  '@typescript-eslint/eslint-plugin@7.18.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.7.3))(eslint@8.57.1)(typescript@5.7.3)':
+    dependencies:
+      '@eslint-community/regexpp': 4.12.1
+      '@typescript-eslint/parser': 7.18.0(eslint@8.57.1)(typescript@5.7.3)
+      '@typescript-eslint/scope-manager': 7.18.0
+      '@typescript-eslint/type-utils': 7.18.0(eslint@8.57.1)(typescript@5.7.3)
+      '@typescript-eslint/utils': 7.18.0(eslint@8.57.1)(typescript@5.7.3)
+      '@typescript-eslint/visitor-keys': 7.18.0
+      eslint: 8.57.1
+      graphemer: 1.4.0
+      ignore: 5.3.2
+      natural-compare: 1.4.0
+      ts-api-utils: 1.4.3(typescript@5.7.3)
+    optionalDependencies:
+      typescript: 5.7.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/eslint-plugin@7.18.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.2))(eslint@8.57.1)(typescript@5.9.2)':
     dependencies:
       '@eslint-community/regexpp': 4.12.1
@@ -14376,6 +14453,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/experimental-utils@5.62.0(eslint@8.57.1)(typescript@5.7.3)':
+    dependencies:
+      '@typescript-eslint/utils': 5.62.0(eslint@8.57.1)(typescript@5.7.3)
+      eslint: 8.57.1
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+
   '@typescript-eslint/experimental-utils@5.62.0(eslint@8.57.1)(typescript@5.9.2)':
     dependencies:
       '@typescript-eslint/utils': 5.62.0(eslint@8.57.1)(typescript@5.9.2)
@@ -14383,6 +14468,19 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
       - typescript
+
+  '@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.7.3)':
+    dependencies:
+      '@typescript-eslint/scope-manager': 7.18.0
+      '@typescript-eslint/types': 7.18.0
+      '@typescript-eslint/typescript-estree': 7.18.0(typescript@5.7.3)
+      '@typescript-eslint/visitor-keys': 7.18.0
+      debug: 4.4.1
+      eslint: 8.57.1
+    optionalDependencies:
+      typescript: 5.7.3
+    transitivePeerDependencies:
+      - supports-color
 
   '@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.2)':
     dependencies:
@@ -14442,6 +14540,18 @@ snapshots:
     dependencies:
       typescript: 5.9.2
 
+  '@typescript-eslint/type-utils@7.11.0(eslint@8.57.1)(typescript@5.7.3)':
+    dependencies:
+      '@typescript-eslint/typescript-estree': 7.11.0(typescript@5.7.3)
+      '@typescript-eslint/utils': 7.11.0(eslint@8.57.1)(typescript@5.7.3)
+      debug: 4.4.1
+      eslint: 8.57.1
+      ts-api-utils: 1.4.3(typescript@5.7.3)
+    optionalDependencies:
+      typescript: 5.7.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/type-utils@7.11.0(eslint@8.57.1)(typescript@5.9.2)':
     dependencies:
       '@typescript-eslint/typescript-estree': 7.11.0(typescript@5.9.2)
@@ -14451,6 +14561,18 @@ snapshots:
       ts-api-utils: 1.4.3(typescript@5.9.2)
     optionalDependencies:
       typescript: 5.9.2
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/type-utils@7.18.0(eslint@8.57.1)(typescript@5.7.3)':
+    dependencies:
+      '@typescript-eslint/typescript-estree': 7.18.0(typescript@5.7.3)
+      '@typescript-eslint/utils': 7.18.0(eslint@8.57.1)(typescript@5.7.3)
+      debug: 4.4.1
+      eslint: 8.57.1
+      ts-api-utils: 1.4.3(typescript@5.7.3)
+    optionalDependencies:
+      typescript: 5.7.3
     transitivePeerDependencies:
       - supports-color
 
@@ -14486,6 +14608,20 @@ snapshots:
 
   '@typescript-eslint/types@8.42.0': {}
 
+  '@typescript-eslint/typescript-estree@5.62.0(typescript@5.7.3)':
+    dependencies:
+      '@typescript-eslint/types': 5.62.0
+      '@typescript-eslint/visitor-keys': 5.62.0
+      debug: 4.4.1
+      globby: 11.1.0
+      is-glob: 4.0.3
+      semver: 7.7.2
+      tsutils: 3.21.0(typescript@5.7.3)
+    optionalDependencies:
+      typescript: 5.7.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/typescript-estree@5.62.0(typescript@5.9.2)':
     dependencies:
       '@typescript-eslint/types': 5.62.0
@@ -14497,6 +14633,21 @@ snapshots:
       tsutils: 3.21.0(typescript@5.9.2)
     optionalDependencies:
       typescript: 5.9.2
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/typescript-estree@7.11.0(typescript@5.7.3)':
+    dependencies:
+      '@typescript-eslint/types': 7.11.0
+      '@typescript-eslint/visitor-keys': 7.11.0
+      debug: 4.4.1
+      globby: 11.1.0
+      is-glob: 4.0.3
+      minimatch: 9.0.5
+      semver: 7.7.2
+      ts-api-utils: 1.4.3(typescript@5.7.3)
+    optionalDependencies:
+      typescript: 5.7.3
     transitivePeerDependencies:
       - supports-color
 
@@ -14512,6 +14663,21 @@ snapshots:
       ts-api-utils: 1.4.3(typescript@5.9.2)
     optionalDependencies:
       typescript: 5.9.2
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/typescript-estree@7.18.0(typescript@5.7.3)':
+    dependencies:
+      '@typescript-eslint/types': 7.18.0
+      '@typescript-eslint/visitor-keys': 7.18.0
+      debug: 4.4.1
+      globby: 11.1.0
+      is-glob: 4.0.3
+      minimatch: 9.0.5
+      semver: 7.7.2
+      ts-api-utils: 1.4.3(typescript@5.7.3)
+    optionalDependencies:
+      typescript: 5.7.3
     transitivePeerDependencies:
       - supports-color
 
@@ -14546,6 +14712,21 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/utils@5.62.0(eslint@8.57.1)(typescript@5.7.3)':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.8.0(eslint@8.57.1)
+      '@types/json-schema': 7.0.15
+      '@types/semver': 7.7.1
+      '@typescript-eslint/scope-manager': 5.62.0
+      '@typescript-eslint/types': 5.62.0
+      '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.7.3)
+      eslint: 8.57.1
+      eslint-scope: 5.1.1
+      semver: 7.7.2
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+
   '@typescript-eslint/utils@5.62.0(eslint@8.57.1)(typescript@5.9.2)':
     dependencies:
       '@eslint-community/eslint-utils': 4.8.0(eslint@8.57.1)
@@ -14561,12 +14742,34 @@ snapshots:
       - supports-color
       - typescript
 
+  '@typescript-eslint/utils@7.11.0(eslint@8.57.1)(typescript@5.7.3)':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.8.0(eslint@8.57.1)
+      '@typescript-eslint/scope-manager': 7.11.0
+      '@typescript-eslint/types': 7.11.0
+      '@typescript-eslint/typescript-estree': 7.11.0(typescript@5.7.3)
+      eslint: 8.57.1
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+
   '@typescript-eslint/utils@7.11.0(eslint@8.57.1)(typescript@5.9.2)':
     dependencies:
       '@eslint-community/eslint-utils': 4.8.0(eslint@8.57.1)
       '@typescript-eslint/scope-manager': 7.11.0
       '@typescript-eslint/types': 7.11.0
       '@typescript-eslint/typescript-estree': 7.11.0(typescript@5.9.2)
+      eslint: 8.57.1
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+
+  '@typescript-eslint/utils@7.18.0(eslint@8.57.1)(typescript@5.7.3)':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.8.0(eslint@8.57.1)
+      '@typescript-eslint/scope-manager': 7.18.0
+      '@typescript-eslint/types': 7.18.0
+      '@typescript-eslint/typescript-estree': 7.18.0(typescript@5.7.3)
       eslint: 8.57.1
     transitivePeerDependencies:
       - supports-color
@@ -15122,7 +15325,7 @@ snapshots:
 
   axios@1.11.0:
     dependencies:
-      follow-redirects: 1.15.11(debug@4.4.1)
+      follow-redirects: 1.15.11(debug@4.3.7)
       form-data: 4.0.4
       proxy-from-env: 1.1.0
     transitivePeerDependencies:
@@ -16206,6 +16409,50 @@ snapshots:
       eslint: 8.57.1
       semver: 7.7.2
 
+  eslint-config-neon@0.1.62(eslint@8.57.1)(svelte@3.59.2)(typescript@5.7.3):
+    dependencies:
+      '@angular-eslint/eslint-plugin': 17.5.3(eslint@8.57.1)(typescript@5.7.3)
+      '@angular-eslint/eslint-plugin-template': 17.5.3(eslint@8.57.1)(typescript@5.7.3)
+      '@angular-eslint/template-parser': 17.5.3(eslint@8.57.1)(typescript@5.7.3)
+      '@next/eslint-plugin-next': 14.2.32
+      '@rushstack/eslint-patch': 1.12.0
+      '@typescript-eslint/eslint-plugin': 7.18.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.7.3))(eslint@8.57.1)(typescript@5.7.3)
+      '@typescript-eslint/parser': 7.18.0(eslint@8.57.1)(typescript@5.7.3)
+      astro-eslint-parser: 0.16.3
+      eslint-config-prettier: 9.1.2(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-i@2.29.1)(eslint@8.57.1)
+      eslint-mdx: 3.6.2(eslint@8.57.1)
+      eslint-plugin-astro: 0.33.1(eslint@8.57.1)
+      eslint-plugin-cypress: 2.15.2(eslint@8.57.1)
+      eslint-plugin-import: eslint-plugin-i@2.29.1(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
+      eslint-plugin-jsdoc: 48.11.0(eslint@8.57.1)
+      eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.1)
+      eslint-plugin-mdx: 3.6.2(eslint@8.57.1)
+      eslint-plugin-n: 16.6.2(eslint@8.57.1)
+      eslint-plugin-promise: 6.6.0(eslint@8.57.1)
+      eslint-plugin-react: 7.37.5(eslint@8.57.1)
+      eslint-plugin-react-hooks: 4.6.2(eslint@8.57.1)
+      eslint-plugin-rxjs: 5.0.3(eslint@8.57.1)(typescript@5.7.3)
+      eslint-plugin-rxjs-angular: 2.0.1(eslint@8.57.1)(typescript@5.7.3)
+      eslint-plugin-sonarjs: 0.25.1(eslint@8.57.1)
+      eslint-plugin-svelte3: 4.0.0(eslint@8.57.1)(svelte@3.59.2)
+      eslint-plugin-tsdoc: 0.2.17
+      eslint-plugin-typescript-sort-keys: 3.3.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.7.3))(eslint@8.57.1)(typescript@5.7.3)
+      eslint-plugin-unicorn: 52.0.0(eslint@8.57.1)
+      eslint-plugin-vue: 9.33.0(eslint@8.57.1)
+      globals: 15.15.0
+      typescript-eslint: 7.18.0(eslint@8.57.1)(typescript@5.7.3)
+      vue-eslint-parser: 9.4.3(eslint@8.57.1)
+    transitivePeerDependencies:
+      - bluebird
+      - eslint
+      - eslint-import-resolver-webpack
+      - eslint-plugin-import-x
+      - remark-lint-file-extension
+      - supports-color
+      - svelte
+      - typescript
+
   eslint-config-neon@0.1.62(eslint@8.57.1)(svelte@3.59.2)(typescript@5.9.2):
     dependencies:
       '@angular-eslint/eslint-plugin': 17.5.3(eslint@8.57.1)(typescript@5.9.2)
@@ -16254,6 +16501,16 @@ snapshots:
     dependencies:
       eslint: 8.57.1
 
+  eslint-etc@5.2.1(eslint@8.57.1)(typescript@5.7.3):
+    dependencies:
+      '@typescript-eslint/experimental-utils': 5.62.0(eslint@8.57.1)(typescript@5.7.3)
+      eslint: 8.57.1
+      tsutils: 3.21.0(typescript@5.7.3)
+      tsutils-etc: 1.4.2(tsutils@3.21.0(typescript@5.7.3))(typescript@5.7.3)
+      typescript: 5.7.3
+    transitivePeerDependencies:
+      - supports-color
+
   eslint-etc@5.2.1(eslint@8.57.1)(typescript@5.9.2):
     dependencies:
       '@typescript-eslint/experimental-utils': 5.62.0(eslint@8.57.1)(typescript@5.9.2)
@@ -16283,7 +16540,7 @@ snapshots:
       tinyglobby: 0.2.14
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: eslint-plugin-i@2.29.1(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
+      eslint-plugin-import: eslint-plugin-i@2.29.1(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -16305,6 +16562,17 @@ snapshots:
       vfile: 6.0.3
     transitivePeerDependencies:
       - bluebird
+      - supports-color
+
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-i@2.29.1)(eslint@8.57.1))(eslint@8.57.1):
+    dependencies:
+      debug: 3.2.7
+    optionalDependencies:
+      '@typescript-eslint/parser': 7.18.0(eslint@8.57.1)(typescript@5.7.3)
+      eslint: 8.57.1
+      eslint-import-resolver-node: 0.3.9
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-i@2.29.1)(eslint@8.57.1)
+    transitivePeerDependencies:
       - supports-color
 
   eslint-module-utils@2.12.1(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-i@2.29.1)(eslint@8.57.1))(eslint@8.57.1):
@@ -16366,6 +16634,23 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.2
     transitivePeerDependencies:
+      - supports-color
+
+  eslint-plugin-i@2.29.1(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
+    dependencies:
+      debug: 4.4.1
+      doctrine: 3.0.0
+      eslint: 8.57.1
+      eslint-import-resolver-node: 0.3.9
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-i@2.29.1)(eslint@8.57.1))(eslint@8.57.1)
+      get-tsconfig: 4.10.1
+      is-glob: 4.0.3
+      minimatch: 3.1.2
+      semver: 7.7.2
+    transitivePeerDependencies:
+      - '@typescript-eslint/parser'
+      - eslint-import-resolver-typescript
+      - eslint-import-resolver-webpack
       - supports-color
 
   eslint-plugin-i@2.29.1(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
@@ -16518,6 +16803,18 @@ snapshots:
       string.prototype.matchall: 4.0.12
       string.prototype.repeat: 1.0.0
 
+  eslint-plugin-rxjs-angular@2.0.1(eslint@8.57.1)(typescript@5.7.3):
+    dependencies:
+      '@typescript-eslint/experimental-utils': 5.62.0(eslint@8.57.1)(typescript@5.7.3)
+      common-tags: 1.8.2
+      eslint: 8.57.1
+      eslint-etc: 5.2.1(eslint@8.57.1)(typescript@5.7.3)
+      requireindex: 1.2.0
+      tslib: 2.8.1
+      typescript: 5.7.3
+    transitivePeerDependencies:
+      - supports-color
+
   eslint-plugin-rxjs-angular@2.0.1(eslint@8.57.1)(typescript@5.9.2):
     dependencies:
       '@typescript-eslint/experimental-utils': 5.62.0(eslint@8.57.1)(typescript@5.9.2)
@@ -16527,6 +16824,22 @@ snapshots:
       requireindex: 1.2.0
       tslib: 2.8.1
       typescript: 5.9.2
+    transitivePeerDependencies:
+      - supports-color
+
+  eslint-plugin-rxjs@5.0.3(eslint@8.57.1)(typescript@5.7.3):
+    dependencies:
+      '@typescript-eslint/experimental-utils': 5.62.0(eslint@8.57.1)(typescript@5.7.3)
+      common-tags: 1.8.2
+      decamelize: 5.0.1
+      eslint: 8.57.1
+      eslint-etc: 5.2.1(eslint@8.57.1)(typescript@5.7.3)
+      requireindex: 1.2.0
+      rxjs-report-usage: 1.0.6
+      tslib: 2.8.1
+      tsutils: 3.21.0(typescript@5.7.3)
+      tsutils-etc: 1.4.2(tsutils@3.21.0(typescript@5.7.3))(typescript@5.7.3)
+      typescript: 5.7.3
     transitivePeerDependencies:
       - supports-color
 
@@ -16559,6 +16872,17 @@ snapshots:
     dependencies:
       '@microsoft/tsdoc': 0.14.2
       '@microsoft/tsdoc-config': 0.16.2
+
+  eslint-plugin-typescript-sort-keys@3.3.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.7.3))(eslint@8.57.1)(typescript@5.7.3):
+    dependencies:
+      '@typescript-eslint/experimental-utils': 5.62.0(eslint@8.57.1)(typescript@5.7.3)
+      '@typescript-eslint/parser': 7.18.0(eslint@8.57.1)(typescript@5.7.3)
+      eslint: 8.57.1
+      json-schema: 0.4.0
+      natural-compare-lite: 1.4.0
+      typescript: 5.7.3
+    transitivePeerDependencies:
+      - supports-color
 
   eslint-plugin-typescript-sort-keys@3.3.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.2))(eslint@8.57.1)(typescript@5.9.2):
     dependencies:
@@ -17388,7 +17712,7 @@ snapshots:
   http-proxy@1.18.1:
     dependencies:
       eventemitter3: 4.0.7
-      follow-redirects: 1.15.11(debug@4.4.1)
+      follow-redirects: 1.15.11(debug@4.3.7)
       requires-port: 1.0.0
     transitivePeerDependencies:
       - debug
@@ -20526,6 +20850,10 @@ snapshots:
 
   trough@2.2.0: {}
 
+  ts-api-utils@1.4.3(typescript@5.7.3):
+    dependencies:
+      typescript: 5.7.3
+
   ts-api-utils@1.4.3(typescript@5.9.2):
     dependencies:
       typescript: 5.9.2
@@ -20586,6 +20914,24 @@ snapshots:
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
 
+  ts-node@10.9.2(@types/node@22.18.1)(typescript@5.7.3):
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      '@tsconfig/node10': 1.0.11
+      '@tsconfig/node12': 1.0.11
+      '@tsconfig/node14': 1.0.3
+      '@tsconfig/node16': 1.0.4
+      '@types/node': 22.18.1
+      acorn: 8.15.0
+      acorn-walk: 8.3.4
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.2
+      make-error: 1.3.6
+      typescript: 5.7.3
+      v8-compile-cache-lib: 3.0.1
+      yn: 3.1.1
+
   ts-node@10.9.2(@types/node@22.18.1)(typescript@5.9.2):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
@@ -20635,12 +20981,24 @@ snapshots:
 
   tslib@2.8.1: {}
 
+  tsutils-etc@1.4.2(tsutils@3.21.0(typescript@5.7.3))(typescript@5.7.3):
+    dependencies:
+      '@types/yargs': 17.0.33
+      tsutils: 3.21.0(typescript@5.7.3)
+      typescript: 5.7.3
+      yargs: 17.7.2
+
   tsutils-etc@1.4.2(tsutils@3.21.0(typescript@5.9.2))(typescript@5.9.2):
     dependencies:
       '@types/yargs': 17.0.33
       tsutils: 3.21.0(typescript@5.9.2)
       typescript: 5.9.2
       yargs: 17.7.2
+
+  tsutils@3.21.0(typescript@5.7.3):
+    dependencies:
+      tslib: 1.14.1
+      typescript: 5.7.3
 
   tsutils@3.21.0(typescript@5.9.2):
     dependencies:
@@ -20745,6 +21103,17 @@ snapshots:
 
   typedarray@0.0.6: {}
 
+  typescript-eslint@7.18.0(eslint@8.57.1)(typescript@5.7.3):
+    dependencies:
+      '@typescript-eslint/eslint-plugin': 7.18.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.7.3))(eslint@8.57.1)(typescript@5.7.3)
+      '@typescript-eslint/parser': 7.18.0(eslint@8.57.1)(typescript@5.7.3)
+      '@typescript-eslint/utils': 7.18.0(eslint@8.57.1)(typescript@5.7.3)
+      eslint: 8.57.1
+    optionalDependencies:
+      typescript: 5.7.3
+    transitivePeerDependencies:
+      - supports-color
+
   typescript-eslint@7.18.0(eslint@8.57.1)(typescript@5.9.2):
     dependencies:
       '@typescript-eslint/eslint-plugin': 7.18.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.2))(eslint@8.57.1)(typescript@5.9.2)
@@ -20766,6 +21135,10 @@ snapshots:
       typescript: 5.9.2
     transitivePeerDependencies:
       - supports-color
+
+  typescript@5.5.4: {}
+
+  typescript@5.7.3: {}
 
   typescript@5.9.2: {}
 

--- a/tests/brokerClient.integration.test.js
+++ b/tests/brokerClient.integration.test.js
@@ -1,12 +1,14 @@
 // integration: exercises real ws server
 import test from "ava";
 import { WebSocketServer } from "ws";
+import { once } from "events";
 
 import { sleep } from "@promethean/test-utils/sleep";
 import { BrokerClient } from "@shared/js/brokerClient.js";
 
 test.serial("BrokerClient sends messages and handles callbacks", async (t) => {
   const wss = new WebSocketServer({ port: 0 });
+  await once(wss, "listening");
   const port = wss.address().port;
   const received = [];
   let task;
@@ -68,6 +70,7 @@ test.serial("BrokerClient sends messages and handles callbacks", async (t) => {
 
 test.serial("BrokerClient reconnects and flushes queue", async (t) => {
   const wss = new WebSocketServer({ port: 0 });
+  await once(wss, "listening");
   const port = wss.address().port;
   const received = [];
   let connectionCount = 0;


### PR DESCRIPTION
## Summary
- export `sleep` subpath from test-utils and map TypeScript path
- depend on `@promethean/test-utils` in packages using the new helper
- await WebSocket server readiness before reading ports in broker client tests

## Testing
- `pnpm --filter @promethean/test-utils build`
- `pnpm --filter @promethean/agent-ecs build` *(fails: Cannot find module '@promethean/utils/sleep.js')*
- `pnpm --filter @promethean/event build` *(fails: type errors in event package)*
- `pnpm exec ava tests/brokerClient.integration.test.js` *(fails: Cannot find package '@shared/js')*


------
https://chatgpt.com/codex/tasks/task_e_68ba7c4697a483249d4a0ebbd5628185