### PR TITLE
fix: run dev scripts concurrently

### DIFF
--- a/scripts/dev.mjs
+++ b/scripts/dev.mjs
@@ -32,17 +32,22 @@ export async function findRunnablePackages(root = process.cwd()) {
   return runnable;
 }
 
+export function buildDevArgs(packages) {
+  const args = ['run', '-r', '--parallel', '--workspace-root'];
+  for (const pkg of packages) {
+    args.push('--filter', pkg);
+  }
+  args.push('dev');
+  return args;
+}
+
 async function main() {
   const packages = await findRunnablePackages();
   if (packages.length === 0) {
     console.log('No runnable packages with a dev script found.');
     return;
   }
-  const args = ['run', '-r'];
-  for (const pkg of packages) {
-    args.push('--filter', pkg);
-  }
-  args.push('dev');
+  const args = buildDevArgs(packages);
   const child = spawn('pnpm', args, { stdio: 'inherit' });
   child.on('exit', (code) => process.exit(code ?? 0));
 }

--- a/tests/dev-script.test.js
+++ b/tests/dev-script.test.js
@@ -2,7 +2,7 @@ import test from 'ava';
 import { promises as fs } from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
-import { findRunnablePackages } from '../scripts/dev.mjs';
+import { findRunnablePackages, buildDevArgs } from '../scripts/dev.mjs';
 
 test('findRunnablePackages returns packages with dev script', async (t) => {
   const tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'devpkg-'));
@@ -22,4 +22,19 @@ test('findRunnablePackages returns packages with dev script', async (t) => {
 
   const pkgs = await findRunnablePackages(tmp);
   t.deepEqual(pkgs, ['a']);
+});
+
+test('buildDevArgs runs packages in parallel from workspace root', (t) => {
+  const args = buildDevArgs(['a', 'b']);
+  t.deepEqual(args, [
+    'run',
+    '-r',
+    '--parallel',
+    '--workspace-root',
+    '--filter',
+    'a',
+    '--filter',
+    'b',
+    'dev',
+  ]);
 });


### PR DESCRIPTION
## Summary
- ensure dev runner executes workspace packages in parallel
- test argument construction for concurrent dev script execution

## Testing
- `pnpm exec biome lint scripts/dev.mjs tests/dev-script.test.js`
- `pnpm exec ava --config ./config/ava.config.mjs tests/dev-script.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68bb8f106ccc8324b94da574202091f2