### PR TITLE
fix(buildfix): allow --root=false to disable workspace mode

### DIFF
--- a/changelog.d/2025.09.10.18.25.16.fixed.md
+++ b/changelog.d/2025.09.10.18.25.16.fixed.md
@@ -1,0 +1,1 @@
+fix buildfix --root flag: allow --root=false|no|0 to disable workspace mode and document usage

--- a/packages/buildfix/README.md
+++ b/packages/buildfix/README.md
@@ -19,6 +19,17 @@ Or run the full pipeline with [piper](https://github.com/promethean-framework/pi
 pnpm --filter @promethean/piper run buildfix --config packages/buildfix/pipelines.json
 ```
 
+### Workspace vs single project
+
+`bf:01-errors` runs in workspace mode by default, scanning the current
+directory for every `tsconfig.json`. To process a single project, disable
+workspace mode by passing `--root=false` (also accepts `--root=no` or
+`--root=0`) and provide `--tsconfig`:
+
+```sh
+pnpm --filter @promethean/buildfix bf:01-errors --root=false --tsconfig path/to/tsconfig.json
+```
+
 ## Pipeline steps
 
 1. **bf-errors** – gather TypeScript diagnostics into `.cache/buildfix/errors.json`.

--- a/packages/buildfix/src/01-errors.ts
+++ b/packages/buildfix/src/01-errors.ts
@@ -1,4 +1,4 @@
-import * as path from "path";
+import * as path from "node:path";
 
 import { parseArgs, tsc, codeFrame, writeJSON } from "./utils.js";
 import type { ErrorList, BuildError } from "./types.js";
@@ -11,12 +11,18 @@ const args = parseArgs({
 });
 
 const rawRoot: unknown = args["--root"];
-const root =
-  rawRoot === true ||
-  rawRoot === "true" ||
-  rawRoot === undefined ||
-  rawRoot === null ||
-  rawRoot === ""
+const disableRoot =
+  rawRoot === false ||
+  rawRoot === 0 ||
+  (typeof rawRoot === "string" &&
+    ["false", "no", "0"].includes(rawRoot.toLowerCase()));
+const root: string | undefined = disableRoot
+  ? undefined
+  : rawRoot === true ||
+      rawRoot === undefined ||
+      rawRoot === null ||
+      (typeof rawRoot === "string" && rawRoot.trim() === "") ||
+      (typeof rawRoot === "string" && rawRoot.toLowerCase() === "true")
     ? process.cwd()
     : String(rawRoot).trim();
 
@@ -42,7 +48,7 @@ async function collectForTsconfig(tsconfigPath: string): Promise<BuildError[]> {
 }
 
 async function main() {
-  const outFile = path.resolve(args["--out"]!);
+  const outFile = path.resolve(args["--out"] as string);
   let errors: BuildError[] = [];
   let tsconfig: string | undefined;
 
@@ -62,7 +68,7 @@ async function main() {
     }
     tsconfig = `workspace:${rootAbs}`;
   } else {
-    const single = path.resolve(args["--tsconfig"]!);
+    const single = path.resolve(args["--tsconfig"] as string);
     tsconfig = single;
     errors = await collectForTsconfig(single);
   }

--- a/packages/buildfix/src/tests/errors.step.test.ts
+++ b/packages/buildfix/src/tests/errors.step.test.ts
@@ -41,7 +41,7 @@ test("bf:01-errors writes error list", async (t) => {
     `node ${path.join(
       PKG_ROOT,
       "dist/01-errors.js",
-    )} --tsconfig ${tsconfig} --out ${outPath}`,
+    )} --root false --tsconfig ${tsconfig} --out ${outPath}`,
     PKG_ROOT,
   );
   t.is(code, 0);

--- a/packages/buildfix/src/tests/integration/pipeline.run.test.ts
+++ b/packages/buildfix/src/tests/integration/pipeline.run.test.ts
@@ -44,7 +44,7 @@ test.serial("buildfix pipeline runs end-to-end", async (t) => {
         `node ${path.join(
           PKG_ROOT,
           "dist/01-errors.js",
-        )} --tsconfig ${tsconfig} --out ${errorsPath}`,
+        )} --root false --tsconfig ${tsconfig} --out ${errorsPath}`,
         PKG_ROOT,
       )
     ).code,


### PR DESCRIPTION
## Summary
- allow `--root=false|no|0` to opt out of workspace mode
- document single-tsconfig mode and adjust tests

## Testing
- `pnpm lint:diff` *(fails: 'origin' does not appear to be a git repository)*
- `pnpm exec biome lint packages/buildfix/src/01-errors.ts packages/buildfix/src/tests/errors.step.test.ts packages/buildfix/src/tests/integration/pipeline.run.test.ts packages/buildfix/README.md changelog.d/2025.09.10.18.25.16.fixed.md`
- `pnpm --filter @promethean/buildfix test`


------
https://chatgpt.com/codex/tasks/task_e_68c1bfa428848324ae97bd672e1767fd