### PR TITLE
refactor llm types and logging

### DIFF
--- a/changelog.d/2025.09.12.18.58.29.changed.md
+++ b/changelog.d/2025.09.12.18.58.29.changed.md
@@ -1,0 +1,1 @@
+- refactor llm service types and logging

--- a/packages/llm/package.json
+++ b/packages/llm/package.json
@@ -30,6 +30,7 @@
     },
     "module": "dist/index.js",
     "dependencies": {
+        "@promethean/utils": "workspace:*",
         "@huggingface/inference": "^4.7.1",
         "@types/javascript-time-ago": "^2.5.0",
         "@types/js-yaml": "^4.0.9",

--- a/packages/llm/src/external.d.ts
+++ b/packages/llm/src/external.d.ts
@@ -1,0 +1,28 @@
+declare module '@shared/js/serviceTemplate.js' {
+    export type Broker = {
+        publish(topic: string, message: unknown): void;
+    };
+    export type BrokerTask = {
+        id: string;
+        payload?: {
+            prompt?: string;
+            context?: readonly unknown[];
+            format?: unknown;
+            tools?: unknown;
+            replyTopic?: string;
+        };
+    };
+    export function startService(opts: {
+        id: string;
+        queues: readonly string[];
+        handleTask: (task: BrokerTask) => Promise<void>;
+    }): Promise<Broker>;
+}
+
+declare module '@promethean/legacy/heartbeat/index.js' {
+    export class HeartbeatClient {
+        constructor(options: { name: string });
+        sendOnce(): Promise<void>;
+        start(): void;
+    }
+}

--- a/packages/llm/src/index.ts
+++ b/packages/llm/src/index.ts
@@ -1,17 +1,39 @@
 import http from 'http';
 
 import type { Request, Response, Express } from 'express';
-import type { WebSocket } from 'ws';
+import type { WebSocket, RawData } from 'ws';
 import express from 'express';
 import { WebSocketServer } from 'ws';
-import { retry } from '@promethean/utils';
+import { retry, createLogger } from '@promethean/utils';
 
 import { loadDriver, LLMDriver } from './drivers/index.js';
 import type { Tool } from './tools.js';
 
+type ContextItem = { readonly role: string; readonly content: string };
+type GenerateArgs = {
+    readonly prompt: string;
+    readonly context?: readonly ContextItem[];
+    readonly format?: unknown;
+    readonly tools?: Tool[];
+};
+
+type TaskPayload = GenerateArgs & {
+    readonly replyTopic?: string;
+};
+
+export type BrokerTask = {
+    readonly id: string;
+    readonly payload?: TaskPayload;
+};
+
+export type Broker = {
+    publish(topic: string, message: unknown): void;
+};
+
 export const app: Express = express();
 app.use(express.json({ limit: '500mb' }));
 
+/* eslint-disable functional/no-let */
 let driver: LLMDriver | null = null;
 
 export async function loadModel(): Promise<LLMDriver> {
@@ -19,74 +41,72 @@ export async function loadModel(): Promise<LLMDriver> {
     return driver;
 }
 
-let generateFn = async ({
-    prompt,
-    context = [],
-    format,
-    tools = [],
-}: {
-    prompt: string;
-    context?: any[];
-    format?: any;
-    tools?: Tool[];
-}): Promise<any> => {
+const log = createLogger({ service: 'llm' });
+
+let generateFn = async ({ prompt, context = [], format, tools = [] }: GenerateArgs): Promise<unknown> => {
     const d = await loadModel();
-    return d.generate({ prompt, context, format, tools });
+    return d.generate({ prompt, context: context as ContextItem[], format, tools });
 };
 
 export function setGenerateFn(fn: typeof generateFn): void {
     generateFn = fn;
 }
 
-export const generate = async (
-    args: Readonly<{ prompt: string; context?: any[]; format?: any; tools?: Tool[] }>,
-): Promise<unknown> => {
+export const generate = async (args: Readonly<GenerateArgs>): Promise<unknown> => {
     return retry(() => generateFn({ ...args }), {
         attempts: 6,
         backoff: (a: number) => (a - 1) * 1610,
     });
 };
 
-let broker: any;
+let broker: Broker | null = null;
+/* eslint-enable functional/no-let */
 
-export function setBroker(b: any): void {
+export function setBroker(b: Broker): void {
     broker = b;
 }
 
-export async function handleTask(task: any): Promise<void> {
-    const payload = task?.payload || {};
+export async function handleTask(task: BrokerTask): Promise<void> {
+    const payload = task.payload ?? ({} as TaskPayload);
     const { prompt, context = [], format = null, tools = [], replyTopic } = payload;
     const reply = await generate({ prompt, context, format, tools });
-    console.log('handling llm task', task);
+    log.info('handling llm task', { task });
     if (replyTopic && broker) {
         broker.publish(replyTopic, { reply, taskId: task.id });
     }
 }
 
 app.post('/generate', async (req: Request, res: Response) => {
-    const { prompt, context = [], format = null, tools = [] } = req.body || {};
+    const { prompt, context = [], format = null, tools = [] } = (req.body || {}) as GenerateArgs;
+    // eslint-disable-next-line functional/no-try-statements
     try {
         const reply = await generate({ prompt, context, format, tools });
         res.json({ reply });
-    } catch (err: any) {
-        res.status(500).json({ error: err.message });
+    } catch (err) {
+        const error = err as Error;
+        res.status(500).json({ error: error.message });
     }
 });
 
 export async function start(port = Number(process.env.LLM_PORT) || 8888): Promise<http.Server> {
     if (process.env.DISABLE_BROKER !== '1') {
+        // eslint-disable-next-line functional/no-try-statements
         try {
-            // @ts-ignore
-            const { startService } = await import('@shared/js/serviceTemplate.js');
+            const { startService } = (await import('@shared/js/serviceTemplate.js')) as {
+                startService(opts: {
+                    id: string;
+                    queues: readonly string[];
+                    handleTask: (task: BrokerTask) => Promise<void>;
+                }): Promise<Broker>;
+            };
             broker = await startService({
                 id: process.env.name || 'llm',
                 queues: ['llm.generate'],
                 handleTask,
             });
         } catch (err) {
-            console.error('Failed to initialize broker', err);
+            log.error('Failed to initialize broker', { err: err as Error });
         }
-        // @ts-ignore
         const { HeartbeatClient } = await import('@promethean/legacy/heartbeat/index.js');
         const hb = new HeartbeatClient({ name: process.env.name || 'llm' });
         await hb.sendOnce();
@@ -96,13 +116,16 @@ export async function start(port = Number(process.env.LLM_PORT) || 8888): Promis
     const server = http.createServer(app);
     const wss = new WebSocketServer({ server, path: '/generate' });
     wss.on('connection', (ws: WebSocket) => {
-        ws.on('message', async (data: any) => {
+        ws.on('message', async (data: RawData) => {
+            // eslint-disable-next-line functional/no-try-statements
             try {
-                const { prompt, context = [], format = null, tools = [] } = JSON.parse(data.toString());
+                const parsed = JSON.parse(data.toString()) as unknown;
+                const { prompt, context = [], format = null, tools = [] } = parsed as GenerateArgs;
                 const reply = await generate({ prompt, context, format, tools });
                 ws.send(JSON.stringify({ reply }));
-            } catch (err: any) {
-                ws.send(JSON.stringify({ error: err.message }));
+            } catch (err) {
+                const error = err as Error;
+                ws.send(JSON.stringify({ error: error.message }));
             }
         });
     });
@@ -113,8 +136,8 @@ export async function start(port = Number(process.env.LLM_PORT) || 8888): Promis
 }
 
 if (process.env.NODE_ENV !== 'test') {
-    start().catch((err) => {
-        console.error('Failed to start LLM service', err);
+    start().catch((err: unknown) => {
+        log.error('Failed to start LLM service', { err: err as Error });
         process.exit(1);
     });
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2213,6 +2213,9 @@ importers:
       '@huggingface/inference':
         specifier: ^4.7.1
         version: 4.7.1
+      '@promethean/utils':
+        specifier: workspace:*
+        version: link:../utils
       '@types/javascript-time-ago':
         specifier: ^2.5.0
         version: 2.5.0


### PR DESCRIPTION
## Summary
- replace loose any signatures with typed GenerateArgs, BrokerTask, and Broker
- add heartbeat and broker module declarations to drop ts-ignore directives
- switch LLM service to structured logging and expose broker setters

## Testing
- `pnpm exec eslint packages/llm/src/index.ts`
- `pnpm --filter @promethean/llm test`
- `pnpm lint:diff` *(fails: Parsing error: eslint.config.ts not found by the project service)*


------
https://chatgpt.com/codex/tasks/task_e_68c46bc43ed88324ba05cb41af287ba5