### PR TITLE
feat(utils): centralize cosine similarity

### DIFF
--- a/packages/boardrev/src/04-match-context.ts
+++ b/packages/boardrev/src/04-match-context.ts
@@ -3,13 +3,8 @@ import { promises as fs } from "fs";
 
 import matter from "gray-matter";
 
-import {
-  parseArgs,
-  listTaskFiles,
-  ollamaEmbed,
-  cosine,
-  writeText,
-} from "./utils.js";
+import { parseArgs, listTaskFiles, ollamaEmbed, writeText } from "./utils.js";
+import { cosine } from "@promethean/utils";
 import type { RepoDoc, Embeddings, TaskContext } from "./types.js";
 
 const args = parseArgs({
@@ -25,8 +20,12 @@ async function main() {
   const tasksDir = path.resolve(args["--tasks"]!);
   const files = await listTaskFiles(tasksDir);
 
-  const index: { docs: RepoDoc[] } = JSON.parse(await fs.readFile(path.resolve(args["--index"]!), "utf-8"));
-  const repoEmb: Embeddings = JSON.parse(await fs.readFile(path.resolve(args["--emb"]!), "utf-8"));
+  const index: { docs: RepoDoc[] } = JSON.parse(
+    await fs.readFile(path.resolve(args["--index"]!), "utf-8"),
+  );
+  const repoEmb: Embeddings = JSON.parse(
+    await fs.readFile(path.resolve(args["--emb"]!), "utf-8"),
+  );
   const k = Number(args["--k"]);
 
   const out: TaskContext[] = [];
@@ -53,13 +52,16 @@ async function main() {
       .slice(0, k);
 
     const links = Array.from(raw.matchAll(/\[[^\]]*?\]\(([^)]+)\)/g))
-      .map(m => m[1])
+      .map((m) => m[1])
       .filter((x): x is string => Boolean(x));
 
-      out.push({ taskFile: f.replace(/\\/g,"/"), hits: scored, links });
+    out.push({ taskFile: f.replace(/\\/g, "/"), hits: scored, links });
   }
 
-  await writeText(path.resolve(args["--out"]!), JSON.stringify({ contexts: out }, null, 2));
+  await writeText(
+    path.resolve(args["--out"]!),
+    JSON.stringify({ contexts: out }, null, 2),
+  );
   console.log(`boardrev: matched context for ${out.length} task(s)`);
 }
 

--- a/packages/boardrev/src/test/utils.test.ts
+++ b/packages/boardrev/src/test/utils.test.ts
@@ -1,6 +1,7 @@
 import test from "ava";
 
