### PR TITLE
feat: scaffold docops-style packages with NX

### DIFF
--- a/changelog.d/2025.09.07.21.56.14.added.md
+++ b/changelog.d/2025.09.07.21.56.14.added.md
@@ -1,0 +1,1 @@
+- add package generator for docops-style packages

--- a/changelog.d/2025.09.07.23.06.45.fixed.md
+++ b/changelog.d/2025.09.07.23.06.45.fixed.md
@@ -1,0 +1,1 @@
+- fixed package generator docs and workspace config so the generator runs via `nx`

--- a/docs/package-generator.md
+++ b/docs/package-generator.md
@@ -1,0 +1,21 @@
+# Package Generator
+
+Use the NX package generator to scaffold a new package that matches the `docops` layout.
+
+```bash
+pnpm nx generate ./tools/generators/package --name my-lib
+```
+
+This creates `packages/my-lib` with:
+
+- `package.json` named `@promethean/my-lib`
+- TypeScript config extending the workspace base
+- AVA test setup and sample test
+- default `pipelines.yml`
+- `project.json` wired for `build`, `test`, `lint`, and `typecheck`
+
+Run the new package's tests with:
+
+```bash
+pnpm --filter @promethean/my-lib test
+```

--- a/docs/package-generator.md
+++ b/docs/package-generator.md
@@ -3,7 +3,7 @@
 Use the NX package generator to scaffold a new package that matches the `docops` layout.
 
 ```bash
-pnpm nx generate ./tools/generators/package --name my-lib
+pnpm nx generate ./tools:package --name my-lib
 ```
 
 This creates `packages/my-lib` with:

--- a/nx.json
+++ b/nx.json
@@ -22,5 +22,7 @@
       "dependsOn": ["build"]
     }
   },
-  "projects": {}
+  "projects": {
+    "tools": "tools"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "zod": "3.25.76"
   },
   "devDependencies": {
-    "@nx/devkit": "^21.4.1",
+    "@nx/devkit": "21.4.1",
     "@playwright/test": "^1.55.0",
     "@promethean/test-utils": "workspace:*",
     "@types/jest": "30.0.0",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "@promethean/piper": "workspace:*",
     "@promethean/pm2-helpers": "workspace:*",
     "@promethean/utils": "workspace:*",
-    "@promethean/image-link-generator": "workspace:*",
     "@types/node": "^24.3.1",
     "@xenova/transformers": "2.17.2",
     "adm-zip": "0.5.16",
@@ -65,6 +64,7 @@
     "zod": "3.25.76"
   },
   "devDependencies": {
+    "@nx/devkit": "^21.4.1",
     "@playwright/test": "^1.55.0",
     "@promethean/test-utils": "workspace:*",
     "@types/jest": "30.0.0",
@@ -84,8 +84,7 @@
     "ts-jest": "29.4.1",
     "tsx": "4.20.3",
     "typescript": "5.4.5",
-    "typescript-eslint": "8.42.0",
-    "nx": "^20.0.0"
+    "typescript-eslint": "8.42.0"
   },
   "license": "GPL-3.0-only",
   "volta": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -95,6 +95,9 @@ importers:
         specifier: 3.25.76
         version: 3.25.76
     devDependencies:
+      '@nx/devkit':
+        specifier: ^21.4.1
+        version: 21.4.1(nx@20.8.2)
       '@playwright/test':
         specifier: ^1.55.0
         version: 1.55.0
@@ -5119,6 +5122,11 @@ packages:
     resolution: {integrity: sha512-xhfYPXoV5Dy4UkY0D+v2KkwvnDfiA/8Mt3sWCGI/hM03NsYIH8ZaG6QzS9x7pje5vHZBZJ2v6VRFVTWACnqcmQ==}
     engines: {node: ^16.14.0 || >=18.0.0}
 
