### PR TITLE
refactor: modularize piper file tree

### DIFF
--- a/packages/piper/package.json
+++ b/packages/piper/package.json
@@ -38,6 +38,7 @@
     "@promethean/ui-components": "workspace:*"
   },
   "devDependencies": {
-    "@promethean/test-utils": "workspace:*"
+    "@promethean/test-utils": "workspace:*",
+    "happy-dom": "18.0.1"
   }
 }

--- a/packages/piper/src/frontend/file-tree.ts
+++ b/packages/piper/src/frontend/file-tree.ts
@@ -1,0 +1,183 @@
+import { setSelection } from "./selection.js";
+
+export type FileNode = {
+  type: string;
+  name: string;
+  children?: FileNode[];
+};
+
+async function fetchDir(
+  dir: string,
+): Promise<{ dir: string; tree: FileNode[] }> {
+  const res = await fetch(
+    `/api/files?dir=${encodeURIComponent(
+      dir,
+    )}&maxDepth=1&maxEntries=600&exts=.md,.mdx,.txt,.markdown`,
+  );
+  const json = (await res.json()) as { dir?: string; tree?: FileNode[] };
+  return { dir: json.dir ?? dir, tree: json.tree ?? [] };
+}
+
+function createDir(
+  tree: FileTree,
+  parent: HTMLElement,
+  node: FileNode,
+  parentDir: string,
+): void {
+  const dirPath = `${parentDir}/${node.name}`.replace(/\\/g, "/");
+  const li = document.createElement("li");
+  li.dataset.fullPath = dirPath;
+  const line = document.createElement("div");
+  line.className = "dir-line";
+  const caret = document.createElement("span");
+  caret.textContent = "▶";
+  caret.className = "caret";
+  const icon = document.createElement("span");
+  icon.textContent = "📁";
+  const name = document.createElement("span");
+  name.textContent = node.name;
+  name.className = "dir-name";
+  line.append(caret, icon, name);
+  li.appendChild(line);
+  const sub = document.createElement("ul");
+  sub.style.display = "none";
+  li.appendChild(sub);
+  parent.appendChild(li);
+  line.addEventListener(
+    "click",
+    () => void toggleDir(tree, caret, sub, dirPath),
+  );
+}
+
+async function toggleDir(
+  tree: FileTree,
+  caret: HTMLElement,
+  sub: HTMLElement,
+  dirPath: string,
+): Promise<void> {
+  const next = sub.style.display === "none";
+  caret.textContent = next ? "▼" : "▶";
+  sub.style.display = next ? "block" : "none";
+  if (next && sub.dataset.loaded !== "1") {
+    const cached = tree.cache.get(dirPath);
+    if (cached) {
+      sub.innerHTML = "";
+      renderFiles(tree, sub, cached, dirPath);
+      sub.dataset.loaded = "1";
+      return;
+    }
+    sub.innerHTML = '<li class="loading">Loading…</li>';
+    const { dir, tree: nodes } = await fetchDir(dirPath);
+    sub.innerHTML = "";
+    tree.cache.set(dir, nodes);
+    renderFiles(tree, sub, nodes, dir);
+    sub.dataset.loaded = "1";
+  }
+}
+
+function createFile(
+  tree: FileTree,
+  parent: HTMLElement,
+  node: FileNode,
+  parentDir: string,
+): void {
+  const full = `${parentDir}/${node.name}`.replace(/\\/g, "/");
+  const li = document.createElement("li");
+  const cb = document.createElement("input");
+  cb.type = "checkbox";
+  cb.value = full;
+  cb.addEventListener("change", () => tree.updateSelection());
+  li.appendChild(cb);
+  const span = document.createElement("span");
+  span.className = "file";
+  span.textContent = ` ${node.name}`;
+  span.addEventListener("click", () => {
+    tree.shadowRoot
+      ?.querySelectorAll<HTMLInputElement>("input[type=checkbox]")
+      .forEach((el) => {
+        el.checked = el.value === full;
+      });
+    tree.updateSelection();
+    window.dispatchEvent(
+      new CustomEvent("piper:open-file", { detail: { path: full } }),
+    );
+  });
+  li.appendChild(span);
+  parent.appendChild(li);
+}
+
+function renderFiles(
+  tree: FileTree,
+  parent: HTMLElement,
+  nodes: FileNode[],
+  parentDir: string,
+): void {
+  for (const n of nodes) {
+    if (n.type === "dir") createDir(tree, parent, n, parentDir);
+    else createFile(tree, parent, n, parentDir);
+  }
+}
+
+function initToolbar(shadow: ShadowRoot, onSel: () => void): void {
+  (shadow.getElementById("selAll") as HTMLButtonElement).onclick = () => {
+    shadow
+      .querySelectorAll<HTMLInputElement>("input[type=checkbox]")
+      .forEach((cb) => {
+        cb.checked = true;
+      });
+    onSel();
+  };
+  (shadow.getElementById("selNone") as HTMLButtonElement).onclick = () => {
+    shadow
+      .querySelectorAll<HTMLInputElement>("input[type=checkbox]")
+      .forEach((cb) => {
+        cb.checked = false;
+      });
+    onSel();
+  };
+}
+
+export class FileTree extends HTMLElement {
+  public cache: Map<string, FileNode[]> = new Map();
+
+  async connectedCallback(): Promise<void> {
+    this.attachShadow({ mode: "open" });
+    const link = document.createElement("link");
+    link.rel = "stylesheet";
+    link.href = "/ui/file-tree.css";
+    this.shadowRoot?.appendChild(link);
+    const res = await fetch("/ui/templates/file-tree.html");
+    const tpl = document.createElement("template");
+    tpl.innerHTML = await res.text();
+    this.shadowRoot?.appendChild(tpl.content.cloneNode(true));
+    await this.refresh();
+  }
+
+  async refresh(): Promise<void> {
+    const rootDiv = this.shadowRoot?.getElementById("root");
+    if (!rootDiv) return;
+    rootDiv.innerHTML = "<em>Loading…</em>";
+    const { dir, tree } = await fetchDir(".");
+    this.cache.set(dir, tree);
+    const ul = document.createElement("ul");
+    renderFiles(this, ul, tree, dir);
+    rootDiv.innerHTML = "";
+    rootDiv.appendChild(ul);
+    initToolbar(this.shadowRoot!, () => this.updateSelection());
+  }
+
+  updateSelection(): void {
+    const xs: string[] = [];
+    this.shadowRoot
+      ?.querySelectorAll<HTMLInputElement>("input[type=checkbox]")
+      .forEach((cb) => {
+        if (cb.checked) xs.push(cb.value);
+      });
+    setSelection(xs);
+    window.dispatchEvent(
+      new CustomEvent("piper:files-changed", { detail: xs }),
+    );
+  }
+}
+
+customElements.define("file-tree", FileTree);

