### PR TITLE
feat: rate-limit write-file route in Piper dev UI

### DIFF
--- a/packages/piper/src/dev-ui.ts
+++ b/packages/piper/src/dev-ui.ts
@@ -162,10 +162,10 @@ app.get<{ Querystring: { path?: string } }>(
   {
     config: {
       rateLimit: {
-        max: 10,            // limit each IP to 10 requests per minute
-        timeWindow: '1 minute',
-      }
-    }
+        max: 10, // limit each IP to 10 requests per minute
+        timeWindow: "1 minute",
+      },
+    },
   },
   async (req, reply) => {
     const ROOT = process.cwd();
@@ -186,6 +186,14 @@ app.get<{ Querystring: { path?: string } }>(
 // Write a text file (UTF-8) under the workspace
 app.post<{ Body: { path?: string; content?: string } }>(
   "/api/write-file",
+  {
+    config: {
+      rateLimit: {
+        max: 10, // limit each IP to 10 requests per minute
+        timeWindow: "1 minute",
+      },
+    },
+  },
   async (req, reply) => {
     const ROOT = process.cwd();
     const p = req.body?.path ? path.resolve(req.body.path) : "";


### PR DESCRIPTION
## Summary
- protect `/api/write-file` with per-route rate limiting matching read-file handler

## Testing
- `pnpm exec eslint packages/piper/src/dev-ui.ts` (fails: functional/no-let etc.)
- `pnpm -F @promethean/piper test` (fails: 3 tests failed)

------
https://chatgpt.com/codex/tasks/task_e_68c0eef73ee8832495fecc4a6d8ca564