### PR TITLE
fix: close piper state cache and validate entries

### DIFF
--- a/changelog.d/2025.09.09.05.07.25.fixed.md
+++ b/changelog.d/2025.09.09.05.07.25.fixed.md
@@ -1,0 +1,1 @@
+Ensure piper state cache closes reliably and validate steps loaded from cache.

--- a/packages/piper/src/lib/state.ts
+++ b/packages/piper/src/lib/state.ts
@@ -1,42 +1,71 @@
 import { openLevelCache } from "@promethean/level-cache";
+import type { Cache } from "@promethean/level-cache";
+
+export type Step = Readonly<{
+  fingerprint: string;
+  endedAt: string;
+  exitCode: number | null;
+}>;
+
+export const isValidStep = (val: unknown): val is Step =>
+  typeof val === "object" &&
+  val !== null &&
+  typeof (val as any).fingerprint === "string" &&
+  typeof (val as any).endedAt === "string" &&
+  (typeof (val as any).exitCode === "number" || (val as any).exitCode === null);
 
 export type RunState = {
-  steps: Record<
-    string,
-    { fingerprint: string; endedAt: string; exitCode: number | null }
-  >;
+  steps: Record<string, Step>;
 };
 
 const DB_PATH = ".cache/piper.level";
 
 export async function loadState(pipeline: string): Promise<RunState> {
+  let cache: Cache<Step> | undefined;
   try {
-    const cache = await openLevelCache<any>({
+    cache = await openLevelCache<Step>({
       path: DB_PATH,
       namespace: pipeline,
     });
     const steps: RunState["steps"] = {};
     for await (const [key, val] of cache.entries()) {
-      if (key && val) steps[key] = val;
+      if (typeof key === "string" && key !== "" && isValidStep(val)) {
+        steps[key] = val;
+      }
     }
-    await cache.close();
     return { steps };
   } catch {
     return { steps: {} };
+  } finally {
+    if (cache) {
+      try {
+        await cache.close();
+      } catch {
+        // ignore close errors
+      }
+    }
   }
 }
 
 export async function saveState(pipeline: string, state: RunState) {
+  let cache: Cache<Step> | undefined;
   try {
-    const cache = await openLevelCache<any>({
+    cache = await openLevelCache<Step>({
       path: DB_PATH,
       namespace: pipeline,
     });
     for (const [k, v] of Object.entries(state.steps)) {
       await cache.set(k, v);
     }
-    await cache.close();
   } catch {
     /* ignore persistence errors */
+  } finally {
+    if (cache) {
+      try {
+        await cache.close();
+      } catch {
+        // ignore close errors
+      }
+    }
   }
 }


### PR DESCRIPTION
## Summary
- ensure piper state cache closes even on errors
- validate loaded steps before adding to state
- document piper cache fix

## Testing
- `pnpm --filter @promethean/piper test`
- `pnpm lint:diff`
- `pnpm install`


------
https://chatgpt.com/codex/tasks/task_e_68bfb508b9a883248a7aee54ac2e3890