### PR TITLE
fix(smartgpt-bridge): constrain file paths to repository root

### DIFF
--- a/changelog.d/2025.09.10.03.16.45.fixed.md
+++ b/changelog.d/2025.09.10.03.16.45.fixed.md
@@ -1,0 +1,1 @@
+fix: reject paths outside repository root in smartgpt-bridge file utilities

--- a/packages/smartgpt-bridge/src/tests/unit/files.more.test.ts
+++ b/packages/smartgpt-bridge/src/tests/unit/files.more.test.ts
@@ -41,6 +41,12 @@ test("resolvePath returns null for non-existent", async (t) => {
   t.is(p, null);
 });
 
+test("resolvePath rejects absolute paths outside root", async (t) => {
+  const outside = path.resolve(ROOT, "..", "outside.txt");
+  const p = await resolvePath(ROOT, outside);
+  t.is(p, null);
+});
+
 test("viewFile throws when file missing", async (t) => {
   await t.throwsAsync(() => viewFile(ROOT, "nope.txt", 1, 1));
 });


### PR DESCRIPTION
## Summary
- prevent smartgpt-bridge file utilities from resolving outside repository root
- harden directory listing against path traversal
- test resolution behavior for absolute paths

## Testing
- `pnpm exec biome lint packages/smartgpt-bridge/src/files.ts packages/smartgpt-bridge/src/tests/unit/files.more.test.ts`
- `pnpm --filter @promethean/smartgpt-bridge build`
- `cd packages/smartgpt-bridge && pnpm exec ava dist/tests/unit/files.more.test.js dist/tests/unit/files.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68c0eb15fe80832480dbd47c9a1f4a4b