### PR TITLE
fix: update discord secret scan path

### DIFF
--- a/changelog.d/2025.09.05.23.13.39.changed.md
+++ b/changelog.d/2025.09.05.23.13.39.changed.md
@@ -1,1 +1,1 @@
-Consolidated Discord services into unified `@promethean/discord` package and updated imports.
+Consolidated Discord services into unified `@promethean/discord` package and updated imports. Adjusted CI secret scan to ignore the new package path.

--- a/scripts/ci/secret_scan.sh
+++ b/scripts/ci/secret_scan.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 MATCHES=$(grep -RInE "DISCORD_TOKEN|CLIENT_SECRET|REFRESH_TOKEN|bot_token" \
   --exclude-dir=.git \
-  --exclude-dir=services/ts/discord \
+  --exclude-dir=packages/discord \
   --exclude=config/providers.yml \
   . || true)
 


### PR DESCRIPTION
## Summary
- exclude `packages/discord` directory from CI secret scan
- document secret scan update in changelog

## Testing
- `bash scripts/ci/secret_scan.sh` *(fails: Secret-like strings found outside allowed paths)*

------
https://chatgpt.com/codex/tasks/task_e_68bb7758dc088324ab266e9422ec315b