### PR TITLE
refactor: add js extensions to voice service imports

### DIFF
--- a/packages/voice/src/speaker.ts
+++ b/packages/voice/src/speaker.ts
@@ -10,8 +10,8 @@ import { AudioReceiveStream } from "@discordjs/voice";
 import { User } from "discord.js";
 import * as prism from "prism-media";
 
-import { Transcriber } from "./transcriber";
-import { VoiceRecorder } from "./voice-recorder";
+import { Transcriber } from "./transcriber.js";
+import { VoiceRecorder } from "./voice-recorder.js";
 
 class OpusSilenceFilter extends Transform {
   override _transform(
@@ -56,15 +56,17 @@ export class Speaker extends EventEmitter {
     this.recorder = options.recorder;
   }
 
-  get userId() {
+  get userId(): string {
     return this.user.id;
   }
 
-  get userName() {
+  get userName(): string {
     return this.user.username;
   }
 
-  async handleSpeakingStart(opusStream: AudioReceiveStream) {
+  async handleSpeakingStart(
+    opusStream: AudioReceiveStream,
+  ): Promise<PassThrough> {
     this.isSpeaking = true;
     // Silence filter
     const filter = new OpusSilenceFilter();
@@ -94,12 +96,12 @@ export class Speaker extends EventEmitter {
     return opusStream.pipe(filter).pipe(decoder).pipe(pcmSplitter);
   }
 
-  toggleTranscription() {
+  toggleTranscription(): boolean {
     this.isTranscribing = !this.isTranscribing;
     return this.isTranscribing;
   }
 
-  toggleRecording() {
+  toggleRecording(): boolean {
     this.isRecording = !this.isRecording;
     return this.isRecording;
   }

--- a/packages/voice/src/transcriber.ts
+++ b/packages/voice/src/transcriber.ts
@@ -4,7 +4,7 @@ import { PassThrough } from "node:stream";
 
 import { User } from "discord.js";
 
-import { Speaker } from "./speaker";
+import { Speaker } from "./speaker.js";
 
 export type TranscriberOptions = {
   hostname: string;
@@ -54,17 +54,18 @@ export class Transcriber extends EventEmitter {
     startTime: number,
     speaker: Speaker,
     pcmStream: PassThrough,
-  ) {
+  ): http.ClientRequest {
     this.emit("transcriptStart", { startTime, speaker });
     // ✅ Pipe PCM directly into the HTTP request
     return pcmStream.pipe(
       http
         .request(this.httpOptions, (res) => {
           const transcriptChunks: TranscriptChunk[] = [];
-          res.on("data", (chunk) => {
+          res.on("data", (chunk: Buffer) => {
             const chunkStr = chunk.toString();
             console.log(chunkStr);
-            const transcript = JSON.parse(chunkStr).transcription;
+            const parsed = JSON.parse(chunkStr) as { transcription: string };
+            const transcript = parsed.transcription;
             console.log(`Transcription chunk: ${transcript}`);
             const transcriptObject: TranscriptChunk = {
               startTime,


### PR DESCRIPTION
## Summary
- append .js extensions for local voice-service imports
- improve typing and structure to satisfy linter

## Testing
- `pnpm --filter @promethean/voice-service build`
- `pnpm --filter @promethean/voice-service test`
- `pnpm install`


------
https://chatgpt.com/codex/tasks/task_e_68c5c216f0808324b13f0d925983c37d