### PR TITLE
docs: encourage lint:diff for faster linting

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,7 @@ Under no circumstances should you introduce the following to Promethean:
 - Skeptical, precise, practical. Challenge vague asks with 1–2 targeted
   questions max.
 - Prefer small, auditable changes over grand rewrites.
+- Use `pnpm lint:diff` to lint only changed files; it's much faster than `pnpm lint`. Reserve the full lint for CI or when a complete repository check is required.
 - Tie SonarQube/GitHub insights to specific paths/lines.
 - If there aren't tests, write them.
 

--- a/README.md
+++ b/README.md
@@ -148,6 +148,10 @@ The service management targets `make start`, `make start-tts` and
 `make start-stt` require PM2. You can install it globally as shown above or add
 it as a project dependency.
 
+### Linting
+
+Use `pnpm lint:diff` during development to run ESLint only on files changed relative to `origin/main`. This is much faster than `pnpm lint`, which scans the entire repository. Reserve `pnpm lint` for CI or when a full repo check is required.
+
 ### Testing (JS/TS)
 
 Run JavaScript/TypeScript tests with AVA, split by type:

--- a/changelog.d/2025.09.09.05.24.28.changed.md
+++ b/changelog.d/2025.09.09.05.24.28.changed.md
@@ -1,0 +1,2 @@
+## Changed
+- document `pnpm lint:diff` and encourage using it instead of `pnpm lint` for faster development.

--- a/docs/nx-workspace.md
+++ b/docs/nx-workspace.md
@@ -11,3 +11,5 @@ Promethean uses [Nx](https://nx.dev) to coordinate builds and tests across packa
 - `pnpm nx typecheck <project>` – type-check a package.
 
 Each package under `packages/` provides a `project.json` describing its build and test targets. The root `nx.json` sets default caching and dependency behavior.
+
+For quick local checks, `pnpm lint:diff` runs ESLint only on files changed since `origin/main`. It's much faster than `pnpm lint`, which lints the entire repository; use the full lint only in CI or when necessary.


### PR DESCRIPTION
## Summary
- document `pnpm lint:diff` and advise using it over `pnpm lint` for quicker development cycles
- update agent guidelines and Nx workspace docs with new lint command
- record change in changelog

## Testing
- `pnpm lint:diff` *(fails: fatal bad revision 'origin/main...HEAD')*
- `pnpm install`


------
https://chatgpt.com/codex/tasks/task_e_68bfb99103dc83248fac2f325c13f0ca