### PR TITLE
refactor: assert zero snapshot fields

### DIFF
--- a/packages/worker/src/zero/layout.ts
+++ b/packages/worker/src/zero/layout.ts
@@ -41,7 +41,6 @@ export function allocColumns(rows: number, layout: CompLayout, shared: boolean):
         const buf = shared
             ? new SharedArrayBuffer(Ctor.BYTES_PER_ELEMENT * rows)
             : new ArrayBuffer(Ctor.BYTES_PER_ELEMENT * rows);
-        // @ts-expect-error dynamic constructor
         fields[k] = new Ctor(buf);
     }
     const chBuf = shared ? new SharedArrayBuffer(Math.ceil(rows / 8)) : new ArrayBuffer(Math.ceil(rows / 8));
@@ -54,5 +53,5 @@ export function markChanged(bitset: Uint8Array, i: number) {
 }
 
 export function isChanged(bitset: Uint8Array, i: number) {
-    return (bitset[i >> 3] & (1 << (i & 7))) !== 0;
+    return (bitset[i >> 3]! & (1 << (i & 7))) !== 0;
 }

--- a/packages/worker/src/zero/snapshot.ts
+++ b/packages/worker/src/zero/snapshot.ts
@@ -39,7 +39,7 @@ export function buildSnapshot(world: WorldLike, spec: BuildSpec, query: any): { 
             const v = world.get(e, ctype);
             if (v == null) continue;
             for (const field of Object.keys(L.fields)) {
-                (comps[L.cid].fields[field] as any)[i] = v[field] ?? 0;
+                (comps[L.cid]!.fields[field] as any)[i] = v[field] ?? 0;
             }
         }
         i++;
@@ -50,8 +50,8 @@ export function buildSnapshot(world: WorldLike, spec: BuildSpec, query: any): { 
     if (!shared) {
         transfer.push(snap.eids.buffer);
         for (const L of spec.layouts) {
-            for (const arr of Object.values(snap.comps[L.cid].fields)) transfer.push((arr as any).buffer);
-            transfer.push(snap.comps[L.cid].changed.buffer);
+            for (const arr of Object.values(snap.comps[L.cid]!.fields)) transfer.push((arr as any).buffer);
+            transfer.push(snap.comps[L.cid]!.changed.buffer);
         }
     }
     return { snap, transfer };
@@ -61,7 +61,7 @@ export function commitSnapshot(world: WorldLike, spec: BuildSpec, snap: Snap) {
     const rows = snap.rows;
     for (const L of spec.layouts) {
         const ctype = spec.types[L.cid];
-        const cols = snap.comps[L.cid];
+        const cols = snap.comps[L.cid]!;
         const changed = cols.changed;
         let any = false;
         for (let b = 0; b < changed.length; b++)
@@ -73,7 +73,7 @@ export function commitSnapshot(world: WorldLike, spec: BuildSpec, snap: Snap) {
 
         for (let i = 0; i < rows; i++) {
             if (!isChanged(changed, i)) continue;
-            const eid = snap.eids[i];
+            const eid = snap.eids[i]!;
             if (!world.isAlive(eid)) continue;
             const cur = world.get(eid, ctype) ?? {};
             for (const [field, arr] of Object.entries(cols.fields)) {


### PR DESCRIPTION
## Summary
- remove unused ts-expect-error in zero layout
- assert bitset access and snapshot components

## Testing
- `pnpm exec eslint packages/worker/src/zero/layout.ts packages/worker/src/zero/snapshot.ts` *(fails: Unexpected any, Missing return type, etc.)*
- `pnpm --filter @promethean/worker build`
- `pnpm --filter @promethean/worker test` *(fails: Cannot find module '/workspace/promethean/packages/worker/dist/zero/struct')*
- `pnpm install`


------
https://chatgpt.com/codex/tasks/task_e_68c5c2153758832481931cfdff8b6bf7