+  '@nx/devkit@21.4.1':
+    resolution: {integrity: sha512-rWgMNG2e0tSG5L3vffuMH/aRkn+i9vYHelWkgVAslGBOaqriEg1dCSL/W9I3Fd5lnucHy3DrG1f19uDjv7Dm0A==}
+    peerDependencies:
+      nx: '>= 20 <= 22'
+
   '@nx/nx-darwin-arm64@20.8.2':
     resolution: {integrity: sha512-t+bmCn6sRPNGU6hnSyWNvbQYA/KgsxGZKYlaCLRwkNhI2akModcBUqtktJzCKd1XHDqs6EkEFBWjFr8/kBEkSg==}
     engines: {node: '>= 10'}
@@ -6980,6 +6988,11 @@ packages:
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
 
+  ejs@3.1.10:
+    resolution: {integrity: sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==}
+    engines: {node: '>=0.10.0'}
+    hasBin: true
+
   electron-to-chromium@1.5.214:
     resolution: {integrity: sha512-TpvUNdha+X3ybfU78NoQatKvQEm1oq3lf2QbnmCEdw+Bd9RuIAY+hJTvq1avzHM0f7EJfnH3vbCnbzKzisc/9Q==}
 
@@ -7563,6 +7576,9 @@ packages:
 
   file-uri-to-path@1.0.0:
     resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
+
+  filelist@1.0.4:
+    resolution: {integrity: sha512-w1cEuf3S+DrLCQL7ET6kz+gmlJdbq9J7yXCSjK/OZCPA+qEN1WyF4ZAf0YYJa4/shHJra2t/d/r8SV4Ji+x+8Q==}
 
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
@@ -8251,6 +8267,11 @@ packages:
   jackspeak@4.1.1:
     resolution: {integrity: sha512-zptv57P3GpL+O0I7VdMJNBZCu+BPHVQUk55Ft8/QCJjTVxrnJHuVuX/0Bl2A6/+2oyR/ZMEuFKwmzqqZ/U5nPQ==}
     engines: {node: 20 || >=22}
+
+  jake@10.9.4:
+    resolution: {integrity: sha512-wpHYzhxiVQL+IV05BLE2Xn34zW1S223hvjtqk0+gsPrwd/8JNLXJgZZM/iPFsYc1xyphF+6M6EvdE5E9MBGkDA==}
+    engines: {node: '>=10'}
+    hasBin: true
 
   javascript-time-ago@2.5.11:
     resolution: {integrity: sha512-Zeyf5R7oM1fSMW9zsU3YgAYwE0bimEeF54Udn2ixGd8PUwu+z1Yc5t4Y8YScJDMHD6uCx6giLt3VJR5K4CMwbg==}
@@ -12173,6 +12194,18 @@ snapshots:
     dependencies:
       which: 4.0.0
 
+  '@nx/devkit@21.4.1(nx@20.8.2)':
+    dependencies:
+      ejs: 3.1.10
+      enquirer: 2.3.6
+      ignore: 5.3.2
+      minimatch: 9.0.3
+      nx: 20.8.2
+      semver: 7.7.2
+      tmp: 0.2.5
+      tslib: 2.8.1
+      yargs-parser: 21.1.1
+
   '@nx/nx-darwin-arm64@20.8.2':
     optional: true
 
@@ -13453,7 +13486,7 @@ snapshots:
 
   axios@1.11.0:
     dependencies:
-      follow-redirects: 1.15.11(debug@4.3.7)
+      follow-redirects: 1.15.11(debug@4.4.1)
       form-data: 4.0.4
       proxy-from-env: 1.1.0
     transitivePeerDependencies:
@@ -14305,6 +14338,10 @@ snapshots:
       safe-buffer: 5.2.1
 
   ee-first@1.1.1: {}
+
+  ejs@3.1.10:
+    dependencies:
+      jake: 10.9.4
 
   electron-to-chromium@1.5.214: {}
 
@@ -15301,6 +15338,10 @@ snapshots:
 
   file-uri-to-path@1.0.0: {}
 
+  filelist@1.0.4:
+    dependencies:
+      minimatch: 5.1.6
+
   fill-range@7.1.1:
     dependencies:
       to-regex-range: 5.0.1
@@ -15683,7 +15724,7 @@ snapshots:
   http-proxy@1.18.1:
     dependencies:
       eventemitter3: 4.0.7
