### PR TITLE
chore(agent-ecs): remove unused import

### DIFF
--- a/packages/agent-ecs/src/systems/speechArbiter.ts
+++ b/packages/agent-ecs/src/systems/speechArbiter.ts
@@ -1,5 +1,4 @@
 // loose typing to avoid cross-package type coupling
-import type { defineAgentComponents } from '../components.js';
 
 type BargeState = { speakingSince: number | null; paused: boolean };
 


### PR DESCRIPTION
## Summary
- drop unused `defineAgentComponents` import from `speechArbiter`

## Testing
- `pnpm exec eslint packages/agent-ecs/src/systems/speechArbiter.ts` *(fails: numerous pre-existing lint errors)*
- `pnpm --filter @promethean/agent-ecs typecheck`
- `pnpm --filter @promethean/agent-ecs test` *(fails: Cannot find module '/workspace/config/ava.config.base.mjs')*
- `pnpm install`


------
https://chatgpt.com/codex/tasks/task_e_68c5c21e05d4832488fab6e52e8e003e