### PR TITLE
refactor(symdocs): remove unused variable

### DIFF
--- a/packages/symdocs/src/utils.ts
+++ b/packages/symdocs/src/utils.ts
@@ -6,20 +6,29 @@ import * as ts from "typescript";
 
 export const OLLAMA_URL = process.env.OLLAMA_URL ?? "http://localhost:11434";
 
-export function parseArgs(defaults: Record<string, string>) {
-  const out = { ...defaults };
-  const a = process.argv.slice(2);
-  for (let i = 0; i < a.length; i++) {
-    const k = a[i] ?? "";
-    if (!k.startsWith("--")) continue;
-    const next = a[i + 1] ?? "";
-    const v = next && !next.startsWith("--") ? a[++i] ?? "true" : "true";
-    out[k] = v;
-  }
-  return out;
+export function parseArgs(
+  defaults: Record<string, string>,
+): Record<string, string> {
+  const args = process.argv.slice(2);
+  const parse = (
+    index: number,
+    acc: Record<string, string>,
+  ): Record<string, string> => {
+    if (index >= args.length) return acc;
+    const key = args[index] ?? "";
+    if (!key.startsWith("--")) return parse(index + 1, acc);
+    const next = args[index + 1] ?? "";
+    const value = next && !next.startsWith("--") ? next : "true";
+    const nextIndex = value === "true" ? index + 1 : index + 2;
+    return parse(nextIndex, { ...acc, [key]: value });
+  };
+  return parse(0, { ...defaults });
 }
 
-export async function listFilesRec(root: string, exts: Set<string>) {
+export async function listFilesRec(
+  root: string,
+  exts: Set<string>,
+): Promise<string[]> {
   const out: string[] = [];
   async function walk(d: string) {
     const ents = await fs.readdir(d, { withFileTypes: true });
@@ -33,11 +42,11 @@ export async function listFilesRec(root: string, exts: Set<string>) {
   return out.filter((p) => exts.has(path.extname(p).toLowerCase()));
 }
 
-export function sha1(s: string) {
+export function sha1(s: string): string {
   return crypto.createHash("sha1").update(s).digest("hex");
 }
 
-export function relFromRepo(abs: string) {
+export function relFromRepo(abs: string): string {
   return path.relative(process.cwd(), abs).replace(/\\/g, "/");
 }
 
@@ -49,32 +58,35 @@ export function getLangFromExt(p: string): "ts" | "tsx" | "js" | "jsx" {
   return "js";
 }
 
-export function makeProgram(rootFiles: string[], tsconfigPath?: string) {
-  let options: ts.CompilerOptions = {
+export function makeProgram(
+  rootFiles: string[],
+  tsconfigPath?: string,
+): ts.Program {
+  const baseOptions: ts.CompilerOptions = {
     target: ts.ScriptTarget.ES2022,
     module: ts.ModuleKind.ESNext,
     strict: true,
   };
-
-  if (tsconfigPath) {
-    const configFile = ts.readConfigFile(tsconfigPath, ts.sys.readFile);
-    if (configFile.error) {
-      throw new Error(
-        ts.formatDiagnosticsWithColorAndContext([configFile.error], {
-          getCanonicalFileName: (f) => f,
-          getCurrentDirectory: ts.sys.getCurrentDirectory,
-          getNewLine: () => ts.sys.newLine,
-        }),
-      );
-    }
-    const parse = ts.parseJsonConfigFileContent(
-      configFile.config,
-      ts.sys,
-      path.dirname(tsconfigPath),
-    );
-    options = { ...parse.options, ...options };
-  }
-
+  const options = tsconfigPath
+    ? (() => {
+        const configFile = ts.readConfigFile(tsconfigPath, ts.sys.readFile);
+        if (configFile.error) {
+          throw new Error(
+            ts.formatDiagnosticsWithColorAndContext([configFile.error], {
+              getCanonicalFileName: (f) => f,
+              getCurrentDirectory: ts.sys.getCurrentDirectory,
+              getNewLine: () => ts.sys.newLine,
+            }),
+          );
+        }
+        const parse = ts.parseJsonConfigFileContent(
+          configFile.config,
+          ts.sys,
+          path.dirname(tsconfigPath),
+        );
+        return { ...parse.options, ...baseOptions };
+      })()
+    : baseOptions;
   return ts.createProgram(rootFiles, options);
 }
 
@@ -83,19 +95,18 @@ export function getJsDocText(node: ts.Node): string | undefined {
   if (!jsdocs?.length) return undefined;
   const texts: string[] = [];
   for (const d of jsdocs) {
-    // @ts-ignore - d may have comment property
-    const c = (d as any).comment;
-    if (typeof c === "string") texts.push(c);
+    if ("comment" in d && typeof d.comment === "string") {
+      texts.push(d.comment);
+    }
   }
   return texts.join("\n\n").trim() || undefined;
 }
 
 export function getNodeText(src: string, node: ts.Node): string {
-  const sf = node.getSourceFile();
   return src.slice(node.getFullStart(), node.getEnd());
 }
 
-export function posToLine(sf: ts.SourceFile, pos: number) {
+export function posToLine(sf: ts.SourceFile, pos: number): number {
   const { line } = sf.getLineAndCharacterOfPosition(pos);
   return line + 1;
 }


### PR DESCRIPTION
## Summary
- refactor argument parsing and TypeScript utilities in symdocs for lint compliance
- drop unused `getSourceFile` lookup in `getNodeText`

## Testing
- `pnpm exec eslint packages/symdocs/src/utils.ts`
- `pnpm lint:diff`
- `pnpm --filter @promethean/symdocs build`
- `pnpm install`


------
https://chatgpt.com/codex/tasks/task_e_68c5c20ff5e883249b0c515bb862bc09