### PR TITLE
piper: consider extraEnv in cache fingerprints

### DIFF
--- a/changelog.d/2025.09.10.03.20.23.changed.md
+++ b/changelog.d/2025.09.10.03.20.23.changed.md
@@ -1,0 +1,1 @@
+piper: include extraEnv overlay in step fingerprint.

--- a/packages/piper/src/hash.ts
+++ b/packages/piper/src/hash.ts
@@ -50,6 +50,7 @@ export async function stepFingerprint(
   step: any,
   cwd: string,
   preferContent: boolean,
+  extraEnv?: Readonly<Record<string, string>>,
 ) {
   const mode =
     step.cache === "content" || preferContent
@@ -71,6 +72,7 @@ export async function stepFingerprint(
     jsDepsHash = (await fingerprintJsDeps(modPath, mode)).hash;
   }
 
+  const env = { ...(step.env ?? {}), ...(extraEnv ?? {}) }; // step.env then extraEnv (extraEnv overrides)
   const configHash = sha1(
     JSON.stringify({
       id: step.id,
@@ -78,7 +80,7 @@ export async function stepFingerprint(
       deps: step.deps,
       cmd: step.shell ?? step.node ?? step.ts ?? step.js,
       args: step.args ?? step.ts?.args ?? step.js?.args,
-      env: step.env,
+      env,
     }),
   );
   return sha1(inputsHash + "|" + jsDepsHash + "|" + configHash);

--- a/packages/piper/src/runner.ts
+++ b/packages/piper/src/runner.ts
@@ -138,7 +138,12 @@ export async function runPipeline(
     await sem.take();
     try {
       const cwd = path.resolve(s.cwd || ".");
-      const fp = await stepFingerprint(s, cwd, !!opts.contentHash);
+      const fp = await stepFingerprint(
+        s,
+        cwd,
+        !!opts.contentHash,
+        opts.extraEnv,
+      );
       const haveOutputs = s.outputs.length
         ? await listOutputsExist(s.outputs, cwd)
         : false;

--- a/packages/piper/src/test/hash.test.ts
+++ b/packages/piper/src/test/hash.test.ts
@@ -6,110 +6,106 @@ import test, { ExecutionContext } from "ava";
 import { fingerprintFromGlobs, stepFingerprint } from "../hash.js";
 
 async function withTmp(
-	_t: ExecutionContext<unknown>,
-	fn: {
-		(dir: any): Promise<void>;
-		(dir: any): Promise<void>;
-		(arg0: string): any;
-	},
+  _t: ExecutionContext<unknown>,
+  fn: {
+    (dir: any): Promise<void>;
+    (dir: any): Promise<void>;
+    (arg0: string): any;
+  },
 ) {
-	const dir = path.join(
-		process.cwd(),
-		"test-tmp",
-		String(Date.now()) + "-" + Math.random().toString(36).slice(2),
-	);
-	await fs.mkdir(dir, { recursive: true });
-	try {
-		await fn(dir);
-	} finally {
-		await fs.rm(dir, { recursive: true, force: true });
-	}
+  const dir = path.join(
+    process.cwd(),
+    "test-tmp",
+    String(Date.now()) + "-" + Math.random().toString(36).slice(2),
+  );
+  await fs.mkdir(dir, { recursive: true });
+  try {
+    await fn(dir);
+  } finally {
+    await fs.rm(dir, { recursive: true, force: true });
+  }
 }
 
 test("fingerprintFromGlobs: content vs mtime", async (t) => {
-	await withTmp(t, async (dir) => {
-		const a = path.join(dir, "a.txt");
-		const b = path.join(dir, "b.txt");
-		await fs.writeFile(a, "hello", "utf8");
-		await fs.writeFile(b, "world", "utf8");
+  await withTmp(t, async (dir) => {
+    const a = path.join(dir, "a.txt");
+    const b = path.join(dir, "b.txt");
+    await fs.writeFile(a, "hello", "utf8");
+    await fs.writeFile(b, "world", "utf8");
 
-		const contentHash1 = await fingerprintFromGlobs(
-			["*.txt"],
-			dir,
-			"content",
-		);
-		const mtimeHash1 = await fingerprintFromGlobs(["*.txt"], dir, "mtime");
-		t.truthy(contentHash1);
-		t.truthy(mtimeHash1);
+    const contentHash1 = await fingerprintFromGlobs(["*.txt"], dir, "content");
+    const mtimeHash1 = await fingerprintFromGlobs(["*.txt"], dir, "mtime");
+    t.truthy(contentHash1);
+    t.truthy(mtimeHash1);
 
-		// change content
-		await fs.writeFile(a, "HELLO", "utf8");
-		const contentHash2 = await fingerprintFromGlobs(
-			["*.txt"],
-			dir,
-			"content",
-		);
-		const mtimeHash2 = await fingerprintFromGlobs(["*.txt"], dir, "mtime");
+    // change content
+    await fs.writeFile(a, "HELLO", "utf8");
+    const contentHash2 = await fingerprintFromGlobs(["*.txt"], dir, "content");
+    const mtimeHash2 = await fingerprintFromGlobs(["*.txt"], dir, "mtime");
 
-		t.not(
-			contentHash1,
-			contentHash2,
-			"content hash changes when file content changes",
-		);
-		// mtime likely also changes, but ensure at least one differs
-		t.truthy(mtimeHash1 !== mtimeHash2 || contentHash1 !== contentHash2);
-	});
+    t.not(
+      contentHash1,
+      contentHash2,
+      "content hash changes when file content changes",
+    );
+    // mtime likely also changes, but ensure at least one differs
+    t.truthy(mtimeHash1 !== mtimeHash2 || contentHash1 !== contentHash2);
+  });
 });
 
 test("stepFingerprint covers inputs and config", async (t) => {
-	await withTmp(t, async (dir) => {
-		const a = path.join(dir, "a.txt");
-		await fs.writeFile(a, "hello", "utf8");
-		const step = {
-			id: "s",
-			deps: [],
-			cwd: ".",
-			env: {},
-			inputs: ["a.txt"],
-			outputs: [],
-			cache: "content",
-		};
+  await withTmp(t, async (dir) => {
+    const a = path.join(dir, "a.txt");
+    await fs.writeFile(a, "hello", "utf8");
+    const step = {
+      id: "s",
+      deps: [],
+      cwd: ".",
+      env: {},
+      inputs: ["a.txt"],
+      outputs: [],
+      cache: "content",
+    };
 
-		const fp1 = await stepFingerprint(step, dir, true);
-		await fs.writeFile(a, "HELLO", "utf8");
-		const fp2 = await stepFingerprint(step, dir, true);
-		t.not(fp1, fp2, "fingerprint changes when input content changes");
+    const fp1 = await stepFingerprint(step, dir, true);
+    await fs.writeFile(a, "HELLO", "utf8");
+    const fp2 = await stepFingerprint(step, dir, true);
+    t.not(fp1, fp2, "fingerprint changes when input content changes");
 
-		const step2 = { ...step, env: { X: "1" } };
-		const fp3 = await stepFingerprint(step2, dir, true);
-		t.not(fp2, fp3, "fingerprint changes when config/env changes");
-	});
+    const step2 = { ...step, env: { X: "1" } };
+    const fp3 = await stepFingerprint(step2, dir, true);
+    t.not(fp2, fp3, "fingerprint changes when config/env changes");
+
+    const fp4 = await stepFingerprint(step2, dir, true, { X: "2" });
+    const fp5 = await stepFingerprint({ ...step, env: { X: "2" } }, dir, true);
+    t.is(fp4, fp5, "extraEnv overrides step.env in fingerprint");
+  });
 });
 
 test("stepFingerprint includes js step config", async (t) => {
-	await withTmp(t, async (dir) => {
-		const base = {
-			id: "s",
-			deps: [],
-			cwd: ".",
-			env: {},
-			inputs: [],
-			outputs: [],
-			cache: "content",
-			js: { module: "./a.js", export: "default", args: { x: 1 } },
-		};
-		const fp1 = await stepFingerprint(base, dir, true);
-		const fp2 = await stepFingerprint(
-			{ ...base, js: { ...base.js, args: { x: 2 } } },
-			dir,
-			true,
-		);
-		t.not(fp1, fp2, "fingerprint changes when js args change");
-		const fp3 = await stepFingerprint(
-			{ ...base, js: { ...base.js, module: "./b.js" } },
-			dir,
-			true,
-		);
-		t.not(fp1, fp3, "fingerprint changes when js module changes");
-	});
+  await withTmp(t, async (dir) => {
+    const base = {
+      id: "s",
+      deps: [],
+      cwd: ".",
+      env: {},
+      inputs: [],
+      outputs: [],
+      cache: "content",
+      js: { module: "./a.js", export: "default", args: { x: 1 } },
+    };
+    const fp1 = await stepFingerprint(base, dir, true);
+    const fp2 = await stepFingerprint(
+      { ...base, js: { ...base.js, args: { x: 2 } } },
+      dir,
+      true,
+    );
+    t.not(fp1, fp2, "fingerprint changes when js args change");
+    const fp3 = await stepFingerprint(
+      { ...base, js: { ...base.js, module: "./b.js" } },
+      dir,
+      true,
+    );
+    t.not(fp1, fp3, "fingerprint changes when js module changes");
+  });
 });

--- a/packages/piper/src/types.ts
+++ b/packages/piper/src/types.ts
@@ -60,7 +60,7 @@ export type RunOptions = {
   concurrency?: number; // parallelism for independent steps
   contentHash?: boolean; // prefer content hashing even if cache=mtime
   reportDir?: string; // write markdown reports
-  extraEnv?: Record<string, string>; // dev-ui: overlay env passed to steps
+  extraEnv?: Readonly<Record<string, string>>; // dev-ui: overlay env passed to steps; keys shadow step.env
 };
 
 export type StepResult = {


### PR DESCRIPTION
## Summary
- treat RunOptions.extraEnv as read-only and document that it overrides step.env
- include extraEnv overlay when hashing step env for cache fingerprinting
- add coverage for extraEnv precedence in stepFingerprint

## Testing
- `pnpm lint:diff`
- `pnpm --filter @promethean/piper test` *(fails: make1 should re-execute)*
- `pnpm install`


------
https://chatgpt.com/codex/tasks/task_e_68c0eb1490c0832492e633c84f3dd9c2