### PR TITLE
chore(file-watcher): add tsconfig

### DIFF
--- a/packages/file-watcher/package.json
+++ b/packages/file-watcher/package.json
@@ -4,7 +4,7 @@
   "main": "dist/index.js",
   "type": "module",
   "scripts": {
-    "build": "tsc",
+    "build": "tsc -p tsconfig.json",
     "prestart": "pnpm run build",
     "start": "node dist/index.js",
     "start:dev": "node --loader ts-node/esm src/index.ts",

--- a/packages/file-watcher/tsconfig.json
+++ b/packages/file-watcher/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "extends": "../../config/tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "composite": true,
+    "declaration": true,
+    "lib": ["es2021"],
+    "allowJs": true,
+    "paths": {
+      "@shared/ts/*": ["../shared/ts/dist/*"],
+      "@promethean/test-utils/*": ["../test-utils/dist/*"],
+      "@promethean/legacy/*": ["../legacy/*"],
+      "@shared/js/*": ["../legacy/*"]
+    },
+    "baseUrl": "."
+  },
+  "include": ["src/**/*.ts"],
+  "references": []
+}


### PR DESCRIPTION
## Summary
- add package-level tsconfig for file-watcher with ES2021 libs and JS support
- point @shared/js to legacy broker client and update build script

## Testing
- `pnpm exec eslint packages/file-watcher/tsconfig.json`
- `pnpm --filter @promethean/file-watcher build`
- `pnpm --filter @promethean/file-watcher test` *(fails: Cannot find package '@shared/js')*
- `pnpm install`


------
https://chatgpt.com/codex/tasks/task_e_68c5c22785208324b34d693adc2b1b56