### PR TITLE
test(docops): cover empty search

### DIFF
--- a/changelog.d/2025.09.07.22.00.14.added.md
+++ b/changelog.d/2025.09.07.22.00.14.added.md
@@ -1,0 +1,1 @@
+Added an e2e test ensuring DocOps shows a prompt instead of querying the API when searching with an empty input.


### PR DESCRIPTION
## Summary
- ensure DocOps UI shows prompt and avoids API call when search term is empty
- document DocOps empty search e2e coverage

## Testing
- `pnpm -C packages/docops test` *(fails: No tests found in dist/tests/helpers/services.js)*
- `pnpm -C packages/docops exec ava dist/tests/e2e/docops.e2e.spec.js`


------
https://chatgpt.com/codex/tasks/task_e_68be000a08a88324a46cb3714899cb3d