### PR TITLE
fix(cli): assert non-null for import arg

### DIFF
--- a/packages/cli/src/lisp.ts
+++ b/packages/cli/src/lisp.ts
@@ -95,26 +95,26 @@ async function cmdRun(args: Argv) {
     const importSpecs = args.filter((a) => a.startsWith('--import'));
     // remove all --import entries and their values if split form used
     for (let i = 0; i < args.length; ) {
-    // Collect --import specs in both forms and remove them from args
-    const merged: string[] = [];
-    for (let i = 0; i < args.length; ) {
-        const ai = args[i];
-        if (ai === '--import') {
-            const v = args[i + 1];
-            if (!v || v.startsWith('-')) {
-                throw new Error('--import requires name=path[:export]');
+        // Collect --import specs in both forms and remove them from args
+        const merged: string[] = [];
+        for (let i = 0; i < args.length; ) {
+            const ai = args[i]!;
+            if (ai === '--import') {
+                const v = args[i + 1];
+                if (!v || v.startsWith('-')) {
+                    throw new Error('--import requires name=path[:export]');
+                }
+                merged.push(v);
+                args.splice(i, 2);
+            } else if (ai.startsWith('--import=')) {
+                merged.push(ai.slice('--import='.length));
+                args.splice(i, 1);
+            } else {
+                i++;
             }
-            merged.push(v);
-            args.splice(i, 2);
-        } else if (ai.startsWith('--import=')) {
-            merged.push(ai.slice('--import='.length));
-            args.splice(i, 1);
-        } else {
-            i++;
         }
-    }
 
-    // merged now contains only 'name=path[:export]' specs
+        // merged now contains only 'name=path[:export]' specs
     }
     const file = args.shift();
     if (!file) return printUsage();


### PR DESCRIPTION
## Summary
- assert args entry non-null when parsing `--import` specs in CLI lisp tool

## Testing
- `pnpm --filter @promethean/cli build`
- `pnpm --filter @promethean/cli test` *(fails: Couldn't find any files to test)*
- `pnpm install`


------
https://chatgpt.com/codex/tasks/task_e_68c5c211e0e48324b2958efd5bf39368

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * CLI now accepts both split (--import name=path[:export]) and inline (--import=name=path[:export]) forms.
  * Automatically normalizes and merges import specifications for consistent behavior.
  * Resolves imports before execution for smoother runs.
  * Maintains validation with clear errors for invalid split-form inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->