### PR TITLE
fix: robust agent log tail reading

### DIFF
--- a/packages/smartgpt-bridge/src/store.ts
+++ b/packages/smartgpt-bridge/src/store.ts
@@ -35,7 +35,8 @@ export async function updateAgentMeta(id: string, patch: any) {
     const raw = await fs.readFile(path.join(dir, "meta.json"), "utf8");
     cur = JSON.parse(raw);
   } catch {}
-  const next = { ...cur, ...patch };
+  // Keep the meta id consistent with the directory id
+  const next = { ...cur, ...patch, id };
   await fs.writeFile(
     path.join(dir, "meta.json"),
     JSON.stringify(next, null, 2),
@@ -57,9 +58,17 @@ export async function readAgentLogTail(
   const dir = agentDir(id);
   const logPath = path.join(dir, "output.log");
   try {
-    const data = await fs.readFile(logPath);
-    const start = Math.max(0, data.length - bytes);
-    return data.subarray(start).toString("utf8");
+    const fh = await fs.open(logPath, "r");
+    try {
+      const { size } = await fh.stat();
+      const start = Math.max(0, size - bytes);
+      const len = size - start;
+      const buf = Buffer.alloc(len);
+      await fh.read(buf, 0, len, start);
+      return buf.toString("utf8");
+    } finally {
+      await fh.close();
+    }
   } catch {
     return "";
   }


### PR DESCRIPTION
## Summary
- ensure agent metadata keeps id consistent when patching
- stream agent log tail without loading entire file into memory

## Testing
- `pnpm lint packages/smartgpt-bridge/src/store.ts`
- `pnpm -F @promethean/smartgpt-bridge test` *(fails: FastifyError FST_ERR_PLUGIN_VERSION_MISMATCH)*

------
https://chatgpt.com/codex/tasks/task_e_68c0edb69e408324a67b46929469402c