-import { parseArgs, cosine } from "../utils.js";
+import { parseArgs } from "../utils.js";
+import { cosine } from "@promethean/utils";
 
 test("parseArgs merges defaults and argv", (t) => {
   const prev = process.argv;

--- a/packages/boardrev/src/utils.ts
+++ b/packages/boardrev/src/utils.ts
@@ -114,17 +114,3 @@ export async function ollamaJSON(model: string, prompt: string): Promise<any> {
 }
 
 /** Cosine similarity: safe when vectors differ in length. */
-export function cosine(a: number[], b: number[]) {
-  let dot = 0,
-    na = 0,
-    nb = 0;
-  const n = Math.min(a.length, b.length);
-  for (let i = 0; i < n; i++) {
-    const ai = a[i]!;
-    const bi = b[i]!;
-    dot += ai * bi;
-    na += ai * ai;
-    nb += bi * bi;
-  }
-  return !na || !nb ? 0 : dot / (Math.sqrt(na) * Math.sqrt(nb));
-}

--- a/packages/boardrev/test/utils.test.ts
+++ b/packages/boardrev/test/utils.test.ts
@@ -1,7 +1,8 @@
 import test from "ava";
-import { parseArgs, cosine } from "../src/utils.js";
+import { parseArgs } from "../src/utils.js";
+import { cosine } from "@promethean/utils";
 
-test("parseArgs merges defaults and argv", t => {
+test("parseArgs merges defaults and argv", (t) => {
   const prev = process.argv;
   process.argv = ["node", "script", "--foo", "bar"];
   const args = parseArgs({ "--foo": "baz", "--a": "1" });
@@ -10,7 +11,7 @@ test("parseArgs merges defaults and argv", t => {
   process.argv = prev;
 });
 
-test("cosine computes similarity", t => {
+test("cosine computes similarity", (t) => {
   t.is(cosine([1, 0], [0, 1]), 0);
   t.true(Math.abs(cosine([1, 1], [1, 1]) - 1) < 1e-9);
 });

--- a/packages/codepack/package.json
+++ b/packages/codepack/package.json
@@ -12,6 +12,7 @@
     "code:all": "pnpm code:01-extract && pnpm code:02-embed && pnpm code:03-cluster && pnpm code:04-name && pnpm code:05-materialize"
   },
   "dependencies": {
+    "@promethean/utils": "workspace:*",
     "gray-matter": "4.0.3",
     "remark-parse": "11.0.0",
     "unified": "11.0.4",

--- a/packages/codepack/src/03-cluster.ts
+++ b/packages/codepack/src/03-cluster.ts
@@ -1,7 +1,8 @@
 // src/03-cluster.ts
 import { promises as fs } from "fs";
 import * as path from "path";
-import { parseArgs, cosine } from "./utils.js";
+import { parseArgs } from "./utils.js";
+import { cosine } from "@promethean/utils";
 import type { BlockManifest, EmbeddingMap, Cluster } from "./types.js";
 
 const args = parseArgs({

--- a/packages/codepack/src/utils.ts
+++ b/packages/codepack/src/utils.ts
@@ -43,20 +43,6 @@ export function sha1(s: string): string {
   return crypto.createHash("sha1").update(s).digest("hex");
 }
 
-export function cosine(a: number[], b: number[]) {
-  let dot = 0,
-    na = 0,
-    nb = 0;
-  const n = Math.min(a.length, b.length);
-  for (let i = 0; i < n; i++) {
-    dot += a[i] * b[i];
-    na += a[i] * a[i];
-    nb += b[i] * b[i];
-  }
-  if (!na || !nb) return 0;
-  return dot / (Math.sqrt(na) * Math.sqrt(nb));
-}
-
 export function relPath(fromRoot: string, fileAbs: string) {
   return path.relative(fromRoot, fileAbs).replace(/\\/g, "/");
 }

--- a/packages/cookbookflow/src/03-group.ts
+++ b/packages/cookbookflow/src/03-group.ts
@@ -1,14 +1,15 @@
 import { promises as fs } from "fs";
 import * as path from "path";
 
-import { parseArgs, cosine, writeJSON } from "./utils.js";
+import { parseArgs, writeJSON } from "./utils.js";
+import { cosine } from "@promethean/utils";
 import type { ClassesFile, GroupsFile, Group } from "./types.js";
 
 const args = parseArgs({
   "--in": ".cache/cookbook/classes.json",
   "--out": ".cache/cookbook/groups.json",
   "--min-sim": "0.82",
-  "--max-size": "12"
+  "--max-size": "12",
 } as const);
 
 async function main() {
@@ -31,15 +32,17 @@ async function main() {
     // greedy nearest neighbors within same key
     for (const other of ids) {
       if (id === other || seen.has(other)) continue;
-        const c = cf.classes[other]!;
-        if (`${c.task}|${c.runtime}|${c.language}` !== key) continue;
-        const sim = cosine(centroid ?? [], cf.embeddings[other] ?? []);
+      const c = cf.classes[other]!;
+      if (`${c.task}|${c.runtime}|${c.language}` !== key) continue;
+      const sim = cosine(centroid ?? [], cf.embeddings[other] ?? []);
       if (sim >= minSim) members.push(other);
       if (members.length >= maxSize) break;
     }
 
-    members.forEach(m => seen.add(m));
-    const g: Group = centroid ? { key, blockIds: members, centroid } : { key, blockIds: members };
+    members.forEach((m) => seen.add(m));
+    const g: Group = centroid
+      ? { key, blockIds: members, centroid }
+      : { key, blockIds: members };
     groups.push(g);
   }
 

--- a/packages/cookbookflow/src/utils.ts
+++ b/packages/cookbookflow/src/utils.ts
@@ -89,20 +89,6 @@ export async function ollamaJSON(model: string, prompt: string): Promise<any> {
       .trim(),
   );
 }
-export function cosine(a: number[], b: number[]) {
-  let dot = 0,
-    na = 0,
-    nb = 0;
-  const n = Math.min(a.length, b.length);
-  for (let i = 0; i < n; i++) {
-    const ai = a[i]!;
-    const bi = b[i]!;
-    dot += ai * bi;
-    na += ai * ai;
-    nb += bi * bi;
-  }
-  return !na || !nb ? 0 : dot / (Math.sqrt(na) * Math.sqrt(nb));
-}
 
 export async function execShell(cmd: string, args: string[], cwd: string) {
   return new Promise<{ code: number | null; stdout: string; stderr: string }>(

--- a/packages/docops/package.json
+++ b/packages/docops/package.json
@@ -27,6 +27,7 @@
     "uuid": "^12.0.0",
     "yaml": "^2.8.1",
     "zod": "^4.1.5",
-    "@promethean/fs": "workspace:*"
+    "@promethean/fs": "workspace:*",
+    "@promethean/utils": "workspace:*"
   }
 }

--- a/packages/docops/src/tests/utils.parse.test.ts
+++ b/packages/docops/src/tests/utils.parse.test.ts
@@ -8,11 +8,11 @@ import {
   injectAnchors,
   anchorId,
   relMdLink,
-  cosine,
   writeJSONArrayStream,
   writeNDJSON,
   safeReplacer,
 } from "../utils.js";
+import { cosine } from "@promethean/utils";
 
 async function withTmp(fn: (dir: string) => Promise<void> | void) {
   const dir = path.join(

--- a/packages/docops/src/utils.ts
+++ b/packages/docops/src/utils.ts
@@ -94,22 +94,6 @@ export function frontToYAML(front: Front): string {
   return yaml.stringify(front, { indent: 2, simpleKeys: true });
 }
 
-export function cosine(a: number[], b: number[]): number {
-  let dot = 0,
-    na = 0,
-    nb = 0;
-  const n = Math.min(a.length, b.length);
-  for (let i = 0; i < n; i++) {
-    const ai = a[i]!;
-    const bi = b[i]!;
-    dot += ai * bi;
-    na += ai * ai;
-    nb += bi * bi;
-  }
-  if (na === 0 || nb === 0) return 0;
-  return dot / (Math.sqrt(na) * Math.sqrt(nb));
-}
-
 export function parseMarkdownChunks(markdown: string): Chunk[] {
   const ast = unified().use(remarkParse).parse(markdown) as any;
   const chunks: Chunk[] = [];

--- a/packages/simtask/package.json
+++ b/packages/simtask/package.json
@@ -20,6 +20,7 @@
     "sim:all": "pnpm sim:01-scan && pnpm sim:02-embed && pnpm sim:03-cluster && pnpm sim:04-plan && pnpm sim:05-write"
   },
   "dependencies": {
+    "@promethean/utils": "workspace:*",
     "gray-matter": "^4.0.3",
     "yaml": "^2.5.0",
     "zod": "^3.23.8"

--- a/packages/simtask/src/03-cluster.ts
+++ b/packages/simtask/src/03-cluster.ts
@@ -1,7 +1,8 @@
 import { promises as fs } from "fs";
 import * as path from "path";
 
-import { parseArgs, cosine } from "./utils.js";
+import { parseArgs } from "./utils.js";
+import { cosine } from "@promethean/utils";
 import type { ScanResult, EmbeddingMap, Cluster } from "./types.js";
 
 const args = parseArgs({

--- a/packages/simtask/src/utils.ts
+++ b/packages/simtask/src/utils.ts
@@ -96,19 +96,3 @@ export function getJsDocText(node: ts.Node): string | undefined {
 export function getNodeText(src: string, node: ts.Node): string {
   return src.slice(node.getFullStart(), node.getEnd());
 }
-
-export function cosine(a: number[], b: number[]) {
-  let dot = 0,
-    na = 0,
-    nb = 0;
-  const n = Math.min(a.length, b.length);
-  for (let i = 0; i < n; i++) {
-    const av = a[i]!;
-    const bv = b[i]!;
-    dot += av * bv;
-    na += av * av;
-    nb += bv * bv;
-  }
-  if (!na || !nb) return 0;
-  return dot / (Math.sqrt(na) * Math.sqrt(nb));
-}

--- a/packages/utils/src/cosine.ts
+++ b/packages/utils/src/cosine.ts
@@ -1,0 +1,16 @@
+export function cosine(a: readonly number[], b: readonly number[]): number {
+  const n = Math.min(a.length, b.length);
+  const { dot, na, nb } = Array.from({ length: n }).reduce<{
+    dot: number;
+    na: number;
+    nb: number;
+  }>(
+    (acc, _, i) => ({
+      dot: acc.dot + a[i]! * b[i]!,
+      na: acc.na + a[i]! * a[i]!,
+      nb: acc.nb + b[i]! * b[i]!,
+    }),
+    { dot: 0, na: 0, nb: 0 },
+  );
+  return na === 0 || nb === 0 ? 0 : dot / (Math.sqrt(na) * Math.sqrt(nb));
+}

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -6,3 +6,4 @@ export { retry } from "./retry.js";
 export type { RetryOptions } from "./retry.js";
 export { slug } from "./slug.js";
 export { parseArgs } from "./parse-args.js";
+export { cosine } from "./cosine.js";

--- a/packages/utils/src/tests/cosine.test.ts
+++ b/packages/utils/src/tests/cosine.test.ts
@@ -1,0 +1,8 @@
+import test from "ava";
+
+import { cosine } from "../cosine.js";
+
+test("cosine similarity basics", (t) => {
+  t.is(cosine([1, 0], [0, 1]), 0);
+  t.true(Math.abs(cosine([1, 1], [1, 1]) - 1) < 1e-9);
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -745,6 +745,9 @@ importers:
       '@promethean/fs':
         specifier: workspace:*
         version: link:../fs
+      '@promethean/utils':
+        specifier: workspace:*
+        version: link:../utils
       gray-matter:
         specifier: 4.0.3
         version: 4.0.3
@@ -1370,6 +1373,9 @@ importers:
       '@promethean/fs':
         specifier: workspace:*
         version: link:../fs
+      '@promethean/utils':
+        specifier: workspace:*
+        version: link:../utils
       '@types/level':
         specifier: ^8.0.0
         version: 8.0.0
@@ -3313,6 +3319,9 @@ importers:
 
   packages/simtask:
     dependencies:
+      '@promethean/utils':
+        specifier: workspace:*
+        version: link:../utils
       gray-matter:
         specifier: ^4.0.3
         version: 4.0.3
@@ -14169,7 +14178,7 @@ snapshots:
 
   axios@1.11.0:
     dependencies:
-      follow-redirects: 1.15.11(debug@4.4.1)
+      follow-redirects: 1.15.11(debug@4.3.7)
       form-data: 4.0.4
       proxy-from-env: 1.1.0
     transitivePeerDependencies:
@@ -16541,7 +16550,7 @@ snapshots:
   http-proxy@1.18.1:
     dependencies:
       eventemitter3: 4.0.7
-      follow-redirects: 1.15.11(debug@4.4.1)
+      follow-redirects: 1.15.11(debug@4.3.7)
       requires-port: 1.0.0
     transitivePeerDependencies:
       - debug


### PR DESCRIPTION
## Summary
- add shared cosine similarity helper to @promethean/utils
- remove package-level cosine implementations and import shared helper
- expose cosine from utils public API and update dependent packages

## Testing
- `pnpm --filter @promethean/utils test`
- `pnpm --filter @promethean/boardrev build`
- `pnpm --filter @promethean/boardrev exec ava src/test/utils.test.ts test/utils.test.ts --config ../../config/ava.config.mjs` *(fails: Cannot find module '/workspace/promethean/packages/boardrev/src/utils.js')*
- `pnpm --filter @promethean/codepack exec node -e "console.log('codepack ok')"`
- `pnpm --filter @promethean/simtasks build`
- `pnpm --filter @promethean/cookbookflow build`
- `pnpm --filter @promethean/docops test` *(fails: ENOENT /workspace/promethean/packages/docops/dist/dev-ui.js)*
- `pnpm install`
- `pnpm lint:diff` *(fails: 1171 problems)*

------
https://chatgpt.com/codex/tasks/task_e_68c61a659dc08324808945f902bb92be

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced a cosine similarity utility in the shared utils package for reuse across projects.
- Refactor
  - Consolidated cosine usage to the shared utils package across multiple modules without changing behavior.
- Tests
  - Added unit tests for the cosine utility and updated existing tests to use the shared implementation.
- Chores
  - Updated dependencies to include the shared utils package where needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->