### PR TITLE
feat: unify recursive file listing utility

### DIFF
--- a/packages/codepack/package.json
+++ b/packages/codepack/package.json
@@ -17,6 +17,7 @@
     "unified": "11.0.4",
     "unist-util-visit": "5.0.0",
     "zod": "3.23.8",
-    "@promethean/fs": "workspace:*"
+    "@promethean/fs": "workspace:*",
+    "@promethean/utils": "workspace:*"
   }
 }

--- a/packages/codepack/src/01-extract.ts
+++ b/packages/codepack/src/01-extract.ts
@@ -2,8 +2,9 @@
 import { promises as fs } from "fs";
 import * as path from "path";
 import matter from "gray-matter";
-import { parseArgs, listFilesRec, relPath, sha1 } from "./utils.js";
+import { parseArgs, relPath, sha1 } from "./utils.js";
 import { extractCodeBlocksWithContext, detectFilenameHint } from "./utils.js";
+import { listFilesRec } from "@promethean/utils";
 import type { BlockManifest, CodeBlock } from "./types.js";
 
 const args = parseArgs({

--- a/packages/codepack/src/utils.ts
+++ b/packages/codepack/src/utils.ts
@@ -1,4 +1,3 @@
-import { promises as fs } from "fs";
 import * as path from "path";
 import matter from "gray-matter";
 import { unified } from "unified";
@@ -21,22 +20,6 @@ export function parseArgs(defaults: Record<string, string>) {
     out[k] = v;
   }
   return out;
-}
-
-export async function listFilesRec(root: string, exts: Set<string>) {
-  const out: string[] = [];
-  async function walk(d: string) {
-    const ents = await fs.readdir(d, { withFileTypes: true });
-    for (const e of ents) {
-      const p = path.join(d, e.name);
-      if (e.isDirectory()) await walk(p);
-      else out.push(p);
-    }
-  }
-  await walk(root);
-  return out.filter((p) =>
-    exts.size ? exts.has(path.extname(p).toLowerCase()) : true,
-  );
 }
 
 export function sha1(s: string): string {

--- a/packages/docops/package.json
+++ b/packages/docops/package.json
@@ -27,6 +27,7 @@
     "uuid": "^12.0.0",
     "yaml": "^2.8.1",
     "zod": "^4.1.5",
-    "@promethean/fs": "workspace:*"
+    "@promethean/fs": "workspace:*",
+    "@promethean/utils": "workspace:*"
   }
 }

--- a/packages/docops/src/00-purge.ts
+++ b/packages/docops/src/00-purge.ts
@@ -3,7 +3,8 @@ import { promises as fs } from "node:fs";
 import * as path from "node:path";
 import { pathToFileURL } from "node:url";
 
-import { parseArgs, listFilesRec, stripGeneratedSections } from "./utils.js";
+import { parseArgs, stripGeneratedSections } from "./utils.js";
+import { listFilesRec } from "@promethean/utils";
 
 // CLI entry
 

--- a/packages/docops/src/01-frontmatter.ts
+++ b/packages/docops/src/01-frontmatter.ts
@@ -9,7 +9,8 @@ import { z } from "zod";
 import ollama from "ollama";
 
 import { openDB } from "./db.js";
-import { parseArgs, listFilesRec, randomUUID } from "./utils.js";
+import { parseArgs, randomUUID } from "./utils.js";
+import { listFilesRec } from "@promethean/utils";
 import type { Front } from "./types.js";
 import type { DBs } from "./db.js";
 

--- a/packages/docops/src/02-embed.ts
+++ b/packages/docops/src/02-embed.ts
@@ -10,12 +10,8 @@ import { ChromaClient } from "chromadb";
 import { OllamaEmbeddingFunction } from "@chroma-core/ollama";
 
 import { DBs } from "./db.js";
-import {
-  parseArgs,
-  listFilesRec,
-  parseMarkdownChunks,
-  OLLAMA_URL,
-} from "./utils.js";
+import { parseArgs, parseMarkdownChunks, OLLAMA_URL } from "./utils.js";
+import { listFilesRec } from "@promethean/utils";
 import { Chunk } from "./types.js";
 // CLI entry
 

--- a/packages/docops/src/06-rename.ts
+++ b/packages/docops/src/06-rename.ts
@@ -4,7 +4,8 @@ import { pathToFileURL } from "node:url";
 
 import matter from "gray-matter";
 
