### PR TITLE
chore: update test scopes

### DIFF
--- a/packages/cephalon/src/tests/actions.leave-voice.test.ts
+++ b/packages/cephalon/src/tests/actions.leave-voice.test.ts
@@ -5,13 +5,27 @@ import runLeave from "../actions/leave-voice.js";
 import type { LeaveVoiceScope } from "../actions/leave-voice.scope.js";
 
 function makeScope(allow = true, left = true): LeaveVoiceScope {
+  const logger = {
+    debug() {},
+    info() {},
+    warn() {},
+    error() {},
+    audit(_msg: string, _fields?: unknown) {},
+    child() {
+      return logger;
+    },
+  };
   return {
-    logger: { debug() {}, info() {}, warn() {}, error() {} },
+    logger,
     policy: {
-      async assertAllowed() {
+      async assertAllowed(
+        _subject: string,
+        _action: string,
+        _resource?: string,
+      ) {
         if (!allow) throw new NotAllowedError("Permission denied");
       },
-      async checkCapability(_agentId?: unknown, _cap?: unknown) {},
+      async checkCapability(_agentId: string, _cap: unknown) {},
     },
     voice: {
       async leaveGuild() {

--- a/packages/cephalon/src/tests/actions.ping.test.ts
+++ b/packages/cephalon/src/tests/actions.ping.test.ts
@@ -5,14 +5,28 @@ import runPing from "../actions/ping.js";
 import type { PingScope } from "../actions/ping.scope.js";
 
 function makeScope(allow = true): PingScope {
+  const logger = {
+    debug() {},
+    info() {},
+    warn() {},
+    error() {},
+    audit(_msg: string, _fields?: unknown) {},
+    child() {
+      return logger;
+    },
+  };
   return {
-    logger: { debug() {}, info() {}, warn() {}, error() {} },
+    logger,
     policy: {
-      async assertAllowed(subject: string) {
+      async assertAllowed(
+        subject: string,
+        _action: string,
+        _resource?: string,
+      ) {
         if (!allow || subject === "deny")
           throw new NotAllowedError("Permission denied");
       },
-      async checkCapability(_agentId?: unknown, _cap?: unknown) {},
+      async checkCapability(_agentId: string, _cap: unknown) {},
     },
     time: () => new Date("2020-01-01T00:00:00Z"),
   };


### PR DESCRIPTION
## Summary
- update test scopes for leave-voice and ping actions
- add audit and child stubs to test loggers

## Testing
- `pnpm lint packages/cephalon/src/tests/actions.leave-voice.test.ts packages/cephalon/src/tests/actions.ping.test.ts`
- `pnpm --filter @promethean/cephalon exec tsc -b` *(fails: Cannot find module '@promethean/agent-ecs'...)*
- `pnpm --filter @promethean/cephalon test` *(fails: Cannot find module '@promethean/voice-service/dist/voice-synth.js')*


------
https://chatgpt.com/codex/tasks/task_e_68c5c223d0408324a6d2399e34896a51