### PR TITLE
fix(piper): reuse semaphore for JS step lock

### DIFF
--- a/changelog.d/2025.09.07.22.36.29.fixed.md
+++ b/changelog.d/2025.09.07.22.36.29.fixed.md
@@ -1,0 +1,1 @@
+fix: reuse existing semaphore for JS step lock


### PR DESCRIPTION
## Summary
- reuse `semaphore` helper for `runJSFunction` lock
- document fix

## Testing
- `pre-commit run --files packages/piper/src/fsutils.ts changelog.d/2025.09.07.22.36.29.fixed.md`
- `pnpm -F @promethean/piper test`

------
https://chatgpt.com/codex/tasks/task_e_68be08a3e2f48324acb92ff07b424629