### PR TITLE
fix(piper): hash js modules to bust cache

### DIFF
--- a/changelog.d/2025.09.07.22.33.06.fixed.md
+++ b/changelog.d/2025.09.07.22.33.06.fixed.md
@@ -1,0 +1,1 @@
+fix(piper): key JS module reloads by file hash to limit cache growth

--- a/packages/piper/src/runner.ts
+++ b/packages/piper/src/runner.ts
@@ -1,6 +1,7 @@
 import * as path from "path";
 import { promises as fs } from "fs";
 import { pathToFileURL } from "url";
+import { createHash } from "crypto";
 
 import * as chokidar from "chokidar";
 import * as YAML from "yaml";
@@ -128,23 +129,25 @@ export async function runPipeline(
         stderr: "",
       };
 
-      if (s.shell) execRes = await runShell(s.shell, cwd, s.env, s.timeoutMs);
-      else if (s.node)
-        execRes = await runNode(s.node, s.args, cwd, s.env, s.timeoutMs);
-      else if (s.ts) execRes = await runTSModule(s, cwd, s.env, s.timeoutMs);
-      else if (s.js) {
-        const modPath = path.isAbsolute(s.js.module)
-          ? s.js.module
-          : path.resolve(cwd, s.js.module);
-        const modUrl = pathToFileURL(modPath);
-        modUrl.search = `?t=${Date.now()}`;
-        const mod = await import(modUrl.href);
-        const fn =
-          (s.js.export && (mod as any)[s.js.export]) ??
-          (mod as any).default ??
-          mod;
-        execRes = await runJSFunction(fn as any, s.js.args);
-      }
+        if (s.shell) execRes = await runShell(s.shell, cwd, s.env, s.timeoutMs);
+        else if (s.node)
+          execRes = await runNode(s.node, s.args, cwd, s.env, s.timeoutMs);
+        else if (s.ts) execRes = await runTSModule(s, cwd, s.env, s.timeoutMs);
+        else if (s.js) {
+          const modPath = path.isAbsolute(s.js.module)
+            ? s.js.module
+            : path.resolve(cwd, s.js.module);
+          const modUrl = pathToFileURL(modPath);
+          const buf = await fs.readFile(modPath);
+          const sha = createHash("sha1").update(buf).digest("hex");
+          modUrl.search = `?sha=${sha}`;
+          const mod = await import(modUrl.href);
+          const fn =
+            (s.js.export && (mod as any)[s.js.export]) ??
+            (mod as any).default ??
+            mod;
+          execRes = await runJSFunction(fn as any, s.js.args);
+        }
 
       const endedAt = new Date().toISOString();
       const out: StepResult = {


### PR DESCRIPTION
## Summary
- hash JS modules by file content when reloading steps to avoid growing cache
- document change in changelog

## Testing
- `pnpm --filter @promethean/piper test`


------
https://chatgpt.com/codex/tasks/task_e_68be07ab5c2483248fc99566f9e98c13