### PR TITLE
fix: serve compiled piper dev ui

### DIFF
--- a/changelog.d/2025.09.09.15.08.13.fixed.md
+++ b/changelog.d/2025.09.09.15.08.13.fixed.md
@@ -1,0 +1,1 @@
+fix: serve compiled Piper Dev UI assets from build output to avoid missing main.js

--- a/packages/piper/src/dev-ui.ts
+++ b/packages/piper/src/dev-ui.ts
@@ -26,7 +26,7 @@ const UI_ROOT = path.resolve(
 
 const FRONTEND_DIST = path.resolve(
   path.dirname(url.fileURLToPath(import.meta.url)),
-  "./frontend",
+  "../dist/frontend",
 );
 
 async function loadConfig() {


### PR DESCRIPTION
## Summary
- serve Piper Dev UI frontend from compiled build output
- note fix in changelog

## Testing
- ⚠️ `pnpm lint:diff` (fatal: bad revision 'origin/main...HEAD')
- ✅ `pnpm exec eslint packages/piper/src/dev-ui.ts packages/piper/src/frontend/main.ts`
- ✅ `pnpm --filter @promethean/piper build`
- ✅ `pnpm --filter @promethean/piper test`


------
https://chatgpt.com/codex/tasks/task_e_68c04235bd248324a8753480aa5ad1cd