### PR TITLE
chore(docops): run full test suite

### DIFF
--- a/packages/docops/package.json
+++ b/packages/docops/package.json
@@ -3,7 +3,7 @@
   "type": "module",
   "scripts": {
     "build": "tsc -p tsconfig.json",
-    "test": "rimraf dist && tsc -p tsconfig.json && ava dist/tests/frontend/selection.test.js",
+    "test": "pnpm run build && ava --config ../../config/ava.config.mjs",
     "coverage": "pnpm build && c8 ava",
     "doc:dev-ui": "pnpm build && node ./dist/dev-ui.js --dir ../../docs/unique --collection docs-cosine --port 3939"
   },


### PR DESCRIPTION
## Summary
- run docops build before tests and execute full ava suite

## Testing
- `pnpm exec biome lint packages/docops/package.json`
- `pnpm --filter @promethean/docops test` *(fails: Pipeline run should complete successfully)*

------
https://chatgpt.com/codex/tasks/task_e_68c1d26372f88324966155058178b195