### PR TITLE
feat: scaffold docops-style packages with NX

### DIFF
--- a/changelog.d/2025.09.07.23.06.45.fixed.md
+++ b/changelog.d/2025.09.07.23.06.45.fixed.md
@@ -1,0 +1,1 @@
+- fixed package generator docs and workspace config so the generator runs via `nx`

--- a/docs/package-generator.md
+++ b/docs/package-generator.md
@@ -3,7 +3,7 @@
 Use the NX package generator to scaffold a new package that matches the `docops` layout.
 
 ```bash
-pnpm nx generate ./tools/generators/package --name my-lib
+pnpm nx generate ./tools:package --name my-lib
 ```
 
 This creates `packages/my-lib` with:

--- a/nx.json
+++ b/nx.json
@@ -22,5 +22,7 @@
       "dependsOn": ["build"]
     }
   },
-  "projects": {}
+  "projects": {
+    "tools": "tools"
+  }
 }

--- a/tools/generators.json
+++ b/tools/generators.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://json.schemastore.org/nx-generator.json",
+  "generators": {
+    "package": {
+      "factory": "./generators/package/index.js",
+      "schema": "./generators/package/schema.json",
+      "description": "Generate a new package"
+    }
+  }
+}

--- a/tools/index.js
+++ b/tools/index.js
@@ -1,0 +1,1 @@
+export default {};

--- a/tools/package.json
+++ b/tools/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@promethean/tools",
+  "version": "0.0.0",
+  "type": "module",
+  "main": "index.js",
+  "generators": "./generators.json"
+}

--- a/tools/project.json
+++ b/tools/project.json
@@ -1,0 +1,7 @@
+{
+  "name": "tools",
+  "root": "tools",
+  "projectType": "library",
+  "targets": {},
+  "generators": "./generators.json"
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,20 @@
+{
+  "compileOnSave": false,
+  "compilerOptions": {
+    "rootDir": ".",
+    "sourceMap": true,
+    "declaration": false,
+    "moduleResolution": "node",
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "importHelpers": true,
+    "target": "es2015",
+    "module": "esnext",
+    "lib": ["es2020", "dom"],
+    "skipLibCheck": true,
+    "skipDefaultLibCheck": true,
+    "baseUrl": ".",
+    "paths": {}
+  },
+  "exclude": ["node_modules", "tmp"]
+}


### PR DESCRIPTION
## Summary
- register workspace tools project so Nx can resolve local generators
- document invoking package generator via `pnpm nx generate ./tools:package`
- add root tsconfig for Nx compatibility

## Testing
- `pnpm nx generate ./tools:package --name tmp-lib --dry-run`
- `pnpm exec ava tests/integration/package-generator.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68be0fa63a608324a4bb63c8fdf883e4