### PR TITLE
fix(piper): hash js module graphs and cache workers

### DIFF
--- a/changelog.d/2025.09.07.23.14.08.fixed.md
+++ b/changelog.d/2025.09.07.23.14.08.fixed.md
@@ -1,0 +1,1 @@
+fix(piper): hash JS step dependencies and prune module cache

--- a/packages/piper/src/lib/js-worker.ts
+++ b/packages/piper/src/lib/js-worker.ts
@@ -1,0 +1,27 @@
+import { parentPort, workerData } from "worker_threads";
+
+const { modulePath, exportName } = workerData as {
+  modulePath: string;
+  exportName?: string;
+};
+
+async function load() {
+  const mod = await import(modulePath);
+  const fn =
+    (exportName && (mod as any)[exportName]) ??
+    (mod as any).default ??
+    mod;
+  parentPort!.on("message", async ({ args }) => {
+    try {
+      const res = await fn(args as any);
+      parentPort!.postMessage({ ok: true, res: typeof res === "string" ? res : "" });
+    } catch (err) {
+      parentPort!.postMessage({
+        ok: false,
+        err: err instanceof Error ? err.message : String(err),
+      });
+    }
+  });
+}
+
+load();


### PR DESCRIPTION
## Summary
- compute Merkle hashes across JS dependency graphs
- execute JS steps in worker threads cached by hash with TTL/LRU eviction
- cover helper reloads in js-step tests

## Testing
- `pnpm --filter @promethean/piper test`


------
https://chatgpt.com/codex/tasks/task_e_68be114fe00883248f1216d0c53190c7