-      follow-redirects: 1.15.11(debug@4.3.7)
+      follow-redirects: 1.15.11(debug@4.4.1)
       requires-port: 1.0.0
     transitivePeerDependencies:
       - debug
@@ -16020,6 +16061,12 @@ snapshots:
   jackspeak@4.1.1:
     dependencies:
       '@isaacs/cliui': 8.0.2
+
+  jake@10.9.4:
+    dependencies:
+      async: 3.2.6
+      filelist: 1.0.4
+      picocolors: 1.1.1
 
   javascript-time-ago@2.5.11:
     dependencies:

--- a/tests/integration/package-generator.test.js
+++ b/tests/integration/package-generator.test.js
@@ -1,0 +1,19 @@
+import test from "ava";
+import { createTreeWithEmptyWorkspace } from "@nx/devkit/testing.js";
+import { readJson } from "@nx/devkit";
+import generator from "../../tools/generators/package/index.js";
+
+const exists = (tree, path) => tree.exists(path);
+
+test("scaffolds docops-style package", async (t) => {
+  const tree = createTreeWithEmptyWorkspace();
+  await generator(tree, { name: "demo" });
+  t.true(exists(tree, "packages/demo/package.json"));
+  t.true(exists(tree, "packages/demo/tsconfig.json"));
+  t.true(exists(tree, "packages/demo/ava.config.mjs"));
+  t.true(exists(tree, "packages/demo/pipelines.yml"));
+  t.true(exists(tree, "packages/demo/project.json"));
+  t.true(exists(tree, "packages/demo/src/tests/sample.test.ts"));
+  const pkg = readJson(tree, "packages/demo/package.json");
+  t.is(pkg.name, "@promethean/demo");
+});

--- a/tools/generators.json
+++ b/tools/generators.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://json.schemastore.org/nx-generator.json",
+  "generators": {
+    "package": {
+      "factory": "./generators/package/index.js",
+      "schema": "./generators/package/schema.json",
+      "description": "Generate a new package"
+    }
+  }
+}

--- a/tools/generators/package/files/ava.config.mjs__tmpl__
+++ b/tools/generators/package/files/ava.config.mjs__tmpl__
@@ -1,0 +1,1 @@
+export { default } from "../../config/ava.config.mjs";

--- a/tools/generators/package/files/package.json__tmpl__
+++ b/tools/generators/package/files/package.json__tmpl__
@@ -1,0 +1,10 @@
+{
+  "name": "@promethean/<%= name %>",
+  "type": "module",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "test": "pnpm build && ava",
+    "coverage": "pnpm build && c8 ava"
+  },
+  "dependencies": {}
+}

--- a/tools/generators/package/files/package.json__tmpl__
+++ b/tools/generators/package/files/package.json__tmpl__
@@ -2,7 +2,9 @@
   "name": "@promethean/<%= name %>",
   "type": "module",
   "scripts": {
-    "build": "tsc -p tsconfig.json",
+    "build": "tsc -b",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "clean": "rimraf dist",
     "test": "pnpm build && ava",
     "coverage": "pnpm build && c8 ava"
   },

--- a/tools/generators/package/files/pipelines.yml__tmpl__
+++ b/tools/generators/package/files/pipelines.yml__tmpl__
@@ -1,0 +1,5 @@
+pipelines:
+  - name: <%= name %>
+    steps:
+      - id: example
+        shell: echo "running <%= name %> pipeline"

--- a/tools/generators/package/files/project.json__tmpl__
+++ b/tools/generators/package/files/project.json__tmpl__
@@ -21,7 +21,7 @@
     "test": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "ava",
+        "command": "pnpm build && ava",
         "cwd": "packages/<%= name %>"
       }
     },

--- a/tools/generators/package/files/project.json__tmpl__
+++ b/tools/generators/package/files/project.json__tmpl__
@@ -1,0 +1,37 @@
+{
+  "name": "ts-<%= name %>",
+  "root": "packages/<%= name %>",
+  "sourceRoot": "packages/<%= name %>/src",
+  "targets": {
+    "build": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "tsc -b",
+        "cwd": "packages/<%= name %>"
+      },
+      "outputs": ["{projectRoot}/dist"]
+    },
+    "typecheck": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "tsc -p tsconfig.json --noEmit",
+        "cwd": "packages/<%= name %>"
+      }
+    },
+    "test": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "ava",
+        "cwd": "packages/<%= name %>"
+      }
+    },
+    "lint": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "eslint .",
+        "cwd": "packages/<%= name %>"
+      }
+    }
+  },
+  "tags": ["scope:packages"]
+}

