### PR TITLE
fix(piper): isolate js step env and cache config

### DIFF
--- a/changelog.d/2025.09.07.22.25.46.fixed.md
+++ b/changelog.d/2025.09.07.22.25.46.fixed.md
@@ -1,0 +1,2 @@
+- fix JS step environment isolation to avoid cross-contamination when running concurrently
+- include js step configuration in fingerprint to prevent stale cache

--- a/packages/piper/src/fsutils.ts
+++ b/packages/piper/src/fsutils.ts
@@ -10,68 +10,84 @@ import { PiperStep } from "./types.js";
 
 export { ensureDir };
 
+class Mutex {
+	private queue: (() => void)[] = [];
+	private locked = false;
+	async acquire() {
+		if (this.locked) await new Promise<void>((res) => this.queue.push(res));
+		else this.locked = true;
+	}
+	release() {
+		const next = this.queue.shift();
+		if (next) next();
+		else this.locked = false;
+	}
+}
+
+const envMutex = new Mutex();
+
 export async function readTextMaybe(p: string) {
-  try {
-    return await fs.readFile(p, "utf-8");
-  } catch (err: any) {
-    if ((err as NodeJS.ErrnoException)?.code === "ENOENT") return undefined;
-    throw err;
-  }
+	try {
+		return await fs.readFile(p, "utf-8");
+	} catch (err: any) {
+		if ((err as NodeJS.ErrnoException)?.code === "ENOENT") return undefined;
+		throw err;
+	}
 }
 
 export async function writeText(p: string, s: string) {
-  await ensureDir(path.dirname(p));
-  await fs.writeFile(p, s, "utf-8");
+	await ensureDir(path.dirname(p));
+	await fs.writeFile(p, s, "utf-8");
 }
 
 export async function listOutputsExist(outputs: string[], cwd: string) {
-  const results = await Promise.all(
-    outputs.map((pat) => globby(pat, { cwd, absolute: true, dot: true })),
-  );
-  return results.every((files) => files.length > 0);
+	const results = await Promise.all(
+		outputs.map((pat) => globby(pat, { cwd, absolute: true, dot: true })),
+	);
+	return results.every((files) => files.length > 0);
 }
 
 export function runShell(
-  cmd: string,
-  cwd: string,
-  env: Record<string, string>,
-  timeoutMs?: number,
+	cmd: string,
+	cwd: string,
+	env: Record<string, string>,
+	timeoutMs?: number,
 ) {
-  return runSpawn(cmd, {
-    cwd,
-    env,
-    shell: true,
-    ...(timeoutMs ? { timeoutMs } : {}),
-  });
+	return runSpawn(cmd, {
+		cwd,
+		env,
+		shell: true,
+		...(timeoutMs ? { timeoutMs } : {}),
+	});
 }
 
 export function runNode(
-  file: string,
-  args: string[] | undefined,
-  cwd: string,
-  env: Record<string, string>,
-  timeoutMs?: number,
+	file: string,
+	args: string[] | undefined,
+	cwd: string,
+	env: Record<string, string>,
+	timeoutMs?: number,
 ) {
-  const cmd = process.execPath;
-  const finalArgs = [file, ...(args ?? [])];
-  return runSpawn(cmd, {
-    cwd,
-    env,
-    args: finalArgs,
-    ...(timeoutMs ? { timeoutMs } : {}),
-  });
+	const cmd = process.execPath;
+	const finalArgs = [file, ...(args ?? [])];
+	return runSpawn(cmd, {
+		cwd,
+		env,
+		args: finalArgs,
+		...(timeoutMs ? { timeoutMs } : {}),
+	});
 }
 
 export async function runTSModule(
-  step: PiperStep,
-  cwd: string,
-  env: Record<string, string>,
-  timeoutMs?: number,
+	step: PiperStep,
+	cwd: string,
+	env: Record<string, string>,
+	timeoutMs?: number,
 ) {
-  const modPath = path.isAbsolute(step.ts!.module)
-    ? step.ts!.module
-    : path.resolve(cwd, step.ts!.module);
-  const code = `
+	const modPath = path.isAbsolute(step.ts!.module)
+		? step.ts!.module
+		: path.resolve(cwd, step.ts!.module);
+	const code = `
     import mod from ${JSON.stringify(modPath)};
     const exportName = ${JSON.stringify(step.ts!.export ?? "")};
     const fn =
@@ -81,110 +97,120 @@ export async function runTSModule(
     const res = await fn(${JSON.stringify(step.ts!.args ?? {})});
     if (typeof res === 'string') process.stdout.write(res);
   `;
-  // Lazy-run via node -e with ESM loader
-  const cmd = process.execPath;
-  const args = ["--input-type=module", "-e", code];
-  return runSpawn(cmd, {
-    cwd,
-    env,
-    args,
-    ...(timeoutMs ? { timeoutMs } : {}),
-  });
+	// Lazy-run via node -e with ESM loader
+	const cmd = process.execPath;
+	const args = ["--input-type=module", "-e", code];
+	return runSpawn(cmd, {
+		cwd,
+		env,
+		args,
+		...(timeoutMs ? { timeoutMs } : {}),
+	});
 }
 
 export async function runJSModule(
-  step: PiperStep,
-  cwd: string,
-  env: Record<string, string>,
-  timeoutMs?: number,
+	step: PiperStep,
+	cwd: string,
+	env: Record<string, string>,
+	timeoutMs?: number,
 ) {
-  const modPath = path.isAbsolute(step.js!.module)
-    ? step.js!.module
-    : path.resolve(cwd, step.js!.module);
-  const url = pathToFileURL(modPath).href;
-  const prevEnv: Record<string, string | undefined> = {};
-  for (const [k, v] of Object.entries(env)) {
-    prevEnv[k] = process.env[k];
-    process.env[k] = v;
-  }
-  let timer: NodeJS.Timeout | undefined;
-  try {
-    const mod: any = await import(url);
-    const fn =
-      (step.js!.export && mod[step.js!.export]) || mod.default || mod;
-    const call = fn(step.js!.args ?? {});
-    const res = timeoutMs
-      ? await Promise.race([
-          call,
-          new Promise((_, reject) =>
-            (timer = setTimeout(() => reject(new Error("timeout")), timeoutMs)),
-          ),
-        ])
-      : await call;
-    const out = typeof res === "string" ? res : "";
-    return { code: 0, stdout: out, stderr: "" };
-  } catch (err: any) {
-    return { code: 1, stdout: "", stderr: String(err?.stack ?? err) };
-  } finally {
-    if (timer) clearTimeout(timer);
-    for (const [k, v] of Object.entries(prevEnv)) {
-      if (v === undefined) delete process.env[k];
-      else process.env[k] = v;
-    }
-  }
+	const modPath = path.isAbsolute(step.js!.module)
+		? step.js!.module
+		: path.resolve(cwd, step.js!.module);
+	const url = pathToFileURL(modPath).href;
+	await envMutex.acquire();
+	const prevEnv: Record<string, string | undefined> = {};
+	for (const [k, v] of Object.entries(env)) {
+		prevEnv[k] = process.env[k];
+		process.env[k] = v;
+	}
+	let timer: NodeJS.Timeout | undefined;
+	try {
+		const mod: any = await import(url);
+		const fn =
+			(step.js!.export && mod[step.js!.export]) || mod.default || mod;
+		const call = fn(step.js!.args ?? {});
+		const res = timeoutMs
+			? await Promise.race([
+					call,
+					new Promise(
+						(_, reject) =>
+							(timer = setTimeout(
+								() => reject(new Error("timeout")),
+								timeoutMs,
+							)),
+					),
+				])
+			: await call;
+		const out = typeof res === "string" ? res : "";
+		return { code: 0, stdout: out, stderr: "" };
+	} catch (err: any) {
+		return { code: 1, stdout: "", stderr: String(err?.stack ?? err) };
+	} finally {
+		if (timer) clearTimeout(timer);
+		for (const [k, v] of Object.entries(prevEnv)) {
+			if (v === undefined) delete process.env[k];
+			else process.env[k] = v;
+		}
+		envMutex.release();
+	}
 }
 
 function runSpawn(
-  cmd: string,
-  opts: {
-    cwd: string;
-    env: NodeJS.ProcessEnv;
-    shell?: boolean;
-    args?: string[];
-    timeoutMs?: number;
-  },
+	cmd: string,
+	opts: {
+		cwd: string;
+		env: NodeJS.ProcessEnv;
+		shell?: boolean;
+		args?: string[];
+		timeoutMs?: number;
+	},
 ) {
-  return new Promise<{ code: number | null; stdout: string; stderr: string }>(
-    (resolve) => {
-      const child = opts.shell
-        ? spawn(cmd, {
-            cwd: opts.cwd,
-            env: { ...process.env, ...opts.env },
-            shell: true,
-            stdio: ["ignore", "pipe", "pipe"],
-            detached: process.platform !== "win32",
-          })
-        : spawn(cmd, opts.args ?? [], {
-            cwd: opts.cwd,
-            env: { ...process.env, ...opts.env },
-            stdio: ["ignore", "pipe", "pipe"],
-            detached: process.platform !== "win32",
-          });
+	return new Promise<{ code: number | null; stdout: string; stderr: string }>(
+		(resolve) => {
+			const child = opts.shell
+				? spawn(cmd, {
+						cwd: opts.cwd,
+						env: { ...process.env, ...opts.env },
+						shell: true,
+						stdio: ["ignore", "pipe", "pipe"],
+						detached: process.platform !== "win32",
+					})
+				: spawn(cmd, opts.args ?? [], {
+						cwd: opts.cwd,
+						env: { ...process.env, ...opts.env },
+						stdio: ["ignore", "pipe", "pipe"],
+						detached: process.platform !== "win32",
+					});
 
-      let out = "",
-        err = "";
-      const killTimer =
-        opts.timeoutMs && opts.timeoutMs > 0
-          ? setTimeout(() => {
-              try {
-                if (process.platform !== "win32" && child.pid) {
-                  process.kill(-child.pid, "SIGKILL");
-                } else {
-                  child.kill("SIGKILL");
-                }
-              } catch {}
-            }, opts.timeoutMs)
-          : undefined;
+			let out = "",
+				err = "";
+			const killTimer =
+				opts.timeoutMs && opts.timeoutMs > 0
+					? setTimeout(() => {
+							try {
+								if (process.platform !== "win32" && child.pid) {
+									process.kill(-child.pid, "SIGKILL");
+								} else {
+									child.kill("SIGKILL");
+								}
+							} catch {}
+						}, opts.timeoutMs)
+					: undefined;
 
-      child.stdout.on("data", (d) => (out += String(d)));
-      child.stderr.on("data", (d) => (err += String(d)));
-      child.on("close", (code) => {
-        if (killTimer) clearTimeout(killTimer as any);
-        resolve({ code, stdout: out, stderr: err });
-      });
-      child.on("error", () =>
-        resolve({ code: 127, stdout: out, stderr: err || "failed to spawn" }),
-      );
-    },
-  );
+			child.stdout.on("data", (d) => (out += String(d)));
+			child.stderr.on("data", (d) => (err += String(d)));
+			child.on("close", (code) => {
+				if (killTimer) clearTimeout(killTimer as any);
+				resolve({ code, stdout: out, stderr: err });
+			});
+			child.on("error", () =>
+				resolve({
+					code: 127,
+					stdout: out,
+					stderr: err || "failed to spawn",
+				}),
+			);
+		},
+	);
 }

--- a/packages/piper/src/hash.ts
+++ b/packages/piper/src/hash.ts
@@ -4,63 +4,63 @@ import * as crypto from "crypto";
 import { globby } from "globby";
 
 export function sha1(s: string) {
-  return crypto.createHash("sha1").update(s).digest("hex");
+	return crypto.createHash("sha1").update(s).digest("hex");
 }
 
 export async function fingerprintFromGlobs(
-  globs: string[],
-  cwd: string,
-  mode: "content" | "mtime" = "content",
+	globs: string[],
+	cwd: string,
+	mode: "content" | "mtime" = "content",
 ): Promise<string> {
-  const files = await globby(globs, {
-    cwd,
-    absolute: true,
-    dot: true,
-    followSymbolicLinks: false,
-  });
-  files.sort();
-  const h = crypto.createHash("sha1");
-  for (const f of files) {
-    try {
-      const st = await fs.stat(f);
-      h.update(Buffer.from(f));
-      if (mode === "content") {
-        if (st.size === 0) {
-          h.update("0");
-          continue;
-        }
-        const buf = await fs.readFile(f);
-        h.update(buf);
-      } else {
-        h.update(`${st.mtimeMs}|${st.size}`);
-      }
-    } catch {
-      /* ignore missing */
-    }
-  }
-  return h.digest("hex");
+	const files = await globby(globs, {
+		cwd,
+		absolute: true,
+		dot: true,
+		followSymbolicLinks: false,
+	});
+	files.sort();
+	const h = crypto.createHash("sha1");
+	for (const f of files) {
+		try {
+			const st = await fs.stat(f);
+			h.update(Buffer.from(f));
+			if (mode === "content") {
+				if (st.size === 0) {
+					h.update("0");
+					continue;
+				}
+				const buf = await fs.readFile(f);
+				h.update(buf);
+			} else {
+				h.update(`${st.mtimeMs}|${st.size}`);
+			}
+		} catch {
+			/* ignore missing */
+		}
+	}
+	return h.digest("hex");
 }
 
 /** include step configuration & env in the fingerprint */
 export async function stepFingerprint(
-  step: any,
-  cwd: string,
-  preferContent: boolean,
+	step: any,
+	cwd: string,
+	preferContent: boolean,
 ) {
-  const mode =
-    step.cache === "content" || preferContent
-      ? "content"
-      : step.cache ?? "content";
-  const inputsHash = await fingerprintFromGlobs(step.inputs ?? [], cwd, mode);
-  const configHash = sha1(
-    JSON.stringify({
-      id: step.id,
-      name: step.name,
-      deps: step.deps,
-      cmd: step.shell ?? step.node ?? step.ts,
-      args: step.args ?? step.ts?.args,
-      env: step.env,
-    }),
-  );
-  return sha1(inputsHash + "|" + configHash);
+	const mode =
+		step.cache === "content" || preferContent
+			? "content"
+			: (step.cache ?? "content");
+	const inputsHash = await fingerprintFromGlobs(step.inputs ?? [], cwd, mode);
+	const configHash = sha1(
+		JSON.stringify({
+			id: step.id,
+			name: step.name,
+			deps: step.deps,
+			cmd: step.shell ?? step.node ?? step.ts ?? step.js,
+			args: step.args ?? step.ts?.args ?? step.js?.args,
+			env: step.env,
+		}),
+	);
+	return sha1(inputsHash + "|" + configHash);
 }

--- a/packages/piper/src/test/hash.test.ts
+++ b/packages/piper/src/test/hash.test.ts
@@ -6,74 +6,110 @@ import test, { ExecutionContext } from "ava";
 import { fingerprintFromGlobs, stepFingerprint } from "../hash.js";
 
 async function withTmp(
-  _t: ExecutionContext<unknown>,
-  fn: {
-    (dir: any): Promise<void>;
-    (dir: any): Promise<void>;
-    (arg0: string): any;
-  },
+	_t: ExecutionContext<unknown>,
+	fn: {
+		(dir: any): Promise<void>;
+		(dir: any): Promise<void>;
+		(arg0: string): any;
+	},
 ) {
-  const dir = path.join(
-    process.cwd(),
-    "test-tmp",
-    String(Date.now()) + "-" + Math.random().toString(36).slice(2),
-  );
-  await fs.mkdir(dir, { recursive: true });
-  try {
-    await fn(dir);
-  } finally {
-    await fs.rm(dir, { recursive: true, force: true });
-  }
+	const dir = path.join(
+		process.cwd(),
+		"test-tmp",
+		String(Date.now()) + "-" + Math.random().toString(36).slice(2),
+	);
+	await fs.mkdir(dir, { recursive: true });
+	try {
+		await fn(dir);
+	} finally {
+		await fs.rm(dir, { recursive: true, force: true });
+	}
 }
 
 test("fingerprintFromGlobs: content vs mtime", async (t) => {
-  await withTmp(t, async (dir) => {
-    const a = path.join(dir, "a.txt");
-    const b = path.join(dir, "b.txt");
-    await fs.writeFile(a, "hello", "utf8");
-    await fs.writeFile(b, "world", "utf8");
+	await withTmp(t, async (dir) => {
+		const a = path.join(dir, "a.txt");
+		const b = path.join(dir, "b.txt");
+		await fs.writeFile(a, "hello", "utf8");
+		await fs.writeFile(b, "world", "utf8");
 
-    const contentHash1 = await fingerprintFromGlobs(["*.txt"], dir, "content");
-    const mtimeHash1 = await fingerprintFromGlobs(["*.txt"], dir, "mtime");
-    t.truthy(contentHash1);
-    t.truthy(mtimeHash1);
+		const contentHash1 = await fingerprintFromGlobs(
+			["*.txt"],
+			dir,
+			"content",
+		);
+		const mtimeHash1 = await fingerprintFromGlobs(["*.txt"], dir, "mtime");
+		t.truthy(contentHash1);
+		t.truthy(mtimeHash1);
 
-    // change content
-    await fs.writeFile(a, "HELLO", "utf8");
-    const contentHash2 = await fingerprintFromGlobs(["*.txt"], dir, "content");
-    const mtimeHash2 = await fingerprintFromGlobs(["*.txt"], dir, "mtime");
+		// change content
+		await fs.writeFile(a, "HELLO", "utf8");
+		const contentHash2 = await fingerprintFromGlobs(
+			["*.txt"],
+			dir,
+			"content",
+		);
+		const mtimeHash2 = await fingerprintFromGlobs(["*.txt"], dir, "mtime");
 
-    t.not(
-      contentHash1,
-      contentHash2,
-      "content hash changes when file content changes",
-    );
-    // mtime likely also changes, but ensure at least one differs
-    t.truthy(mtimeHash1 !== mtimeHash2 || contentHash1 !== contentHash2);
-  });
+		t.not(
+			contentHash1,
+			contentHash2,
+			"content hash changes when file content changes",
+		);
+		// mtime likely also changes, but ensure at least one differs
+		t.truthy(mtimeHash1 !== mtimeHash2 || contentHash1 !== contentHash2);
+	});
 });
 
 test("stepFingerprint covers inputs and config", async (t) => {
-  await withTmp(t, async (dir) => {
-    const a = path.join(dir, "a.txt");
-    await fs.writeFile(a, "hello", "utf8");
-    const step = {
-      id: "s",
-      deps: [],
-      cwd: ".",
-      env: {},
-      inputs: ["a.txt"],
-      outputs: [],
-      cache: "content",
-    };
+	await withTmp(t, async (dir) => {
+		const a = path.join(dir, "a.txt");
+		await fs.writeFile(a, "hello", "utf8");
+		const step = {
+			id: "s",
+			deps: [],
+			cwd: ".",
+			env: {},
+			inputs: ["a.txt"],
+			outputs: [],
+			cache: "content",
+		};
 
-    const fp1 = await stepFingerprint(step, dir, true);
-    await fs.writeFile(a, "HELLO", "utf8");
-    const fp2 = await stepFingerprint(step, dir, true);
-    t.not(fp1, fp2, "fingerprint changes when input content changes");
+		const fp1 = await stepFingerprint(step, dir, true);
+		await fs.writeFile(a, "HELLO", "utf8");
+		const fp2 = await stepFingerprint(step, dir, true);
+		t.not(fp1, fp2, "fingerprint changes when input content changes");
 
-    const step2 = { ...step, env: { X: "1" } };
-    const fp3 = await stepFingerprint(step2, dir, true);
-    t.not(fp2, fp3, "fingerprint changes when config/env changes");
-  });
+		const step2 = { ...step, env: { X: "1" } };
+		const fp3 = await stepFingerprint(step2, dir, true);
+		t.not(fp2, fp3, "fingerprint changes when config/env changes");
+	});
+});
+
+test("stepFingerprint includes js step config", async (t) => {
+	await withTmp(t, async (dir) => {
+		const base = {
+			id: "s",
+			deps: [],
+			cwd: ".",
+			env: {},
+			inputs: [],
+			outputs: [],
+			cache: "content",
+			js: { module: "./a.js", export: "default", args: { x: 1 } },
+		};
+		const fp1 = await stepFingerprint(base, dir, true);
+		const fp2 = await stepFingerprint(
+			{ ...base, js: { ...base.js, args: { x: 2 } } },
+			dir,
+			true,
+		);
+		t.not(fp1, fp2, "fingerprint changes when js args change");
+		const fp3 = await stepFingerprint(
+			{ ...base, js: { ...base.js, module: "./b.js" } },
+			dir,
+			true,
+		);
+		t.not(fp1, fp3, "fingerprint changes when js module changes");
+	});
 });

--- a/packages/piper/src/test/js-step.test.ts
+++ b/packages/piper/src/test/js-step.test.ts
@@ -7,70 +7,133 @@ import YAML from "yaml";
 import { runPipeline } from "../runner.js";
 
 async function withTmp(fn: (dir: string) => Promise<void>) {
-  const dir = path.join(
-    process.cwd(),
-    "test-tmp",
-    String(Date.now()) + "-" + Math.random().toString(36).slice(2),
-  );
-  await fs.mkdir(dir, { recursive: true });
-  try {
-    await fn(dir);
-  } finally {
-    await fs.rm(dir, { recursive: true, force: true });
-  }
+	const dir = path.join(
+		process.cwd(),
+		"test-tmp",
+		String(Date.now()) + "-" + Math.random().toString(36).slice(2),
+	);
+	await fs.mkdir(dir, { recursive: true });
+	try {
+		await fn(dir);
+	} finally {
+		await fs.rm(dir, { recursive: true, force: true });
+	}
 }
 
-test("runPipeline executes js function steps", async (t) => {
-  await withTmp(async (dir) => {
-    const prevCwd = process.cwd();
-    process.chdir(dir);
-    try {
-      const libPath = path.join(dir, "lib.js");
-      await fs.writeFile(
-        libPath,
-        "import { promises as fs } from 'fs';\nexport async function make({file,content}){await fs.writeFile(file, content, 'utf8');return 'made';}\n",
-        "utf8",
-      );
-      const cfg = {
-        pipelines: [
-          {
-            name: "demo",
-            steps: [
-              {
-                id: "make",
-                cwd: ".",
-                deps: [],
-                inputs: [],
-                outputs: ["out.txt"],
-                cache: "content",
-                js: {
-                  module: "./lib.js",
-                  export: "make",
-                  args: { file: "out.txt", content: "hi" },
-                },
-              },
-              {
-                id: "cat",
-                cwd: ".",
-                deps: ["make"],
-                inputs: ["out.txt"],
-                outputs: ["out2.txt"],
-                cache: "content",
-                shell: "cat out.txt > out2.txt",
-              },
-            ],
-          },
-        ],
-      };
-      const pipelinesPath = path.join(dir, "pipelines.yaml");
-      await fs.writeFile(pipelinesPath, YAML.stringify(cfg), "utf8");
-      const res = await runPipeline(pipelinesPath, "demo", { concurrency: 2 });
-      t.is(res.length, 2);
-      t.true(res.every((r) => !r.skipped));
-      const out = await fs.readFile(path.join(dir, "out2.txt"), "utf8");
-      t.is(out, "hi");
-    } finally {
-      process.chdir(prevCwd);
-    }
-  });
+test.serial("runPipeline executes js function steps", async (t) => {
+	await withTmp(async (dir) => {
+		const libPath = path.join(dir, "lib.js");
+		await fs.writeFile(
+			libPath,
+			"import { promises as fs } from 'fs';\nexport async function make({file,content}){await fs.writeFile(file, content, 'utf8');return 'made';}\n",
+			"utf8",
+		);
+		const cfg = {
+			pipelines: [
+				{
+					name: "demo",
+					steps: [
+						{
+							id: "make",
+							cwd: dir,
+							deps: [],
+							inputs: [],
+							outputs: ["out.txt"],
+							cache: "content",
+							js: {
+								module: "./lib.js",
+								export: "make",
+								args: {
+									file: path.join(dir, "out.txt"),
+									content: "hi",
+								},
+							},
+						},
+						{
+							id: "cat",
+							cwd: dir,
+							deps: ["make"],
+							inputs: ["out.txt"],
+							outputs: ["out2.txt"],
+							cache: "content",
+							shell: "cat out.txt > out2.txt",
+						},
+					],
+				},
+			],
+		};
+		const pipelinesPath = path.join(dir, "pipelines.yaml");
+		await fs.writeFile(pipelinesPath, YAML.stringify(cfg), "utf8");
+		const res = await runPipeline(pipelinesPath, "demo", {
+			concurrency: 2,
+		});
+		t.is(res.length, 2);
+		t.true(res.every((r) => !r.skipped));
+		const out = await fs.readFile(path.join(dir, "out2.txt"), "utf8");
+		t.is(out, "hi");
+	});
+});
+
+test.serial("JS steps isolate process.env when run concurrently", async (t) => {
+	await withTmp(async (dir) => {
+		const libPath = path.join(dir, "envmod.js");
+		await fs.writeFile(
+			libPath,
+			"import { promises as fs } from 'fs';\nexport async function dump({file,key,delay}){await new Promise(r=>setTimeout(r,delay));await fs.writeFile(file, process.env[key]||'', 'utf8');}\n",
+			"utf8",
+		);
+		const cfg = {
+			pipelines: [
+				{
+					name: "env",
+					steps: [
+						{
+							id: "one",
+							cwd: dir,
+							deps: [],
+							inputs: [],
+							outputs: ["a.txt"],
+							cache: "content",
+							env: { V: "1" },
+							js: {
+								module: "./envmod.js",
+								export: "dump",
+								args: {
+									file: path.join(dir, "a.txt"),
+									key: "V",
+									delay: 50,
+								},
+							},
+						},
+						{
+							id: "two",
+							cwd: dir,
+							deps: [],
+							inputs: [],
+							outputs: ["b.txt"],
+							cache: "content",
+							env: { V: "2" },
+							js: {
+								module: "./envmod.js",
+								export: "dump",
+								args: {
+									file: path.join(dir, "b.txt"),
+									key: "V",
+									delay: 50,
+								},
+							},
+						},
+					],
+				},
+			],
+		};
+		const pipelinesPath = path.join(dir, "pipelines.yaml");
+		await fs.writeFile(pipelinesPath, YAML.stringify(cfg), "utf8");
+		await runPipeline(pipelinesPath, "env", { concurrency: 2 });
+		const aOut = await fs.readFile(path.join(dir, "a.txt"), "utf8");
+		const bOut = await fs.readFile(path.join(dir, "b.txt"), "utf8");
+		t.is(aOut, "1");
+		t.is(bOut, "2");
+		t.is(process.env.V, undefined);
+	});
 });


### PR DESCRIPTION
## Summary
- guard JS steps behind mutex to avoid concurrent process.env mutations
- hash JS step configuration to ensure cache invalidation
- add tests for JS env isolation and fingerprinting

## Testing
- `pnpm --filter @promethean/piper test`


------
https://chatgpt.com/codex/tasks/task_e_68be05feaed08324a549ed50161269d2