### PR TITLE
test(buildfix): add pipeline tests

### DIFF
--- a/changelog.d/2025.09.09.05.19.34.added.md
+++ b/changelog.d/2025.09.09.05.19.34.added.md
@@ -1,0 +1,1 @@
+Added unit and integration tests for Buildfix pipeline steps and updated package scripts and documentation.

--- a/packages/buildfix/README.md
+++ b/packages/buildfix/README.md
@@ -26,3 +26,17 @@ pnpm --filter @promethean/piper run buildfix --config packages/buildfix/pipeline
 3. **bf-report** – render a Markdown report under `docs/agile/reports/buildfix`.
 
 See `pipelines.json` for the full configuration.
+
+## Tests
+
+Run unit and integration tests:
+
+```sh
+pnpm --filter @promethean/buildfix test
+```
+
+Run only the integration tests:
+
+```sh
+pnpm --filter @promethean/buildfix test:integration
+```

--- a/packages/buildfix/package.json
+++ b/packages/buildfix/package.json
@@ -17,6 +17,8 @@
     "bf:03-report": "node ./dist/03-report.js",
     "bf:all": "pnpm build && pnpm bf:01-errors && pnpm bf:02-iterate && pnpm bf:03-report",
     "test": "pnpm build && ava",
+    "test:unit": "pnpm build && ava \"dist/tests/**/*.js\" \"!dist/tests/integration/**/*.js\"",
+    "test:integration": "pnpm build && ava \"dist/tests/integration/**/*.js\"",
     "coverage": "pnpm build && c8 ava",
     "doc:report": "pnpm build && node ./dist/03-report.js"
   },

--- a/packages/buildfix/src/tests/errors.step.test.ts
+++ b/packages/buildfix/src/tests/errors.step.test.ts
@@ -1,0 +1,52 @@
+import test from "ava";
+import { promises as fs } from "node:fs";
+import * as path from "node:path";
+import * as url from "node:url";
+import { randomUUID } from "node:crypto";
+
+import { run } from "../utils.js";
+
+const PKG_ROOT = path.resolve(
+  path.dirname(url.fileURLToPath(import.meta.url)),
+  "../..",
+);
+
+// Minimal tsconfig with a single file containing a type error
+async function createProject() {
+  const dir = path.join(PKG_ROOT, "test-tmp", `proj-${randomUUID()}`);
+  await fs.mkdir(path.join(dir, "src"), { recursive: true });
+  await fs.writeFile(
+    path.join(dir, "src", "bad.ts"),
+    "export const x: number = 'oops';\n",
+  );
+  await fs.writeFile(
+    path.join(dir, "tsconfig.json"),
+    JSON.stringify(
+      {
+        compilerOptions: { target: "ES2020", strict: true },
+        include: ["src/**/*"],
+      },
+      null,
+      2,
+    ),
+  );
+  return dir;
+}
+
+test("bf:01-errors writes error list", async (t) => {
+  const dir = await createProject();
+  const outPath = path.join(dir, "errors.json");
+  const tsconfig = path.join(dir, "tsconfig.json");
+  const { code } = await run(
+    `node ${path.join(
+      PKG_ROOT,
+      "dist/01-errors.js",
+    )} --tsconfig ${tsconfig} --out ${outPath}`,
+    PKG_ROOT,
+  );
+  t.is(code, 0);
+  const data = JSON.parse(await fs.readFile(outPath, "utf-8"));
+  t.true(Array.isArray(data.errors));
+  t.true(data.errors.length >= 1);
+  t.truthy(data.errors[0].code);
+});

--- a/packages/buildfix/src/tests/integration/pipeline.run.test.ts
+++ b/packages/buildfix/src/tests/integration/pipeline.run.test.ts
@@ -1,0 +1,87 @@
+import test from "ava";
+import { promises as fs } from "node:fs";
+import * as path from "node:path";
+import * as url from "node:url";
+import { randomUUID } from "node:crypto";
+
+import { run } from "../../utils.js";
+
+const PKG_ROOT = path.resolve(
+  path.dirname(url.fileURLToPath(import.meta.url)),
+  "../../..",
+);
+
+async function createProject() {
+  const dir = path.join(PKG_ROOT, "test-tmp", `pipeline-${randomUUID()}`);
+  await fs.mkdir(path.join(dir, "src"), { recursive: true });
+  await fs.writeFile(
+    path.join(dir, "src", "bad.ts"),
+    "export const x: number = 'oops';\n",
+  );
+  await fs.writeFile(
+    path.join(dir, "tsconfig.json"),
+    JSON.stringify(
+      {
+        compilerOptions: { target: "ES2020", strict: true },
+        include: ["src/**/*"],
+      },
+      null,
+      2,
+    ),
+  );
+  return dir;
+}
+
+test.serial("buildfix pipeline runs end-to-end", async (t) => {
+  const dir = await createProject();
+  const errorsPath = path.join(dir, "errors.json");
+  const tsconfig = path.join(dir, "tsconfig.json");
+
+  // step 1
+  t.is(
+    (
+      await run(
+        `node ${path.join(
+          PKG_ROOT,
+          "dist/01-errors.js",
+        )} --tsconfig ${tsconfig} --out ${errorsPath}`,
+        PKG_ROOT,
+      )
+    ).code,
+    0,
+  );
+
+  // step 2
+  t.is(
+    (
+      await run(
+        `node ${path.join(
+          PKG_ROOT,
+          "dist/02-iterate.js",
+        )} --errors ${errorsPath} --out ${dir} --max-cycles 0 --git off`,
+        PKG_ROOT,
+      )
+    ).code,
+    0,
+  );
+
+  // step 3
+  const summaryPath = path.join(dir, "summary.json");
+  const historyRoot = path.join(dir, "history");
+  const reportDir = path.join(dir, "reports");
+  t.is(
+    (
+      await run(
+        `node ${path.join(
+          PKG_ROOT,
+          "dist/03-report.js",
+        )} --summary ${summaryPath} --history-root ${historyRoot} --out ${reportDir}`,
+        PKG_ROOT,
+      )
+    ).code,
+    0,
+  );
+
+  const files = await fs.readdir(reportDir);
+  t.true(files.some((f) => f.endsWith(".md")));
+});