--- a/tools/generators/package/files/src/index.ts__tmpl__
+++ b/tools/generators/package/files/src/index.ts__tmpl__
@@ -1,0 +1,3 @@
+export function placeholder() {
+  return "<%= name %>";
+}

--- a/tools/generators/package/files/src/tests/sample.test.ts__tmpl__
+++ b/tools/generators/package/files/src/tests/sample.test.ts__tmpl__
@@ -1,0 +1,6 @@
+import test from "ava";
+import { placeholder } from "@promethean/<%= name %>";
+
+test("placeholder returns name", (t) => {
+  t.is(placeholder(), "<%= name %>");
+});

--- a/tools/generators/package/files/tsconfig.json__tmpl__
+++ b/tools/generators/package/files/tsconfig.json__tmpl__
@@ -1,0 +1,11 @@
+{
+  "extends": "../../config/tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "composite": true,
+    "declaration": true
+  },
+  "include": ["src/**/*"],
+  "references": []
+}

--- a/tools/generators/package/index.js
+++ b/tools/generators/package/index.js
@@ -1,0 +1,15 @@
+import { generateFiles, joinPathFragments, names, formatFiles } from "@nx/devkit";
+import { fileURLToPath } from "node:url";
+import { dirname } from "node:path";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+export default async function generator(tree, schema) {
+  const normalized = names(schema.name).fileName;
+  const projectRoot = joinPathFragments("packages", normalized);
+  generateFiles(tree, joinPathFragments(__dirname, "files"), projectRoot, {
+    tmpl: "",
+    name: normalized,
+  });
+  await formatFiles(tree);
+}

--- a/tools/generators/package/schema.json
+++ b/tools/generators/package/schema.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "http://json-schema.org/schema",
+  "title": "Package generator",
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string",
+      "description": "Package name",
+      "$default": {
+        "$source": "argv",
+        "index": 0
+      }
+    }
+  },
+  "required": ["name"]
+}

--- a/tools/index.js
+++ b/tools/index.js
@@ -1,0 +1,1 @@
+export default {};

--- a/tools/package.json
+++ b/tools/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@promethean/tools",
+  "version": "0.0.0",
+  "type": "module",
+  "main": "index.js",
+  "generators": "./generators.json"
+}

--- a/tools/project.json
+++ b/tools/project.json
@@ -1,0 +1,7 @@
+{
+  "name": "tools",
+  "root": "tools",
+  "projectType": "library",
+  "targets": {},
+  "generators": "./generators.json"
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,20 @@
+{
+  "compileOnSave": false,
+  "compilerOptions": {
+    "rootDir": ".",
+    "sourceMap": true,
+    "declaration": false,
+    "moduleResolution": "node",
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "importHelpers": true,
+    "target": "es2015",
+    "module": "esnext",
+    "lib": ["es2020", "dom"],
+    "skipLibCheck": true,
+    "skipDefaultLibCheck": true,
+    "baseUrl": ".",
+    "paths": {}
+  },
+  "exclude": ["node_modules", "tmp"]
+}


### PR DESCRIPTION
## Summary
- add NX generator to scaffold docops-style package structure
- document package generator usage
- test generator to verify required files

## Testing
- `pnpm exec ava tests/integration/package-generator.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68bdfc4f0efc8324868bc7d38f7f9977

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Introduced a generator to scaffold docops-style packages with build, test, lint, and typecheck tasks.
* Bug Fixes
  * Ensured the package generator runs correctly via the workspace tooling.
* Documentation
  * Added guidance for using the package generator, including commands and expected project structure.
* Tests
  * Added integration tests validating package scaffolding and configuration.
* Chores
  * Cleaned up dependencies, updated workspace configuration to recognize tools, and added a base TypeScript config for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->