### PR TITLE
Potential fix for code scanning alert no. 344: Missing rate limiting

### DIFF
--- a/packages/smartgpt-bridge/src/fastifyApp.ts
+++ b/packages/smartgpt-bridge/src/fastifyApp.ts
@@ -4,7 +4,7 @@ import Fastify from "fastify";
 import swagger from "@fastify/swagger";
 import swaggerUi from "@fastify/swagger-ui";
 import ajvformats from "ajv-formats";
-
+import rateLimit from "@fastify/rate-limit";
 import { createFastifyAuth } from "./fastifyAuth.js";
 import { registerV0Routes } from "./routes/v0/index.js";
 import { indexerManager } from "./indexer.js";
@@ -213,6 +213,12 @@ export async function buildFastifyApp(ROOT_PATH) {
 
   app.register(
     async (v1Scope) => {
+      // Register rate limiting for v1 routes
+      await v1Scope.register(rateLimit, {
+        max: 100, // max 100 requests per windowMs
+        timeWindow: 15 * 60 * 1000, // 15 minutes
+      });
+
       const v1Auth = createFastifyAuth();
       if (v1Auth.enabled) v1Scope.addHook("onRequest", v1Auth.preHandler);
       await registerV1Routes(v1Scope);


### PR DESCRIPTION
Potential fix for [https://github.com/riatzukiza/promethean/security/code-scanning/344](https://github.com/riatzukiza/promethean/security/code-scanning/344)

To address this, you should register a rate-limiting middleware for the `/v1` routes—specifically, for all requests passing through the v1 scope where the authentication hook lives. This can be achieved using the well-known `@fastify/rate-limit` plugin. You will need to import and register it within the scope of v1 routes inside the main Fastify app construction function.

1. **Import** the rate limiting plugin: `@fastify/rate-limit`.
2. **Register** the plugin within the v1 route scope (`v1Scope`), so it applies to all `/v1` requests.
3. Configure reasonable defaults, e.g., `max: 100 requests per 15 minutes per IP`, or per documentation.
4. Make minimal and explicit changes to only the affected area—inside the `/v1` route registration (lines 215–219).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added request rate limiting to v1 endpoints. Clients are limited to 100 requests per 15 minutes; exceeding the limit returns a rate-limit response.
  - Scope is limited to v1 only; v0 behavior remains unchanged.
  - No changes to the public API surface or client integration flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->