### PR TITLE
feat(voice): add recorder error handling

### DIFF
--- a/packages/voice/package.json
+++ b/packages/voice/package.json
@@ -5,8 +5,8 @@
   "main": "dist/index.js",
   "scripts": {
     "build": "tsc",
-    "test": "cross-env TS_NODE_TRANSPILE_ONLY=1 ava --config ../../../config/ava.config.mjs tests/dummy.test.ts",
-    "coverage": "cross-env TS_NODE_TRANSPILE_ONLY=1 c8 ava tests/dummy.test.ts",
+    "test": "cross-env TS_NODE_TRANSPILE_ONLY=1 ava --config ../../../config/ava.config.mjs \"src/tests/**/*.ts\"",
+    "coverage": "cross-env TS_NODE_TRANSPILE_ONLY=1 c8 ava \"src/tests/**/*.ts\"",
     "lint": "pnpm exec eslint . || true",
     "format": "pnpm exec prettier --write ."
   },
@@ -29,7 +29,7 @@
       "ts": "module"
     },
     "files": [
-      "tests/**/*.ts"
+      "src/tests/**/*.ts"
     ],
     "nodeArguments": [
       "--loader",

--- a/packages/voice/src/speaker.ts
+++ b/packages/voice/src/speaker.ts
@@ -4,7 +4,7 @@
 // import { once } from 'node:events';
 import { PassThrough } from "node:stream";
 import { Transform, TransformCallback } from "node:stream";
-import EventEmitter from "node:events";
+import { EventEmitter } from "node:events";
 
 import { AudioReceiveStream } from "@discordjs/voice";
 import { User } from "discord.js";
@@ -12,6 +12,9 @@ import * as prism from "prism-media";
 
 import type { Transcriber } from "./transcriber.js";
 import type { VoiceRecorder } from "./voice-recorder.js";
+
+export type SpeakerEvents = Record<string, never>;
+
 class OpusSilenceFilter extends Transform {
   override _transform(
     chunk: Buffer,
@@ -38,7 +41,7 @@ export type SpeakerOptions = {
   recorder: VoiceRecorder;
 };
 
-export class Speaker extends EventEmitter {
+export class Speaker extends EventEmitter<SpeakerEvents> {
   logTranscript?: boolean;
   isRecording: boolean = false;
   isTranscribing: boolean = false;

--- a/packages/voice/src/tests/voice-recorder.test.ts
+++ b/packages/voice/src/tests/voice-recorder.test.ts
@@ -1,0 +1,46 @@
+import test from "ava";
+import { PassThrough } from "node:stream";
+import { mkdtempSync, existsSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, relative } from "node:path";
+import { VoiceRecorder } from "../voice-recorder.js";
+import type { User } from "discord.js";
+
+test("saves pcm stream to wav file", async (t) => {
+  const dir = mkdtempSync(join(tmpdir(), "voice-recorder-"));
+  const recorder = new VoiceRecorder({
+    saveDest: relative(process.cwd(), dir),
+  });
+  const user = { id: "123", username: "u" } as unknown as User;
+  const pcm = new PassThrough();
+  const saveTime = Date.now();
+
+  recorder.recordPCMStream(saveTime, user, pcm);
+
+  const done = new Promise<void>((resolve, reject) => {
+    recorder.once("saved", (meta) => {
+      t.true(existsSync(meta.filename));
+      rmSync(meta.filename);
+      rmSync(dir, { recursive: true, force: true });
+      resolve();
+    });
+    recorder.once("error", reject);
+  });
+
+  pcm.end(Buffer.alloc(2));
+  await done;
+});
+
+test("emits error when write fails", async (t) => {
+  const dir = join("nonexistent", "dir");
+  const recorder = new VoiceRecorder({ saveDest: dir });
+  const user = { id: "123", username: "u" } as unknown as User;
+  const pcm = new PassThrough();
+  const saveTime = Date.now();
+  recorder.recordPCMStream(saveTime, user, pcm);
+  const err = await new Promise<unknown>((resolve) => {
+    recorder.once("error", resolve);
+    pcm.end(Buffer.alloc(2));
+  });
+  t.truthy(err);
+});

--- a/packages/voice/src/transcriber.ts
+++ b/packages/voice/src/transcriber.ts
@@ -1,10 +1,11 @@
-import EventEmitter from "node:events";
+import { EventEmitter } from "node:events";
 import http, { RequestOptions } from "node:http";
 import { PassThrough } from "node:stream";
 
 import { User } from "discord.js";
 
 import type { Speaker } from "./speaker.js";
+import { createLogger } from "@promethean/utils";
 
 export type TranscriberOptions = {
   hostname: string;
@@ -26,8 +27,18 @@ export type FinalTranscript = {
   transcript: string;
   originalTranscript?: string;
 };
-export class Transcriber extends EventEmitter {
+export type TranscriberEvents = {
+  readonly transcriptStart: (data: {
+    startTime: number;
+    speaker: Speaker;
+  }) => void;
+  readonly transcriptChunk: (chunk: TranscriptChunk) => void;
+  readonly transcriptEnd: (final: FinalTranscript) => void;
+};
+
+export class Transcriber extends EventEmitter<TranscriberEvents> {
   httpOptions: RequestOptions;
+  #log = createLogger({ service: "voice:transcriber" });
 
   constructor(
     options: TranscriberOptions = {
@@ -63,10 +74,10 @@ export class Transcriber extends EventEmitter {
           const transcriptChunks: TranscriptChunk[] = [];
           res.on("data", (chunk: Buffer) => {
             const chunkStr = chunk.toString();
-            console.log(chunkStr);
+            this.#log.debug("chunk", { chunk: chunkStr });
             const parsed = JSON.parse(chunkStr) as { transcription: string };
             const transcript = parsed.transcription;
-            console.log(`Transcription chunk: ${transcript}`);
+            this.#log.info("transcription chunk", { transcript });
             const transcriptObject: TranscriptChunk = {
               startTime,
               speaker,
@@ -77,7 +88,7 @@ export class Transcriber extends EventEmitter {
             this.emit("transcriptChunk", transcriptObject);
           });
           res.on("end", async () => {
-            console.log("Transcription ended");
+            this.#log.info("transcription ended");
 
             const originalTranscript = transcriptChunks
               .map((t) => t.text)
@@ -95,7 +106,7 @@ export class Transcriber extends EventEmitter {
           });
         })
         .on("error", (err) => {
-          console.error("Transcription request error:", err);
+          this.#log.error("transcription request error", { err });
         }),
     );
   }

--- a/packages/voice/src/voice-session.ts
+++ b/packages/voice/src/voice-session.ts
@@ -1,7 +1,8 @@
 import { randomUUID, UUID } from "crypto";
-import EventEmitter from "events";
+import { EventEmitter } from "node:events";
 
 import {
+  AudioPlayer,
   AudioPlayerStatus,
   EndBehaviorType,
   StreamType,
@@ -20,6 +21,7 @@ import { Speaker } from "./speaker.js";
 import { Transcriber } from "./transcriber.js";
 import { VoiceRecorder } from "./voice-recorder.js";
 import { VoiceSynth } from "./voice-synth.js";
+import { createLogger } from "@promethean/utils";
 
 /**
    Handles all things voice. Emits an event when a user begins speaking, and when they stop speaking
@@ -30,7 +32,12 @@ export type VoiceSessionOptions = {
   voiceChannelId: string;
   guild: discord.Guild;
 };
-export class VoiceSession extends EventEmitter {
+export type VoiceSessionEvents = {
+  readonly audioPlayerStart: (player: AudioPlayer) => void;
+  readonly audioPlayerStop: (player: AudioPlayer) => void;
+};
+
+export class VoiceSession extends EventEmitter<VoiceSessionEvents> {
   id: UUID;
   guild: discord.Guild;
   voiceChannelId: string;
@@ -41,6 +48,7 @@ export class VoiceSession extends EventEmitter {
   transcriber: Transcriber;
   recorder: VoiceRecorder;
   voiceSynth: VoiceSynth;
+  #log = createLogger({ service: "voice:session" });
   constructor(options: VoiceSessionOptions) {
     super();
     this.id = randomUUID();
@@ -74,7 +82,7 @@ export class VoiceSession extends EventEmitter {
     try {
       this.registerSpeakingListener();
     } catch (err) {
-      console.error(err);
+      this.#log.error("failed to register speaking listener", { err });
       throw new Error("Something went wrong starting the voice session");
     }
   }
@@ -91,16 +99,16 @@ export class VoiceSession extends EventEmitter {
             try {
               speaker.stream?.destroy();
             } catch (e) {
-              console.warn("Failed to destroy stream cleanly", e);
+              this.#log.warn("failed to destroy stream cleanly", { err: e });
             }
           });
 
           speaker.stream.on("error", (err: unknown) => {
-            console.warn(`Stream error for ${userId}:`, err);
+            this.#log.warn("stream error", { userId, err });
           });
 
           speaker.stream.on("close", () => {
-            console.log(`Stream closed for ${userId}`);
+            this.#log.info("stream closed", { userId });
             speaker.stream = null;
           });
 

--- a/packages/voice/tsconfig.eslint.json
+++ b/packages/voice/tsconfig.eslint.json
@@ -1,0 +1,3 @@
+{
+  "extends": "./tsconfig.json"
+}

--- a/packages/voice/tsconfig.json
+++ b/packages/voice/tsconfig.json
@@ -4,5 +4,5 @@
     "outDir": "dist",
     "rootDir": "src"
   },
-  "include": ["src/*.ts"]
+  "include": ["src/**/*.ts"]
 }


### PR DESCRIPTION
## Summary
- type voice event emitters and replace console.log with structured logger
- propagate wav writer errors and log failures when saving
- add voice recorder tests for success and failure cases

## Testing
- `pnpm --filter @promethean/voice-service test`
- `pnpm install`


------
https://chatgpt.com/codex/tasks/task_e_68c61af494808324965a6a254fc0b5c8