### PR TITLE
fix: add rate limiting and HS fallback

### DIFF
--- a/changelog.d/2025.09.05.23.17.14.fixed.md
+++ b/changelog.d/2025.09.05.23.17.14.fixed.md
@@ -1,0 +1,1 @@
+fix: add HS fallback and rate limiting in smartgpt-bridge auth

--- a/packages/smartgpt-bridge/src/routes/v0/index.ts
+++ b/packages/smartgpt-bridge/src/routes/v0/index.ts
@@ -3,6 +3,7 @@ import { createRequire } from "module";
 import crypto from "crypto";
 
 import { createRemoteJWKSet, jwtVerify, decodeProtectedHeader } from "jose";
+import rateLimit from "@fastify/rate-limit";
 
 // Route modules (legacy)
 import { createLogger } from "@promethean/utils";
@@ -49,7 +50,8 @@ function timingSafeEqual(a, b) {
 }
 
 export async function registerV0Routes(app) {
-	// Old auth semantics (from src/auth.js), adapted for Fastify and scoped to /v0 only
+       await app.register(rateLimit, { max: 100, timeWindow: "1 minute" });
+       // Old auth semantics (from src/auth.js), adapted for Fastify and scoped to /v0 only
 	const enabled =
 		String(process.env.AUTH_ENABLED || "false").toLowerCase() === "true";
 	const mode = (process.env.AUTH_MODE || "static").toLowerCase(); // 'static' | 'jwt'
@@ -195,16 +197,16 @@ export async function registerV0Routes(app) {
 					if (/missing jwks/i.test(msg) && jwtSecret) {
 						// HS fallback
 						const key = new TextEncoder().encode(String(jwtSecret));
-						const { payload } = await jwtVerify(
-							String(token),
-							key,
-							{
-								algorithms: ["HS256", "HS384", "HS512"],
-								iss: jwtIssuer || undefined,
-								aud: jwtAudience || undefined,
-								clockTolerance: "60s",
-							},
-						);
+                                                 const { payload } = await jwtVerify(
+                                                         String(token),
+                                                         key,
+                                                         {
+                                                                 algorithms: ["HS256", "HS384", "HS512"],
+                                                                 issuer: jwtIssuer || undefined,
+                                                                 audience: jwtAudience || undefined,
+                                                                 clockTolerance: "60s",
+                                                         },
+                                                 );
 						req.user = payload;
 						return;
 					}


### PR DESCRIPTION
## Summary
- rate limit legacy v0 routes and /auth/me endpoint
- fallback to HS JWT verification when JWKS unavailable
- enforce issuer/audience on HS verification

## Testing
- `pnpm --filter @promethean/smartgpt-bridge test` *(fails: @promethean/fs build: TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_68bb6ef70f00832485ab13b04425cb62