### PR TITLE
feat(boardrev): add priority enum and tests

### DIFF
--- a/packages/boardrev/package.json
+++ b/packages/boardrev/package.json
@@ -19,7 +19,8 @@
     "br:04-match": "tsx src/04-match-context.ts",
     "br:05-eval": "tsx src/05-evaluate.ts",
     "br:06-report": "tsx src/06-report.ts",
-    "br:all": "pnpm br:01-fm && pnpm br:02-prompts && pnpm br:03-index && pnpm br:04-match && pnpm br:05-eval && pnpm br:06-report"
+    "br:all": "pnpm br:01-fm && pnpm br:02-prompts && pnpm br:03-index && pnpm br:04-match && pnpm br:05-eval && pnpm br:06-report",
+    "test": "pnpm run build && ava --config ../../config/ava.config.mjs"
   },
   "dependencies": {
     "@promethean/utils": "workspace:*",

--- a/packages/boardrev/src/01-ensure-fm.ts
+++ b/packages/boardrev/src/01-ensure-fm.ts
@@ -1,10 +1,9 @@
-/* eslint-disable */
 import * as path from "path";
 import { randomUUID as nodeRandomUUID } from "node:crypto";
 
 import matter from "gray-matter";
+import { createLogger, slug } from "@promethean/utils";
 
-import { slug } from "@promethean/utils";
 import {
   parseArgs,
   listTaskFiles,
@@ -13,6 +12,9 @@ import {
   normStatus,
 } from "./utils.js";
 import type { TaskFM } from "./types.js";
+import { Priority } from "./types.js";
+
+const logger = createLogger({ service: "boardrev" });
 
 const args = parseArgs({
   "--dir": "docs/agile/tasks",
@@ -24,41 +26,48 @@ function randomUUID() {
   return globalThis.crypto?.randomUUID?.() ?? nodeRandomUUID();
 }
 
-async function main() {
-  const dir = path.resolve(args["--dir"]!);
+export async function ensureFM({
+  dir,
+  defaultPriority,
+  defaultStatus,
+}: Readonly<{
+  dir: string;
+  defaultPriority: Priority;
+  defaultStatus: string;
+}>): Promise<number> {
   const files = await listTaskFiles(dir);
-  let updated = 0;
+  const results = await Promise.all(
+    files.map(async (file) => {
+      const raw = await readMaybe(file);
+      if (!raw) return 0;
+      const gm = matter(raw);
+      const fm = gm.data as Partial<TaskFM>;
+      if (!needsFM(fm)) return 0;
+      const title =
+        fm.title ??
+        inferTitle(gm.content) ??
+        slug(path.basename(file, ".md")).replace(/-/g, " ");
+      const payload: Readonly<TaskFM> = {
+        uuid: fm.uuid ?? (await randomUUID()),
+        title,
+        status: normStatus(fm.status ?? defaultStatus),
+        priority: fm.priority ?? defaultPriority,
+        labels: Array.isArray(fm.labels) ? fm.labels : [],
+        created_at: fm.created_at ?? new Date().toISOString(),
+        ...(fm.assignee ? { assignee: fm.assignee } : {}),
+      };
+      const final = matter.stringify(gm.content.trimStart() + "\n", payload, {
+        language: "yaml",
+      });
+      await writeText(file, final);
+      return 1;
+    }),
+  );
+  return results.reduce((a: number, b) => a + b, 0);
+}
 
-  for (const f of files) {
-    const raw = await readMaybe(f);
-    if (!raw) continue;
-    const gm = matter(raw);
-    const fm = gm.data as Partial<TaskFM>;
-    const needs = !fm || !fm.title || !fm.uuid || !fm.status || !fm.priority;
-
-    if (!needs) continue;
-
-    const title =
-      fm.title ??
-      inferTitle(gm.content) ??
-      slug(path.basename(f, ".md")).replace(/-/g, " ");
-    const payload: TaskFM = {
-      uuid: fm.uuid ?? (await randomUUID()),
-      title,
-      status: normStatus(fm.status ?? args["--default-status"]!),
-      priority: (fm.priority as any) ?? args["--default-priority"]!,
-      labels: Array.isArray(fm.labels) ? fm.labels : [],
-      created_at: fm.created_at ?? new Date().toISOString(),
-      ...(fm.assignee ? { assignee: fm.assignee } : {}),
-    };
-
-    const final = matter.stringify(gm.content.trimStart() + "\n", payload, {
-      language: "yaml",
-    });
-    await writeText(f, final);
-    updated++;
-  }
-  console.log(`boardrev: ensured front matter on ${updated} file(s)`);
+function needsFM(fm?: Readonly<Partial<TaskFM>>) {
+  return !fm || !fm.title || !fm.uuid || !fm.status || !fm.priority;
 }
 
 function inferTitle(body: string) {
@@ -66,7 +75,17 @@ function inferTitle(body: string) {
   return m?.[1]?.trim();
 }
 
-main().catch((e) => {
-  console.error(e);
-  process.exit(1);
-});
+if (import.meta.main) {
+  const dir = path.resolve(args["--dir"]!);
+  const defaultPriority = args["--default-priority"]! as Priority;
+  const defaultStatus = args["--default-status"]!;
+
+  ensureFM({ dir, defaultPriority, defaultStatus })
+    .then((updated) => {
+      logger.info(`boardrev: ensured front matter on ${updated} file(s)`);
+    })
+    .catch((err) => {
+      logger.error((err as Error).message);
+      throw err;
+    });
+}

--- a/packages/boardrev/src/test/ensure-fm.test.ts
+++ b/packages/boardrev/src/test/ensure-fm.test.ts
@@ -1,0 +1,47 @@
+import { promises as fs } from "fs";
+import * as os from "os";
+import * as path from "path";
+
+import test from "ava";
+import matter from "gray-matter";
+
+import { ensureFM } from "../01-ensure-fm.js";
+import { Priority, type TaskFM } from "../types.js";
+
+async function tmpdir(): Promise<string> {
+  return fs.mkdtemp(path.join(os.tmpdir(), "boardrev-test-"));
+}
+
+test("fills missing priority and status with defaults", async (t) => {
+  const dir = await tmpdir();
+  const file = path.join(dir, "task.md");
+  await fs.writeFile(file, "---\ntitle: t\n---\nbody\n");
+
+  const updated = await ensureFM({
+    dir,
+    defaultPriority: Priority.P2,
+    defaultStatus: "backlog",
+  });
+  t.is(updated, 1);
+
+  const gm = matter(await fs.readFile(file, "utf8"));
+  const fm = gm.data as TaskFM;
+  t.is(fm.priority, Priority.P2);
+  t.is(fm.status, "backlog");
+});
+
+test("normalizes default status", async (t) => {
+  const dir = await tmpdir();
+  const file = path.join(dir, "task.md");
+  await fs.writeFile(file, "---\ntitle: t\n---\nbody\n");
+
+  await ensureFM({
+    dir,
+    defaultPriority: Priority.P3,
+    defaultStatus: "ToDo",
+  });
+
+  const gm = matter(await fs.readFile(file, "utf8"));
+  const fm = gm.data as TaskFM;
+  t.is(fm.status, "todo");
+});

--- a/packages/boardrev/src/types.ts
+++ b/packages/boardrev/src/types.ts
@@ -1,29 +1,37 @@
+export enum Priority {
+  P0 = "P0",
+  P1 = "P1",
+  P2 = "P2",
+  P3 = "P3",
+  P4 = "P4",
+}
+
 export type TaskFM = {
   uuid: string;
   title: string;
-  status: string;     // e.g., backlog|todo|doing|review|blocked|done
-  priority: "P0"|"P1"|"P2"|"P3"|"P4";
+  status: string; // e.g., backlog|todo|doing|review|blocked|done
+  priority: Priority;
   labels?: string[];
   created_at?: string;
   assignee?: string;
 };
 
 export type TaskDoc = {
-  file: string;          // repo-relative path
+  file: string; // repo-relative path
   fm: TaskFM;
-  content: string;       // body without FM
+  content: string; // body without FM
 };
 
 export type PromptChunk = {
-  heading: string;       // e.g., "todo"
-  prompt: string;        // markdown body under that heading
+  heading: string; // e.g., "todo"
+  prompt: string; // markdown body under that heading
 };
 
 export type RepoDoc = {
-  path: string;          // repo-relative
-  kind: "code"|"doc";
+  path: string; // repo-relative
+  kind: "code" | "doc";
   size: number;
-  excerpt: string;       // first N lines
+  excerpt: string; // first N lines
 };
 
 export type Embeddings = Record<string, number[]>; // key -> vector
@@ -31,20 +39,20 @@ export type Embeddings = Record<string, number[]>; // key -> vector
 export type ContextHit = {
   path: string;
   score: number;
-  kind: "code"|"doc";
+  kind: "code" | "doc";
   excerpt: string;
 };
 
 export type TaskContext = {
   taskFile: string;
   hits: ContextHit[];
-  links: string[];     // explicit links found in task
+  links: string[]; // explicit links found in task
 };
 
 export type EvalItem = {
   taskFile: string;
   inferred_status: string;
-  confidence: number;  // 0..1
+  confidence: number; // 0..1
   summary: string;
   suggested_actions: string[];
   blockers?: string[];


### PR DESCRIPTION
## Summary
- add Priority enum and use logger instead of console
- expose front-matter helper and remove process.exit
- test default priority and status handling

## Testing
- `pnpm --filter @promethean/boardrev test`
- `pnpm install`


------
https://chatgpt.com/codex/tasks/task_e_68c61ae527a08324b1769d305c630ef0