### PR TITLE
fix: reject unsupported runTests modes

### DIFF
--- a/packages/ava-mcp/src/tools.ts
+++ b/packages/ava-mcp/src/tools.ts
@@ -105,9 +105,13 @@ test("${testName}", t => {
       tap: boolean;
     }) => {
       const { files, match, watch, tap } = input;
+      if (watch) {
+        throw new Error("watch mode is not supported");
+      }
+      if (tap) {
+        throw new Error("tap reporter is not supported");
+      }
       const args = ["--yes", "ava", "--json"];
-      if (tap) args.push("--tap");
-      if (watch) args.push("--watch");
       match?.forEach((m: string) => args.push("--match", m));
       if (files?.length) args.push(...files);
 


### PR DESCRIPTION
## Summary
- prevent tdd.runTests from running in watch or TAP mode, avoiding hangs and JSON parsing errors

## Testing
- ⚠️ `pnpm lint:diff` (failed: 'origin' does not appear to be a git repository)
- ✅ `pnpm --filter @promethean/ava-mcp test`


------
https://chatgpt.com/codex/tasks/task_e_68c1e4e53c78832488ba6efe88c59200