### PR TITLE
fix: destroy errored log stream

### DIFF
--- a/packages/smartgpt-bridge/src/log-stream.ts
+++ b/packages/smartgpt-bridge/src/log-stream.ts
@@ -14,6 +14,13 @@ export function buildLogStream(fsMod: typeof fs = fs): NodeJS.WritableStream {
         console.error("log file stream error", error);
         const idx = outputs.indexOf(fileStream);
         if (idx !== -1) outputs.splice(idx, 1);
+        try {
+          if (typeof (fileStream as any).destroy === "function") {
+            (fileStream as any).destroy();
+          }
+        } catch {
+          // ignore destroy errors
+        }
       });
       outputs.push(fileStream);
     } catch {


### PR DESCRIPTION
## Summary
- destroy log file stream when errors occur to avoid leaking descriptors

## Testing
- `pnpm lint packages/smartgpt-bridge/src/log-stream.ts`
- `pnpm -F @promethean/smartgpt-bridge test` *(fails: FST_ERR_PLUGIN_VERSION_MISMATCH)*

------
https://chatgpt.com/codex/tasks/task_e_68c0ee51c1608324a3e2a1a73254942b