### PR TITLE
fix: align web-utils rootDir with exports

### DIFF
--- a/changelog.d/2025.09.05.23.52.12.fixed.md
+++ b/changelog.d/2025.09.05.23.52.12.fixed.md
@@ -1,0 +1,1 @@
+- fix: align `@promethean/web-utils` build output with package exports by setting `rootDir` to `src`

--- a/packages/web-utils/src/tests/crawler.test.ts
+++ b/packages/web-utils/src/tests/crawler.test.ts
@@ -1,6 +1,6 @@
 import test from "ava";
 
-import { crawlPage } from '../src/crawler.js';
+import { crawlPage } from '../crawler.js';
 
 test("crawlPage fetches and extracts links", async (t) => {
   const html = `<html><head><title>Example</title></head><body>

--- a/packages/web-utils/src/tests/image-links.test.ts
+++ b/packages/web-utils/src/tests/image-links.test.ts
@@ -2,7 +2,7 @@ import test from "ava";
 import { mkdtemp, writeFile, stat } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { findBrokenImageLinks, fixBrokenImageLinks } from '../src/image-links.js';
+import { findBrokenImageLinks, fixBrokenImageLinks } from '../image-links.js';
 
 test("finds broken markdown and org image links", async (t) => {
 	const dir = await mkdtemp(path.join(os.tmpdir(), "img-test-"));

--- a/packages/web-utils/tsconfig.json
+++ b/packages/web-utils/tsconfig.json
@@ -1,11 +1,11 @@
 {
   "extends": "../../config/tsconfig.base.json",
   "compilerOptions": {
-    "rootDir": ".",
+    "rootDir": "src",
     "outDir": "dist",
     "composite": true,
     "declaration": true
   },
-  "include": ["src/**/*", "test/**/*"],
+  "include": ["src/**/*"],
   "references": []
 }


### PR DESCRIPTION
## Summary
- set `rootDir` to `src` to match `@promethean/web-utils` exports
- move tests under `src/tests` for compilation with new layout

## Testing
- `pnpm --filter @promethean/web-utils test`

------
https://chatgpt.com/codex/tasks/task_e_68bb7771356c8324af163868a79835be