### PR TITLE
docs(docops): align testing notes with AVA and esmock

### DIFF
--- a/packages/docops/src/tests/TESTING_NOTES.md
+++ b/packages/docops/src/tests/TESTING_NOTES.md
@@ -1,6 +1,6 @@
-This package's frontend tests are written for the existing repository test runner (Vitest or Jest) with a jsdom environment.
+This package's frontend tests should use AVA with a jsdom-like environment. For ESM-safe mocking, use `esmock`.
 
-- They mock "./selection.js" and "./api.js" modules used by renderSelectedMarkdown.
+- They mock "./selection.js" and "./api.js" modules used by renderSelectedMarkdown with `esmock`.
 - Scenarios covered:
   - no DOM
   - no selection


### PR DESCRIPTION
## Summary
- update DocOps testing notes to state AVA and esmock usage

## Testing
- `pnpm lint:diff` *(fails: fatal: 'origin' does not appear to be a git repository)*

------
https://chatgpt.com/codex/tasks/task_e_68c0708dd1a48324beb59866cb1f98ea