--- a/packages/buildfix/src/tests/iterate.step.test.ts
+++ b/packages/buildfix/src/tests/iterate.step.test.ts
@@ -1,0 +1,49 @@
+import test from "ava";
+import { promises as fs } from "node:fs";
+import * as path from "node:path";
+import * as url from "node:url";
+import { randomUUID } from "node:crypto";
+
+import { run } from "../utils.js";
+
+const PKG_ROOT = path.resolve(
+  path.dirname(url.fileURLToPath(import.meta.url)),
+  "../..",
+);
+
+test("bf:02-iterate generates summary without attempts when max-cycles=0", async (t) => {
+  const tmp = path.join(PKG_ROOT, "test-tmp", `iterate-${randomUUID()}`);
+  await fs.mkdir(tmp, { recursive: true });
+  const errors = {
+    createdAt: new Date().toISOString(),
+    tsconfig: "tsconfig.json",
+    errors: [
+      {
+        key: "k1",
+        file: "file.ts",
+        line: 1,
+        col: 1,
+        code: "TS1",
+        message: "msg",
+        frame: "",
+      },
+    ],
+  };
+  const errorsPath = path.join(tmp, "errors.json");
+  await fs.writeFile(errorsPath, JSON.stringify(errors, null, 2));
+
+  const { code } = await run(
+    `node ${path.join(
+      PKG_ROOT,
+      "dist/02-iterate.js",
+    )} --errors ${errorsPath} --out ${tmp} --max-cycles 0 --git off`,
+    PKG_ROOT,
+  );
+  t.is(code, 0);
+  const summary = JSON.parse(
+    await fs.readFile(path.join(tmp, "summary.json"), "utf-8"),
+  );
+  t.is(summary.items.length, 1);
+  t.is(summary.items[0].attempts, 0);
+  t.false(summary.items[0].resolved);
+});

--- a/packages/buildfix/src/tests/report.step.test.ts
+++ b/packages/buildfix/src/tests/report.step.test.ts
@@ -1,0 +1,48 @@
+import test from "ava";
+import { promises as fs } from "node:fs";
+import * as path from "node:path";
+import * as url from "node:url";
+import { randomUUID } from "node:crypto";
+
+import { run } from "../utils.js";
+
+const PKG_ROOT = path.resolve(
+  path.dirname(url.fileURLToPath(import.meta.url)),
+  "../..",
+);
+
+test("bf:03-report renders markdown report", async (t) => {
+  const tmp = path.join(PKG_ROOT, "test-tmp", `report-${randomUUID()}`);
+  const histRoot = path.join(tmp, "history");
+  const key = "k1";
+  await fs.mkdir(path.join(histRoot, key), { recursive: true });
+  await fs.writeFile(
+    path.join(histRoot, key, "history.json"),
+    JSON.stringify({ key, file: "f.ts", code: "TS1", attempts: [] }, null, 2),
+  );
+  const summaryPath = path.join(tmp, "summary.json");
+  await fs.writeFile(
+    summaryPath,
+    JSON.stringify(
+      {
+        iteratedAt: new Date().toISOString(),
+        tsconfig: "tsconfig.json",
+        maxCycles: 0,
+        items: [{ key, resolved: false, attempts: 0 }],
+      },
+      null,
+      2,
+    ),
+  );
+  const outDir = path.join(tmp, "reports");
+  const { code } = await run(
+    `node ${path.join(
+      PKG_ROOT,
+      "dist/03-report.js",
+    )} --summary ${summaryPath} --history-root ${histRoot} --out ${outDir}`,
+    PKG_ROOT,
+  );
+  t.is(code, 0);
+  const files = await fs.readdir(outDir);
+  t.true(files.some((f) => f.endsWith(".md")));
+});


### PR DESCRIPTION
## Summary
- add unit tests for buildfix pipeline steps
- cover end-to-end pipeline with integration test
- document and expose test scripts

## Testing
- `pnpm --filter @promethean/buildfix test`
- `pnpm --filter @promethean/buildfix test:integration`
- `pnpm install`


------
https://chatgpt.com/codex/tasks/task_e_68bfb81fbeec83248eb4aab5d8f70c0b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Added a Tests section to Buildfix README with instructions for running unit and integration tests.
- Tests
  - Introduced unit tests for error detection and iteration steps.
  - Added an integration test validating the full Buildfix pipeline.
  - Added a test verifying markdown report generation.
- Chores
  - Added npm scripts to run unit and integration tests separately, with build steps executed before tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->