### PR TITLE
feat(piper): add js step execution

### DIFF
--- a/changelog.d/2025.09.07.21.51.57.added.md
+++ b/changelog.d/2025.09.07.21.51.57.added.md
@@ -1,0 +1,1 @@
+- piper supports in-process JS function steps via `js` target

--- a/packages/piper/src/runner.ts
+++ b/packages/piper/src/runner.ts
@@ -16,6 +16,7 @@ import {
   runNode,
   runShell,
   runTSModule,
+  runJSModule,
   writeText,
 } from "./fsutils.js";
 import { stepFingerprint } from "./hash.js";
@@ -130,6 +131,7 @@ export async function runPipeline(
       else if (s.node)
         execRes = await runNode(s.node, s.args, cwd, s.env, s.timeoutMs);
       else if (s.ts) execRes = await runTSModule(s, cwd, s.env, s.timeoutMs);
+      else if (s.js) execRes = await runJSModule(s, cwd, s.env, s.timeoutMs);
 
       const endedAt = new Date().toISOString();
       const out: StepResult = {

--- a/packages/piper/src/test/js-step.test.ts
+++ b/packages/piper/src/test/js-step.test.ts
@@ -1,0 +1,76 @@
+import * as fs from "fs/promises";
+import * as path from "path";
+
+import test from "ava";
+import YAML from "yaml";
+
+import { runPipeline } from "../runner.js";
+
+async function withTmp(fn: (dir: string) => Promise<void>) {
+  const dir = path.join(
+    process.cwd(),
+    "test-tmp",
+    String(Date.now()) + "-" + Math.random().toString(36).slice(2),
+  );
+  await fs.mkdir(dir, { recursive: true });
+  try {
+    await fn(dir);
+  } finally {
+    await fs.rm(dir, { recursive: true, force: true });
+  }
+}
+
+test("runPipeline executes js function steps", async (t) => {
+  await withTmp(async (dir) => {
+    const prevCwd = process.cwd();
+    process.chdir(dir);
+    try {
+      const libPath = path.join(dir, "lib.js");
+      await fs.writeFile(
+        libPath,
+        "import { promises as fs } from 'fs';\nexport async function make({file,content}){await fs.writeFile(file, content, 'utf8');return 'made';}\n",
+        "utf8",
+      );
+      const cfg = {
+        pipelines: [
+          {
+            name: "demo",
+            steps: [
+              {
+                id: "make",
+                cwd: ".",
+                deps: [],
+                inputs: [],
+                outputs: ["out.txt"],
+                cache: "content",
+                js: {
+                  module: "./lib.js",
+                  export: "make",
+                  args: { file: "out.txt", content: "hi" },
+                },
+              },
+              {
+                id: "cat",
+                cwd: ".",
+                deps: ["make"],
+                inputs: ["out.txt"],
+                outputs: ["out2.txt"],
+                cache: "content",
+                shell: "cat out.txt > out2.txt",
+              },
+            ],
+          },
+        ],
+      };
+      const pipelinesPath = path.join(dir, "pipelines.yaml");
+      await fs.writeFile(pipelinesPath, YAML.stringify(cfg), "utf8");
+      const res = await runPipeline(pipelinesPath, "demo", { concurrency: 2 });
+      t.is(res.length, 2);
+      t.true(res.every((r) => !r.skipped));
+      const out = await fs.readFile(path.join(dir, "out2.txt"), "utf8");
+      t.is(out, "hi");
+    } finally {
+      process.chdir(prevCwd);
+    }
+  });
+});

--- a/packages/piper/src/types.ts
+++ b/packages/piper/src/types.ts
@@ -16,9 +16,14 @@ export const StepSchema = z.object({
     export: z.string().default("default"),
     args: z.any().optional()
   }).optional(),
+  js: z.object({                    // import and run a JS function in-process
+    module: z.string(),
+    export: z.string().default("default"),
+    args: z.any().optional(),
+  }).optional(),
   args: z.array(z.string()).optional(),
   timeoutMs: z.number().optional()
-}).refine(s => !!(s.shell || s.node || s.ts), { message: "step must define shell|node|ts" });
+}).refine(s => !!(s.shell || s.node || s.ts || s.js), { message: "step must define shell|node|ts|js" });
 
 export const PipelineSchema = z.object({
   name: z.string().min(1),


### PR DESCRIPTION
## Summary
- allow steps to reference JS modules via new `js` target
- execute JS steps in-process using dynamic `import()`
- test JS function steps alongside CLI commands

## Testing
- `pnpm --filter @promethean/piper test`


------
https://chatgpt.com/codex/tasks/task_e_68bdfc4cf61c832480879f694237d135