### PR TITLE
refactor: centralize Discord channel parsing and token bucket drain

### DIFF
--- a/changelog.d/2025.09.12.18.54.10.changed.md
+++ b/changelog.d/2025.09.12.18.54.10.changed.md
@@ -1,0 +1,1 @@
+Extracted Discord channel ID helper, added token bucket drain utility, and adopted immutable Map updates.

--- a/packages/discord/src/index.ts
+++ b/packages/discord/src/index.ts
@@ -1,6 +1,6 @@
-export { handleSocialMessageCreated as indexAttachments } from './attachment-indexer/index.js';
-export { handleSocialMessageCreated as indexMessage } from './message-indexer/index.js';
-export { embedMessage } from './message-embedder/index.js';
-export { GatewayPublisher } from './gateway/gateway.js';
-export { DiscordRestProxy } from './rest/rest.js';
-export { convert } from './embedder/converter.js';
+export { handleSocialMessageCreated as indexAttachments } from "./attachment-indexer/index.js";
+export { handleSocialMessageCreated as indexMessage } from "./message-indexer/index.js";
+export { embedMessage } from "./message-embedder/index.js";
+export { GatewayPublisher } from "./gateway/gateway.js";
+export { DiscordRestProxy, getChannelId } from "./rest/rest.js";
+export { convert } from "./embedder/converter.js";

--- a/packages/monitoring/src/limiter.ts
+++ b/packages/monitoring/src/limiter.ts
@@ -1,34 +1,50 @@
 export class TokenBucket {
-    private capacity: number;
-    private tokens: number;
-    private refillPerSec: number;
-    private last: number;
+  private capacity: number;
+  private tokens: number;
+  private refillPerSec: number;
+  private last: number;
 
-    constructor({ capacity, refillPerSec }: { capacity: number; refillPerSec: number }) {
-        this.capacity = capacity;
-        this.tokens = capacity;
-        this.refillPerSec = refillPerSec;
-        this.last = Date.now();
-    }
+  constructor({
+    capacity,
+    refillPerSec,
+  }: {
+    capacity: number;
+    refillPerSec: number;
+  }) {
+    this.capacity = capacity;
+    this.tokens = capacity;
+    this.refillPerSec = refillPerSec;
+    this.last = Date.now();
+  }
 
-    private refill() {
-        const now = Date.now();
-        const delta = (now - this.last) / 1000;
-        this.tokens = Math.min(this.capacity, this.tokens + delta * this.refillPerSec);
-        this.last = now;
-    }
+  private refill() {
+    const now = Date.now();
+    const delta = (now - this.last) / 1000;
+    this.tokens = Math.min(
+      this.capacity,
+      this.tokens + delta * this.refillPerSec,
+    );
+    this.last = now;
+  }
 
-    tryConsume(n = 1): boolean {
-        this.refill();
-        if (this.tokens >= n) {
-            this.tokens -= n;
-            return true;
-        }
-        return false;
+  tryConsume(n = 1): boolean {
+    this.refill();
+    if (this.tokens >= n) {
+      this.tokens -= n;
+      return true;
     }
+    return false;
+  }
 
-    deficit(n = 1): number {
-        this.refill();
-        return Math.max(0, n - this.tokens);
-    }
+  deficit(n = 1): number {
+    this.refill();
+    return Math.max(0, n - this.tokens);
+  }
+
+  drain(): number {
+    this.refill();
+    const drained = this.tokens;
+    this.tokens = 0;
+    return drained;
+  }
 }

--- a/packages/monitoring/tests/limiter.test.js
+++ b/packages/monitoring/tests/limiter.test.js
@@ -1,34 +1,42 @@
-import test from 'ava';
+import test from "ava";
 
-import { sleep } from '@promethean/test-utils/sleep.js';
+import { sleep } from "@promethean/test-utils/sleep.js";
 
-import { TokenBucket } from '../dist/limiter.js';
+import { TokenBucket } from "../dist/limiter.js";
 
 // ensure TokenBucket enforces capacity and returns deficit
-test('TokenBucket enforces capacity', (t) => {
-    const bucket = new TokenBucket({ capacity: 5, refillPerSec: 1 });
-    t.true(bucket.tryConsume(3));
-    t.false(bucket.tryConsume(3));
-    t.true(Math.abs(bucket.deficit(3) - 1) < 1e-6);
+test("TokenBucket enforces capacity", (t) => {
+  const bucket = new TokenBucket({ capacity: 5, refillPerSec: 1 });
+  t.true(bucket.tryConsume(3));
+  t.false(bucket.tryConsume(3));
+  t.true(Math.abs(bucket.deficit(3) - 1) < 1e-6);
 });
 
 // ensure tokens refill over time
-test('TokenBucket refills over time', async (t) => {
-    t.timeout?.(5000);
-    const bucket = new TokenBucket({ capacity: 1, refillPerSec: 1 });
-    t.true(bucket.tryConsume());
-    t.false(bucket.tryConsume());
-    await sleep(1100);
-    t.true(bucket.tryConsume());
+test("TokenBucket refills over time", async (t) => {
+  t.timeout?.(5000);
+  const bucket = new TokenBucket({ capacity: 1, refillPerSec: 1 });
+  t.true(bucket.tryConsume());
+  t.false(bucket.tryConsume());
+  await sleep(1100);
+  t.true(bucket.tryConsume());
 });
 
-test('TokenBucket limits and refills with capacity 2', async (t) => {
-    const bucket = new TokenBucket({ capacity: 2, refillPerSec: 1 });
-    t.true(bucket.tryConsume());
-    t.true(bucket.tryConsume());
-    t.false(bucket.tryConsume());
-    const deficit = bucket.deficit();
-    t.true(deficit > 0);
-    await sleep(1100);
-    t.true(bucket.tryConsume());
+test("TokenBucket limits and refills with capacity 2", async (t) => {
+  const bucket = new TokenBucket({ capacity: 2, refillPerSec: 1 });
+  t.true(bucket.tryConsume());
+  t.true(bucket.tryConsume());
+  t.false(bucket.tryConsume());
+  const deficit = bucket.deficit();
+  t.true(deficit > 0);
+  await sleep(1100);
+  t.true(bucket.tryConsume());
+});
+
+test("TokenBucket drain empties remaining tokens", (t) => {
+  const bucket = new TokenBucket({ capacity: 5, refillPerSec: 1 });
+  t.true(bucket.tryConsume(2));
+  const drained = bucket.drain();
+  t.is(drained, 3);
+  t.false(bucket.tryConsume());
 });


### PR DESCRIPTION
## Summary
- add `TokenBucket.drain()` utility
- centralize Discord channel ID parsing with `getChannelId`
- update REST proxy to use immutable map updates and drain on 429

## Testing
- `pnpm --filter @promethean/monitoring test`
- `pnpm --filter @promethean/discord test` *(fails: Cannot find module '@promethean/attachment-embedder' and other missing types)*
- `pnpm lint:diff` *(fails: parsing error for eslint.config.ts and lint errors in discord REST proxy)*
- `pnpm install`


------
https://chatgpt.com/codex/tasks/task_e_68c46bc9254883248ebcd255a64dd1c8