### PR TITLE
fix: avoid global event override in piper dev UI

### DIFF
--- a/changelog.d/2025.09.09.05.38.17.fixed.md
+++ b/changelog.d/2025.09.09.05.38.17.fixed.md
@@ -1,0 +1,1 @@
+fix: isolate dev UI step execution events per request to avoid race conditions


### PR DESCRIPTION
## Summary
- handle step events with per-request emitter in Piper dev UI
- allow `runPipeline` to take an optional emit handler to prevent cross-request races
- isolate test runs in temporary directories so LevelDB state opens cleanly
- document event emitter change in changelog

## Testing
- `pnpm --filter @promethean/piper build`
- `pnpm --filter @promethean/piper test`
- `pnpm install`


------
https://chatgpt.com/codex/tasks/task_e_68bfbbb8c07083249f780491b6debb1a