### PR TITLE
feat(buildfix): add tests and pipeline config

### DIFF
--- a/packages/buildfix/README.md
+++ b/packages/buildfix/README.md
@@ -4,9 +4,10 @@ Buildfix automates fixing TypeScript build errors.
 
 ## Usage
 
-Run the commands individually:
+Build the package first, then run commands individually:
 
 ```sh
+pnpm --filter @promethean/buildfix build
 pnpm --filter @promethean/buildfix bf:01-errors
 pnpm --filter @promethean/buildfix bf:02-iterate
 pnpm --filter @promethean/buildfix bf:03-report

--- a/packages/buildfix/ava.config.mjs
+++ b/packages/buildfix/ava.config.mjs
@@ -4,6 +4,5 @@ export default {
   ...base,
   files: [
     "dist/tests/**/*.js",
-    "dist/test/**/*.js",
   ],
 };

--- a/packages/buildfix/package.json
+++ b/packages/buildfix/package.json
@@ -10,21 +10,21 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.json",
-    "bf:01-errors": "tsx src/01-errors.ts",
-    "bf:02-iterate": "tsx src/02-iterate.ts",
-    "bf:03-report": "tsx src/03-report.ts",
-    "bf:all": "pnpm bf:01-errors && pnpm bf:02-iterate && pnpm bf:03-report",
+    "clean": "rimraf dist .cache && tsc -b --clean",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "bf:01-errors": "node ./dist/01-errors.js",
+    "bf:02-iterate": "node ./dist/02-iterate.js",
+    "bf:03-report": "node ./dist/03-report.js",
+    "bf:all": "pnpm build && pnpm bf:01-errors && pnpm bf:02-iterate && pnpm bf:03-report",
     "test": "pnpm build && ava",
     "coverage": "pnpm build && c8 ava",
     "doc:report": "pnpm build && node ./dist/03-report.js"
   },
   "dependencies": {
-    "globby": "^14.0.2",
-    "ts-morph": "^22.0.0",
-    "yaml": "^2.5.0",
-    "zod": "^3.23.8"
+    "globby": "14.0.2",
+    "ts-morph": "22.0.0",
+    "yaml": "2.5.0",
+    "zod": "3.23.8"
   },
-  "devDependencies": {
-    "tsx": "^4.19.2"
-  }
+  "devDependencies": {}
 }

--- a/packages/buildfix/pipelines.json
+++ b/packages/buildfix/pipelines.json
@@ -4,7 +4,19 @@
       "name": "buildfix",
       "steps": [
         {
+          "id": "bf-build",
+          "shell": "pnpm --filter @promethean/buildfix build",
+          "inputs": [
+            "packages/buildfix/tsconfig.json",
+            "packages/buildfix/src/**/*"
+          ],
+          "outputs": [
+            "packages/buildfix/dist/**"
+          ]
+        },
+        {
           "id": "bf-errors",
+          "deps": ["bf-build"],
           "shell": "pnpm --filter @promethean/buildfix bf:01-errors --tsconfig tsconfig.json --out .cache/buildfix/errors.json",
           "inputs": [
             "tsconfig.json",
@@ -16,11 +28,8 @@
         },
         {
           "id": "bf-iterate",
-          "deps": ["bf-errors"],
+          "deps": ["bf-build", "bf-errors"],
           "shell": "pnpm --filter @promethean/buildfix bf:02-iterate --errors .cache/buildfix/errors.json --out .cache/buildfix --model qwen3:4b --max-cycles 5 --git per-error --commit-on always --branch-prefix buildfix --remote origin --push false --use-gh false --rollback-on-regress true",
-          "env": {
-            "OLLAMA_URL": "${OLLAMA_URL}"
-          },
           "inputs": [
             ".cache/buildfix/errors.json",
             "tsconfig.json",
@@ -34,7 +43,7 @@
         },
         {
           "id": "bf-report",
-          "deps": ["bf-iterate"],
+          "deps": ["bf-build", "bf-iterate"],
           "shell": "pnpm --filter @promethean/buildfix bf:03-report --summary .cache/buildfix/summary.json --history-root .cache/buildfix/history --out docs/agile/reports/buildfix",
           "inputs": [
             ".cache/buildfix/summary.json"

--- a/packages/buildfix/project.json
+++ b/packages/buildfix/project.json
@@ -22,6 +22,7 @@
     },
     "test": {
       "executor": "nx:run-commands",
+      "dependsOn": ["build"],
       "options": {
         "command": "ava",
         "cwd": "packages/buildfix"

--- a/packages/buildfix/src/tests/utils.test.ts
+++ b/packages/buildfix/src/tests/utils.test.ts
@@ -8,7 +8,7 @@ test.afterEach(() => {
   process.argv = origArgv.slice();
 });
 
-test('parseArgs overrides defaults with CLI values', (t) => {
+test.serial('parseArgs overrides defaults with CLI values', (t) => {
   process.argv = ['node', 'test', '--foo', 'bar', '--flag'];
   const out = parseArgs({ '--foo': 'baz', '--flag': 'false' });
   t.is(out['--foo'], 'bar');

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -403,21 +403,17 @@ importers:
   packages/buildfix:
     dependencies:
       globby:
-        specifier: ^14.0.2
+        specifier: 14.0.2
         version: 14.0.2
       ts-morph:
-        specifier: ^22.0.0
+        specifier: 22.0.0
         version: 22.0.0
       yaml:
-        specifier: ^2.5.0
-        version: 2.8.1
+        specifier: 2.5.0
+        version: 2.5.0
       zod:
-        specifier: ^3.23.8
-        version: 3.25.76
-    devDependencies:
-      tsx:
-        specifier: ^4.19.2
-        version: 4.20.3
+        specifier: 3.23.8
+        version: 3.23.8
 
   packages/cephalon:
     dependencies:
@@ -13453,7 +13449,7 @@ snapshots:
 
   axios@1.11.0:
     dependencies:
-      follow-redirects: 1.15.11(debug@4.3.7)
+      follow-redirects: 1.15.11(debug@4.4.1)
       form-data: 4.0.4
       proxy-from-env: 1.1.0
     transitivePeerDependencies:
@@ -15683,7 +15679,7 @@ snapshots:
   http-proxy@1.18.1:
     dependencies:
       eventemitter3: 4.0.7
-      follow-redirects: 1.15.11(debug@4.3.7)
+      follow-redirects: 1.15.11(debug@4.4.1)
       requires-port: 1.0.0
     transitivePeerDependencies:
       - debug


### PR DESCRIPTION
## Summary
- run buildfix pipeline against compiled artifacts and drop OLLAMA_URL override
- pin buildfix package deps and run scripts on built JS
- document build-first usage and ensure Nx tests depend on build

## Testing
- `pnpm --filter @promethean/buildfix typecheck`
- `pnpm --filter @promethean/buildfix test`


------
https://chatgpt.com/codex/tasks/task_e_68be02b74cf083248ef0c2939316a1b0