### PR TITLE
fix: ensure findCardLI visitor returns

### DIFF
--- a/packages/markdown/src/kanban.ts
+++ b/packages/markdown/src/kanban.ts
@@ -408,6 +408,7 @@ export class MarkdownBoard {
                     return EXIT;
                 }
             }
+            return;
         });
         return found ?? null;
     }


### PR DESCRIPTION
## Summary
- add explicit return in MarkdownBoard's findCardLI visitor so all code paths return

## Testing
- `pnpm exec eslint packages/markdown/src/kanban.ts` *(fails: 118 errors, 62 warnings)*
- `pnpm --filter @promethean/markdown build`
- `pnpm --filter @promethean/markdown test` *(fails: Couldn’t find any files to test)*
- `pnpm install`


------
https://chatgpt.com/codex/tasks/task_e_68c5c219426483249ea19e394034793f