### PR TITLE
refactor: remove shared prom-lib references

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "script:lint-tasks": "tsx --tsconfig tsconfig.scripts.json scripts/lint_tasks.ts",
     "postinstall": "pnpm --filter @promethean/piper^... run build && pnpm --filter @promethean/piper run build",
     "generateBuildErrorReport": "pnpm -r --no-bail build | grep 'error' -i >|build-errors.txt",
-    "codemod:aliases": "pnpm -w --filter @promethean/alias-rewrite... build && alias-rewrite --from @shared/prom-lib --to @promethean-",
     "check:flat": "node scripts/check-flat.js",
     "enforce:esm-ext": "eslint \"packages/**/src/**/*.{ts,tsx}\" --rule 'import/extensions: [2, \"always\", { ignorePackages: true }]'"
   },

--- a/packages/alias-rewrite/src/cli.ts
+++ b/packages/alias-rewrite/src/cli.ts
@@ -8,8 +8,8 @@ type Args = { fromPrefix: string; toPrefix: string; globs: string[] };
 const parseArgs = (argv: string[]): Args => {
   const fromIdx = argv.indexOf("--from");
   const toIdx = argv.indexOf("--to");
-  const fromPrefix = fromIdx >= 0 ? argv[fromIdx + 1] : "@shared/prom-lib";
-  const toPrefix = toIdx >= 0 ? argv[toIdx + 1] : "@promethean-";
+  const fromPrefix = fromIdx >= 0 ? argv[fromIdx + 1] : "@old";
+  const toPrefix = toIdx >= 0 ? argv[toIdx + 1] : "@new-";
   const globs = argv.filter((x) => !x.startsWith("--"));
   return { fromPrefix, toPrefix, globs };
 };

--- a/packages/alias-rewrite/src/lib.ts
+++ b/packages/alias-rewrite/src/lib.ts
@@ -4,7 +4,7 @@ import { dirname, join } from "node:path";
 type Rewrite = (from: string) => string | null;
 
 export const mkAliasRewriter =
