### PR TITLE
feat: add dev runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,20 @@ pm2 start agents/duck/ecosystem.config.js
 
 Choose the config inside `agents/<agent>/` for other agents.
 
+## Development workflow
+
+Run all package development scripts without Docker:
+
+```bash
+pnpm dev:all
+```
+
+For a full-stack environment using containers:
+
+```bash
+docker compose up
+```
+
 Set `AGENT_NAME` in your environment before launching agent services to isolate collections and data.
 Promethean is a modular cognitive architecture for building embodied AI agents. It breaks the system
 into small services that handle speech-to-text, text-to-speech, memory, and higher level reasoning.

--- a/changelog.d/2025.09.06.00.24.22.added.md
+++ b/changelog.d/2025.09.06.00.24.22.added.md
@@ -1,0 +1,1 @@
+- add shared dev runner for packages and document dev workflow

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "postinstall": "pnpm --filter @promethean/piper^... run build && pnpm --filter @promethean/piper run build",
     "generateBuildErrorReport": "pnpm -r --no-bail build | grep 'error' -i >|build-errors.txt",
     "check:flat": "node scripts/check-flat.js",
-    "enforce:esm-ext": "eslint \"packages/**/src/**/*.{ts,tsx}\" --rule 'import/extensions: [2, \"always\", { ignorePackages: true }]'"
+    "enforce:esm-ext": "eslint \"packages/**/src/**/*.{ts,tsx}\" --rule 'import/extensions: [2, \"always\", { ignorePackages: true }]'",
+    "dev:all": "node scripts/dev.mjs"
   },
   "bin": {
     "prom": "./bin/promethean.js"

--- a/scripts/dev.mjs
+++ b/scripts/dev.mjs
@@ -1,0 +1,55 @@
+#!/usr/bin/env node
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { spawn } from 'node:child_process';
+
+/**
+ * Discover packages that expose a `dev` script.
+ * @param {string} root repository root
+ * @returns {Promise<string[]>} list of package names
+ */
+export async function findRunnablePackages(root = process.cwd()) {
+  const packagesDir = path.join(root, 'packages');
+  let entries;
+  try {
+    entries = await fs.readdir(packagesDir, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+  const runnable = [];
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    const pkgJsonPath = path.join(packagesDir, entry.name, 'package.json');
+    try {
+      const pkg = JSON.parse(await fs.readFile(pkgJsonPath, 'utf8'));
+      if (pkg.scripts?.dev) {
+        runnable.push(pkg.name ?? entry.name);
+      }
+    } catch {
+      // ignore
+    }
+  }
+  return runnable;
+}
+
+async function main() {
+  const packages = await findRunnablePackages();
+  if (packages.length === 0) {
+    console.log('No runnable packages with a dev script found.');
+    return;
+  }
+  const args = ['run', '-r'];
+  for (const pkg of packages) {
+    args.push('--filter', pkg);
+  }
+  args.push('dev');
+  const child = spawn('pnpm', args, { stdio: 'inherit' });
+  child.on('exit', (code) => process.exit(code ?? 0));
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
+}

--- a/tests/dev-script.test.js
+++ b/tests/dev-script.test.js
@@ -1,0 +1,25 @@
+import test from 'ava';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { findRunnablePackages } from '../scripts/dev.mjs';
+
+test('findRunnablePackages returns packages with dev script', async (t) => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'devpkg-'));
+  const pkgsDir = path.join(tmp, 'packages');
+  await fs.mkdir(path.join(pkgsDir, 'a'), { recursive: true });
+  await fs.writeFile(
+    path.join(pkgsDir, 'a', 'package.json'),
+    JSON.stringify({ name: 'a', scripts: { dev: 'node index.js' } }),
+    'utf8'
+  );
+  await fs.mkdir(path.join(pkgsDir, 'b'), { recursive: true });
+  await fs.writeFile(
+    path.join(pkgsDir, 'b', 'package.json'),
+    JSON.stringify({ name: 'b', scripts: { test: 'echo test' } }),
+    'utf8'
+  );
+
+  const pkgs = await findRunnablePackages(tmp);
+  t.deepEqual(pkgs, ['a']);
+});


### PR DESCRIPTION
## Summary
- add dev script runner to spawn package dev processes
- expose `pnpm dev:all` root command
- document no-docker vs docker workflows

## Testing
- `pnpm exec biome lint scripts/dev.mjs tests/dev-script.test.js`
- `pnpm exec ava --config ./config/ava.config.mjs tests/dev-script.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68bb7e72bfdc8324989f9cddff2e9ac6