-import { parseArgs, slugify, extnamePrefer, listFilesRec } from "./utils.js";
+import { parseArgs, slugify, extnamePrefer } from "./utils.js";
+import { listFilesRec } from "@promethean/utils";
 import type { Front } from "./types.js";
 // CLI
 

--- a/packages/docops/src/tests/utils.misc.test.ts
+++ b/packages/docops/src/tests/utils.misc.test.ts
@@ -5,7 +5,6 @@ import test from "ava";
 
 import {
   parseArgs,
-  listFilesRec,
   randomUUID,
   slugify,
   extnamePrefer,
@@ -15,6 +14,7 @@ import {
   stripGeneratedSections,
   frontToYAML,
 } from "../utils.js";
+import { listFilesRec } from "@promethean/utils";
 
 async function withTmp(fn: (dir: string) => Promise<void> | void) {
   const dir = path.join(

--- a/packages/docops/src/utils.ts
+++ b/packages/docops/src/utils.ts
@@ -4,7 +4,6 @@ import { once } from "node:events";
 import { createWriteStream } from "node:fs";
 import { randomUUID as nodeRandomUUID } from "node:crypto";
 
-import { listFiles } from "@promethean/fs";
 import { unified } from "unified";
 import remarkParse from "remark-parse";
 import { visit } from "unist-util-visit";
@@ -30,20 +29,6 @@ export function parseArgs(
     }
   }
   return out;
-}
-
-export async function listFilesRec(
-  root: string,
-  exts: Set<string>,
-): Promise<string[]> {
-  const files = await listFiles(root, { includeHidden: false });
-  return (
-    files
-      .map((f) => f.path)
-      // exclude Emacs lockfiles like .#file.md which can cause crashes
-      .filter((p) => !path.basename(p).startsWith(".#"))
-      .filter((p) => exts.has(path.extname(p).toLowerCase()))
-  );
 }
 
 export function randomUUID(): string {

--- a/packages/simtask/package.json
+++ b/packages/simtask/package.json
@@ -22,7 +22,8 @@
   "dependencies": {
     "gray-matter": "^4.0.3",
     "yaml": "^2.5.0",
-    "zod": "^3.23.8"
+    "zod": "^3.23.8",
+    "@promethean/utils": "workspace:*"
   },
   "devDependencies": {
     "tsx": "^4.19.2"

--- a/packages/simtask/src/01-scan.ts
+++ b/packages/simtask/src/01-scan.ts
@@ -5,7 +5,6 @@ import * as ts from "typescript";
 
 import {
   parseArgs,
-  listFilesRec,
   makeProgram,
   posToLine,
   getJsDocText,
@@ -13,6 +12,7 @@ import {
   relFromRepo,
   sha1,
 } from "./utils.js";
+import { listFilesRec } from "@promethean/utils";
 import type { FunctionInfo, ScanResult, FnKind } from "./types.js";
 
 const args = parseArgs({

--- a/packages/simtask/src/utils.ts
+++ b/packages/simtask/src/utils.ts
@@ -1,4 +1,3 @@
-import { promises as fs } from "fs";
 import * as path from "path";
 import * as crypto from "crypto";
 
@@ -22,32 +21,6 @@ export function parseArgs(defaults: Record<string, string>) {
     }
     out[k] = v;
   }
-  return out;
-}
-
-export async function listFilesRec(root: string, exts: Set<string>) {
-  const out: string[] = [];
-  async function walk(d: string) {
-    const ents = await fs.readdir(d, { withFileTypes: true });
-    for (const e of ents) {
-      const p = path.join(d, e.name);
-      if (e.isDirectory()) {
-        if (
-          [
-            "node_modules",
-            "dist",
-            "build",
-            "coverage",
-            ".turbo",
-            ".next",
-          ].includes(e.name)
-        )
-          continue;
-        await walk(p);
-      } else if (exts.has(path.extname(p).toLowerCase())) out.push(p);
-    }
-  }
-  await walk(root);
   return out;
 }
 

--- a/packages/symdocs/package.json
+++ b/packages/symdocs/package.json
@@ -19,7 +19,8 @@
   "dependencies": {
     "gray-matter": "^4.0.3",
     "yaml": "^2.5.0",
-    "zod": "^3.23.8"
+    "zod": "^3.23.8",
+    "@promethean/utils": "workspace:*"
   },
   "devDependencies": {
     "tsx": "^4.19.2"

--- a/packages/symdocs/src/01-scan.ts
+++ b/packages/symdocs/src/01-scan.ts
@@ -5,7 +5,6 @@ import * as ts from "typescript";
 
 import {
   parseArgs,
-  listFilesRec,
   makeProgram,
   getJsDocText,
   getNodeText,
@@ -16,6 +15,7 @@ import {
   signatureForFunction,
   typeToString,
 } from "./utils.js";
+import { listFilesRec } from "@promethean/utils";
 import type { SymKind, SymbolInfo, ScanResult } from "./types.js";
 
 const args = parseArgs({

--- a/packages/symdocs/src/04-graph.ts
+++ b/packages/symdocs/src/04-graph.ts
@@ -1,5 +1,6 @@
 import { promises as fs } from "fs";
 import * as path from "path";
+import { listFilesRec } from "@promethean/utils";
 
 type Pkg = {
   name: string; // npm name, e.g. @promethean/foo
@@ -349,37 +350,6 @@ function collectDeclaredDeps(pkg: any): Set<string> {
     for (const k of Object.keys(o)) names.add(k);
   }
   return names;
-}
-
-async function listFilesRec(
-  root: string,
-  exts: Set<string>,
-): Promise<string[]> {
-  const out: string[] = [];
-  async function walk(d: string) {
-    const ents = await fs.readdir(d, { withFileTypes: true });
-    for (const e of ents) {
-      const p = path.join(d, e.name);
-      if (e.isDirectory()) {
-        if (
-          [
-            "node_modules",
-            "dist",
-            "build",
-            "coverage",
-            ".turbo",
-            ".next",
-          ].includes(e.name)
-        )
-          continue;
-        await walk(p);
-      } else {
-        if (exts.has(path.extname(p).toLowerCase())) out.push(p);
-      }
-    }
-  }
-  await walk(root);
-  return out;
 }
 
 const IMPORT_RE = [

--- a/packages/symdocs/src/utils.ts
+++ b/packages/symdocs/src/utils.ts
@@ -1,4 +1,3 @@
-import { promises as fs } from "fs";
 import * as path from "path";
 import * as crypto from "crypto";
 
@@ -23,23 +22,6 @@ export function parseArgs(
     return parse(nextIndex, { ...acc, [key]: value });
   };
   return parse(0, { ...defaults });
-}
-
-export async function listFilesRec(
-  root: string,
-  exts: Set<string>,
-): Promise<string[]> {
-  const out: string[] = [];
-  async function walk(d: string) {
-    const ents = await fs.readdir(d, { withFileTypes: true });
-    for (const e of ents) {
-      const p = path.join(d, e.name);
-      if (e.isDirectory()) await walk(p);
-      else out.push(p);
-    }
-  }
-  await walk(root);
-  return out.filter((p) => exts.has(path.extname(p).toLowerCase()));
 }
 
 export function sha1(s: string): string {

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -6,3 +6,4 @@ export { retry } from "./retry.js";
 export type { RetryOptions } from "./retry.js";
 export { slug } from "./slug.js";
 export { parseArgs } from "./parse-args.js";
+export { listFilesRec } from "./list-files-rec.js";

--- a/packages/utils/src/list-files-rec.ts
+++ b/packages/utils/src/list-files-rec.ts
@@ -1,0 +1,39 @@
+import { promises as fs } from "fs";
+import * as path from "path";
+
+const IGNORE_DIRS = new Set([
+  "node_modules",
+  "dist",
+  "build",
+  "coverage",
+  ".turbo",
+  ".next",
+]);
+
+/**
+ * Recursively list files under `root` matching extensions in `exts`.
+ * Hidden files/directories and common build outputs are skipped.
+ */
+export async function listFilesRec(
+  root: string,
+  exts: Set<string>,
+): Promise<string[]> {
+  const out: string[] = [];
+  async function walk(dir: string) {
+    const entries = await fs.readdir(dir, { withFileTypes: true });
+    for (const e of entries) {
+      if (e.name.startsWith(".")) continue; // skip hidden
+      const full = path.join(dir, e.name);
+      if (e.isDirectory()) {
+        if (IGNORE_DIRS.has(e.name)) continue;
+        await walk(full);
+      } else {
+        if (e.name.startsWith(".#")) continue; // emacs lockfiles
+        const ext = path.extname(e.name).toLowerCase();
+        if (exts.size === 0 || exts.has(ext)) out.push(full);
+      }
+    }
+  }
+  await walk(root);
+  return out;
+}

--- a/packages/utils/src/tests/list-files-rec.test.ts
+++ b/packages/utils/src/tests/list-files-rec.test.ts
@@ -1,0 +1,43 @@
+import * as path from "path";
+import * as fs from "fs/promises";
+
+import test from "ava";
+
+import { listFilesRec } from "../list-files-rec.js";
+
+async function withTmp(fn: (dir: string) => Promise<void> | void) {
+  const dir = path.join(
+    process.cwd(),
+    "test-tmp",
+    String(Date.now()) + "-" + Math.random().toString(36).slice(2),
+  );
+  await fs.mkdir(dir, { recursive: true });
+  try {
+    await fn(dir);
+  } finally {
+    await fs.rm(dir, { recursive: true, force: true });
+  }
+}
+
+test("listFilesRec filters by extension and skips ignored paths", async (t) => {
+  await withTmp(async (dir) => {
+    const root = path.join(dir, "root");
+    await fs.mkdir(path.join(root, "node_modules"), { recursive: true });
+    await fs.mkdir(path.join(root, "dist"), { recursive: true });
+    await fs.mkdir(path.join(root, "sub"), { recursive: true });
+    await fs.writeFile(path.join(root, "a.md"), "# A", "utf8");
+    await fs.writeFile(path.join(root, "b.txt"), "B", "utf8");
+    await fs.writeFile(path.join(root, ".#lock.md"), "LOCK", "utf8");
+    await fs.writeFile(path.join(root, "node_modules", "c.md"), "C", "utf8");
+    await fs.writeFile(path.join(root, "dist", "d.txt"), "D", "utf8");
+    await fs.writeFile(path.join(root, "sub", "e.md"), "E", "utf8");
+
+    const files = await listFilesRec(root, new Set([".md", ".txt"]));
+    t.true(files.some((p) => p.endsWith("a.md")));
+    t.true(files.some((p) => p.endsWith("b.txt")));
+    t.true(files.some((p) => p.endsWith(path.join("sub", "e.md"))));
+    t.false(files.some((p) => p.includes("node_modules")));
+    t.false(files.some((p) => p.includes("dist")));
+    t.false(files.some((p) => path.basename(p).startsWith(".#")));
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14169,7 +14169,7 @@ snapshots:
 
   axios@1.11.0:
     dependencies:
-      follow-redirects: 1.15.11(debug@4.4.1)
+      follow-redirects: 1.15.11(debug@4.3.7)
       form-data: 4.0.4
       proxy-from-env: 1.1.0
     transitivePeerDependencies:
@@ -16541,7 +16541,7 @@ snapshots:
   http-proxy@1.18.1:
     dependencies:
       eventemitter3: 4.0.7
-      follow-redirects: 1.15.11(debug@4.4.1)
+      follow-redirects: 1.15.11(debug@4.3.7)
       requires-port: 1.0.0
     transitivePeerDependencies:
       - debug


### PR DESCRIPTION
## Summary
- add shared `listFilesRec` helper to utils and export it
- remove ad-hoc file walkers in docops, symdocs, codepack, and simtasks packages
- cover file helper with tests and update package dependencies

## Testing
- `pnpm lint:diff`
- `pnpm --filter @promethean/utils test`
- `pnpm --filter @promethean/docops build`
- `pnpm --filter @promethean/symdocs build`
- `pnpm --filter @promethean/codepack test`
- `pnpm --filter @promethean/simtasks build`
- `pnpm install`


------
https://chatgpt.com/codex/tasks/task_e_68c61aa841948324854b0ae625e12bd1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Consolidated file discovery logic into a shared utilities package and updated references across multiple tools. Removed duplicate implementations with no change to runtime behavior.
- Chores
  - Updated workspace dependencies to include the shared utilities package where needed.
- Tests
  - Added unit tests to validate directory scanning and filtering behavior of the shared utilities.
- Documentation
  - N/A (no user-facing docs changed)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->