### PR TITLE
fix: escape scaffolded test names

### DIFF
--- a/packages/ava-mcp/src/tests/scaffold.test.ts
+++ b/packages/ava-mcp/src/tests/scaffold.test.ts
@@ -2,6 +2,7 @@ import test from "ava";
 import { promises as fs } from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import type { Server } from "@modelcontextprotocol/sdk/server";
 import { registerTddTools } from "../index.js";
 
 test("scaffoldTest creates a spec", async (t) => {
@@ -9,19 +10,53 @@ test("scaffoldTest creates a spec", async (t) => {
   const modulePath = path.join(tmp, "foo.ts");
   await fs.writeFile(modulePath, "export const foo = 1;\n");
 
-  const handlers: Record<string, any> = {};
+  const handlers: Record<string, (input: unknown) => Promise<unknown>> = {};
   const server = {
-    registerTool: (_name: string, _schema: unknown, handler: any) => {
-      handlers[_name] = handler;
+    registerTool: (
+      name: string,
+      _schema: unknown,
+      handler: (input: unknown) => Promise<unknown>,
+    ) => {
+      handlers[name] = handler;
     },
-  } as any;
+  } as unknown as Server;
 
   registerTddTools(server);
-  const result = await handlers["tdd.scaffoldTest"]({
+  const handler = handlers["tdd.scaffoldTest"]!;
+  const result = (await handler({
     modulePath,
     testName: "works",
-  });
+  })) as { specPath: string };
 
+  t.true(result.specPath.endsWith(".spec.ts"));
   const specContent = await fs.readFile(result.specPath, "utf8");
   t.true(specContent.includes("t.fail()"));
+});
+
+test("scaffoldTest creates a property-based spec when template=prop", async (t) => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "ava-mcp-"));
+  const modulePath = path.join(tmp, "bar.ts");
+  await fs.writeFile(modulePath, "export const bar = 2;\n");
+
+  const handlers: Record<string, (input: unknown) => Promise<unknown>> = {};
+  const server = {
+    registerTool: (
+      name: string,
+      _schema: unknown,
+      handler: (input: unknown) => Promise<unknown>,
+    ) => {
+      handlers[name] = handler;
+    },
+  } as unknown as Server;
+
+  registerTddTools(server);
+  const handler = handlers["tdd.scaffoldTest"]!;
+  const { specPath } = (await handler({
+    modulePath,
+    testName: "prop works",
+    template: "prop",
+  })) as { specPath: string };
+
+  const specContent = await fs.readFile(specPath, "utf8");
+  t.true(specContent.includes('import fc from "fast-check"'));
 });


### PR DESCRIPTION
## Summary
- escape provided test names when scaffolding to preserve quotes/newlines
- use default fast-check import in generated property tests
- configure execFile timeouts and buffers for external commands

## Testing
- `pnpm --filter @promethean/ava-mcp lint`
- `pnpm --filter @promethean/ava-mcp test`


------
https://chatgpt.com/codex/tasks/task_e_68c1df1b72a0832491f3feea0ada6f68