### PR TITLE
chore: generate docops-style JSON pipelines for packages

### DIFF
--- a/changelog.d/2025.09.09.03.50.54.changed.md
+++ b/changelog.d/2025.09.09.03.50.54.changed.md
@@ -1,0 +1,1 @@
+- replace package generator pipeline template with docops-style JSON and update docs/tests

--- a/docs/package-generator.md
+++ b/docs/package-generator.md
@@ -11,7 +11,7 @@ This creates `packages/my-lib` with:
 - `package.json` named `@promethean/my-lib`
 - TypeScript config extending the workspace base
 - AVA test setup and sample test
-- default `pipelines.yml`
+- default docops-style `pipelines.json`
 - `project.json` wired for `build`, `test`, `lint`, and `typecheck`
 
 Run the new package's tests with:

--- a/tests/integration/package-generator.test.js
+++ b/tests/integration/package-generator.test.js
@@ -11,7 +11,10 @@ test("scaffolds docops-style package", async (t) => {
   t.true(exists(tree, "packages/demo/package.json"));
   t.true(exists(tree, "packages/demo/tsconfig.json"));
   t.true(exists(tree, "packages/demo/ava.config.mjs"));
-  t.true(exists(tree, "packages/demo/pipelines.yml"));
+  t.true(exists(tree, "packages/demo/pipelines.json"));
+  const pipeline = readJson(tree, "packages/demo/pipelines.json");
+  t.is(pipeline.pipelines[0].name, "demo");
+  t.is(pipeline.pipelines[0].steps[0].shell, 'echo "running demo pipeline"');
   t.true(exists(tree, "packages/demo/project.json"));
   t.true(exists(tree, "packages/demo/src/tests/sample.test.ts"));
   const pkg = readJson(tree, "packages/demo/package.json");

--- a/tools/generators/package/files/pipelines.json__tmpl__
+++ b/tools/generators/package/files/pipelines.json__tmpl__
@@ -1,0 +1,13 @@
+{
+  "pipelines": [
+    {
+      "name": "<%= name %>",
+      "steps": [
+        {
+          "id": "example",
+          "shell": "echo \"running <%= name %> pipeline\""
+        }
+      ]
+    }
+  ]
+}

--- a/tools/generators/package/files/pipelines.yml__tmpl__
+++ b/tools/generators/package/files/pipelines.yml__tmpl__
@@ -1,5 +1,0 @@
-pipelines:
-  - name: <%= name %>
-    steps:
-      - id: example
-        shell: echo "running <%= name %> pipeline"

--- a/tools/generators/package/index.js
+++ b/tools/generators/package/index.js
@@ -1,4 +1,9 @@
-import { generateFiles, joinPathFragments, names, formatFiles } from "@nx/devkit";
+import {
+  generateFiles,
+  joinPathFragments,
+  names,
+  formatFiles,
+} from "@nx/devkit";
 import { fileURLToPath } from "node:url";
 import { dirname } from "node:path";
 
@@ -10,6 +15,7 @@ export default async function generator(tree, schema) {
   generateFiles(tree, joinPathFragments(__dirname, "files"), projectRoot, {
     tmpl: "",
     name: normalized,
+    pipelineExt: "json",
   });
   await formatFiles(tree);
 }


### PR DESCRIPTION
## Summary
- switch package generator to output docops-style `pipelines.json`
- update docs and tests for JSON pipeline configs

## Testing
- `pnpm ava tests/integration/package-generator.test.js`
- `pnpm install`


------
https://chatgpt.com/codex/tasks/task_e_68bfa390ff648324a07f112556a80ab6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Generated packages now include a docops-style pipelines.json instead of pipelines.yml, with the same pipeline structure and an example echo step.

* **Documentation**
  * Updated package generator docs to reference pipelines.json as the default pipeline configuration.

* **Tests**
  * Adjusted integration tests to validate pipelines.json presence and contents.

* **Chores**
  * Added a changelog entry documenting the transition to JSON for the pipeline artifact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->