### PR TITLE
docs: update ts-ls-lsp references

### DIFF
--- a/config/mcp_servers.edn
+++ b/config/mcp_servers.edn
@@ -28,6 +28,14 @@
           "/home/err/.volta/bin/typescript-language-server"
           "--stdio"]}
 
+  ;; compatibility alias for older configs
+  :lsp-mcp
+  {:command "npx"
+   :args ["tritlo/lsp-mcp"
+          "typescript"
+          "/home/err/.volta/bin/typescript-language-server"
+          "--stdio"]}
+
   ;; :sonarlint-lsp
   ;; {:command "npx"
   ;;  :args ["tritlo/lsp-mcp"

--- a/docs/Nexus/conversations/chatgpt/2025/08/Pnpm build continue on fail.md
+++ b/docs/Nexus/conversations/chatgpt/2025/08/Pnpm build continue on fail.md
@@ -173,7 +173,7 @@ Chat URL: https://chat.openai.com/c/68b2337b-6e5c-8323-b4c9-b4f9eaa544d0
 > **Trade-offs**
 > - *Accuracy on type errors*: LSP route (Path 1) = **authoritative** (tsserver). Refactor servers (Path 2) are powerful but may not mirror editor diagnostics perfectly. cite
 > - *Edits at scale*: ts-morph servers often have richer **batch refactoring** tools out of the box. citeturn1view0
-> - *Stack*: If you want **all TypeScript** (no Go), use **lsp-mcp**; otherwise **isaacphi/mcp-language-server** is very capable and popular. citeturn5view0turn2view0
+- *Stack*: If you want **all TypeScript** (no Go), use **ts-ls-lsp**; otherwise **isaacphi/mcp-language-server** is very capable and popular. citeturn5view0turn2view0
 > 
 > ## What I’d do (pragmatic)
 > 1) **Start with LSP bridge** so MCP sees the exact same types/errors as VS Code. 
@@ -245,7 +245,7 @@ Chat URL: https://chat.openai.com/c/68b2337b-6e5c-8323-b4c9-b4f9eaa544d0
 > ```json
 > {
 >  "mcpServers": {
->  "lsp-mcp": {
+>  "ts-ls-lsp": {
 >  "type": "stdio",
 >  "command": "npx",
 >  "args": [
@@ -279,7 +279,7 @@ Chat URL: https://chat.openai.com/c/68b2337b-6e5c-8323-b4c9-b4f9eaa544d0
 > ## Troubleshooting (pragmatic)
 > 
 > - **No tools showing up in the client?** Re-check JSON syntax and absolute paths; Claude-style docs explain the flow + where logs live. citeturn3view0 
-> - **Still no diagnostics?** For `lsp-mcp`, you likely forgot `start_lsp`. For `mcp-language-server`, ensure the `--stdio` is after `--`. citeturn1view0turn2view0 
+- **Still no diagnostics?** For `ts-ls-lsp`, you likely forgot `start_lsp`. For `mcp-language-server`, ensure the `--stdio` is after `--`. citeturn1view0turn2view0
 > - **Non-global Node installs (nvm/asdf)?** Extend `PATH` to your Node bin dir so `typescript-language-server` is discoverable. (npm page confirms it’s the official LSP wrapper around `tsserver`.) cite
 > 
 > If you tell me **which MCP client on Ubuntu** you’re using (Windsurf, Cursor, Lobe, etc.), I’ll hand you the exact file path + any client-specific quirks.
@@ -339,7 +339,7 @@ Chat URL: https://chat.openai.com/c/68b2337b-6e5c-8323-b4c9-b4f9eaa544d0
 > 
 > ---
 > 
-> ## Option B — `lsp-mcp` (all TypeScript stack)
+> ## Option B — `ts-ls-lsp` (all TypeScript stack)
 > 
 > **Config (no Go):**
 > ```json
@@ -357,7 +357,7 @@ Chat URL: https://chat.openai.com/c/68b2337b-6e5c-8323-b4c9-b4f9eaa544d0
 > ```json
 > { "tool": "start_lsp", "arguments": { "root_dir": "/ABS/PATH/TO/YOUR/REPO" } }
 > ```
-> (`lsp-mcp` has TS integration tests for hovers, completions, diagnostics, code actions.) cite
+> (`ts-ls-lsp` has TS integration tests for hovers, completions, diagnostics, code actions.) cite
 > 
 > ---
 > 

--- a/docs/Nexus/conversations/chatgpt/2025/08/pnpm-build-continue-on-fail.md
+++ b/docs/Nexus/conversations/chatgpt/2025/08/pnpm-build-continue-on-fail.md
@@ -173,7 +173,7 @@ Chat URL: https://chat.openai.com/c/68b2337b-6e5c-8323-b4c9-b4f9eaa544d0
 > **Trade-offs**
 > - *Accuracy on type errors*: LSP route (Path 1) = **authoritative** (tsserver). Refactor servers (Path 2) are powerful but may not mirror editor diagnostics perfectly. cite
 > - *Edits at scale*: ts-morph servers often have richer **batch refactoring** tools out of the box. citeturn1view0
-> - *Stack*: If you want **all TypeScript** (no Go), use **lsp-mcp**; otherwise **isaacphi/mcp-language-server** is very capable and popular. citeturn5view0turn2view0
+- *Stack*: If you want **all TypeScript** (no Go), use **ts-ls-lsp**; otherwise **isaacphi/mcp-language-server** is very capable and popular. citeturn5view0turn2view0
 > 
 > ## What I’d do (pragmatic)
 > 1) **Start with LSP bridge** so MCP sees the exact same types/errors as VS Code. 
