### PR TITLE
refactor: pin discord embedder deps and add embedding gateway link

### DIFF
--- a/packages/cephalon/src/tests/embedding.test.ts
+++ b/packages/cephalon/src/tests/embedding.test.ts
@@ -6,7 +6,7 @@ import test from "ava";
 // Use memory broker via BrokerClient
 // @ts-ignore dynamic import of JS modules
 
-import { RemoteEmbeddingFunction } from "@promethean/embedding/remote.js";
+import { RemoteEmbeddingFunction } from "@promethean/embedding";
 const clientModule = await import("@promethean/legacy/brokerClient.js");
 const { BrokerClient } = clientModule;
 

--- a/packages/discord-embedder/package.json
+++ b/packages/discord-embedder/package.json
@@ -6,6 +6,8 @@
   "type": "module",
   "scripts": {
     "build": "tsc",
+    "clean": "rimraf dist",
+    "typecheck": "tsc --noEmit --incremental false -p .",
     "test": "pnpm run build && ava --config ../../../config/ava.config.mjs",
     "coverage": "pnpm run build && c8 ava --config ../../../config/ava.config.mjs",
     "build:check": "tsc --noEmit --incremental false -p .",
@@ -27,23 +29,23 @@
   "author": "Amish Shah <amishshah.2k@gmail.com>",
   "license": "GPL-3.0-only",
   "dependencies": {
-    "@discordjs/voice": "^0.18.0",
+    "@discordjs/voice": "0.18.0",
     "@promethean/embedding": "workspace:*",
     "@promethean/legacy": "workspace:*",
-    "@promethean/persistence": "file:../persistence",
-    "chromadb": "^3.0.9",
-    "discord.js": "^14.17.3",
-    "dotenv": "^17.2.0",
-    "libsodium-wrappers": "^0.7.13",
-    "mongodb": "^6.17.0",
-    "node-crc": "^1.3.2",
-    "ollama": "^0.5.16",
-    "pnpm": "^10.13.1",
-    "prism-media": "^2.0.0-alpha.0",
-    "wav": "^1.0.2",
-    "ws": "^8.18.3"
+    "@promethean/persistence": "workspace:*",
+    "chromadb": "3.0.9",
+    "discord.js": "14.17.3",
+    "dotenv": "17.2.0",
+    "libsodium-wrappers": "0.7.13",
+    "mongodb": "6.17.0",
+    "node-crc": "1.3.2",
+    "ollama": "0.5.16",
+    "pnpm": "10.13.1",
+    "prism-media": "2.0.0-alpha.0",
+    "wav": "1.0.2",
+    "ws": "8.18.3"
   },
   "devDependencies": {
-    "@types/ws": "^8.5.12"
+    "@types/ws": "8.5.12"
   }
 }

--- a/packages/discord-embedder/src/tests/embedding.test.ts
+++ b/packages/discord-embedder/src/tests/embedding.test.ts
@@ -1,5 +1,5 @@
 import test from "ava";
-import { RemoteEmbeddingFunction } from "@promethean/embedding/remote.js";
+import { RemoteEmbeddingFunction } from "@promethean/embedding";
 
 class MockBrokerClient {
   handlers: Record<string, ((e: any) => void)[]> = {};

--- a/packages/discord-embedder/tsconfig.json
+++ b/packages/discord-embedder/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../config/tsconfig.service.json",
+  "extends": "../../config/tsconfig.base.json",
   "compilerOptions": {
     "outDir": "dist",
     "rootDir": "src",
@@ -7,15 +7,14 @@
     "moduleResolution": "Bundler",
     "baseUrl": ".",
     "paths": {
-      "@shared/js/*": ["../../js/*"],
-      "@promethean/persistence": ["../persistence/dist/index"],
-      "@promethean/persistence/*": ["../persistence/dist/*"],
-      "@promethean/embedding": ["../embedding/dist/index"],
-      "@promethean/embedding/*": ["../embedding/dist/*"]
+      "@shared/js/*": ["../../js/*"]
     },
-    "allowArbitraryExtensions": true,
-    "types": ["node"]
+    "allowArbitraryExtensions": true
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules"],
+  "references": [
+    { "path": "../embedding" },
+    { "path": "../persistence" }
+  ]
 }

--- a/packages/discord-gateway/package.json
+++ b/packages/discord-gateway/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@promethean/event": "workspace:*",
     "@promethean/platform": "workspace:*",
-    "@promethean/providers": "workspace:*"
+    "@promethean/providers": "workspace:*",
+    "@promethean/embedding": "workspace:*"
   }
 }

--- a/packages/embedding/src/tests/attachment.test.ts
+++ b/packages/embedding/src/tests/attachment.test.ts
@@ -1,8 +1,7 @@
 import test from "ava";
+import { embedAttachments } from "@promethean/embedding";
 
 test("embeds attachments into provider+tenant namespace", async (t) => {
-  try {
-     const { embedAttachments } = await import("@promethean/embedding");
     const out = await embedAttachments({
       message_id: "m1",
       author_urn: "urn:discord:user:duck:u1",
@@ -30,8 +29,4 @@ test("embeds attachments into provider+tenant namespace", async (t) => {
       t.regex(out.ns, /discord__duck/);
       t.is(out.ids.length, 2);
     }
-  } catch (err) {
-    t.log(`skipping: ${err}`);
-    t.pass();
-  }
 });

--- a/packages/persistence/src/dualStore.ts
+++ b/packages/persistence/src/dualStore.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from 'node:crypto';
 
 import type { Collection as ChromaCollection } from 'chromadb';
-import { RemoteEmbeddingFunction } from '@promethean/embedding/remote.js';
+import { RemoteEmbeddingFunction } from '@promethean/embedding';
 import type { Collection, OptionalUnlessRequiredId, WithId } from 'mongodb';
 import { AGENT_NAME } from '@promethean/legacy/env.js';
 

--- a/packages/smartgpt-bridge/src/remoteEmbedding.ts
+++ b/packages/smartgpt-bridge/src/remoteEmbedding.ts
@@ -1,6 +1,6 @@
 // @ts-nocheck
 // Adapter to shared RemoteEmbeddingFunction with testable broker injection and timeouts.
-import { RemoteEmbeddingFunction as SharedRemoteEmbedding } from "@promethean/embedding/remote.js";
+import { RemoteEmbeddingFunction as SharedRemoteEmbedding } from "@promethean/embedding";
 
 export class RemoteEmbeddingFunction extends SharedRemoteEmbedding {
   constructor(


### PR DESCRIPTION
## Summary
- pin Discord embedder dependencies and add clean/typecheck scripts
- switch embedder tsconfig to project references
- drop try/catch from embedding attachment test
- replace deep embedding imports and add embedding dependency for discord gateway

## Testing
- `pnpm -F @promethean/embedding test` *(fails: Cannot find module 'chromadb')*
- `pnpm -F @promethean/discord-embedder test` *(fails: Cannot find module '@promethean/legacy/heartbeat/index.js')*
- `pnpm -F @promethean/cephalon test` *(fails: Cannot find module '@promethean/agent-ecs')*
- `pnpm -F @promethean/persistence test` *(fails: Cannot find module '@promethean/embedding')*
- `pnpm -F @promethean/smartgpt-bridge test` *(fails: build dependencies missing)*
- `pnpm -F @promethean/discord-gateway test` *(fails: Cannot find module '@promethean/event/dist/memory.js')*

------
https://chatgpt.com/codex/tasks/task_e_68bb7c8ecda88324ada88a8e4d4e0480