-  (fromPrefix = "@shared/prom-lib", toPrefix = "@promethean-"): Rewrite =>
+  (fromPrefix = "@old", toPrefix = "@new-"): Rewrite =>
   (spec) => {
     if (!spec.startsWith(fromPrefix)) return null;
     const rest = spec.slice(fromPrefix.length).replace(/^\/+/, "");

--- a/packages/alias-rewrite/src/tests/lib.test.ts
+++ b/packages/alias-rewrite/src/tests/lib.test.ts
@@ -6,9 +6,9 @@ import { join } from "node:path";
 import { mkdirSync } from "node:fs";
 
 test("alias rewrite", (t) => {
-  const r = mkAliasRewriter("@shared/prom-lib", "@promethean-");
-  t.is(r("@shared/prom-lib/logger"), "@promethean-logger");
-  t.is(r("@shared/prom-lib/utils/path/to/x"), "@promethean-utils/path/to/x");
+  const r = mkAliasRewriter("@old", "@new-");
+  t.is(r("@old/logger"), "@new-logger");
+  t.is(r("@old/utils/path/to/x"), "@new-utils/path/to/x");
   t.is(r("lodash"), null);
 });
 

--- a/packages/cephalon-discord/src/index.ts
+++ b/packages/cephalon-discord/src/index.ts
@@ -1,4 +1,3 @@
-// import { PostMessage } from '@shared/prom-lib';
 
 export function createPostMessage(
   provider: string,

--- a/packages/discord-attachment-indexer/src/index.ts
+++ b/packages/discord-attachment-indexer/src/index.ts
@@ -1,4 +1,5 @@
-import { fileBackedRegistry, mongoForTenant, topic } from "@shared/prom-lib";
+import { fileBackedRegistry, topic } from "@promethean/platform";
+import { mongoForTenant } from "@promethean/effects/mongo.js";
 
 export async function handleSocialMessageCreated(evt: any) {
   if (!evt.attachments?.length) return [];

--- a/packages/discord-gateway/src/gateway.ts
+++ b/packages/discord-gateway/src/gateway.ts
@@ -1,8 +1,6 @@
-import {
-  InMemoryEventBus,
-  topic,
-  normalizeDiscordMessage,
-} from "@shared/prom-lib";
+import { InMemoryEventBus } from "@promethean/event/memory.js";
+import { topic } from "@promethean/platform";
+import { normalizeDiscordMessage } from "@promethean/providers/discord/normalize.js";
 
 export class GatewayPublisher {
   constructor(private bus: InMemoryEventBus) {}

--- a/packages/discord-gateway/src/index.ts
+++ b/packages/discord-gateway/src/index.ts
@@ -1,7 +1,4 @@
-import {
-  fileBackedRegistry,
-  topic, // , SocialMessageCreated, toUrn
-} from "@shared/prom-lib";
+import { fileBackedRegistry, topic } from "@promethean/platform"; // , SocialMessageCreated, toUrn
 
 // Stub Gateway: would connect to Discord WS, normalize MESSAGE_CREATE to SocialMessageCreated
 async function main() {

--- a/packages/discord-gateway/tests/flow.test.js
+++ b/packages/discord-gateway/tests/flow.test.js
@@ -1,5 +1,5 @@
 import test from "ava";
-import { InMemoryEventBus } from "@shared/prom-lib";
+import { InMemoryEventBus } from "@promethean/event/memory.js";
 import { GatewayPublisher } from "../src/gateway.js";
 import { handleSocialMessageCreated as indexMessage } from "../../discord-message-indexer/src/index.js";
 import { handleSocialMessageCreated as indexAttachments } from "../../discord-attachment-indexer/src/index.js";

--- a/packages/discord-gateway/tests/gateway.test.js
+++ b/packages/discord-gateway/tests/gateway.test.js
@@ -1,5 +1,5 @@
 import test from "ava";
-import { InMemoryEventBus } from "@shared/prom-lib";
+import { InMemoryEventBus } from "@promethean/event/memory.js";
 import { GatewayPublisher } from "../src/gateway.js";
 
 test("publishes raw and normalized events to bus", async (t) => {

--- a/packages/discord-message-embedder/src/index.ts
+++ b/packages/discord-message-embedder/src/index.ts
@@ -1,6 +1,6 @@
-import { fileBackedRegistry } from "@shared/prom-lib";
-import { makeChromaWrapper } from "@shared/prom-lib";
-import { makeDeterministicEmbedder } from "@shared/prom-lib";
+import { fileBackedRegistry } from "@promethean/platform";
+import { makeChromaWrapper } from "@promethean/migrations/chroma.js";
+import { makeDeterministicEmbedder } from "@promethean/migrations/embedder.js";
 
 export async function embedMessage(evt: any) {
   if (!evt.text || !evt.text.trim()) return null;

--- a/packages/discord-message-indexer/src/index.ts
+++ b/packages/discord-message-indexer/src/index.ts
@@ -1,4 +1,5 @@
-import { topic, fileBackedRegistry, mongoForTenant } from "@shared/prom-lib";
+import { topic, fileBackedRegistry } from "@promethean/platform";
+import { mongoForTenant } from "@promethean/effects/mongo.js";
 
 export async function handleSocialMessageCreated(evt: any) {
   const reg = fileBackedRegistry();

--- a/packages/migrations/src/backfill.js
+++ b/packages/migrations/src/backfill.js
@@ -1,9 +1,9 @@
 #!/usr/bin/env node
 import { MongoClient } from 'mongodb';
-import { makeDeterministicEmbedder } from '@shared/prom-lib';
-import { makeChromaWrapper } from '@shared/prom-lib';
-import { makeCheckpointStore } from '@shared/prom-lib';
-import { checksumFor } from '@shared/prom-lib';
+import { makeDeterministicEmbedder } from './embedder.js';
+import { makeChromaWrapper } from './chroma.js';
+import { makeCheckpointStore } from './checkpoints.js';
+import { checksumFor } from './integrity.js';
 import fs from 'node:fs';
 import path from 'node:path';
 


### PR DESCRIPTION
## Summary
- replace `@shared/prom-lib` imports with `@promethean/*` modules
- drop codemod script and update alias-rewrite defaults
- clean cephalon-discord stub comment

## Testing
- `pnpm --filter @promethean/alias-rewrite test` *(fails: Couldn’t find any files to test)*
- `pnpm --filter @promethean/discord-message-indexer lint` *(fails: Command "@biomejs/biome" not found)*
- `pnpm --filter @promethean/discord-message-indexer test` *(fails: Couldn’t find any files to test)*
- `pnpm --filter @promethean/discord-attachment-indexer lint` *(fails: Command "@biomejs/biome" not found)*
- `pnpm --filter @promethean/discord-attachment-indexer test` *(fails: Couldn’t find any files to test)*
- `pnpm --filter @promethean/discord-message-embedder lint` *(fails: Command "@biomejs/biome" not found)*
- `pnpm --filter @promethean/discord-message-embedder test` *(fails: Couldn’t find any files to test)*
- `pnpm --filter @promethean/cephalon-discord lint` *(fails: Command "@biomejs/biome" not found)*
- `pnpm --filter @promethean/cephalon-discord test`
- `pnpm --filter @promethean/discord-gateway lint` *(fails: Command "@biomejs/biome" not found)*
- `pnpm --filter @promethean/discord-gateway test` *(fails: Cannot find module '@promethean/event/dist/memory.js')*
- `pnpm --filter @promethean/migrations lint`
- `pnpm --filter @promethean/migrations test` *(fails: Type '{ id: string; phase: Phase; batch: number; updatedAt: string; lastId: string | undefined; resumeToken: unknown; }' is not assignable to type 'Checkpoint')*


------
https://chatgpt.com/codex/tasks/task_e_68bb49e16aa0832499a0a9b52f2c24a7