@@ -245,7 +245,7 @@ Chat URL: https://chat.openai.com/c/68b2337b-6e5c-8323-b4c9-b4f9eaa544d0
 > ```json
 > {
 >  "mcpServers": {
->  "lsp-mcp": {
+>  "ts-ls-lsp": {
 >  "type": "stdio",
 >  "command": "npx",
 >  "args": [
@@ -279,7 +279,7 @@ Chat URL: https://chat.openai.com/c/68b2337b-6e5c-8323-b4c9-b4f9eaa544d0
 > ## Troubleshooting (pragmatic)
 > 
 > - **No tools showing up in the client?** Re-check JSON syntax and absolute paths; Claude-style docs explain the flow + where logs live. citeturn3view0 
-> - **Still no diagnostics?** For `lsp-mcp`, you likely forgot `start_lsp`. For `mcp-language-server`, ensure the `--stdio` is after `--`. citeturn1view0turn2view0 
+- **Still no diagnostics?** For `ts-ls-lsp`, you likely forgot `start_lsp`. For `mcp-language-server`, ensure the `--stdio` is after `--`. citeturn1view0turn2view0
 > - **Non-global Node installs (nvm/asdf)?** Extend `PATH` to your Node bin dir so `typescript-language-server` is discoverable. (npm page confirms it’s the official LSP wrapper around `tsserver`.) cite
 > 
 > If you tell me **which MCP client on Ubuntu** you’re using (Windsurf, Cursor, Lobe, etc.), I’ll hand you the exact file path + any client-specific quirks.
@@ -339,7 +339,7 @@ Chat URL: https://chat.openai.com/c/68b2337b-6e5c-8323-b4c9-b4f9eaa544d0
 > 
 > ---
 > 
-> ## Option B — `lsp-mcp` (all TypeScript stack)
+> ## Option B — `ts-ls-lsp` (all TypeScript stack)
 > 
 > **Config (no Go):**
 > ```json
@@ -357,7 +357,7 @@ Chat URL: https://chat.openai.com/c/68b2337b-6e5c-8323-b4c9-b4f9eaa544d0
 > ```json
 > { "tool": "start_lsp", "arguments": { "root_dir": "/ABS/PATH/TO/YOUR/REPO" } }
 > ```
-> (`lsp-mcp` has TS integration tests for hovers, completions, diagnostics, code actions.) cite
+> (`ts-ls-lsp` has TS integration tests for hovers, completions, diagnostics, code actions.) cite
 > 
 > ---
 > 

