### PR TITLE
test: add pipeline run e2e spec

### DIFF
--- a/changelog.d/2025.09.07.21.58.00.added.md
+++ b/changelog.d/2025.09.07.21.58.00.added.md
@@ -1,0 +1,1 @@
+Add pipeline run E2E test for DocOps UI.

--- a/packages/docops/src/tests/e2e/pipeline.run.spec.ts
+++ b/packages/docops/src/tests/e2e/pipeline.run.spec.ts
@@ -1,0 +1,167 @@
+// GPL-3.0-only
+import * as path from "node:path";
+import * as url from "node:url";
+import { promises as fs } from "node:fs";
+import { v4 as uuidv4 } from "uuid";
+
+import test from "ava";
+import {
+	withPage,
+	shutdown,
+	startProcessWithPort,
+} from "@promethean/test-utils";
+import { ensureServices } from "../helpers/services.js";
+
+const PKG_ROOT = path.resolve(
+	path.dirname(url.fileURLToPath(import.meta.url)),
+	"../../../",
+);
+
+const DOC_FIXTURE_PATH = path.join(PKG_ROOT, "test-tmp", `docs-${uuidv4()}`);
+const TMP_DB = path.join(PKG_ROOT, ".cache", `docops-pipeline-${uuidv4()}`);
+
+let state: { stop: () => Promise<void>; baseUrl?: string } | null = null;
+
+test.before(async () => {
+	await ensureServices();
+	await fs.mkdir(DOC_FIXTURE_PATH, { recursive: true });
+	await fs.writeFile(
+		path.join(DOC_FIXTURE_PATH, "run.md"),
+		"---\ntitle: run\n---\n# Sample\n",
+	);
+	const { stop, baseUrl } = await startProcessWithPort({
+		cmd: "node",
+		args: [
+			path.join(PKG_ROOT, "dist/dev-ui.js"),
+			"--dir",
+			DOC_FIXTURE_PATH,
+			"--collection",
+			uuidv4(),
+			"--port",
+			":PORT",
+		],
+		cwd: PKG_ROOT,
+		env: { ...process.env, DOCOPS_DB: TMP_DB },
+		stdio: "inherit",
+		ready: {
+			kind: "http",
+			url: "http://127.0.0.1:PORT/health",
+			timeoutMs: 60_000,
+		},
+		port: { mode: "free" },
+		baseUrlTemplate: (p) => `http://127.0.0.1:${p}/`,
+	});
+	const next: { stop: () => Promise<void>; baseUrl?: string } = { stop };
+	if (baseUrl) next.baseUrl = baseUrl;
+	state = next;
+});
+
+test.after.always(async () => {
+	try {
+		await state?.stop?.();
+	} finally {
+		state = null;
+		try {
+			await shutdown();
+		} finally {
+			await Promise.all([
+				fs.rm(TMP_DB, { recursive: true, force: true }).catch(() => {}),
+				fs
+					.rm(DOC_FIXTURE_PATH, { recursive: true, force: true })
+					.catch(() => {}),
+			]);
+		}
+	}
+});
+
+const byId = (id: string) => `#${id}`;
+
+async function clickFileInTree(page: any, label: string) {
+	const item = page.getByRole("treeitem", { name: label }).first();
+	if (await item.count().then((n: number) => n > 0)) {
+		await item.click();
+		return;
+	}
+	const clicked = await page.evaluate((wanted: string) => {
+		const host = document.querySelector("file-tree") as HTMLElement & {
+			shadowRoot?: ShadowRoot | null;
+		};
+		if (!host) return false;
+		const root = host.shadowRoot ?? host;
+		const anchors = root.querySelectorAll("a, li, span, div, button");
+		for (const el of anchors) {
+			if ((el.textContent || "").trim() === wanted) {
+				(el as HTMLElement).click();
+				return true;
+			}
+		}
+		return false;
+	}, label);
+	if (!clicked) {
+		throw new Error(`Could not click file "${label}" in <file-tree>`);
+	}
+}
+
+test.serial(
+	"DocOps Pipeline Run: executes pipeline and refreshes file tree",
+	withPage,
+	{ baseUrl: () => state?.baseUrl },
+	async (t, fixtures) => {
+		const page =
+			(fixtures as any).page ??
+			(await (async () => {
+				const res = await fixtures.pageGoto?.("/");
+				t.truthy(res, "app responded at /");
+				throw new Error(
+					"withPage did not expose a Playwright `page`. Extend @promethean/test-utils to provide it.",
+				);
+			})());
+
+		await page.goto(`${state!.baseUrl}`, { waitUntil: "domcontentloaded" });
+
+		await page.fill(byId("dir"), DOC_FIXTURE_PATH);
+		const coll = `e2e-${uuidv4().slice(0, 8)}`;
+		await page.fill(byId("collection"), coll);
+
+		await page.click(byId("refresh"));
+		await page.waitForFunction(() => {
+			const sel = document.getElementById(
+				"doclist",
+			) as HTMLSelectElement | null;
+			return !!sel && sel.options.length >= 0;
+		});
+
+		await clickFileInTree(page, "run.md");
+
+		await page.click(byId("run"));
+		await page.waitForFunction(() => {
+			const prog = document.getElementById(
+				"overallProgress",
+			) as HTMLProgressElement | null;
+			const logs = document.getElementById("logs")?.textContent || "";
+			return (prog && prog.value >= 100) || logs.includes("Done.");
+		});
+
+		const logsText = await page.textContent("#logs");
+		t.true(
+			!!logsText &&
+				logsText.split(/\n/).filter((l: string) => l.trim().length > 0)
+					.length >= 1,
+			"Logs should contain at least one line",
+		);
+
+		await page.waitForFunction(() => {
+			const sel = document.getElementById(
+				"doclist",
+			) as HTMLSelectElement | null;
+			return !!sel && sel.options.length > 0;
+		});
+		const count = await page.evaluate(() => {
+			const sel = document.getElementById(
+				"doclist",
+			) as HTMLSelectElement | null;
+			return sel ? sel.options.length : 0;
+		});
+		t.true(count > 0, "Doc list repopulated after run");
+	},
+);


### PR DESCRIPTION
## Summary
- add pipeline run end-to-end test for DocOps UI
- document change in changelog

## Testing
- `pnpm exec biome lint packages/docops/src/tests/e2e/pipeline.run.spec.ts`
- `pnpm --filter @promethean/docops test` *(fails: TimeoutError page.waitForFunction)*

------
https://chatgpt.com/codex/tasks/task_e_68bdff60764483248ee6d95a253b8b08