### PR TITLE
feat(utils): add shared relFromRepo

### DIFF
--- a/packages/boardrev/src/06-report.ts
+++ b/packages/boardrev/src/06-report.ts
@@ -4,7 +4,7 @@ import { promises as fs } from "fs";
 
 import matter from "gray-matter";
 
-import { slug } from "@promethean/utils";
+import { slug, relFromRepo } from "@promethean/utils";
 import { parseArgs, writeText } from "./utils.js";
 import type { EvalItem } from "./types.js";
 
@@ -105,10 +105,6 @@ async function main() {
     `# Board Reports\n\n- [Latest](${path.basename(out)})\n`,
   );
   console.log(`boardrev: wrote report → ${path.relative(process.cwd(), out)}`);
-}
-
-function relFromRepo(abs: string) {
-  return abs.replace(process.cwd().replace(/\\/g, "/") + "/", "");
 }
 
 main().catch((e) => {

--- a/packages/boardrev/src/utils.ts
+++ b/packages/boardrev/src/utils.ts
@@ -61,10 +61,6 @@ export function normStatus(s: string) {
   return "todo";
 }
 
-export function relFromRepo(abs: string) {
-  return path.relative(process.cwd(), abs).replace(/\\/g, "/");
-}
-
 /**
  * Ollama embeddings.
  * NOTE: Some tooling/docs reference /api/embed; /api/embeddings is widely used.

--- a/packages/codemods/package.json
+++ b/packages/codemods/package.json
@@ -20,7 +20,8 @@
     "diff": "^5.2.0",
     "globby": "^14.0.2",
     "ts-morph": "^22.0.0",
-    "yaml": "^2.5.0"
+    "yaml": "^2.5.0",
+    "@promethean/utils": "workspace:*"
   },
   "devDependencies": {
     "tsx": "^4.19.2"

--- a/packages/codemods/src/03-run.ts
+++ b/packages/codemods/src/03-run.ts
@@ -5,7 +5,8 @@ import { pathToFileURL } from "node:url";
 import { Project, SyntaxKind } from "ts-morph";
 import { diffLines } from "diff";
 
-import { listCodeFiles, relFromRepo } from "./utils.js";
+import { listCodeFiles } from "./utils.js";
+import { relFromRepo } from "@promethean/utils";
 
 const args = parseArgs({
   "--root": "packages",
@@ -15,7 +16,7 @@ const args = parseArgs({
   "--specs": ".cache/codemods/specs.json",
   "--delete-duplicates": "true",
 });
- 
+
 const specsPath = args["--specs"];
 
 function parseArgs<T extends Record<string, string>>(defaults: T): T {
@@ -117,7 +118,7 @@ async function main() {
 
       if (MODE === "dry") {
         const diffs = diffLines(before, after);
-         
+
         const pretty = diffs
           .map((part: any) => {
             const prefix = part.added ? "+" : part.removed ? "-" : " ";

--- a/packages/codemods/src/utils.ts
+++ b/packages/codemods/src/utils.ts
@@ -29,10 +29,6 @@ export async function listCodeFiles(root: string) {
   return globby(patterns);
 }
 
-export function relFromRepo(abs: string) {
-  return path.relative(process.cwd(), abs).replace(/\\/g, "/");
-}
-
 export function importPathRelative(
   fromFileAbs: string,
   canonicalFileAbs: string,

--- a/packages/semvergaurd/src/utils.ts
+++ b/packages/semvergaurd/src/utils.ts
@@ -1,6 +1,5 @@
 import { promises as fs } from "fs";
 import * as path from "path";
-
 export const OLLAMA_URL = process.env.OLLAMA_URL ?? "http://localhost:11434";
 
 export function parseArgs(def: Record<string, string>) {
@@ -27,10 +26,6 @@ export async function readJSON<T>(p: string): Promise<T | undefined> {
 export async function writeJSON(p: string, data: any) {
   await fs.mkdir(path.dirname(p), { recursive: true });
   await fs.writeFile(p, JSON.stringify(data, null, 2), "utf-8");
-}
-
-export function rel(abs: string) {
-  return path.relative(process.cwd(), abs).replace(/\\/g, "/");
 }
 
 export async function ollamaJSON(model: string, prompt: string) {

--- a/packages/simtask/package.json
+++ b/packages/simtask/package.json
@@ -22,7 +22,8 @@
   "dependencies": {
     "gray-matter": "^4.0.3",
     "yaml": "^2.5.0",
-    "zod": "^3.23.8"
+    "zod": "^3.23.8",
+    "@promethean/utils": "workspace:*"
   },
   "devDependencies": {
     "tsx": "^4.19.2"

--- a/packages/simtask/src/01-scan.ts
+++ b/packages/simtask/src/01-scan.ts
@@ -10,9 +10,9 @@ import {
   posToLine,
   getJsDocText,
   getNodeText,
-  relFromRepo,
   sha1,
 } from "./utils.js";
+import { relFromRepo } from "@promethean/utils";
 import type { FunctionInfo, ScanResult, FnKind } from "./types.js";
 
 const args = parseArgs({

--- a/packages/simtask/src/utils.ts
+++ b/packages/simtask/src/utils.ts
@@ -55,10 +55,6 @@ export function sha1(s: string) {
   return crypto.createHash("sha1").update(s).digest("hex");
 }
 
-export function relFromRepo(abs: string) {
-  return path.relative(process.cwd(), abs).replace(/\\/g, "/");
-}
-
 export function makeProgram(rootFiles: string[], tsconfigPath?: string) {
   let options: ts.CompilerOptions = {
     target: ts.ScriptTarget.ES2022,

--- a/packages/symdocs/package.json
+++ b/packages/symdocs/package.json
@@ -19,7 +19,8 @@
   "dependencies": {
     "gray-matter": "^4.0.3",
     "yaml": "^2.5.0",
-    "zod": "^3.23.8"
+    "zod": "^3.23.8",
+    "@promethean/utils": "workspace:*"
   },
   "devDependencies": {
     "tsx": "^4.19.2"

--- a/packages/symdocs/src/01-scan.ts
+++ b/packages/symdocs/src/01-scan.ts
@@ -11,11 +11,11 @@ import {
   getNodeText,
   posToLine,
   sha1,
-  relFromRepo,
   getLangFromExt,
   signatureForFunction,
   typeToString,
 } from "./utils.js";
+import { relFromRepo } from "@promethean/utils";
 import type { SymKind, SymbolInfo, ScanResult } from "./types.js";
 
 const args = parseArgs({

--- a/packages/symdocs/src/utils.ts
+++ b/packages/symdocs/src/utils.ts
@@ -46,10 +46,6 @@ export function sha1(s: string): string {
   return crypto.createHash("sha1").update(s).digest("hex");
 }
 
-export function relFromRepo(abs: string): string {
-  return path.relative(process.cwd(), abs).replace(/\\/g, "/");
-}
-
 export function getLangFromExt(p: string): "ts" | "tsx" | "js" | "jsx" {
   const e = path.extname(p).toLowerCase();
   if (e === ".ts") return "ts";

--- a/packages/testgap/src/01-scan-exports.ts
+++ b/packages/testgap/src/01-scan-exports.ts
@@ -5,7 +5,8 @@ import { globby } from "globby";
 import { Project } from "ts-morph";
 
 import { parseArgs } from "@promethean/utils";
-import { writeJSON, rel } from "./utils.js";
+import { writeJSON } from "./utils.js";
+import { relFromRepo } from "@promethean/utils";
 import type { ExportScan, ExportSymbol } from "./types.js";
 
 const args = parseArgs({
@@ -38,7 +39,7 @@ async function main() {
     for (const sf of project
       .getSourceFiles()
       .filter((s) => s.getFilePath().startsWith(pkgRoot))) {
-      const file = rel(sf.getFilePath().replace(/\\/g, "/"));
+      const file = relFromRepo(sf.getFilePath().replace(/\\/g, "/"));
       for (const [name, decls] of sf.getExportedDeclarations()) {
         const d = decls[0];
         if (!d) continue;

--- a/packages/testgap/src/02-read-coverage.ts
+++ b/packages/testgap/src/02-read-coverage.ts
@@ -4,7 +4,8 @@ import { promises as fs } from "fs";
 import { globby } from "globby";
 
 import { parseArgs } from "@promethean/utils";
-import { writeJSON, rel } from "./utils.js";
+import { writeJSON } from "./utils.js";
+import { relFromRepo } from "@promethean/utils";
 import type { CoverageIndex, FileCoverage } from "./types.js";
 
 const args = parseArgs({
@@ -23,7 +24,7 @@ function parseLCOV(raw: string): FileCoverage[] {
       covered = 0;
     const coveredLines: number[] = [];
     for (const line of lines) {
-      if (line.startsWith("SF:")) file = rel(line.slice(3).trim());
+      if (line.startsWith("SF:")) file = relFromRepo(line.slice(3).trim());
       if (line.startsWith("DA:")) {
         const [nStr, hitsStr] = line.slice(3).split(",");
         const n = Number(nStr),

--- a/packages/testgap/src/utils.ts
+++ b/packages/testgap/src/utils.ts
@@ -1,6 +1,5 @@
 import { promises as fs } from "fs";
 import * as path from "path";
-
 export const OLLAMA_URL = process.env.OLLAMA_URL ?? "http://localhost:11434";
 
 export async function writeJSON(p: string, data: any) {
@@ -17,10 +16,6 @@ export async function readMaybe(p: string) {
     return undefined;
   }
 }
-export function rel(p: string) {
-  return p.replace(process.cwd().replace(/\\/g, "/") + "/", "");
-}
-
 export async function ollamaJSON(model: string, prompt: string) {
   const res = await fetch(`${OLLAMA_URL}/api/generate`, {
     method: "POST",

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -6,3 +6,4 @@ export { retry } from "./retry.js";
 export type { RetryOptions } from "./retry.js";
 export { slug } from "./slug.js";
 export { parseArgs } from "./parse-args.js";
+export { relFromRepo } from "./path.js";

--- a/packages/utils/src/path.ts
+++ b/packages/utils/src/path.ts
@@ -1,0 +1,12 @@
+import * as path from "path";
+
+/**
+ * Return the repository-relative path for an absolute path.
+ * Always uses forward slashes as separators for cross-platform consistency.
+ */
+export function relFromRepo(absPath: string): string {
+  const repoRoot = process.cwd();
+  const abs = path.resolve(absPath);
+  const rel = path.relative(repoRoot, abs);
+  return rel.split(path.sep).join("/");
+}

--- a/packages/utils/src/tests/rel-from-repo.test.ts
+++ b/packages/utils/src/tests/rel-from-repo.test.ts
@@ -1,0 +1,11 @@
+import * as path from "path";
+
+import test from "ava";
+
+import { relFromRepo } from "../path.js";
+
+test("relFromRepo normalizes separators", (t) => {
+  const abs = path.join(process.cwd(), "foo", "bar", "baz.txt");
+  const rel = relFromRepo(abs);
+  t.is(rel, "foo/bar/baz.txt");
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -723,6 +723,9 @@ importers:
 
   packages/codemods:
     dependencies:
+      '@promethean/utils':
+        specifier: workspace:*
+        version: link:../utils
       diff:
         specifier: ^5.2.0
         version: 5.2.0
@@ -3313,6 +3316,9 @@ importers:
 
   packages/simtask:
     dependencies:
+      '@promethean/utils':
+        specifier: workspace:*
+        version: link:../utils
       gray-matter:
         specifier: ^4.0.3
         version: 4.0.3
@@ -3606,6 +3612,9 @@ importers:
 
   packages/symdocs:
     dependencies:
+      '@promethean/utils':
+        specifier: workspace:*
+        version: link:../utils
       gray-matter:
         specifier: ^4.0.3
         version: 4.0.3
@@ -14169,7 +14178,7 @@ snapshots:
 
   axios@1.11.0:
     dependencies:
-      follow-redirects: 1.15.11(debug@4.4.1)
+      follow-redirects: 1.15.11(debug@4.3.7)
       form-data: 4.0.4
       proxy-from-env: 1.1.0
     transitivePeerDependencies:
@@ -16541,7 +16550,7 @@ snapshots:
   http-proxy@1.18.1:
     dependencies:
       eventemitter3: 4.0.7
-      follow-redirects: 1.15.11(debug@4.4.1)
+      follow-redirects: 1.15.11(debug@4.3.7)
       requires-port: 1.0.0
     transitivePeerDependencies:
       - debug


### PR DESCRIPTION
## Summary
- add cross-platform `relFromRepo` helper to `@promethean/utils`
- replace custom path helpers in simtask, symdocs, codemods, boardrev, semverguard and testgap with shared version
- remove redundant implementations

## Testing
- `pnpm --filter @promethean/utils test`
- `pnpm --filter @promethean/codemods build`
- `pnpm --filter @promethean/boardrev build`
- `pnpm --filter @promethean/symdocs build`
- `pnpm --filter @promethean/simtasks build`
- `pnpm --filter @promethean/semverguard build`
- `pnpm --filter @promethean/testgap build`
- `pnpm install`


------
https://chatgpt.com/codex/tasks/task_e_68c61a75607c83248c186f7d312b302b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated path handling to a shared utility for consistent, cross-platform relative paths across packages. No user-facing behavior changes.

* **Chores**
  * Added shared utilities dependency to multiple packages to standardize path operations.

* **Tests**
  * Introduced unit test to validate path normalization behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->