### PR TITLE
feat(piper): add step retry support

### DIFF
--- a/changelog.d/2025.09.09.14.40.34.added.md
+++ b/changelog.d/2025.09.09.14.40.34.added.md
@@ -1,0 +1,1 @@
+Piper steps support a `retry` count allowing failed steps to rerun automatically.

--- a/packages/piper/src/lib/events.ts
+++ b/packages/piper/src/lib/events.ts
@@ -1,9 +1,16 @@
 import type { StepResult } from "../types.js";
 
 export type PiperEvent =
-  | { type: 'start', stepId: string, at: string }
-  | { type: 'skip', stepId: string, at: string, reason: string }
-  | { type: 'end', stepId: string, at: string, result: StepResult };
+  | { type: "start"; stepId: string; at: string }
+  | { type: "skip"; stepId: string; at: string; reason: string }
+  | {
+      type: "retry";
+      stepId: string;
+      at: string;
+      attempt: number;
+      exitCode: number | null;
+    }
+  | { type: "end"; stepId: string; at: string; result: StepResult };
 
 export function emitEvent(ev: PiperEvent, json: boolean) {
   if (!json) return;

--- a/packages/piper/src/lib/state.ts
+++ b/packages/piper/src/lib/state.ts
@@ -41,8 +41,6 @@ export async function loadState(pipeline: string): Promise<RunState> {
         steps[key] = val;
       }
     }
-      }
-    }
     return { steps };
   } catch {
     return { steps: {} };

--- a/packages/piper/src/runner.ts
+++ b/packages/piper/src/runner.ts
@@ -175,7 +175,7 @@ export async function runPipeline(
         opts.json ?? false,
       );
 
-      const execRes = await (async () => {
+      const runOnce = async () => {
         if (s.inputSchema) {
           try {
             const inFiles = await globby(s.inputs, { cwd });
@@ -220,7 +220,27 @@ export async function runPipeline(
           }
         }
         return base;
-      })();
+      };
+
+      let attempt = 0;
+      let execRes = await runOnce();
+      while (execRes.code !== 0 && attempt < s.retry) {
+        attempt++;
+        emitEvent(
+          {
+            type: "retry",
+            stepId: s.id,
+            at: new Date().toISOString(),
+            attempt,
+            exitCode: execRes.code,
+          },
+          opts.json ?? false,
+        );
+        console.log(
+          `[piper] step ${s.id} failed (exit ${execRes.code}); retry ${attempt}/${s.retry}`,
+        );
+        execRes = await runOnce();
+      }
 
       const endedAt = new Date().toISOString();
       const out: StepResult = {

--- a/packages/piper/src/test/retry.test.ts
+++ b/packages/piper/src/test/retry.test.ts
@@ -1,0 +1,87 @@
+import * as fs from "fs/promises";
+import * as path from "path";
+
+import test from "ava";
+
+import { runPipeline } from "../runner.js";
+
+async function withTmp(fn: (dir: string) => Promise<void>) {
+  const dir = path.join(
+    process.cwd(),
+    "test-tmp",
+    String(Date.now()) + "-" + Math.random().toString(36).slice(2),
+  );
+  await fs.mkdir(dir, { recursive: true });
+  try {
+    await fn(dir);
+  } finally {
+    await fs.rm(dir, { recursive: true, force: true });
+  }
+}
+
+test("runPipeline retries failed steps", async (t) => {
+  await withTmp(async (dir) => {
+    const prevCwd = process.cwd();
+    process.chdir(dir);
+    try {
+      const cfg = {
+        pipelines: [
+          {
+            name: "demo",
+            steps: [
+              {
+                id: "flaky",
+                cwd: ".",
+                deps: [],
+                inputs: [],
+                outputs: [],
+                cache: "content",
+                retry: 1,
+                shell:
+                  "n=$(cat count 2>/dev/null || echo 0); n=$((n+1)); echo $n > count; [ $n -ge 2 ]",
+              },
+            ],
+          },
+        ],
+      };
+      const pipelinesPath = path.join(dir, "pipelines.json");
+      await fs.writeFile(pipelinesPath, JSON.stringify(cfg, null, 2), "utf8");
+
+      const events: string[] = [];
+      const origWrite = process.stdout.write.bind(process.stdout);
+      (process.stdout.write as any) = (s: string | Uint8Array) => {
+        events.push(s.toString());
+        return true;
+      };
+      try {
+        const res = await runPipeline(pipelinesPath, "demo", {
+          concurrency: 1,
+          contentHash: true,
+          json: true,
+        });
+        t.is(res[0]?.exitCode, 0);
+      } finally {
+        (process.stdout.write as any) = origWrite;
+      }
+
+      const count = await fs.readFile(path.join(dir, "count"), "utf8");
+      t.is(count.trim(), "2");
+
+      const parsed = events
+        .map((e) => {
+          try {
+            return JSON.parse(e);
+          } catch {
+            return null;
+          }
+        })
+        .filter(Boolean) as any[];
+      const retryEvents = parsed.filter((ev) => ev.type === "retry");
+      t.is(retryEvents.length, 1);
+      t.is(retryEvents[0].attempt, 1);
+      t.is(retryEvents[0].stepId, "flaky");
+    } finally {
+      process.chdir(prevCwd);
+    }
+  });
+});

--- a/packages/piper/src/types.ts
+++ b/packages/piper/src/types.ts
@@ -33,6 +33,7 @@ export const StepSchema = z
       .optional(),
     args: z.array(z.string()).optional(),
     timeoutMs: z.number().optional(),
+    retry: z.number().default(0),
   })
   .refine((s) => !!(s.shell || s.node || s.ts || s.js), {
     message: "step must define shell|node|ts|js",


### PR DESCRIPTION
## Summary
- add `retry` option to Piper steps
- retry failed steps up to configured count and emit retry events
- cover retry behavior with AVA tests

## Testing
- `pnpm lint:diff`
- `pnpm --filter @promethean/piper test`
- `pnpm install`


------
https://chatgpt.com/codex/tasks/task_e_68c03b3d7da8832495abbf903289a4ec