### PR TITLE
fix(buildfix): allow OLLAMA_URL pass-through

### DIFF
--- a/packages/buildfix/pipelines.json
+++ b/packages/buildfix/pipelines.json
@@ -18,9 +18,6 @@
           "id": "bf-iterate",
           "deps": ["bf-errors"],
           "shell": "pnpm --filter @promethean/buildfix bf:02-iterate --errors .cache/buildfix/errors.json --out .cache/buildfix --model qwen3:4b --max-cycles 5 --git per-error --commit-on always --branch-prefix buildfix --remote origin --push false --use-gh false --rollback-on-regress true",
-          "env": {
-            "OLLAMA_URL": "${OLLAMA_URL}"
-          },
           "inputs": [
             ".cache/buildfix/errors.json",
             "tsconfig.json",


### PR DESCRIPTION
## Summary
- remove explicit OLLAMA_URL override in buildfix pipeline to let runtime env pass through

## Testing
- `pnpm --filter @promethean/buildfix test`
- `pnpm --filter @promethean/buildfix lint` *(fails: None of the selected packages has a "lint" script)*

------
https://chatgpt.com/codex/tasks/task_e_68be018c3e748324afb5b116e5d381c8