### PR TITLE
feat(piper): add js step support

### DIFF
--- a/changelog.d/2025.09.07.21.53.53.added.md
+++ b/changelog.d/2025.09.07.21.53.53.added.md
@@ -1,0 +1,1 @@
+feat(piper): support in-process js steps

--- a/packages/piper/src/fsutils.ts
+++ b/packages/piper/src/fsutils.ts
@@ -91,6 +91,26 @@ export async function runTSModule(
   });
 }
 
+export async function runJSFunction(
+  fn: (args: unknown) => unknown | Promise<unknown>,
+  args: unknown,
+) {
+  try {
+    const res = await fn(args as any);
+    return {
+      code: 0,
+      stdout: typeof res === "string" ? res : "",
+      stderr: "",
+    };
+  } catch (err: unknown) {
+    return {
+      code: 1,
+      stdout: "",
+      stderr: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
 function runSpawn(
   cmd: string,
   opts: {

--- a/packages/piper/src/hash.ts
+++ b/packages/piper/src/hash.ts
@@ -57,8 +57,8 @@ export async function stepFingerprint(
       id: step.id,
       name: step.name,
       deps: step.deps,
-      cmd: step.shell ?? step.node ?? step.ts,
-      args: step.args ?? step.ts?.args,
+      cmd: step.shell ?? step.node ?? step.ts ?? step.js,
+      args: step.args ?? step.ts?.args ?? step.js?.args,
       env: step.env,
     }),
   );

--- a/packages/piper/src/runner.ts
+++ b/packages/piper/src/runner.ts
@@ -16,6 +16,7 @@ import {
   runNode,
   runShell,
   runTSModule,
+  runJSFunction,
   writeText,
 } from "./fsutils.js";
 import { stepFingerprint } from "./hash.js";
@@ -130,6 +131,17 @@ export async function runPipeline(
       else if (s.node)
         execRes = await runNode(s.node, s.args, cwd, s.env, s.timeoutMs);
       else if (s.ts) execRes = await runTSModule(s, cwd, s.env, s.timeoutMs);
+      else if (s.js) {
+        const modPath = path.isAbsolute(s.js.module)
+          ? s.js.module
+          : path.resolve(cwd, s.js.module);
+        const mod = await import(modPath);
+        const fn =
+          (s.js.export && (mod as any)[s.js.export]) ??
+          (mod as any).default ??
+          mod;
+        execRes = await runJSFunction(fn as any, s.js.args);
+      }
 
       const endedAt = new Date().toISOString();
       const out: StepResult = {

--- a/packages/piper/src/test/js-step.test.ts
+++ b/packages/piper/src/test/js-step.test.ts
@@ -1,0 +1,73 @@
+import * as fs from "fs/promises";
+import * as path from "path";
+
+import test from "ava";
+
+import { runPipeline } from "../runner.js";
+
+async function withTmp(fn: (dir: string) => Promise<void>) {
+  const dir = path.join(
+    process.cwd(),
+    "test-tmp",
+    String(Date.now()) + "-" + Math.random().toString(36).slice(2),
+  );
+  await fs.mkdir(dir, { recursive: true });
+  try {
+    await fn(dir);
+  } finally {
+    await fs.rm(dir, { recursive: true, force: true });
+  }
+}
+
+test("pipeline supports shell and js steps", async (t) => {
+  await withTmp(async (dir) => {
+    const prev = process.cwd();
+    process.chdir(dir);
+    try {
+      const modPath = path.join(dir, "mod.js");
+      await fs.writeFile(
+        modPath,
+        "export async function run() {\n" +
+          "  const txt = await (await import('fs/promises')).readFile('out.txt','utf8');\n" +
+          "  return txt.trim().toUpperCase();\n" +
+          "}\n",
+        "utf8",
+      );
+      const cfg = {
+        pipelines: [
+          {
+            name: "demo",
+            steps: [
+              {
+              id: "make",
+              cwd: ".",
+              deps: [],
+              inputs: [],
+              outputs: ["out.txt"],
+              cache: "content",
+              shell: "echo hello > out.txt",
+            },
+            {
+              id: "js",
+              cwd: ".",
+              deps: ["make"],
+              inputs: ["out.txt"],
+              outputs: [],
+              cache: "content",
+              js: { module: "./mod.js", export: "run" },
+            },
+          ],
+        },
+      ],
+    };
+      const pipelinesPath = path.join(dir, "pipes.yaml");
+      await fs.writeFile(pipelinesPath, JSON.stringify(cfg), "utf8");
+      const res = await runPipeline(pipelinesPath, "demo", { concurrency: 1 });
+      const jsStep = res.find((r) => r.id === "js");
+      t.truthy(jsStep);
+      t.is(jsStep!.stdout?.trim(), "HELLO");
+    } finally {
+      process.chdir(prev);
+    }
+  });
+});

--- a/packages/piper/src/types.ts
+++ b/packages/piper/src/types.ts
@@ -16,9 +16,14 @@ export const StepSchema = z.object({
     export: z.string().default("default"),
     args: z.any().optional()
   }).optional(),
+  js: z.object({                    // import and run a JS function in-process
+    module: z.string(),
+    export: z.string().default("default"),
+    args: z.any().optional(),
+  }).optional(),
   args: z.array(z.string()).optional(),
   timeoutMs: z.number().optional()
-}).refine(s => !!(s.shell || s.node || s.ts), { message: "step must define shell|node|ts" });
+}).refine(s => !!(s.shell || s.node || s.ts || s.js), { message: "step must define shell|node|ts|js" });
 
 export const PipelineSchema = z.object({
   name: z.string().min(1),


### PR DESCRIPTION
## Summary
- allow piper steps to target in-process JavaScript modules
- execute JS steps via dynamic import without spawning a subprocess
- cover JS steps alongside CLI steps in new tests

## Testing
- `pnpm --filter @promethean/piper test`

------
https://chatgpt.com/codex/tasks/task_e_68bdfc4a55b08324b74b8b443554dbe1