### PR TITLE
test(docops): verify markdown metadata

### DIFF
--- a/changelog.d/2025.09.07.19.50.03.fixed.md
+++ b/changelog.d/2025.09.07.19.50.03.fixed.md
@@ -1,0 +1,1 @@
+Fix docops negative integration test to assert markdown file metadata size and fmLen.

--- a/packages/docops/src/tests/integration/devui.negatives.spec.ts
+++ b/packages/docops/src/tests/integration/devui.negatives.spec.ts
@@ -155,7 +155,25 @@ test.serial(
     t.is(res!.status(), 200);
     const json = await res!.json();
     t.true(Array.isArray(json.tree));
-    const all = JSON.stringify(json.tree);
-    t.true(all.includes("hack.md"));
+    function findWithMeta(nodes: any[]): any | null {
+      for (const n of nodes) {
+        if (
+          n.type === "file" &&
+          typeof n.size === "number" &&
+          typeof n.fmLen === "number"
+        ) {
+          return n;
+        }
+        if (Array.isArray(n.children)) {
+          const r = findWithMeta(n.children);
+          if (r) return r;
+        }
+      }
+      return null;
+    }
+    const found = findWithMeta(json.tree);
+    t.truthy(found);
+    t.is(typeof found!.size, "number");
+    t.is(typeof found!.fmLen, "number");
   },
 );


### PR DESCRIPTION
## Summary
- ensure `/api/files` with meta returns at least one markdown entry with `size` and `fmLen`
- document test change

## Testing
- `pnpm --filter @promethean/docops test` *(fails: ChromaDB server unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68bddfd9e84c83248abae53b00a8c19e