### PR TITLE
fix docops e2e preview

### DIFF
--- a/changelog.d/2025.09.07.18.15.41.fixed.md
+++ b/changelog.d/2025.09.07.18.15.41.fixed.md
@@ -1,0 +1,1 @@
+- fix docops e2e frontmatter preview and add temp docs setup

--- a/packages/docops/src/frontend/main.ts
+++ b/packages/docops/src/frontend/main.ts
@@ -53,12 +53,11 @@ document.addEventListener("DOMContentLoaded", async () => {
     const files = getSelection();
     const docT = (document.getElementById("docT") as HTMLInputElement).value;
     const refT = (document.getElementById("refT") as HTMLInputElement).value;
-    let url = `/api/preview?dir=${encodeURIComponent(
-      dir,
-    )}&docT=${docT}&refT=${refT}`;
+    let url = `/api/preview?docT=${docT}&refT=${refT}`;
     if (files && files.length) {
       url += "&file=" + encodeURIComponent(files[0]!);
     } else {
+      url += "&dir=" + encodeURIComponent(dir);
       const uuid = (document.getElementById("doclist") as HTMLSelectElement)
         .value;
       if (!uuid) {


### PR DESCRIPTION
## Summary
- ensure DocOps preview endpoint works when a file is selected
- add temporary test docs and wait logic in DocOps E2E test

## Testing
- `pnpm --filter @promethean/docops build`
- `pnpm exec ava packages/docops/dist/tests/e2e/docops.e2e.spec.js`


------
https://chatgpt.com/codex/tasks/task_e_68bdc85332ac8324b8134342cccbbea4