### PR TITLE
feat(piper): add in-process js step support

### DIFF
--- a/changelog.d/2025.09.07.22.15.47.fixed.md
+++ b/changelog.d/2025.09.07.22.15.47.fixed.md
@@ -1,0 +1,1 @@
+Serialize JS steps to avoid global stdout/env corruption and add regression test.

--- a/packages/piper/src/test/js-step.test.ts
+++ b/packages/piper/src/test/js-step.test.ts
@@ -21,7 +21,7 @@ async function withTmp(fn: (dir: string) => Promise<void>) {
   }
 }
 
-test("runPipeline executes js function steps", async (t) => {
+test.serial("runPipeline executes js function steps", async (t) => {
   await withTmp(async (dir) => {
     const prevCwd = process.cwd();
     process.chdir(dir);
@@ -75,5 +75,54 @@ test("runJSFunction restores globals on timeout", async (t) => {
   t.is(process.stdout.write, origStdout);
   t.is(process.stderr.write, origStderr);
   t.is(process.env.TEST_VAR, origEnv);
+});
+
+test.serial("js steps execute sequentially to prevent global corruption", async (t) => {
+  await withTmp(async (dir) => {
+    const prevCwd = process.cwd();
+    process.chdir(dir);
+    try {
+      const modSrc = `export async function check(){\n  console.log(process.env.TEST_VAR);\n  await new Promise(r=>setTimeout(r,50));\n  console.log(process.env.TEST_VAR);\n}`;
+      await fs.writeFile(path.join(dir, "mod.js"), modSrc, "utf8");
+      const cfg = {
+        pipelines: [
+          {
+            name: "demo",
+            steps: [
+              {
+                id: "a",
+                cwd: ".",
+                deps: [],
+                inputs: [],
+                outputs: [],
+                cache: "content",
+                env: { TEST_VAR: "A" },
+                js: { module: "./mod.js", export: "check" },
+              },
+              {
+                id: "b",
+                cwd: ".",
+                deps: [],
+                inputs: [],
+                outputs: [],
+                cache: "content",
+                env: { TEST_VAR: "B" },
+                js: { module: "./mod.js", export: "check" },
+              },
+            ],
+          },
+        ],
+      };
+      const pipelinesPath = path.join(dir, "pipelines.yaml");
+      await fs.writeFile(pipelinesPath, YAML.stringify(cfg), "utf8");
+      const res = await runPipeline(pipelinesPath, "demo", { concurrency: 2 });
+      const a = res.find((r) => r.id === "a")!;
+      const b = res.find((r) => r.id === "b")!;
+      t.is(a.stdout, "A\nA\n");
+      t.is(b.stdout, "B\nB\n");
+    } finally {
+      process.chdir(prevCwd);
+    }
+  });
 });
 

--- a/packages/piper/src/test/js-step.test.ts
+++ b/packages/piper/src/test/js-step.test.ts
@@ -5,6 +5,7 @@ import test from "ava";
 import YAML from "yaml";
 
 import { runPipeline } from "../runner.js";
+import { runJSFunction } from "../fsutils.js";
 
 async function withTmp(fn: (dir: string) => Promise<void>) {
   const dir = path.join(
@@ -60,5 +61,19 @@ test("runPipeline executes js function steps", async (t) => {
       process.chdir(prevCwd);
     }
   });
+});
+
+test("runJSFunction restores globals on timeout", async (t) => {
+  const origStdout = process.stdout.write;
+  const origStderr = process.stderr.write;
+  const origEnv = process.env.TEST_VAR;
+  const fn = async () => {
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  };
+  const res = await runJSFunction(fn, {}, { TEST_VAR: "changed" }, 10);
+  t.is(res.code, 124);
+  t.is(process.stdout.write, origStdout);
+  t.is(process.stderr.write, origStderr);
+  t.is(process.env.TEST_VAR, origEnv);
 });
 


### PR DESCRIPTION
## Summary
- allow pipeline steps to run JS modules in-process
- execute JS steps via dynamic import and captured stdout/stderr
- add tests for JS step execution
- restore stdout/stderr and env when JS step times out

## Testing
- `pnpm -F @promethean/piper test`


------
https://chatgpt.com/codex/tasks/task_e_68be0085203c83248442948701897365