### PR TITLE
fix: default dev UI server to localhost

### DIFF
--- a/packages/piper/src/dev-ui.ts
+++ b/packages/piper/src/dev-ui.ts
@@ -13,11 +13,14 @@ import { FileSchema } from "./types.js";
 
 function getArg(flag: string, dflt: string): string {
   const idx = process.argv.indexOf(flag);
-  return idx >= 0 ? process.argv[idx + 1] ?? dflt : dflt;
+  if (idx < 0) return dflt;
+  const val = process.argv[idx + 1];
+  return val && !val.startsWith("-") ? val : dflt;
 }
 
 const CONFIG_PATH = path.resolve(getArg("--config", "pipelines.json"));
 const PORT = Number(getArg("--port", "3939")) || 3939;
+const HOST = getArg("--host", "127.0.0.1");
 
 const UI_ROOT = path.resolve(
   path.dirname(url.fileURLToPath(import.meta.url)),
@@ -145,9 +148,15 @@ app.get<{
 });
 
 app
-  .listen({ port: PORT, host: "0.0.0.0" })
+  .listen({ port: PORT, host: HOST })
   .then(() => {
-    console.log(`Piper Dev UI running on http://localhost:${PORT}`);
+    if (HOST === "0.0.0.0") {
+      console.warn(
+        "[piper] WARNING: dev server bound to 0.0.0.0 exposes it to external networks",
+      );
+    }
+    const shownHost = HOST === "0.0.0.0" ? "localhost" : HOST;
+    console.log(`Piper Dev UI running on http://${shownHost}:${PORT}`);
   })
   .catch((err) => {
     console.error("Failed to start server:", err);

--- a/packages/piper/src/runner.ts
+++ b/packages/piper/src/runner.ts
@@ -26,10 +26,7 @@ import { topoSort } from "./lib/graph.js";
 import { semaphore } from "./lib/concurrency.js";
 import { loadState, saveState, RunState } from "./lib/state.js";
 import { renderReport } from "./lib/report.js";
-import {
-  emitEvent as defaultEmitEvent,
-  type PiperEvent,
-} from "./lib/events.js";
+import { emitEvent, type PiperEvent } from "./lib/events.js";
 
 type ValidateFn = {
   (data: unknown): boolean;
@@ -125,7 +122,7 @@ export async function runPipeline(
   if (!pipeline) throw new Error(`pipeline '${pipelineName}' not found`);
   const steps = topoSort(pipeline.steps);
   const state = await loadState(pipeline.name);
-  const emit = opts.emit ?? defaultEmitEvent;
+  const emit = opts.emit ?? emitEvent;
 
   const sem = semaphore(Math.max(1, opts.concurrency ?? 2));
   // Serialize JS module steps to avoid in-proc global-state races.


### PR DESCRIPTION
## Summary
- bind Piper dev UI to localhost by default with new --host flag
- warn when binding to 0.0.0.0 and clarify log output
- simplify runner emitter import to restore build

## Testing
- `pnpm --filter @promethean/piper build`
- `pnpm --filter @promethean/piper test`
- `pnpm exec eslint packages/piper/src/dev-ui.ts packages/piper/src/runner.ts` *(fails: functional plugin errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c0570d5d18832496b680257d7d1eb0