--- a/docs/unique/mcp-server-config.md
+++ b/docs/unique/mcp-server-config.md
@@ -43,7 +43,7 @@ references:
   ("github" . ("/home/err/devel/promethean/scripts/mcp/bin/github.sh"))
   ("github-chat" . ("/home/err/devel/promethean/scripts/mcp/bin/github_chat.sh"))
   ("haiku-rag" . ("uvx" ["haiku-rag" "serve" "--stdio" "--db" "/home/err/.local/share/haiku-rag/db"]))
-  ("lsp-mcp" . ("npx" ["tritlo/lsp-mcp" "typescript" "/home/err/.volta/bin/typescript-language-server" "--stdio"]))
+  ("ts-ls-lsp" . ("npx" ["tritlo/lsp-mcp" "typescript" "/home/err/.volta/bin/typescript-language-server" "--stdio"]))
   ("npm-helper" . ("npx" ["-y" "npm-helper-mcp"]))
   ("obsidian" . ("/home/err/devel/promethean/scripts/mcp/bin/obsidian.sh"))
   ("sonarqube" . ("/home/err/devel/promethean/scripts/mcp/bin/sonarqube.sh"))))
@@ -69,7 +69,7 @@ First we need the right way with the right data:
          (:command "npx"
                   :args ("-y" "@modelcontextprotocol/server-sonarqube"
                          "~/devel/promethean")))