--- a/packages/piper/src/frontend/main.ts
+++ b/packages/piper/src/frontend/main.ts
@@ -1,16 +1,8 @@
-/* eslint-disable max-lines */
-import { setSelection } from "./selection.js";
+import "./file-tree.js";
 import "./components/piper-step.js";
 
 export type PipelineStep = Record<string, unknown>;
 export type Pipeline = { name: string; steps: PipelineStep[] };
-
-declare global {
-  // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
-  interface Window {
-    __PIPER_HOT?: { reloadAll?: () => void };
-  }
-}
 
 // Dev HMR client: connects to backend events and hot-reloads modules without full refresh
 function startHMR() {
@@ -21,7 +13,11 @@ function startHMR() {
       if (msg.startsWith("frontend:update")) {
         try {
           await import(`/js/main.js?ts=${Date.now()}`);
-          window.__PIPER_HOT?.reloadAll?.();
+          (
+            window as Window & {
+              __PIPER_HOT?: { reloadAll?: () => void };
+            }
+          ).__PIPER_HOT?.reloadAll?.();
         } catch (e) {
           console.warn("hot reload failed", e);
         }
@@ -37,311 +33,165 @@ function startHMR() {
 }
 startHMR();
 
-type FileNode = {
-  type: string;
-  name: string;
-  children?: FileNode[];
-};
-
-// Minimal FileTree custom element (uses /api/files like DocOps)
-class FileTree extends HTMLElement {
-  private cache: Map<string, FileNode[]> = new Map();
-  async connectedCallback() {
-    this.attachShadow({ mode: "open" });
-    const link = document.createElement("link");
-    link.rel = "stylesheet";
-    link.href = "/ui/file-tree.css";
-    this.shadowRoot?.appendChild(link);
-
-    const res = await fetch("/ui/templates/file-tree.html");
-    const tpl = document.createElement("template");
-    tpl.innerHTML = await res.text();
-    this.shadowRoot?.appendChild(tpl.content.cloneNode(true));
-
-    await this.refresh();
-  }
-  /* eslint-disable-next-line max-lines-per-function */
-  async refresh() {
-    const rootDiv = this.shadowRoot?.getElementById("root");
-    if (!rootDiv) return;
-    rootDiv.innerHTML = "<em>Loading…</em>";
-    const res = await fetch(
-      `/api/files?dir=${encodeURIComponent(
-        ".",
-      )}&maxDepth=1&maxEntries=600&exts=.md,.mdx,.txt,.markdown`,
-    );
-    const data = (await res.json()) as { dir: string; tree?: FileNode[] };
-    const baseDir: string = data.dir;
-    const ul = document.createElement("ul");
-    this.cache.set(baseDir, data.tree || []);
-
-    /* eslint-disable-next-line max-lines-per-function */
-    const renderFiles = (
-      parent: HTMLElement,
-      nodes: FileNode[],
-      parentDir: string,
-    ) => {
-      for (const n of nodes) {
-        const li = document.createElement("li");
-        if (n.type === "dir") {
-          const dirPath = `${parentDir}/${n.name}`.replace(/\\/g, "/");
-          li.dataset.fullPath = dirPath;
-          const line = document.createElement("div");
-          line.className = "dir-line";
-          const caret = document.createElement("span");
-          caret.textContent = "▶";
-          caret.className = "caret";
-          const icon = document.createElement("span");
-          icon.textContent = "📁";
-          const name = document.createElement("span");
-          name.textContent = n.name;
-          name.className = "dir-name";
-          line.appendChild(caret);
-          line.appendChild(icon);
-          line.appendChild(name);
-          li.appendChild(line);
-          const sub = document.createElement("ul");
-          sub.style.display = "none";
-          li.appendChild(sub);
-          parent.appendChild(li);
-
-          const isOpen = (): boolean => sub.style.display !== "none";
-          const hasLoaded = (): boolean => sub.dataset.loaded === "1";
-          const markLoaded = (): void => {
-            sub.dataset.loaded = "1";
-          };
-          const toggle = async (): Promise<void> => {
-            const next = !isOpen();
-            caret.textContent = next ? "▼" : "▶";
-            sub.style.display = next ? "block" : "none";
-            if (next && !hasLoaded()) {
-              const cached = this.cache.get(dirPath);
-              if (cached) {
-                sub.innerHTML = "";
-                renderFiles(sub, cached, dirPath);
-                markLoaded();
-              } else {
-                // lazy load this directory
-                sub.innerHTML = '<li class="loading">Loading…</li>';
-                const resp = await fetch(
-                  `/api/files?dir=${encodeURIComponent(
-                    dirPath,
-                  )}&maxDepth=1&maxEntries=600&exts=.md,.mdx,.txt,.markdown`,
-                );
-                const dj = (await resp.json()) as {
-                  dir?: string;
-                  tree?: FileNode[];
-                };
-                sub.innerHTML = "";
-                const tree = dj.tree || [];
-                this.cache.set(dj.dir || dirPath, tree);
-                renderFiles(sub, tree, dj.dir || dirPath);
-                markLoaded();
-              }
-            }
-          };
-          line.addEventListener("click", () => void toggle());
-        } else {
-          const full = `${parentDir}/${n.name}`.replace(/\\/g, "/");
-          const cb = document.createElement("input");
-          cb.type = "checkbox";
-          cb.value = full;
-          cb.addEventListener("change", () => this.updateSelection());
-          li.appendChild(cb);
-          const span = document.createElement("span");
-          span.className = "file";
-          span.textContent = ` ${n.name}`;
-          span.addEventListener("click", () => {
-            this.shadowRoot
-              ?.querySelectorAll<HTMLInputElement>("input[type=checkbox]")
-              .forEach((el) => {
-                el.checked = el.value === full;
-              });
-            this.updateSelection();
-            window.dispatchEvent(
-              new CustomEvent("piper:open-file", { detail: { path: full } }),
-            );
-          });
-          li.appendChild(span);
-          parent.appendChild(li);
-        }
-      }
-    };
-    ul.innerHTML = "";
-    renderFiles(ul, data.tree || [], baseDir);
-    rootDiv.innerHTML = "";
-    rootDiv.appendChild(ul);
-    // toolbar
-    (this.shadowRoot?.getElementById("selAll") as HTMLButtonElement).onclick =
-      () => {
-        this.shadowRoot
-          ?.querySelectorAll<HTMLInputElement>("input[type=checkbox]")
-          .forEach((cb) => {
-            cb.checked = true;
-          });
-        this.updateSelection();
-      };
-    (this.shadowRoot?.getElementById("selNone") as HTMLButtonElement).onclick =
-      () => {
-        this.shadowRoot
-          ?.querySelectorAll<HTMLInputElement>("input[type=checkbox]")
-          .forEach((cb) => {
-            cb.checked = false;
-          });
-        this.updateSelection();
-      };
-  }
-  updateSelection() {
-    const xs: string[] = [];
-    this.shadowRoot
-      ?.querySelectorAll<HTMLInputElement>("input[type=checkbox]")
-      .forEach((cb) => {
-        if (cb.checked) xs.push(cb.value);
-      });
-    setSelection(xs);
-    window.dispatchEvent(
-      new CustomEvent("piper:files-changed", { detail: xs }),
-    );
+async function fetchPipelines(
+  logs: HTMLElement | null,
+): Promise<Pipeline[] | null> {
+  try {
+    const res = await fetch("/api/pipelines");
+    const j = (await res.json()) as { pipelines?: Pipeline[]; error?: string };
+    if (j.error && logs) logs.textContent = `Schema error: ${j.error}`;
+    return j.pipelines ?? [];
+  } catch (e) {
+    if (logs) logs.textContent = `Failed to load pipelines: ${e}`;
+    return null;
   }
 }
-customElements.define("file-tree", FileTree);
 
-// eslint-disable-next-line max-lines-per-function
-async function init(): Promise<void> {
-  const container = document.getElementById("pipelines");
-  const logs = document.getElementById("logs");
-  const tabs = document.getElementById("editorTabs");
-  const editor = document.getElementById(
-    "editor",
-  ) as HTMLTextAreaElement | null;
-  const status = document.getElementById("editorStatus");
-  if (!container || !tabs || !editor || !status) return;
-  const data = await (async (): Promise<{
-    pipelines?: Pipeline[];
-    error?: string;
-  } | null> => {
+function renderPipelineSection(container: HTMLElement, p: Pipeline): void {
+  const section = document.createElement("section");
+  const hdr = document.createElement("div");
+  hdr.style.display = "flex";
+  hdr.style.alignItems = "center";
+  hdr.style.gap = "8px";
+  const btn = document.createElement("button");
+  btn.textContent = "▼";
+  btn.title = "Collapse/Expand";
+  btn.style.border = "none";
+  btn.style.background = "transparent";
+  btn.style.cursor = "pointer";
+  const h = document.createElement("h2");
+  h.textContent = p.name;
+  h.style.margin = "0";
+  hdr.append(btn, h);
+  section.appendChild(hdr);
+  const list = document.createElement("div");
+  const key = `piper:collapse:${p.name}`;
+  const setCollapsed = (c: boolean) => {
+    btn.textContent = c ? "▶" : "▼";
+    list.style.display = c ? "none" : "block";
     try {
-      const res = await fetch("/api/pipelines");
-      return (await res.json()) as { pipelines?: Pipeline[]; error?: string };
-    } catch (e) {
-      if (logs) logs.textContent = `Failed to load pipelines: ${e}`;
-      return null;
-    }
-  })();
-  if (!data) return;
-  if (data?.error && logs) logs.textContent = `Schema error: ${data.error}`;
-  (data.pipelines ?? []).forEach((p) => {
-    const section = document.createElement("section");
-    const hdr = document.createElement("div");
-    hdr.style.display = "flex";
-    hdr.style.alignItems = "center";
-    hdr.style.gap = "8px";
-    const btn = document.createElement("button");
-    btn.textContent = "▼";
-    btn.title = "Collapse/Expand";
-    btn.style.border = "none";
-    btn.style.background = "transparent";
-    btn.style.cursor = "pointer";
-    const h = document.createElement("h2");
-    h.textContent = p.name;
-    h.style.margin = "0";
-    hdr.appendChild(btn);
-    hdr.appendChild(h);
-    section.appendChild(hdr);
-    const list = document.createElement("div");
-    const key = `piper:collapse:${p.name}`;
-    const setCollapsed = (c: boolean) => {
-      btn.textContent = c ? "▶" : "▼";
-      list.style.display = c ? "none" : "block";
-      try {
-        localStorage.setItem(key, c ? "1" : "0");
-      } catch {}
-    };
-    btn.onclick = () => setCollapsed(list.style.display !== "none");
-    const saved =
-      (typeof localStorage !== "undefined"
-        ? localStorage.getItem(key)
-        : null) === "1";
-    setCollapsed(saved);
-    for (const s of p.steps) {
-      type PiperStepEl = HTMLElement & { data?: unknown };
-      const el = document.createElement("piper-step") as PiperStepEl;
-      el.data = { pipeline: p.name, step: s } as unknown;
-      list.appendChild(el);
-    }
-    section.appendChild(list);
-    container.appendChild(section);
-  });
-
-  // Basic tabbed editor behavior
-  type Tab = { path: string; content: string; saved: string; active: boolean };
-  const openTabs: Tab[] = [];
-  const setActive = (p: string) => {
-    openTabs.forEach((t) => {
-      t.active = t.path === p;
-    });
-    const t = openTabs.find((t) => t.active);
-    if (t) {
-      editor.value = t.content;
-      status.textContent =
-        t.path + (t.content !== t.saved ? " (modified)" : "");
-    } else {
-      editor.value = "";
-      status.textContent = "";
-    }
-    renderTabs();
+      localStorage.setItem(key, c ? "1" : "0");
+    } catch {}
   };
-  const renderTabs = () => {
-    tabs.innerHTML = "";
-    for (const t of openTabs) {
-      const el = document.createElement("button");
-      el.textContent =
-        (t.active ? "● " : "○ ") + (t.path.split("/").slice(-1)[0] || t.path);
-      el.className = "tab-button";
-      el.onclick = () => setActive(t.path);
-      const x = document.createElement("span");
-      x.textContent = " ×";
-      x.className = "tab-close";
-      x.onclick = (ev) => {
-        ev.stopPropagation();
-        const idx = openTabs.findIndex((tt) => tt.path === t.path);
-        if (idx >= 0) openTabs.splice(idx, 1);
-        const next = openTabs[idx] || openTabs[idx - 1] || openTabs[0];
-        if (next) setActive(next.path);
-        else setActive("");
-      };
-      el.appendChild(x);
-      tabs.appendChild(el);
-    }
-  };
-  async function openFile(path: string) {
-    // check existing
-    const exists = openTabs.find((t) => t.path === path);
-    if (exists) return setActive(path);
-    const r = await fetch(`/api/read-file?path=${encodeURIComponent(path)}`);
-    if (!r.ok) return;
-    const j = (await r.json()) as { path?: string; content?: string };
-    openTabs.push({
-      path: j.path ?? path,
-      content: j.content ?? "",
-      saved: j.content ?? "",
-      active: false,
-    });
-    setActive(j.path ?? path);
+  btn.onclick = () => setCollapsed(list.style.display !== "none");
+  const saved =
+    (typeof localStorage !== "undefined" ? localStorage.getItem(key) : null) ===
+    "1";
+  setCollapsed(saved);
+  for (const s of p.steps) {
+    type PiperStepEl = HTMLElement & { data?: unknown };
+    const el = document.createElement("piper-step") as PiperStepEl;
+    el.data = { pipeline: p.name, step: s } as unknown;
+    list.appendChild(el);
   }
+  section.appendChild(list);
+  container.appendChild(section);
+}
+
+type Tab = { path: string; content: string; saved: string; active: boolean };
+
+type EditorCtx = {
+  tabs: Tab[];
+  editor: HTMLTextAreaElement;
+  status: HTMLElement;
+  render: () => void;
+};
+
+const setActive = (ctx: EditorCtx, p: string): void => {
+  ctx.tabs.forEach((t) => {
+    t.active = t.path === p;
+  });
+  const t = ctx.tabs.find((tt) => tt.active);
+  if (t) {
+    ctx.editor.value = t.content;
+    ctx.status.textContent =
+      t.path + (t.content !== t.saved ? " (modified)" : "");
+  } else {
+    ctx.editor.value = "";
+    ctx.status.textContent = "";
+  }
+  ctx.render();
+};
+
+const renderTabs = (
+  tabsEl: HTMLElement,
+  openTabs: Tab[],
+  set: (p: string) => void,
+): void => {
+  tabsEl.innerHTML = "";
+  for (const t of openTabs) {
+    const el = document.createElement("button");
+    el.textContent =
+      (t.active ? "● " : "○ ") + (t.path.split("/").slice(-1)[0] || t.path);
+    el.className = "tab-button";
+    el.onclick = () => set(t.path);
+    const x = document.createElement("span");
+    x.textContent = " ×";
+    x.className = "tab-close";
+    x.onclick = (ev) => {
+      ev.stopPropagation();
+      const idx = openTabs.findIndex((tt) => tt.path === t.path);
+      if (idx >= 0) openTabs.splice(idx, 1);
+      const next = openTabs[idx] || openTabs[idx - 1] || openTabs[0];
+      set(next ? next.path : "");
+    };
+    el.appendChild(x);
+    tabsEl.appendChild(el);
+  }
+};
+
+const openFile = async (
+  openTabs: Tab[],
+  path: string,
+  set: (p: string) => void,
+): Promise<void> => {
+  const exists = openTabs.find((t) => t.path === path);
+  if (exists) return set(path);
+  const r = await fetch(`/api/read-file?path=${encodeURIComponent(path)}`);
+  if (!r.ok) return;
+  const j = (await r.json()) as { path?: string; content?: string };
+  openTabs.push({
+    path: j.path ?? path,
+    content: j.content ?? "",
+    saved: j.content ?? "",
+    active: false,
+  });
+  set(j.path ?? path);
+};
+
+function setupEditor(
+  tabsEl: HTMLElement,
+  editor: HTMLTextAreaElement,
+  status: HTMLElement,
+): void {
+  const openTabs: Tab[] = [];
+  const ctx: EditorCtx = {
+    tabs: openTabs,
+    editor,
+    status,
+    render: () => renderTabs(tabsEl, openTabs, (q) => setActive(ctx, q)),
+  };
+  const setActiveBound = (p: string): void => setActive(ctx, p);
+  ctx.render = () => renderTabs(tabsEl, openTabs, setActiveBound);
+  const openFileBound = (p: string) => openFile(openTabs, p, setActiveBound);
   window.addEventListener("piper:open-file", (ev: Event) => {
     const p = (ev as CustomEvent<{ path?: string }>).detail?.path;
-    if (p) void openFile(p);
+    if (p) void openFileBound(p);
   });
+
   editor.addEventListener("input", () => {
     const t = openTabs.find((tt) => tt.active);
     if (!t) return;
     t.content = editor.value;
     status.textContent = t.path + (t.content !== t.saved ? " (modified)" : "");
   });
-  (
-    document.getElementById("saveBtn") as HTMLButtonElement | null
-  )?.addEventListener("click", async () => {
+
+  bindSave(openTabs, status);
+  bindRevert(openTabs, editor, status, () => ctx.render());
+}
+
+const bindSave = (openTabs: Tab[], status: HTMLElement): void => {
+  document.getElementById("saveBtn")?.addEventListener("click", async () => {
     const t = openTabs.find((tt) => tt.active);
     if (!t) return;
     const res = await fetch("/api/write-file", {
@@ -354,9 +204,15 @@ async function init(): Promise<void> {
       status.textContent = t.path;
     }
   });
-  (
-    document.getElementById("revertBtn") as HTMLButtonElement | null
-  )?.addEventListener("click", async () => {
+};
+
+const bindRevert = (
+  openTabs: Tab[],
+  editor: HTMLTextAreaElement,
+  status: HTMLElement,
+  render: () => void,
+): void => {
+  document.getElementById("revertBtn")?.addEventListener("click", async () => {
     const t = openTabs.find((tt) => tt.active);
     if (!t) return;
     const r = await fetch(`/api/read-file?path=${encodeURIComponent(t.path)}`);
@@ -366,8 +222,23 @@ async function init(): Promise<void> {
     t.saved = t.content;
     editor.value = t.content;
     status.textContent = t.path;
-    renderTabs();
+    render();
   });
+};
+
+async function init(): Promise<void> {
+  const container = document.getElementById("pipelines");
+  const logs = document.getElementById("logs");
+  const tabs = document.getElementById("editorTabs");
+  const editor = document.getElementById(
+    "editor",
+  ) as HTMLTextAreaElement | null;
+  const status = document.getElementById("editorStatus");
+  if (!container || !tabs || !editor || !status) return;
+  const pipelines = await fetchPipelines(logs);
+  if (!pipelines) return;
+  pipelines.forEach((p) => renderPipelineSection(container, p));
+  setupEditor(tabs, editor, status);
 }
 
 void init();

--- a/packages/piper/src/frontend/tests/file-tree.test.ts
+++ b/packages/piper/src/frontend/tests/file-tree.test.ts
@@ -1,0 +1,69 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import test from "ava";
+import { Window } from "happy-dom";
+import { sleep } from "@promethean/utils";
+
+const setupDom = (): Window => {
+  const win = new Window();
+  const g = globalThis as unknown as {
+    window: Window;
+    document: Window["document"];
+    HTMLElement: typeof win.HTMLElement;
+    customElements: typeof win.customElements;
+    Event: typeof win.Event;
+    CustomEvent: typeof win.CustomEvent;
+    Node: typeof win.Node;
+    fetch?: typeof win.fetch;
+  };
+  g.window = win;
+  g.document = win.document;
+  g.HTMLElement = win.HTMLElement;
+  g.customElements = win.customElements;
+  g.Event = win.Event;
+  g.CustomEvent = win.CustomEvent;
+  g.Node = win.Node;
+  return win;
+};
+
+test("file-tree emits selection events", async (t) => {
+  const win = setupDom();
+  const tplPath = path.resolve(
+    path.dirname(fileURLToPath(import.meta.url)),
+    "../../../ui/templates/file-tree.html",
+  );
+  const template = readFileSync(tplPath, "utf8");
+  const tree = { dir: ".", tree: [{ type: "file", name: "a.md" }] };
+  win.fetch = async (url: string) => {
+    if (url.includes("/ui/templates/file-tree.html")) {
+      return new win.Response(template);
+    }
+    if (url.startsWith("/api/files")) {
+      return new win.Response(JSON.stringify(tree), {
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+    throw new Error("unknown fetch " + url);
+  };
+  const g = globalThis as unknown as { fetch?: typeof win.fetch };
+  const origFetch = g.fetch;
+  g.fetch = win.fetch.bind(win);
+  await import("../file-tree.js");
+  const el = document.createElement("file-tree");
+  document.body.appendChild(el);
+  await sleep(0);
+  const root = (el.shadowRoot as ShadowRoot).getElementById(
+    "selAll",
+  ) as HTMLButtonElement;
+  const selections: string[][] = [];
+  win.addEventListener("piper:files-changed", (ev) => {
+    selections.push(
+      (ev as unknown as CustomEvent<readonly string[]>).detail.slice(),
+    );
+  });
+  root.click();
+  t.deepEqual(selections[0], ["./a.md"]);
+  g.fetch = origFetch as typeof win.fetch;
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2907,6 +2907,9 @@ importers:
       '@promethean/test-utils':
         specifier: workspace:*
         version: link:../test-utils
+      happy-dom:
+        specifier: 18.0.1
+        version: 18.0.1
 
   packages/platform:
     dependencies:
@@ -5719,6 +5722,9 @@ packages:
   '@types/webidl-conversions@7.0.3':
     resolution: {integrity: sha512-CiJJvcRtIgzadHCYXw7dqEnMNRjhGZlYK05Mj9OyktqV8uVT8fD2BFOB7S1uwBE3Kj2Z+4UyPmFw/Ixgw/LAlA==}
 
+  '@types/whatwg-mimetype@3.0.2':
+    resolution: {integrity: sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==}
+
   '@types/whatwg-url@11.0.5':
     resolution: {integrity: sha512-coYR071JRaHa+xoEvvYqvnIHaVqaYrLPbsufM9BF63HkwI5Lgmy2QR8Q5K/lYDYo5AK82wOvSOS0UsLTpTG7uQ==}
 
@@ -8160,6 +8166,10 @@ packages:
     resolution: {integrity: sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==}
     engines: {node: '>=0.4.7'}
     hasBin: true
+
+  happy-dom@18.0.1:
+    resolution: {integrity: sha512-qn+rKOW7KWpVTtgIUi6RVmTBZJSe2k0Db0vh1f7CWrWclkkc7/Q+FrOfkZIb2eiErLyqu5AXEzE7XthO9JVxRA==}
+    engines: {node: '>=20.0.0'}
 
   has-bigints@1.1.0:
     resolution: {integrity: sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==}
@@ -11312,6 +11322,10 @@ packages:
   whatwg-fetch@3.6.20:
     resolution: {integrity: sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==}
 
+  whatwg-mimetype@3.0.0:
+    resolution: {integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==}
+    engines: {node: '>=12'}
+
   whatwg-url@14.2.0:
     resolution: {integrity: sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==}
     engines: {node: '>=18'}
@@ -13420,6 +13434,8 @@ snapshots:
 
   '@types/webidl-conversions@7.0.3': {}
 
+  '@types/whatwg-mimetype@3.0.2': {}
+
   '@types/whatwg-url@11.0.5':
     dependencies:
       '@types/webidl-conversions': 7.0.3
@@ -14169,7 +14185,7 @@ snapshots:
 
   axios@1.11.0:
     dependencies:
-      follow-redirects: 1.15.11(debug@4.4.1)
+      follow-redirects: 1.15.11(debug@4.3.7)
       form-data: 4.0.4
       proxy-from-env: 1.1.0
     transitivePeerDependencies:
@@ -16482,6 +16498,12 @@ snapshots:
     optionalDependencies:
       uglify-js: 3.19.3
 
+  happy-dom@18.0.1:
+    dependencies:
+      '@types/node': 20.19.11
+      '@types/whatwg-mimetype': 3.0.2
+      whatwg-mimetype: 3.0.0
+
   has-bigints@1.1.0: {}
 
   has-flag@4.0.0: {}
@@ -16541,7 +16563,7 @@ snapshots:
   http-proxy@1.18.1:
     dependencies:
       eventemitter3: 4.0.7
-      follow-redirects: 1.15.11(debug@4.4.1)
+      follow-redirects: 1.15.11(debug@4.3.7)
       requires-port: 1.0.0
     transitivePeerDependencies:
       - debug
@@ -20525,6 +20547,8 @@ snapshots:
   well-known-symbols@2.0.0: {}
 
   whatwg-fetch@3.6.20: {}
+
+  whatwg-mimetype@3.0.0: {}
 
   whatwg-url@14.2.0:
     dependencies:


### PR DESCRIPTION
## Summary
- extract FileTree logic into dedicated `file-tree.ts` with smaller helpers
- streamline frontend initialization and import the new file tree module
- add unit test covering FileTree selection events

## Testing
- `pnpm --filter @promethean/piper test` *(fails: page.waitForFunction timeout in hmr.state test)*
- `pnpm install`

------
https://chatgpt.com/codex/tasks/task_e_68c61adce0b083249e1bfcd1f8ed385c