### PR TITLE
refactor: simplify optional param check

### DIFF
--- a/packages/semvergaurd/src/02-diff.ts
+++ b/packages/semvergaurd/src/02-diff.ts
@@ -98,10 +98,10 @@ function comparePkg(oldP: any, curP: any): DiffResult {
           required = maxSemver(required, addedAreOptional ? "minor" : "major");
         } else {
           // same count; check optionality/return type change
-          const optTightened = newParams.some(
-            (p, i) =>
-              !!p && !!oldParams[i] && oldParams[i].optional && !p.optional,
-          );
+          const optTightened = newParams.some((p, i) => {
+            const oldParam = oldParams[i];
+            return p && oldParam && oldParam.optional && !p.optional;
+          });
           if (optTightened) {
             changes.push({
               name,


### PR DESCRIPTION
## Summary
- refactor optional parameter comparison in semverguard diff to avoid double negation

## Testing
- `pnpm exec eslint packages/semvergaurd/src/02-diff.ts` *(fails: Function 'comparePkg' has too many lines (169). Maximum allowed is 50...)*
- `tsc -p tsconfig.json`
- `pnpm --filter @promethean/semverguard build`
- `pnpm install`

------
https://chatgpt.com/codex/tasks/task_e_68c5c20e17a88324a79a0922d954fde8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved readability of parameter comparison logic to clarify when optional parameters become required.
  * No changes to behavior, control flow, or error handling.

* **Style**
  * Adopted clearer function structure for the comparison logic to enhance maintainability.
  * No impact on runtime behavior.

* **Chores**
  * Internal code quality improvements only; no user-facing changes or API updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->