### PR TITLE
test: verify docops service dependencies

### DIFF
--- a/changelog.d/2025.09.07.18.45.29.added.md
+++ b/changelog.d/2025.09.07.18.45.29.added.md
@@ -1,0 +1,1 @@
+- docops tests now verify Ollama and ChromaDB are running before integration and e2e suites.

--- a/packages/docops/README.md
+++ b/packages/docops/README.md
@@ -49,6 +49,18 @@ await runRename({ dir: 'docs/unique' });
 
 See `docs/docops-pipeline.md` for detailed API docs and architecture.
 
+## Testing
+
+Integration and end-to-end tests expect local Ollama and ChromaDB services.
+Start them before running the suites:
+
+```
+ollama serve &
+chromadb run & # or docker run chromadb/chroma
+pnpm --filter @promethean/docops test      # integration tests
+pnpm --filter @promethean/docops test:e2e  # Playwright e2e tests
+```
+
 ## Notes
 
 - Requires Node 20+ and pnpm.

--- a/packages/docops/src/tests/e2e/docops.e2e.spec.ts
+++ b/packages/docops/src/tests/e2e/docops.e2e.spec.ts
@@ -10,6 +10,7 @@ import {
   shutdown,
   startProcessWithPort,
 } from "@promethean/test-utils";
+import { ensureServices } from "../helpers/services.js";
 
 const PKG_ROOT = path.resolve(
   path.dirname(url.fileURLToPath(import.meta.url)),
@@ -26,6 +27,7 @@ const TMP_DB = path.join(PKG_ROOT, ".cache", `docops-e2e-${uuidv4()}`);
 let state: { stop: () => Promise<void>; baseUrl?: string } | null = null;
 
 test.before(async () => {
+  await ensureServices();
   await fs.mkdir(DOC_FIXTURE_PATH, { recursive: true });
   await fs.writeFile(
     path.join(DOC_FIXTURE_PATH, "hack.md"),

--- a/packages/docops/src/tests/helpers/services.ts
+++ b/packages/docops/src/tests/helpers/services.ts
@@ -1,0 +1,24 @@
+import { Ollama } from "ollama";
+import { ChromaClient } from "chromadb";
+
+/**
+ * Ensure Ollama and ChromaDB services are reachable before running tests.
+ */
+export async function ensureServices() {
+  const ollamaUrl = process.env.OLLAMA_URL ?? "http://localhost:11434";
+  try {
+    const ollamaClient = new Ollama({ host: ollamaUrl });
+    await ollamaClient.list();
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    throw new Error(`Ollama server unavailable at ${ollamaUrl}: ${msg}`);
+  }
+
+  const chromaClient = new ChromaClient({});
+  try {
+    await chromaClient.heartbeat();
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    throw new Error(`ChromaDB server unavailable: ${msg}`);
+  }
+}

--- a/packages/docops/src/tests/helpers/setup.ts
+++ b/packages/docops/src/tests/helpers/setup.ts
@@ -1,0 +1,8 @@
+import test from "ava";
+import { ensureServices } from "./services.js";
+
+test.before(async () => {
+  await ensureServices();
+});
+
+export {};

--- a/packages/docops/src/tests/integration/devui.api.spec.ts
+++ b/packages/docops/src/tests/integration/devui.api.spec.ts
@@ -3,6 +3,7 @@ import * as url from "node:url";
 import { promises as fs } from "node:fs";
 import { v4 as uuidv4 } from "uuid";
 
+import "../helpers/setup.js";
 import test from "ava";
 import {
   withPage,

--- a/packages/docops/src/tests/integration/devui.data.spec.ts
+++ b/packages/docops/src/tests/integration/devui.data.spec.ts
@@ -3,6 +3,7 @@ import * as url from "node:url";
 import { promises as fs } from "node:fs";
 import { v4 as uuidv4 } from "uuid";
 
+import "../helpers/setup.js";
 import test from "ava";
 import {
   withPage,

--- a/packages/docops/src/tests/integration/devui.files.spec.ts
+++ b/packages/docops/src/tests/integration/devui.files.spec.ts
@@ -3,6 +3,7 @@ import * as url from "node:url";
 import { promises as fs } from "node:fs";
 import { v4 as uuidv4 } from "uuid";
 
+import "../helpers/setup.js";
 import test from "ava";
 import {
   withPage,

--- a/packages/docops/src/tests/integration/devui.negatives.spec.ts
+++ b/packages/docops/src/tests/integration/devui.negatives.spec.ts
@@ -3,6 +3,7 @@ import * as url from "node:url";
 import { promises as fs } from "node:fs";
 import { v4 as uuidv4 } from "uuid";
 
+import "../helpers/setup.js";
 import test from "ava";
 import {
   withPage,

--- a/packages/docops/src/tests/integration/devui.params.spec.ts
+++ b/packages/docops/src/tests/integration/devui.params.spec.ts
@@ -3,6 +3,7 @@ import * as url from "node:url";
 import { promises as fs } from "node:fs";
 import { v4 as uuidv4 } from "uuid";
 
+import "../helpers/setup.js";
 import test from "ava";
 import {
   withPage,

--- a/packages/docops/src/tests/integration/devui.pipeline.spec.ts
+++ b/packages/docops/src/tests/integration/devui.pipeline.spec.ts
@@ -3,6 +3,7 @@ import * as url from "node:url";
 import { promises as fs } from "node:fs";
 import { v4 as uuidv4 } from "uuid";
 
+import "../helpers/setup.js";
 import test from "ava";
 import {
   withPage,

--- a/packages/docops/src/tests/integration/devui.spec.ts
+++ b/packages/docops/src/tests/integration/devui.spec.ts
@@ -3,6 +3,7 @@ import * as url from "node:url";
 import { promises as fs } from "node:fs";
 import { v4 as uuidv4 } from "uuid";
 
+import "../helpers/setup.js";
 import test from "ava";
 import {
   withPage,


### PR DESCRIPTION
## Summary
- ensure docops tests fail fast when Ollama or ChromaDB are unavailable
- add shared setup to integration specs and verify services in e2e
- document required local services before running docops tests

## Testing
- `pnpm --filter @promethean/docops test` *(fails: Ollama server unavailable)*
- `pnpm --filter @promethean/docops test:e2e` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68bdd115ac608324a0da0b3b140e6bbe