### PR TITLE
feat: add ava watch tools

### DIFF
--- a/changelog.d/2025.09.10.03.36.14.added.md
+++ b/changelog.d/2025.09.10.03.36.14.added.md
@@ -1,1 +1,2 @@
-- add `@promethean/ava-mcp` package with MCP tools for AVA-based TDD
+Add `@promethean/ava-mcp` package providing MCP tools for AVA-based TDD,
+including watch commands for incremental results.

--- a/docs/ava-mcp.md
+++ b/docs/ava-mcp.md
@@ -2,4 +2,12 @@
 
 Provides Model Context Protocol tools for test-driven development:
 scaffolding tests, running tests, checking coverage, property testing,
-and mutation testing.
+mutation testing, and incremental watch results.
+
+See also [[MCP]] and [[AVA]]. #tdd #mcp
+
+Example:
+```ts
+import { registerTddTools } from "@promethean/ava-mcp";
+registerTddTools(server);
+```

--- a/packages/ava-mcp/src/tests/integration.test.ts
+++ b/packages/ava-mcp/src/tests/integration.test.ts
@@ -28,3 +28,34 @@ test("propertyCheck executes", async (t) => {
     }),
   );
 });
+
+test("watch commands emit output", async (t) => {
+  const tmp = await fs.mkdtemp(path.join(process.cwd(), "tmp-watch-"));
+  t.teardown(() => fs.rm(tmp, { recursive: true, force: true }));
+  const testFile = path.join(tmp, "watch.test.js");
+  await fs.writeFile(
+    testFile,
+    'import test from "ava";\n test("works", t => t.pass());\n',
+  );
+
+  const handlers: Record<string, any> = {};
+  const server = {
+    registerTool: (_n: string, _s: unknown, h: any) => {
+      handlers[_n] = h;
+    },
+  } as any;
+
+  registerTddTools(server);
+  t.teardown(() => handlers["tdd.stopWatch"]?.());
+
+  const rel = path.relative(process.cwd(), testFile);
+  await handlers["tdd.startWatch"]({ files: [rel] });
+  let output = "";
+  for (let i = 0; i < 20 && !output; i++) {
+    await new Promise((res) => setTimeout(res, 500));
+    const res = await handlers["tdd.getWatchChanges"]();
+    output = res.output;
+  }
+  t.true(output.length > 0);
+  await handlers["tdd.stopWatch"]();
+});

--- a/packages/ava-mcp/src/tools.ts
+++ b/packages/ava-mcp/src/tools.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 import { promises as fs } from "node:fs";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
-import { execFile } from "node:child_process";
+import { execFile, spawn } from "node:child_process";
 import { promisify } from "node:util";
 import { minimatch } from "minimatch";
 import fc from "fast-check";
@@ -12,6 +12,8 @@ const execFileAsync = promisify(execFile);
 
 export function registerTddTools(server: Server) {
   const s = server as any;
+  let watchProc: ReturnType<typeof spawn> | null = null;
+  let watchBuffer = "";
   // scaffoldTest
   s.registerTool(
     "tdd.scaffoldTest",
@@ -94,20 +96,11 @@ test("${testName}", t => {
       inputSchema: z.object({
         files: z.array(z.string()).optional(),
         match: z.array(z.string()).optional(),
-        watch: z.boolean().default(false),
-        tap: z.boolean().default(false),
       }),
     },
-    async (input: {
-      files?: string[];
-      match?: string[];
-      watch: boolean;
-      tap: boolean;
-    }) => {
-      const { files, match, watch, tap } = input;
+    async (input: { files?: string[]; match?: string[] }) => {
+      const { files, match } = input;
       const args = ["--yes", "ava", "--json"];
-      if (tap) args.push("--tap");
-      if (watch) args.push("--watch");
       match?.forEach((m: string) => args.push("--match", m));
       if (files?.length) args.push(...files);
 
@@ -124,6 +117,53 @@ test("${testName}", t => {
       };
     },
   );
+
+  // watch commands
+  s.registerTool(
+    "tdd.startWatch",
+    {
+      inputSchema: z.object({
+        files: z.array(z.string()).optional(),
+        match: z.array(z.string()).optional(),
+      }),
+    },
+    async (input: { files?: string[]; match?: string[] }) => {
+      if (watchProc) throw new Error("watch already running");
+      const { files, match } = input;
+      const args = ["--yes", "ava", "--watch"] as string[];
+      match?.forEach((m: string) => args.push("--match", m));
+      if (files?.length) args.push(...files);
+      watchBuffer = "";
+      watchProc = spawn("npx", args, { stdio: ["pipe", "pipe", "pipe"] });
+      watchProc.stdout?.on("data", (d) => {
+        watchBuffer += d.toString();
+      });
+      watchProc.stderr?.on("data", (d) => {
+        watchBuffer += d.toString();
+      });
+      return { started: true };
+    },
+  );
+
+  s.registerTool(
+    "tdd.getWatchChanges",
+    { inputSchema: z.object({}) },
+    async () => {
+      if (!watchProc) throw new Error("watch not running");
+      const out = watchBuffer;
+      watchBuffer = "";
+      return { output: out };
+    },
+  );
+
+  s.registerTool("tdd.stopWatch", { inputSchema: z.object({}) }, async () => {
+    if (!watchProc) return { stopped: false };
+    watchProc.kill();
+    watchProc = null;
+    const out = watchBuffer;
+    watchBuffer = "";
+    return { stopped: true, output: out };
+  });
 
   // coverage
   s.registerTool(


### PR DESCRIPTION
## Summary
- expose startWatch/getWatchChanges/stopWatch MCP tools
- drop watch mode from runTests and document incremental watching

## Testing
- `pnpm lint:diff` (fails: 'origin' does not appear to be a git repository)
- `pnpm --filter @promethean/ava-mcp test`


------
https://chatgpt.com/codex/tasks/task_e_68c1e905e3808324adc2405f2b931330