### PR TITLE
feat(utils): add ts-ast helpers

### DIFF
--- a/packages/simtask/src/01-scan.ts
+++ b/packages/simtask/src/01-scan.ts
@@ -7,12 +7,10 @@ import {
   parseArgs,
   listFilesRec,
   makeProgram,
-  posToLine,
-  getJsDocText,
-  getNodeText,
   relFromRepo,
   sha1,
 } from "./utils.js";
+import { posToLine, getJsDocText, getNodeText } from "@promethean/utils";
 import type { FunctionInfo, ScanResult, FnKind } from "./types.js";
 
 const args = parseArgs({

--- a/packages/simtask/src/utils.ts
+++ b/packages/simtask/src/utils.ts
@@ -77,26 +77,6 @@ export function makeProgram(rootFiles: string[], tsconfigPath?: string) {
   return ts.createProgram(rootFiles, options);
 }
 
-export function posToLine(sf: ts.SourceFile, pos: number) {
-  return sf.getLineAndCharacterOfPosition(pos).line + 1;
-}
-
-export function getJsDocText(node: ts.Node): string | undefined {
-  const jsdocs = ts.getJSDocCommentsAndTags(node) ?? [];
-  if (jsdocs.length === 0) return undefined;
-  const texts: string[] = [];
-  for (const d of jsdocs) {
-    // @ts-ignore
-    const c = (d as any).comment;
-    if (typeof c === "string") texts.push(c);
-  }
-  return texts.join("\n\n").trim() || undefined;
-}
-
-export function getNodeText(src: string, node: ts.Node): string {
-  return src.slice(node.getFullStart(), node.getEnd());
-}
-
 export function cosine(a: number[], b: number[]) {
   let dot = 0,
     na = 0,

--- a/packages/symdocs/src/01-scan.ts
+++ b/packages/symdocs/src/01-scan.ts
@@ -7,15 +7,13 @@ import {
   parseArgs,
   listFilesRec,
   makeProgram,
-  getJsDocText,
-  getNodeText,
-  posToLine,
   sha1,
   relFromRepo,
   getLangFromExt,
   signatureForFunction,
   typeToString,
 } from "./utils.js";
+import { getJsDocText, getNodeText, posToLine } from "@promethean/utils";
 import type { SymKind, SymbolInfo, ScanResult } from "./types.js";
 
 const args = parseArgs({

--- a/packages/symdocs/src/utils.ts
+++ b/packages/symdocs/src/utils.ts
@@ -90,27 +90,6 @@ export function makeProgram(
   return ts.createProgram(rootFiles, options);
 }
 
-export function getJsDocText(node: ts.Node): string | undefined {
-  const jsdocs = ts.getJSDocCommentsAndTags(node);
-  if (!jsdocs?.length) return undefined;
-  const texts: string[] = [];
-  for (const d of jsdocs) {
-    if ("comment" in d && typeof d.comment === "string") {
-      texts.push(d.comment);
-    }
-  }
-  return texts.join("\n\n").trim() || undefined;
-}
-
-export function getNodeText(src: string, node: ts.Node): string {
-  return src.slice(node.getFullStart(), node.getEnd());
-}
-
-export function posToLine(sf: ts.SourceFile, pos: number): number {
-  const { line } = sf.getLineAndCharacterOfPosition(pos);
-  return line + 1;
-}
-
 export function signatureForFunction(
   checker: ts.TypeChecker,
   decl: ts.FunctionLikeDeclarationBase,

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -6,3 +6,4 @@ export { retry } from "./retry.js";
 export type { RetryOptions } from "./retry.js";
 export { slug } from "./slug.js";
 export { parseArgs } from "./parse-args.js";
+export { getJsDocText, getNodeText, posToLine } from "./ts-ast.js";

--- a/packages/utils/src/tests/ts-ast.test.ts
+++ b/packages/utils/src/tests/ts-ast.test.ts
@@ -1,0 +1,24 @@
+import test from "ava";
+import ts from "typescript";
+import { getJsDocText, getNodeText, posToLine } from "@promethean/utils";
+
+test("posToLine returns 1-based line numbers", (t) => {
+  const src = "a\n b";
+  const sf = ts.createSourceFile("x.ts", src, ts.ScriptTarget.ES2022, true);
+  const pos = src.indexOf("b");
+  t.is(posToLine(sf, pos), 2);
+});
+
+test("getJsDocText extracts jsdoc comments", (t) => {
+  const src = "/** hi */\nfunction foo() {}";
+  const sf = ts.createSourceFile("x.ts", src, ts.ScriptTarget.ES2022, true);
+  const node = sf.statements[0] as ts.FunctionDeclaration;
+  t.is(getJsDocText(node), "hi");
+});
+
+test("getNodeText slices source", (t) => {
+  const src = "function foo() {}";
+  const sf = ts.createSourceFile("x.ts", src, ts.ScriptTarget.ES2022, true);
+  const node = sf.statements[0]!;
+  t.is(getNodeText(src, node), src);
+});

--- a/packages/utils/src/ts-ast.ts
+++ b/packages/utils/src/ts-ast.ts
@@ -1,0 +1,33 @@
+import ts from "typescript";
+
+/**
+ * Extracts concatenated JSDoc comments from a node, if any.
+ */
+// eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
+export function getJsDocText(node: Readonly<ts.Node>): string | undefined {
+  const jsdocs = ts.getJSDocCommentsAndTags(node);
+  if (!jsdocs?.length) return undefined;
+  const texts = jsdocs
+    .map((d) =>
+      "comment" in d && typeof d.comment === "string" ? d.comment : undefined,
+    )
+    .filter((c): c is string => Boolean(c));
+  return texts.join("\n\n").trim() || undefined;
+}
+
+/**
+ * Returns the source text for a node from the given source string.
+ */
+// eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
+export function getNodeText(src: string, node: Readonly<ts.Node>): string {
+  return src.slice(node.getFullStart(), node.getEnd());
+}
+
+/**
+ * Converts a position in a SourceFile to a 1-based line number.
+ */
+// eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
+export function posToLine(sf: Readonly<ts.SourceFile>, pos: number): number {
+  const { line } = sf.getLineAndCharacterOfPosition(pos);
+  return line + 1;
+}


### PR DESCRIPTION
## Summary
- add reusable ts-ast utilities for JSDoc, snippet, and line mapping
- use centralized helpers in simtask and symdocs scans
- add unit tests for ts-ast helpers

## Testing
- `pnpm exec eslint packages/utils/src/ts-ast.ts packages/utils/src/tests/ts-ast.test.ts`
- `pnpm --filter @promethean/utils test`
- `pnpm --filter @promethean/simtasks build`
- `pnpm --filter @promethean/symdocs build`
- `pnpm lint:diff` *(fails: numerous existing lint errors across repository)*
- `pnpm install`


------
https://chatgpt.com/codex/tasks/task_e_68c61a7f70308324b9e340cce18ccad3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Centralized common parsing helpers into a shared utilities package for consistency and easier maintenance. No behavior changes expected.
- Tests
  - Added unit tests covering the shared utilities to improve reliability and prevent regressions.
- Chores
  - Expanded the shared utilities’ public surface to support reuse across packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->