-        (:name "lsp-mcp"
+        (:name "ts-ls-lsp"
          (:command "npx"
                   :args ("-y" "@modelcontextprotocol/server-lsp-mcp"
                          "~/devel/promethean")))
@@ -164,7 +164,7 @@ We want to update this so it works to generate the right kind of lisp for mcp.el
   {:command "npx"
    :args ["-y" "npm-helper-mcp"]}
 
-  :lsp-mcp
+  :ts-ls-lsp
   {:command "npx"
    :args ["tritlo/lsp-mcp"
           "typescript"
@@ -222,7 +222,7 @@ Given the above edn config file, we expect `/home/err/devel/promethean/.emacs/la
          (:command "npx"
                   :args ("-y" "@modelcontextprotocol/server-sonarqube"
                          "~/devel/promethean")))
-        (:name "lsp-mcp"
+        (:name "ts-ls-lsp"
          (:command "npx"
                   :args ("-y" "@modelcontextprotocol/server-lsp-mcp"
                          "~/devel/promethean")))

--- a/docs/unique/run-step-api.md
+++ b/docs/unique/run-step-api.md
@@ -617,10 +617,10 @@ refT
     M packages/docops/src/dev-ui.ts
 
 tool running...
-lsp-mcp.get_diagnostics({"file_path":"packages/docops/src/dev-ui.ts"})
+ts-ls-lsp.get_diagnostics({"file_path":"packages/docops/src/dev-ui.ts"})
 
 tool success, duration: 0ms
-lsp-mcp.get_diagnostics({"file_path":"packages/docops/src/dev-ui.ts"})
+ts-ls-lsp.get_diagnostics({"file_path":"packages/docops/src/dev-ui.ts"})
 
 {"file:///home/err/devel/promethean/packages/docops/src/dev-ui.ts": []}
 
@@ -837,29 +837,29 @@ string }
     M packages/docops/src/03-query.ts
 
 tool running...
-lsp-mcp.get_diagnostics({"file_path":"packages/docops/src/03-query.ts"})
+ts-ls-lsp.get_diagnostics({"file_path":"packages/docops/src/03-query.ts"})
 
 tool failed, duration: 1ms
-lsp-mcp.get_diagnostics({"file_path":"packages/docops/src/03-query.ts"})
+ts-ls-lsp.get_diagnostics({"file_path":"packages/docops/src/03-query.ts"})
 
 Error: Failed to get diagnostics: File packages/docops/src/03-query.ts is not open. Please
 open the file with open_document before requesting diagnostics.
 
 tool running...
-lsp-mcp.open_document({"file_path":"packages/docops/
+ts-ls-lsp.open_document({"file_path":"packages/docops/
 src/03-query.ts","language_id":"typescript"})
 
 tool success, duration: 1ms
-lsp-mcp.open_document({"file_path":"packages/docops/
+ts-ls-lsp.open_document({"file_path":"packages/docops/
 src/03-query.ts","language_id":"typescript"})
 
 File successfully opened: packages/docops/src/03-query.ts
 
 tool running...
-lsp-mcp.get_diagnostics({"file_path":"packages/docops/src/03-query.ts"})
+ts-ls-lsp.get_diagnostics({"file_path":"packages/docops/src/03-query.ts"})
 
 tool success, duration: 0ms
-lsp-mcp.get_diagnostics({"file_path":"packages/docops/src/03-query.ts"})
+ts-ls-lsp.get_diagnostics({"file_path":"packages/docops/src/03-query.ts"})
 
 {"file:///home/err/devel/promethean/packages/docops/src/03-query.ts": []}
 
@@ -892,29 +892,29 @@ Promise.all(files.map(processFile)))
     M packages/docops/src/01-frontmatter.ts
 
 tool running...
-lsp-mcp.get_diagnostics({"file_path":"packages/docops/src/01-frontmatter.ts"})
+ts-ls-lsp.get_diagnostics({"file_path":"packages/docops/src/01-frontmatter.ts"})
 
 tool failed, duration: 0ms
-lsp-mcp.get_diagnostics({"file_path":"packages/docops/src/01-frontmatter.ts"})
+ts-ls-lsp.get_diagnostics({"file_path":"packages/docops/src/01-frontmatter.ts"})
 
 Error: Failed to get diagnostics: File packages/docops/src/01-frontmatter.ts is not open.
 Please open the file with open_document before requesting diagnostics.
 
 tool running...
-lsp-mcp.open_document({"file_path":"packages/docops/
+ts-ls-lsp.open_document({"file_path":"packages/docops/
 src/01-frontmatter.ts","language_id":"typescript"})
 
 tool success, duration: 0ms
-lsp-mcp.open_document({"file_path":"packages/docops/
+ts-ls-lsp.open_document({"file_path":"packages/docops/
 src/01-frontmatter.ts","language_id":"typescript"})
 
 File successfully opened: packages/docops/src/01-frontmatter.ts
 
 tool running...
-lsp-mcp.get_diagnostics({"file_path":"packages/docops/src/01-frontmatter.ts"})
+ts-ls-lsp.get_diagnostics({"file_path":"packages/docops/src/01-frontmatter.ts"})
 
 tool success, duration: 0ms
-lsp-mcp.get_diagnostics({"file_path":"packages/docops/src/01-frontmatter.ts"})
+ts-ls-lsp.get_diagnostics({"file_path":"packages/docops/src/01-frontmatter.ts"})
 
 {"file:///home/err/devel/promethean/packages/docops/src/01-frontmatter.ts": [{"range":
 {"start": {"line": 112, "character": 10}, "end": {"line": 112, "character": 20}}, "message":
@@ -957,29 +957,29 @@ total }
     M packages/docops/src/04-relations.ts
 
 tool running...
-lsp-mcp.get_diagnostics({"file_path":"packages/docops/src/04-relations.ts"})
+ts-ls-lsp.get_diagnostics({"file_path":"packages/docops/src/04-relations.ts"})
 
 tool failed, duration: 0ms
-lsp-mcp.get_diagnostics({"file_path":"packages/docops/src/04-relations.ts"})
+ts-ls-lsp.get_diagnostics({"file_path":"packages/docops/src/04-relations.ts"})
 
 Error: Failed to get diagnostics: File packages/docops/src/04-relations.ts is not open.
 Please open the file with open_document before requesting diagnostics.
 
 tool running...
-lsp-mcp.open_document({"file_path":"packages/docops/
+ts-ls-lsp.open_document({"file_path":"packages/docops/
 src/04-relations.ts","language_id":"typescript"})
 
 tool success, duration: 1ms
-lsp-mcp.open_document({"file_path":"packages/docops/
+ts-ls-lsp.open_document({"file_path":"packages/docops/
 src/04-relations.ts","language_id":"typescript"})
 
 File successfully opened: packages/docops/src/04-relations.ts
 
 tool running...
-lsp-mcp.get_diagnostics({"file_path":"packages/docops/src/04-relations.ts"})
+ts-ls-lsp.get_diagnostics({"file_path":"packages/docops/src/04-relations.ts"})
 
 tool success, duration: 0ms
-lsp-mcp.get_diagnostics({"file_path":"packages/docops/src/04-relations.ts"})
+ts-ls-lsp.get_diagnostics({"file_path":"packages/docops/src/04-relations.ts"})
 
 {"file:///home/err/devel/promethean/packages/docops/src/04-relations.ts": [{"range":
 {"start": {"line": 140, "character": 6}, "end": {"line": 140, "character": 16}}, "message":
@@ -1011,29 +1011,29 @@ computeAnchorsByPath(list,
     M packages/docops/src/05-footers.ts
 
 tool running...
-lsp-mcp.get_diagnostics({"file_path":"packages/docops/src/05-footers.ts"})
+ts-ls-lsp.get_diagnostics({"file_path":"packages/docops/src/05-footers.ts"})
 
 tool failed, duration: 0ms
-lsp-mcp.get_diagnostics({"file_path":"packages/docops/src/05-footers.ts"})
+ts-ls-lsp.get_diagnostics({"file_path":"packages/docops/src/05-footers.ts"})
 
 Error: Failed to get diagnostics: File packages/docops/src/05-footers.ts is not open. Please
 open the file with open_document before requesting diagnostics.
 
 tool running...
-lsp-mcp.open_document({"file_path":"packages/docops/
+ts-ls-lsp.open_document({"file_path":"packages/docops/
 src/05-footers.ts","language_id":"typescript"})
 
 tool success, duration: 1ms
-lsp-mcp.open_document({"file_path":"packages/docops/
+ts-ls-lsp.open_document({"file_path":"packages/docops/
 src/05-footers.ts","language_id":"typescript"})
 
 File successfully opened: packages/docops/src/05-footers.ts
 
 tool running...
-lsp-mcp.get_diagnostics({"file_path":"packages/docops/src/05-footers.ts"})
+ts-ls-lsp.get_diagnostics({"file_path":"packages/docops/src/05-footers.ts"})
 
 tool success, duration: 0ms
-lsp-mcp.get_diagnostics({"file_path":"packages/docops/src/05-footers.ts"})
+ts-ls-lsp.get_diagnostics({"file_path":"packages/docops/src/05-footers.ts"})
 
 {"file:///home/err/devel/promethean/packages/docops/src/05-footers.ts": [{"range": {"start":
 {"line": 116, "character": 30}, "end": {"line": 116, "character": 38}}, "message": "This may
@@ -1137,10 +1137,10 @@ percent
     M packages/docops/src/dev-ui.ts
 
 tool running...
-lsp-mcp.get_diagnostics({"file_path":"packages/docops/src/dev-ui.ts"})
+ts-ls-lsp.get_diagnostics({"file_path":"packages/docops/src/dev-ui.ts"})
 
 tool success, duration: 1ms
-lsp-mcp.get_diagnostics({"file_path":"packages/docops/src/dev-ui.ts"})
+ts-ls-lsp.get_diagnostics({"file_path":"packages/docops/src/dev-ui.ts"})
 
 {"file:///home/err/devel/promethean/packages/docops/src/dev-ui.ts": []}
 


### PR DESCRIPTION
## Summary
- add :lsp-mcp compatibility alias mapping to :ts-ls-lsp
- replace outdated :lsp-mcp key usage in docs with :ts-ls-lsp

## Testing
- `pnpm -F @promethean/docops test` *(fails: Error at devui.negatives.spec.ts:154)*

------
https://chatgpt.com/codex/tasks/task_e_68bdceecf3a88324a870ca128992fe74