### PR TITLE
feat(piper): add js step support

### DIFF
--- a/changelog.d/2025.09.07.22.17.48.fixed.md
+++ b/changelog.d/2025.09.07.22.17.48.fixed.md
@@ -1,0 +1,1 @@
+fix(piper): bust js module cache between pipeline runs

--- a/changelog.d/2025.09.07.22.33.06.fixed.md
+++ b/changelog.d/2025.09.07.22.33.06.fixed.md
@@ -1,0 +1,1 @@
+fix(piper): key JS module reloads by file hash to limit cache growth

--- a/packages/piper/src/runner.ts
+++ b/packages/piper/src/runner.ts
@@ -1,5 +1,6 @@
 import * as path from "path";
 import { promises as fs } from "fs";
+import { pathToFileURL } from "url";
 
 import * as chokidar from "chokidar";
 import * as YAML from "yaml";
@@ -135,7 +136,9 @@ export async function runPipeline(
         const modPath = path.isAbsolute(s.js.module)
           ? s.js.module
           : path.resolve(cwd, s.js.module);
-        const mod = await import(modPath);
+        const modUrl = pathToFileURL(modPath);
+        modUrl.search = `?t=${Date.now()}`;
+        const mod = await import(modUrl.href);
         const fn =
           (s.js.export && (mod as any)[s.js.export]) ??
           (mod as any).default ??

--- a/packages/piper/src/runner.ts
+++ b/packages/piper/src/runner.ts
@@ -1,6 +1,7 @@
 import * as path from "path";
 import { promises as fs } from "fs";
 import { pathToFileURL } from "url";
+import { createHash } from "crypto";
 
 import * as chokidar from "chokidar";
 import * as YAML from "yaml";
@@ -128,23 +129,25 @@ export async function runPipeline(
         stderr: "",
       };
 
-      if (s.shell) execRes = await runShell(s.shell, cwd, s.env, s.timeoutMs);
-      else if (s.node)
-        execRes = await runNode(s.node, s.args, cwd, s.env, s.timeoutMs);
-      else if (s.ts) execRes = await runTSModule(s, cwd, s.env, s.timeoutMs);
-      else if (s.js) {
-        const modPath = path.isAbsolute(s.js.module)
-          ? s.js.module
-          : path.resolve(cwd, s.js.module);
-        const modUrl = pathToFileURL(modPath);
-        modUrl.search = `?t=${Date.now()}`;
-        const mod = await import(modUrl.href);
-        const fn =
-          (s.js.export && (mod as any)[s.js.export]) ??
-          (mod as any).default ??
-          mod;
-        execRes = await runJSFunction(fn as any, s.js.args);
-      }
+        if (s.shell) execRes = await runShell(s.shell, cwd, s.env, s.timeoutMs);
+        else if (s.node)
+          execRes = await runNode(s.node, s.args, cwd, s.env, s.timeoutMs);
+        else if (s.ts) execRes = await runTSModule(s, cwd, s.env, s.timeoutMs);
+        else if (s.js) {
+          const modPath = path.isAbsolute(s.js.module)
+            ? s.js.module
+            : path.resolve(cwd, s.js.module);
+          const modUrl = pathToFileURL(modPath);
+          const buf = await fs.readFile(modPath);
+          const sha = createHash("sha1").update(buf).digest("hex");
+          modUrl.search = `?sha=${sha}`;
+          const mod = await import(modUrl.href);
+          const fn =
+            (s.js.export && (mod as any)[s.js.export]) ??
+            (mod as any).default ??
+            mod;
+          execRes = await runJSFunction(fn as any, s.js.args);
+        }
 
       const endedAt = new Date().toISOString();
       const out: StepResult = {


### PR DESCRIPTION
## Summary
- bust JS module cache between pipeline runs
- test JS step reload after edits

## Testing
- `pnpm --filter @promethean/piper test`


------
https://chatgpt.com/codex/tasks/task_e_68be0461fa008324b94eb1b6fff5bf47