### PR TITLE
refactor(sonarflow): use randomUUID and structured logger

### DIFF
--- a/packages/sonarflow/src/04-write.ts
+++ b/packages/sonarflow/src/04-write.ts
@@ -1,9 +1,10 @@
-/* eslint-disable */
+import { randomUUID } from "node:crypto";
 import { promises as fs } from "fs";
 import * as path from "path";
 
 import matter from "gray-matter";
-import { slug } from "@promethean/utils";
+import { createLogger, slug } from "@promethean/utils";
+
 import { parseArgs } from "./utils.js";
 import type { PlanPayload } from "./types.js";
 
@@ -18,11 +19,87 @@ const args = parseArgs({
 const START = "<!-- SONARFLOW:BEGIN -->";
 const END = "<!-- SONARFLOW:END -->";
 
+const log = createLogger({ service: "sonarflow" });
+
 function stripGenerated(text: string) {
   const si = text.indexOf(START),
     ei = text.indexOf(END);
   if (si >= 0 && ei > si) return (text.slice(0, si).trimEnd() + "\n").trimEnd();
   return text.trimEnd();
+}
+
+type Task = PlanPayload["tasks"][number];
+function buildFrontMatter(t: Task, project: string) {
+  return {
+    uuid: randomUUID(),
+    title: t.title,
+    project,
+    priority: t.priority,
+    status: args["--status"]!,
+    labels: Array.from(
+      new Set([
+        ...args["--label"]!.split(",")
+          .map((s) => s.trim())
+          .filter(Boolean),
+        ...(t.labels ?? []),
+      ]),
+    ),
+    created_at: new Date().toISOString(),
+  };
+}
+
+function buildRefsTable(t: Task) {
+  return [
+    "| Issue key | File |",
+    "|---|---|",
+    ...t.refs.map(
+      (r) => `| \`${r.key}\` | \`${r.file}${r.line ? ":" + r.line : ""}\` |`,
+    ),
+  ].join("\n");
+}
+
+function buildBody(t: Task, refsTable: string) {
+  return [
+    START,
+    `# ${t.title}`,
+    "",
+    t.summary,
+    "",
+    "## Steps",
+    "",
+    ...t.steps.map((s, i) => `${i + 1}. ${s}`),
+    "",
+    "## Acceptance criteria",
+    "",
+    ...t.acceptance.map((a) => `- [ ] ${a}`),
+    "",
+    "## References",
+    "",
+    refsTable,
+    "",
+    END,
+    "",
+  ].join("\n");
+}
+
+async function writeTask(t: Task, project: string) {
+  const fname = `${slug(t.title)}.md`;
+  const outPath = path.join(args["--out"]!, fname);
+
+  const fm = buildFrontMatter(t, project);
+  const body = buildBody(t, buildRefsTable(t));
+
+  const existing = await readMaybe(outPath);
+  const gm = existing ? matter(existing) : { content: "", data: {} };
+  const preserved = stripGenerated(gm.content);
+  const final = matter.stringify(
+    (preserved ? preserved + "\n\n" : "") + body,
+    { ...gm.data, ...fm },
+    { language: "yaml" },
+  );
+
+  await fs.writeFile(outPath, final, "utf-8");
+  return `- [${t.title}](${path.basename(outPath)}) — ${t.priority}`;
 }
 
 async function main() {
@@ -31,91 +108,21 @@ async function main() {
   ) as PlanPayload;
 
   await fs.mkdir(path.resolve(args["--out"]!), { recursive: true });
-  const index: string[] = [
+
+  const index = [
     "# SonarQube remediation tasks",
     "",
     `Project: \`${project}\``,
     "",
+    ...(await Promise.all(tasks.map((t) => writeTask(t, project)))),
   ];
-
-  for (const t of tasks) {
-    const fname = `${slug(t.title)}.md`;
-    const outPath = path.join(args["--out"]!, fname);
-
-    const fm = {
-      uuid: cryptoRandomUUID(),
-      title: t.title,
-      project,
-      priority: t.priority,
-      status: args["--status"]!,
-      labels: Array.from(
-        new Set([
-          ...args["--label"]!.split(",")
-            .map((s) => s.trim())
-            .filter(Boolean),
-          ...(t.labels ?? []),
-        ]),
-      ),
-      created_at: new Date().toISOString(),
-    };
-
-    const refsTable = [
-      "| Issue key | File |",
-      "|---|---|",
-      ...t.refs.map(
-        (r) => `| \`${r.key}\` | \`${r.file}${r.line ? ":" + r.line : ""}\` |`,
-      ),
-    ].join("\n");
-
-    const body = [
-      START,
-      `# ${t.title}`,
-      "",
-      t.summary,
-      "",
-      "## Steps",
-      "",
-      ...t.steps.map((s, i) => `${i + 1}. ${s}`),
-      "",
-      "## Acceptance criteria",
-      "",
-      ...t.acceptance.map((a) => `- [ ] ${a}`),
-      "",
-      "## References",
-      "",
-      refsTable,
-      "",
-      END,
-      "",
-    ].join("\n");
-
-    const existing = await readMaybe(outPath);
-    const gm = existing ? matter(existing) : { content: "", data: {} };
-    const preserved = stripGenerated(gm.content);
-    const final = matter.stringify(
-      (preserved ? preserved + "\n\n" : "") + body,
-      { ...gm.data, ...fm },
-      { language: "yaml" },
-    );
-
-    await fs.writeFile(outPath, final, "utf-8");
-    index.push(`- [${t.title}](${path.basename(outPath)}) — ${t.priority}`);
-  }
 
   await fs.writeFile(
     path.join(args["--out"]!, "README.md"),
     index.join("\n") + "\n",
     "utf-8",
   );
-  console.log(
-    `sonarflow: wrote ${tasks.length} task files → ${args["--out"]!}`,
-  );
-}
-
-function cryptoRandomUUID() {
-  // Node 18+
-  // @ts-ignore
-  return globalThis.crypto?.randomUUID?.() ?? require("crypto").randomUUID();
+  log.info(`wrote ${tasks.length} task files → ${args["--out"]!}`);
 }
 async function readMaybe(p: string) {
   try {
@@ -126,6 +133,6 @@ async function readMaybe(p: string) {
 }
 
 main().catch((e) => {
-  console.error(e);
+  log.error("write failed", { err: e });
   process.exit(1);
 });


### PR DESCRIPTION
## Summary
- replace custom crypto helper with native `randomUUID`
- switch console usage to structured logger
- remove file-wide eslint disable and clean up

## Testing
- `pnpm exec eslint packages/sonarflow/src/04-write.ts`
- `pnpm --filter @promethean/sonarflow build`
- `pnpm install`


------
https://chatgpt.com/codex/tasks/task_e_68c61af705a88324a6da43fff03b7c51