### PR TITLE
test(docops): wait for markdown render

### DIFF
--- a/changelog.d/2025.09.07.19.49.53.fixed.md
+++ b/changelog.d/2025.09.07.19.49.53.fixed.md
@@ -1,0 +1,1 @@
+fix: add explicit wait before reading markdown output in DocOps e2e test

--- a/packages/docops/src/tests/e2e/docops.e2e.spec.ts
+++ b/packages/docops/src/tests/e2e/docops.e2e.spec.ts
@@ -165,7 +165,10 @@ test.serial(
 
     // Try direct render via the "Render Selected File" button
     await page.click(byId("renderMd"));
-    await page.waitForSelector(byId("mdRender"));
+    await page.waitForFunction(() => {
+      const el = document.getElementById("mdRender");
+      return !!el && (el.textContent?.length ?? 0) > 0;
+    });
     const mdHtml = await page.textContent(byId("mdRender"));
     t.truthy(
       mdHtml && mdHtml.length > 0,


### PR DESCRIPTION
## Summary
- ensure DocOps E2E waits for markdown render before reading output

## Testing
- `pnpm --filter @promethean/docops test` *(fails: ChromaDB server unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68bddfd7fbf483249c46e7d3d57cb8bc