### PR TITLE
feat: add piper dev ui

### DIFF
--- a/packages/docops/README.md
+++ b/packages/docops/README.md
@@ -1,6 +1,6 @@
 # @promethean/docops
 
-DocOps is a modular documentation pipeline that parses, embeds, queries, relates, and renders Markdown documents. It exposes pure JS/TS functions, a small dev server with a Web UI, and preserves standalone CLI usage for compatibility.
+DocOps is a modular documentation pipeline that parses, embeds, queries, relates, and renders Markdown documents. It exposes pure JS/TS functions, a small dev server with a Web UI, and preserves standalone CLI usage for compatibility. For a generic pipeline UI, you can also use [Piper](../piper/README.md).
 
 ## Features
 
@@ -15,7 +15,7 @@ DocOps is a modular documentation pipeline that parses, embeds, queries, relates
 - UI:
 
 ```bash
-pnpm -C packages/docops doc:dev-ui
+pnpm --filter @promethean/piper dev-ui -- --config packages/docops/pipelines.json
 # open http://localhost:3939
 ```
 

--- a/packages/piper/README.md
+++ b/packages/piper/README.md
@@ -1,0 +1,14 @@
+# @promethean/piper
+
+Piper is a lightweight pipeline runner. It reads a `pipelines.json` file and executes the steps it defines.
+
+## Dev UI
+
+A minimal Fastify server is included to inspect pipelines and trigger steps from the browser.
+
+```bash
+pnpm --filter @promethean/piper dev-ui -- --config pipelines.json
+```
+
+Then open [http://localhost:3939](http://localhost:3939) to run individual steps. The UI lists pipelines and exposes buttons for each step while streaming logs back to the page.
+

--- a/packages/piper/package.json
+++ b/packages/piper/package.json
@@ -12,7 +12,8 @@
     "test": "pnpm build && ava",
     "coverage": "c8 -r text -r lcov ava",
     "clean": "rimraf dist",
-    "prepack": "pnpm run build"
+    "prepack": "pnpm run build",
+    "dev-ui": "tsx src/dev-ui.ts"
   },
   "exports": {
     ".": {
@@ -26,7 +27,9 @@
     "globby": "14.0.2",
     "zod": "3.23.8",
     "@promethean/fs": "workspace:*",
-    "es-module-lexer": "1.5.1"
+    "es-module-lexer": "1.5.1",
+    "fastify": "^5.0.0",
+    "@fastify/static": "^8.2.0"
   },
   "devDependencies": {
     "@promethean/test-utils": "workspace:*"

--- a/packages/piper/src/dev-ui.ts
+++ b/packages/piper/src/dev-ui.ts
@@ -1,0 +1,116 @@
+import * as url from "node:url";
+import * as path from "node:path";
+import { promises as fs } from "node:fs";
+
+import fastifyFactory from "fastify";
+import fastifyStatic from "@fastify/static";
+import type { FastifyReply } from "fastify";
+
+import { runPipeline } from "./runner.js";
+import * as events from "./lib/events.js";
+import type { PiperEvent } from "./lib/events.js";
+import { FileSchema } from "./types.js";
+
+function getArg(flag: string, dflt: string): string {
+  const idx = process.argv.indexOf(flag);
+  return idx >= 0 ? process.argv[idx + 1] ?? dflt : dflt;
+}
+
+const CONFIG_PATH = path.resolve(getArg("--config", "pipelines.json"));
+const PORT = Number(getArg("--port", "3939")) || 3939;
+
+const UI_ROOT = path.resolve(
+  path.dirname(url.fileURLToPath(import.meta.url)),
+  "../ui",
+);
+
+async function loadConfig() {
+  const raw = await fs.readFile(CONFIG_PATH, "utf-8");
+  const parsed = FileSchema.safeParse(JSON.parse(raw));
+  if (!parsed.success) throw new Error(parsed.error.message);
+  return parsed.data;
+}
+
+function sseInit(reply: FastifyReply) {
+  reply.raw.setHeader("Content-Type", "text/event-stream");
+  reply.raw.setHeader("Cache-Control", "no-cache");
+  reply.raw.setHeader("Connection", "keep-alive");
+  reply.hijack();
+  return (line: string) =>
+    reply.raw.write(`data: ${String(line).replace(/\n/g, "\\n")}\n\n`);
+}
+
+const app = fastifyFactory({ logger: false });
+await app.register(fastifyStatic, { root: UI_ROOT, prefix: "/ui" });
+
+app.get("/health", async (_req, reply) => {
+  reply.header("content-type", "application/json");
+  return reply.send({ ok: true });
+});
+
+app.get("/", async (_req, reply) => {
+  const html = await fs.readFile(path.join(UI_ROOT, "index.html"), "utf8");
+  reply.header("content-type", "text/html; charset=utf-8");
+  return reply.send(html);
+});
+
+app.get("/api/pipelines", async (_req, reply) => {
+  const cfg = await loadConfig();
+  reply.header("content-type", "application/json");
+  return reply.send({
+    pipelines: cfg.pipelines.map((p) => ({
+      name: p.name,
+      steps: p.steps.map((s) => ({ id: s.id, name: s.name })),
+    })),
+  });
+});
+
+app.get<{
+  Querystring: { pipeline?: string; step?: string; force?: string };
+}>("/api/run-step", async (req, reply) => {
+  const pipeline = req.query.pipeline ?? "";
+  const step = req.query.step ?? "";
+  const send = sseInit(reply);
+  if (!pipeline || !step) {
+    send("missing pipeline or step");
+    reply.raw.end();
+    return;
+  }
+  const origEmit = events.emitEvent;
+  // eslint-disable-next-line functional/immutable-data
+  (events as { emitEvent: (ev: PiperEvent, json: boolean) => void }).emitEvent =
+    (ev: PiperEvent) => {
+      if (ev.stepId !== step) return;
+      if (ev.type === "start") send(`START ${ev.stepId}`);
+      else if (ev.type === "skip") send(`SKIP ${ev.reason}`);
+      else if (ev.type === "end") {
+        if (ev.result.stdout) send(ev.result.stdout);
+        if (ev.result.stderr) send(ev.result.stderr);
+        send(`EXIT ${ev.result.exitCode}`);
+      }
+    };
+  try {
+    await runPipeline(CONFIG_PATH, pipeline, {
+      json: true,
+      force: req.query.force === "true",
+    });
+  } catch (e: unknown) {
+    send(String((e as Error)?.stack || e));
+  } finally {
+    // eslint-disable-next-line functional/immutable-data
+    (
+      events as { emitEvent: (ev: PiperEvent, json: boolean) => void }
+    ).emitEvent = origEmit;
+  }
+  reply.raw.end();
+});
+
+app
+  .listen({ port: PORT, host: "0.0.0.0" })
+  .then(() => {
+    console.log(`Piper Dev UI running on http://localhost:${PORT}`);
+  })
+  .catch((err) => {
+    console.error("Failed to start server:", err);
+    process.exit(1);
+  });

--- a/packages/piper/ui/index.html
+++ b/packages/piper/ui/index.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<meta charset="utf-8" />
+<title>Piper Dev UI</title>
+<body>
+<h1>Piper Dev UI</h1>
+<div id="pipelines"></div>
+<h2>Logs</h2>
+<pre id="logs">(no logs)</pre>
+<script type="module" src="/ui/main.js"></script>
+</body>

--- a/packages/piper/ui/main.js
+++ b/packages/piper/ui/main.js
@@ -1,0 +1,31 @@
+async function init() {
+  const res = await fetch("/api/pipelines");
+  const data = await res.json();
+  const container = document.getElementById("pipelines");
+  data.pipelines.forEach((p) => {
+    const section = document.createElement("section");
+    const h = document.createElement("h2");
+    h.textContent = p.name;
+    section.appendChild(h);
+    p.steps.forEach((s) => {
+      const btn = document.createElement("button");
+      btn.textContent = s.id;
+      btn.onclick = () => {
+        const logs = document.getElementById("logs");
+        logs.textContent = "";
+        const es = new EventSource(
+          `/api/run-step?pipeline=${encodeURIComponent(
+            p.name,
+          )}&step=${encodeURIComponent(s.id)}`,
+        );
+        es.onmessage = (e) => {
+          logs.textContent += e.data + "\n";
+        };
+        es.onerror = () => es.close();
+      };
+      section.appendChild(btn);
+    });
+    container.appendChild(section);
+  });
+}
+init();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2828,6 +2828,9 @@ importers:
 
   packages/piper:
     dependencies:
+      '@fastify/static':
+        specifier: ^8.2.0
+        version: 8.2.0
       '@promethean/fs':
         specifier: workspace:*
         version: link:../fs
@@ -2840,6 +2843,9 @@ importers:
       es-module-lexer:
         specifier: 1.5.1
         version: 1.5.1
+      fastify:
+        specifier: ^5.0.0
+        version: 5.6.0
       globby:
         specifier: 14.0.2
         version: 14.0.2


### PR DESCRIPTION
## Summary
- add Fastify-powered dev server for Piper to inspect pipelines and run steps
- document usage and tie DocOps instructions to Piper's dev UI

## Testing
- `pnpm install`
- `pnpm --filter @promethean/piper test` *(fails: Database is not open)*
- `pnpm --filter @promethean/docops test` *(fails: TS6133 'baseUrl' is declared but its value is never read)*

------
https://chatgpt.com/codex/tasks/task_e_68bfb82bcac08324b86d007689d810e5