### PR TITLE
chore: migrate biome config from ESLint rules

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,12 +1,17 @@
 {
-    "$schema": "https://biomejs.dev/schemas/2.2.2/schema.json",
-    "formatter": {
-        "lineWidth": 80,
-        "indentWidth": 4
-    },
-    "linter": {
-        "rules": {
-            "recommended": true
-        }
+  "$schema": "https://biomejs.dev/schemas/2.2.2/schema.json",
+  "formatter": { "indentWidth": 4, "lineWidth": 80, "indentStyle": "space" },
+  "linter": {
+    "rules": {
+      "recommended": false,
+      "nursery": {
+        "noFloatingPromises": "error",
+        "noImportCycles": "warn",
+        "useConsistentTypeDefinitions": "error",
+        "useExplicitType": "error"
+      },
+      "style": { "noDefaultExport": "warn" },
+      "suspicious": { "noExplicitAny": "error" }
     }
+  }
 }

--- a/changelog.d/2025.09.10.19.16.24.changed.md
+++ b/changelog.d/2025.09.10.19.16.24.changed.md
@@ -1,0 +1,1 @@
+Migrated Biome configuration to align with existing ESLint rules.

--- a/config/biome.json
+++ b/config/biome.json
@@ -1,11 +1,28 @@
 {
-    "$schema": "https://biomejs.dev/schemas/2.2.2/schema.json",
-    "files": {
-        "includes": ["src/**", "tests/**"]
-    },
-    "linter": {
-        "rules": {
-            "recommended": false
-        }
+  "$schema": "https://biomejs.dev/schemas/2.2.2/schema.json",
+  "files": {
+    "includes": ["src/**", "tests/**"]
+  },
+  "formatter": {
+    "indentWidth": 4,
+    "lineWidth": 80,
+    "indentStyle": "space"
+  },
+  "linter": {
+    "rules": {
+      "recommended": false,
+      "nursery": {
+        "noFloatingPromises": "error",
+        "noImportCycles": "warn",
+        "useConsistentTypeDefinitions": "error",
+        "useExplicitType": "error"
+      },
+      "style": {
+        "noDefaultExport": "warn"
+      },
+      "suspicious": {
+        "noExplicitAny": "error"
+      }
     }
+  }
 }


### PR DESCRIPTION
## Summary
- migrate Biome configs based on existing ESLint configuration
- document Biome migration in changelog

## Testing
- `pnpm lint:diff` *(fails: 'origin' does not appear to be a git repository)*
- `pnpm install`


------
https://chatgpt.com/codex/tasks/task_e_68c1cd53796c8324988b270d9fba0cfb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Strengthened formatting and linting configuration to align with project standards, improving code consistency and type-safety. No user-facing or runtime behavior changes.
* **Documentation**
  * Added changelog entry noting the tooling configuration migration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->