### PR TITLE
feat: add monitoring package for metrics and rate limiting

### DIFF
--- a/packages/discord-rest/package.json
+++ b/packages/discord-rest/package.json
@@ -5,8 +5,8 @@
   "main": "./src/index.ts",
   "scripts": {
     "start": "node --enable-source-maps --experimental-specifier-resolution=node ./src/index.ts",
-    "test": "ava --config ../../../config/ava.config.mjs",
-    "coverage": "c8 ava --config ../../../config/ava.config.mjs",
+    "test": "pnpm run build && ava tests/**/*.test.js",
+    "coverage": "pnpm run build && c8 ava tests/**/*.test.js",
     "build": "tsc -p tsconfig.json",
     "lint": "pnpm dlx @biomejs/biome lint .",
     "typecheck": "tsc --noEmit",


### PR DESCRIPTION
## Summary
- introduce `@promethean/monitoring` with Prometheus helpers and token bucket limiter
- migrate consumers to `@promethean/monitoring`
- clean up legacy `metrics` and `rate` packages and docs
- build `@promethean/discord-rest` before running its test suite

## Testing
- `pnpm test --filter @promethean/monitoring`
- `pnpm test --filter @promethean/discord-rest` *(fails: Cannot find module '@promethean/security' or its corresponding type declarations)*
- `pnpm test --filter @promethean/ws` *(fails: Couldn’t find any files to test)*


------
https://chatgpt.com/codex/tasks/task_e_68bb712a3d1c8324aefe15efe87140f3