### PR TITLE
feat(piper): move FileTree styles to CSS

### DIFF
--- a/changelog.d/2025.09.10.03.16.57.changed.md
+++ b/changelog.d/2025.09.10.03.16.57.changed.md
@@ -1,0 +1,1 @@
+Extract FileTree inline styles into a dedicated CSS file in @promethean/piper.

--- a/packages/piper/src/frontend/file-tree.css
+++ b/packages/piper/src/frontend/file-tree.css
@@ -1,0 +1,54 @@
+:host {
+  display: block;
+  border: 1px solid #ddd;
+  padding: 8px;
+  border-radius: 6px;
+  overflow: auto;
+}
+ul {
+  list-style: none;
+  padding-left: 16px;
+}
+.file {
+  cursor: pointer;
+  color: #0366d6;
+}
+.file:hover {
+  text-decoration: underline;
+}
+.toolbar {
+  display: flex;
+  gap: 6px;
+  align-items: center;
+  margin-bottom: 6px;
+  flex-wrap: wrap;
+}
+.dir-line {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  cursor: pointer;
+  user-select: none;
+}
+.caret {
+  display: inline-block;
+  width: 1em;
+  text-align: center;
+  color: #666;
+}
+.dir-name {
+  font-weight: 600;
+}
+.step-row {
+  margin: 6px 0;
+}
+.step-label {
+  display: inline-block;
+  min-width: 260px;
+}
+.tab-button {
+  padding: 4px 8px;
+}
+.tab-close {
+  cursor: pointer;
+}


### PR DESCRIPTION
## Summary
- replace inline FileTree styles with external CSS file
- add classes for step and tab elements

## Testing
- `pnpm exec biome lint packages/piper/src/frontend/main.ts packages/piper/src/frontend/file-tree.css`
- `pnpm --filter @promethean/piper test` *(fails: make1 should re-execute)*
- `pnpm install`


------
https://chatgpt.com/codex/tasks/task_e_68c0eb179c6c8324a99368780330fb74