### PR TITLE
refactor: migrate ensureDir to fs

### DIFF
--- a/packages/fs/src/streamTree.ts
+++ b/packages/fs/src/streamTree.ts
@@ -107,7 +107,7 @@ export async function* streamTree(root: string, opts: StreamOptions = {}): Async
                 path: p,
                 relative: path.relative(base, p),
                 type,
-                ...(type !== 'dir' ? { size: s.size } : {}),
+                ...(type === 'file' ? { size: s.size } : {}),
                 mtimeMs: s.mtimeMs,
                 ...(type === 'file' ? { ext: path.extname(name) } : {}),
                 depth,

--- a/packages/fs/src/streamTreeConcurrent.ts
+++ b/packages/fs/src/streamTreeConcurrent.ts
@@ -138,7 +138,7 @@ export async function* streamTreeConcurrent(root: string, opts: StreamOptions = 
             path: dirPath,
             relative: path.relative(base, dirPath),
             type,
-            ...(type !== 'dir' ? { size: s.size } : {}),
+            ...(type === 'file' ? { size: s.size } : {}),
             mtimeMs: s.mtimeMs,
             ...(type === 'file' ? { ext: path.extname(name) } : {}),
             depth,

--- a/packages/fs/src/streamTreeGeneratorsConcurrent.ts
+++ b/packages/fs/src/streamTreeGeneratorsConcurrent.ts
@@ -176,7 +176,7 @@ export async function* streamTreeConcurrent(root: string, opts: StreamOptions = 
                     path: absPath,
                     relative: path.relative(base, absPath),
                     type: nodeType,
-                    ...(nodeType !== 'dir' ? { size: s.size } : {}),
+                    ...(nodeType === 'file' ? { size: s.size } : {}),
                     mtimeMs: s.mtimeMs,
                     ...(nodeType === 'file' ? { ext: path.extname(name) } : {}),
                     depth,

--- a/packages/fs/src/tree.ts
+++ b/packages/fs/src/tree.ts
@@ -94,7 +94,7 @@ export async function buildTree(root: string, opts: TreeOptions = {}): Promise<T
             path: p,
             relative,
             type,
-            ...(s.isDirectory() ? {} : { size: s.size }),
+            ...(type === 'file' ? { size: s.size } : {}),
             mtimeMs: s.mtimeMs,
             ...(type === 'file' ? { ext: path.extname(name) } : {}),
         };
@@ -158,7 +158,10 @@ export function filterTree(node: TreeNode, keep: (n: TreeNode) => boolean): Tree
  */
 export function collapseSingleChildDirs(node: TreeNode): TreeNode {
     if (!node.children || node.children.length !== 1) {
-        if (node.children) node.children = node.children.map(collapseSingleChildDirs);
+        if (node.children) {
+            const children = node.children.map(collapseSingleChildDirs);
+            return { ...node, children };
+        }
         return node;
     }
     const only = node.children[0]!;
@@ -175,8 +178,8 @@ export function collapseSingleChildDirs(node: TreeNode): TreeNode {
         };
         return collapseSingleChildDirs(merged);
     }
-    node.children = node.children.map(collapseSingleChildDirs);
-    return node;
+    const children = node.children.map(collapseSingleChildDirs);
+    return { ...node, children };
 }
 
 /** Minimal Dirent-like shim for the predicate hook */

--- a/packages/piper/tsconfig.json
+++ b/packages/piper/tsconfig.json
@@ -7,5 +7,5 @@
     "declaration": true
   },
   "include": ["src/**/*"],
-  "references": [{ "path": "../level-cache" }]
+  "references": [{ "path": "../fs" }, { "path": "../level-cache" }]
 }


### PR DESCRIPTION
## Summary
- limit streamed nodes to report size only for files
- avoid mutating tree nodes when collapsing single-child directories
- reference fs package in piper tsconfig for proper type resolution

## Testing
- `pnpm -w install`
- `pnpm --filter @promethean/fs typecheck`
- `pnpm --filter @promethean/fs test`
- `pnpm --filter @promethean/piper test`


------
https://chatgpt.com/codex/tasks/task_e_68bb67c697f48324aae19fbd42377173