### PR TITLE
chore: drop biome in favor of eslint and prettier

### DIFF
--- a/bb/src/mk/node.clj
+++ b/bb/src/mk/node.clj
@@ -105,8 +105,8 @@
 
 (defn format-ts []
   (if (u/has-pnpm?)
-    (do (u/run-dirs cfg/services-ts "pnpm exec prettier --write" {:shell true})
-        (u/run-dirs cfg/shared-ts "pnpm exec prettier --write" {:shell true}))
+    (do (u/run-dirs cfg/services-ts "pnpm exec prettier --write ." {:shell true})
+        (u/run-dirs cfg/shared-ts "pnpm exec prettier --write ." {:shell true}))
     (u/require-pnpm)))
 
 (defn setup-ts-service []

--- a/changelog.d/2025.09.10.21.00.00.fixed.md
+++ b/changelog.d/2025.09.10.21.00.00.fixed.md
@@ -1,0 +1,1 @@
+Fix Prettier format script to target current directory.

--- a/mk/node.clj
+++ b/mk/node.clj
@@ -105,8 +105,8 @@
 
 (defn format-ts []
   (if (u/has-pnpm?)
-    (do (u/run-dirs cfg/services-ts "pnpm exec prettier --write" {:shell true})
-        (u/run-dirs cfg/shared-ts "pnpm exec prettier --write" {:shell true}))
+    (do (u/run-dirs cfg/services-ts "pnpm exec prettier --write ." {:shell true})
+        (u/run-dirs cfg/shared-ts "pnpm exec prettier --write ." {:shell true}))
     (u/require-pnpm)))
 
 (defn setup-ts-service []


### PR DESCRIPTION
## Summary
- drop Biome configuration and dependency
- rely on root eslint config and prettier for formatting
- update package scripts and templates accordingly
- fix Prettier format command to target current directory

## Testing
- `pnpm install`
- `pnpm lint:diff` *(fails: 'origin' does not appear to be a git repository)*
- `pnpm -r --filter "./packages/*" --if-present test` *(fails: @promethean/contracts has no tests)*
- `pnpm --filter @promethean/agent test`


------
https://chatgpt.com/codex/tasks/task_e_68c1e5bd0cc48324949e76c1c357b4e5