### PR TITLE
fix: wait for docops dev ui in e2e tests

### DIFF
--- a/changelog.d/2025.09.07.00.54.01.fixed.md
+++ b/changelog.d/2025.09.07.00.54.01.fixed.md
@@ -1,0 +1,1 @@
+fix docops e2e tests waiting for dev ui to start

--- a/packages/docops/src/tests/e2e/devui.spec.ts
+++ b/packages/docops/src/tests/e2e/devui.spec.ts
@@ -3,7 +3,7 @@ import * as url from "node:url";
 import { v4 as uuidv4 } from "uuid";
 
 import test from "ava";
-import { registerProcForFileWithPort, withPage } from "@promethean/test-utils";
+import { registerProcForFileWithPort, withPage, shutdown } from "@promethean/test-utils";
 
 const PKG_ROOT = path.resolve(
   path.dirname(url.fileURLToPath(import.meta.url)),
@@ -25,8 +25,17 @@ const { getProc } = registerProcForFileWithPort(test, {
   cwd: PKG_ROOT,
   env: { ...process.env },
   stdio: "inherit",
+  ready: {
+    kind: "http",
+    url: "http://localhost:PORT/health",
+    timeoutMs: 60_000,
+  },
   port: { mode: "free" },
   baseUrlTemplate: (p) => `http://127.0.0.1:${p}/`,
+});
+
+test.after.always(async () => {
+  await shutdown();
 });
 
 test(

--- a/packages/test-utils/src/process.ts
+++ b/packages/test-utils/src/process.ts
@@ -103,9 +103,22 @@ export const startProcessWithPort = async (
     const args =
         port !== undefined ? (rest.args ?? []).map((a) => (a === ':PORT' ? String(port) : a)) : rest.args ?? [];
 
+    const ready = (() => {
+        const r = rest.ready;
+        if (!r) return r;
+        if (r.kind === 'http' && typeof r.url === 'string' && port !== undefined) {
+            return { ...r, url: r.url.replace(':PORT', `:${port}`) } as typeof r;
+        }
+        if (r.kind === 'tcp' && port !== undefined) {
+            return { ...r, port } as typeof r;
+        }
+        return r;
+    })();
+
     const proc = await startProcess({
         ...rest,
         args,
+        ...(ready ? { ready } : {}),
     });
 
     const baseUrl = port !== undefined && baseUrlTemplate ? baseUrlTemplate(port) : undefined;


### PR DESCRIPTION
## Summary
- ensure docops e2e tests wait for dev ui to be ready via health endpoint
- support :PORT substitution in test-utils when waiting for readiness

## Testing
- `pnpm -F @promethean/docops test` *(fails: Timed out while running tests)*

------
https://chatgpt.com/codex/tasks/task_e_68bcd2326c4c8324ac98ab99f6b82855