### PR TITLE
feat(piper): require schemas for I/O

### DIFF
--- a/packages/boardrev/pipelines.json
+++ b/packages/boardrev/pipelines.json
@@ -6,84 +6,69 @@
         {
           "id": "br-fm",
           "shell": "pnpm --filter @promethean/boardrev br:01-fm",
-          "inputs": [
-            "docs/agile/tasks/**/*.md"
-          ],
-          "outputs": [
-            "docs/agile/tasks/**/*.md"
-          ]
+          "inputs": ["docs/agile/tasks/**/*.md"],
+          "inputSchema": "packages/boardrev/schemas/io.schema.json",
+          "outputs": ["docs/agile/tasks/**/*.md"],
+          "outputSchema": "packages/boardrev/schemas/io.schema.json"
         },
         {
           "id": "br-prompts",
-          "deps": [
-            "br-fm"
-          ],
+          "deps": ["br-fm"],
           "shell": "pnpm --filter @promethean/boardrev br:02-prompts --process docs/agile/Process.md --out .cache/boardrev/prompts.json",
-          "inputs": [
-            "docs/agile/Process.md"
-          ],
-          "outputs": [
-            ".cache/boardrev/prompts.json"
-          ]
+          "inputs": ["docs/agile/Process.md"],
+          "inputSchema": "packages/boardrev/schemas/io.schema.json",
+          "outputs": [".cache/boardrev/prompts.json"],
+          "outputSchema": "packages/boardrev/schemas/io.schema.json"
         },
         {
           "id": "br-index",
-          "deps": [
-            "br-fm"
-          ],
+          "deps": ["br-fm"],
           "shell": "pnpm --filter @promethean/boardrev br:03-index --globs \"{README.md,docs/**/*.md,packages/**/{src,lib}/**/*.{ts,tsx,js,jsx}}\"",
           "inputs": [
             "README.md",
             "docs/**/*.md",
             "packages/**/{src,lib}/**/*.{ts,tsx,js,jsx}"
           ],
+          "inputSchema": "packages/boardrev/schemas/io.schema.json",
           "outputs": [
             ".cache/boardrev/repo-index.json",
             ".cache/boardrev/repo-embeddings.json"
-          ]
+          ],
+          "outputSchema": "packages/boardrev/schemas/io.schema.json"
         },
         {
           "id": "br-match",
-          "deps": [
-            "br-prompts",
-            "br-index"
-          ],
+          "deps": ["br-prompts", "br-index"],
           "shell": "pnpm --filter @promethean/boardrev br:04-match --tasks docs/agile/tasks --k 8",
           "inputs": [
             "docs/agile/tasks/**/*.md",
             ".cache/boardrev/repo-index.json",
             ".cache/boardrev/repo-embeddings.json"
           ],
-          "outputs": [
-            ".cache/boardrev/context.json"
-          ]
+          "inputSchema": "packages/boardrev/schemas/io.schema.json",
+          "outputs": [".cache/boardrev/context.json"],
+          "outputSchema": "packages/boardrev/schemas/io.schema.json"
         },
         {
           "id": "br-eval",
-          "deps": [
-            "br-match"
-          ],
+          "deps": ["br-match"],
           "shell": "pnpm --filter @promethean/boardrev br:05-eval --model qwen3:4b",
           "inputs": [
             ".cache/boardrev/prompts.json",
             ".cache/boardrev/context.json"
           ],
-          "outputs": [
-            ".cache/boardrev/evals.json"
-          ]
+          "inputSchema": "packages/boardrev/schemas/io.schema.json",
+          "outputs": [".cache/boardrev/evals.json"],
+          "outputSchema": "packages/boardrev/schemas/io.schema.json"
         },
         {
           "id": "br-report",
-          "deps": [
-            "br-eval"
-          ],
+          "deps": ["br-eval"],
           "shell": "pnpm --filter @promethean/boardrev br:06-report --outDir docs/agile/reports",
-          "inputs": [
-            ".cache/boardrev/evals.json"
-          ],
-          "outputs": [
-            "docs/agile/reports/*.md"
-          ]
+          "inputs": [".cache/boardrev/evals.json"],
+          "inputSchema": "packages/boardrev/schemas/io.schema.json",
+          "outputs": ["docs/agile/reports/*.md"],
+          "outputSchema": "packages/boardrev/schemas/io.schema.json"
         }
       ]
     }

--- a/packages/boardrev/schemas/io.schema.json
+++ b/packages/boardrev/schemas/io.schema.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object"
+}

--- a/packages/buildfix/pipelines.json
+++ b/packages/buildfix/pipelines.json
@@ -10,9 +10,9 @@
             "packages/buildfix/tsconfig.json",
             "packages/buildfix/src/**/*"
           ],
-          "outputs": [
-            "packages/buildfix/dist/**"
-          ]
+          "inputSchema": "packages/buildfix/schemas/io.schema.json",
+          "outputs": ["packages/buildfix/dist/**"],
+          "outputSchema": "packages/buildfix/schemas/io.schema.json"
         },
         {
           "id": "bf-errors",
@@ -21,9 +21,9 @@
             "tsconfig.json",
             "packages/**/{src,lib}/**/*.{ts,tsx,js,jsx}"
           ],
-          "outputs": [
-            ".cache/buildfix/errors.json"
-          ]
+          "inputSchema": "packages/buildfix/schemas/io.schema.json",
+          "outputs": [".cache/buildfix/errors.json"],
+          "outputSchema": "packages/buildfix/schemas/io.schema.json"
         },
         {
           "id": "bf-iterate",
@@ -37,23 +37,23 @@
             "tsconfig.json",
             "packages/**/{src,lib}/**/*.{ts,tsx,js,jsx}"
           ],
+          "inputSchema": "packages/buildfix/schemas/io.schema.json",
           "outputs": [
             ".cache/buildfix/summary.json",
             ".cache/buildfix/history/**",
             ".cache/buildfix/snippets/**"
-          ]
+          ],
+          "outputSchema": "packages/buildfix/schemas/io.schema.json"
         },
         {
           "id": "bf-report",
           "deps": ["bf-build", "bf-iterate"],
 
           "shell": "pnpm --filter @promethean/buildfix bf:03-report --summary .cache/buildfix/summary.json --history-root .cache/buildfix/history --out docs/agile/reports/buildfix",
-          "inputs": [
-            ".cache/buildfix/summary.json"
-          ],
-          "outputs": [
-            "docs/agile/reports/buildfix/*.md"
-          ]
+          "inputs": [".cache/buildfix/summary.json"],
+          "inputSchema": "packages/buildfix/schemas/io.schema.json",
+          "outputs": ["docs/agile/reports/buildfix/*.md"],
+          "outputSchema": "packages/buildfix/schemas/io.schema.json"
         }
       ]
     }

--- a/packages/buildfix/schemas/io.schema.json
+++ b/packages/buildfix/schemas/io.schema.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object"
+}

--- a/packages/codepack/pipelines.json
+++ b/packages/codepack/pipelines.json
@@ -6,48 +6,35 @@
         {
           "id": "code-extract",
           "shell": "pnpm --filter @promethean/codepack code:01-extract --roots docs packages --out .cache/codepack/blocks.json --max-context-lines 12\n",
-          "inputs": [
-            "docs/**/*.md",
-            "README.md"
-          ],
-          "outputs": [
-            ".cache/codepack/blocks.json"
-          ]
+          "inputs": ["docs/**/*.md", "README.md"],
+          "inputSchema": "packages/codepack/schemas/io.schema.json",
+          "outputs": [".cache/codepack/blocks.json"],
+          "outputSchema": "packages/codepack/schemas/io.schema.json"
         },
         {
           "id": "code-embed",
-          "deps": [
-            "code-extract"
-          ],
+          "deps": ["code-extract"],
           "shell": "pnpm --filter @promethean/codepack code:02-embed --in .cache/codepack/blocks.json --out .cache/codepack/embeddings.json --model nomic-embed-text:latest\n",
           "env": {
             "OLLAMA_URL": "${OLLAMA_URL}"
           },
-          "inputs": [
-            ".cache/codepack/blocks.json"
-          ],
-          "outputs": [
-            ".cache/codepack/embeddings.json"
-          ]
+          "inputs": [".cache/codepack/blocks.json"],
+          "inputSchema": "packages/codepack/schemas/io.schema.json",
+          "outputs": [".cache/codepack/embeddings.json"],
+          "outputSchema": "packages/codepack/schemas/io.schema.json"
         },
         {
           "id": "code-cluster",
-          "deps": [
-            "code-embed"
-          ],
+          "deps": ["code-embed"],
           "shell": "pnpm --filter @promethean/codepack code:03-cluster --embeddings .cache/codepack/embeddings.json --min-sim 0.83 --min-size 2 --out .cache/codepack/clusters.json\n",
-          "inputs": [
-            ".cache/codepack/embeddings.json"
-          ],
-          "outputs": [
-            ".cache/codepack/clusters.json"
-          ]
+          "inputs": [".cache/codepack/embeddings.json"],
+          "inputSchema": "packages/codepack/schemas/io.schema.json",
+          "outputs": [".cache/codepack/clusters.json"],
+          "outputSchema": "packages/codepack/schemas/io.schema.json"
         },
         {
           "id": "code-plan",
-          "deps": [
-            "code-cluster"
-          ],
+          "deps": ["code-cluster"],
           "shell": "pnpm --filter @promethean/codepack code:04-plan --blocks .cache/codepack/blocks.json --clusters .cache/codepack/clusters.json --model qwen3:4b --out .cache/codepack/plan.json\n",
           "env": {
             "OLLAMA_URL": "${OLLAMA_URL}"
@@ -56,23 +43,18 @@
             ".cache/codepack/blocks.json",
             ".cache/codepack/clusters.json"
           ],
-          "outputs": [
-            ".cache/codepack/plan.json"
-          ]
+          "inputSchema": "packages/codepack/schemas/io.schema.json",
+          "outputs": [".cache/codepack/plan.json"],
+          "outputSchema": "packages/codepack/schemas/io.schema.json"
         },
         {
           "id": "code-generate",
-          "deps": [
-            "code-plan"
-          ],
+          "deps": ["code-plan"],
           "shell": "pnpm --filter @promethean/codepack code:05-generate --plan .cache/codepack/plan.json --base pseudo --overwrite false --readme true\n",
-          "inputs": [
-            ".cache/codepack/plan.json"
-          ],
-          "outputs": [
-            "pseudo/**",
-            ".cache/codepack/generate.touch"
-          ]
+          "inputs": [".cache/codepack/plan.json"],
+          "inputSchema": "packages/codepack/schemas/io.schema.json",
+          "outputs": ["pseudo/**", ".cache/codepack/generate.touch"],
+          "outputSchema": "packages/codepack/schemas/io.schema.json"
         }
       ]
     }

--- a/packages/codepack/schemas/io.schema.json
+++ b/packages/codepack/schemas/io.schema.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object"
+}

--- a/packages/cookbookflow/pipelines.json
+++ b/packages/cookbookflow/pipelines.json
@@ -6,111 +6,79 @@
         {
           "id": "cb-scan",
           "shell": "pnpm --filter @promethean/cookbookflow cb:01-scan --roots docs examples packages --out .cache/cookbook/blocks.json",
-          "inputs": [
-            "docs/**/*.md",
-            "examples/**/*",
-            "packages/**/README.md"
-          ],
-          "outputs": [
-            ".cache/cookbook/blocks.json"
-          ]
+          "inputs": ["docs/**/*.md", "examples/**/*", "packages/**/README.md"],
+          "inputSchema": "packages/cookbookflow/schemas/io.schema.json",
+          "outputs": [".cache/cookbook/blocks.json"],
+          "outputSchema": "packages/cookbookflow/schemas/io.schema.json"
         },
         {
           "id": "cb-classify",
-          "deps": [
-            "cb-scan"
-          ],
+          "deps": ["cb-scan"],
           "shell": "pnpm --filter @promethean/cookbookflow cb:02-embed-classify --in .cache/cookbook/blocks.json --out .cache/cookbook/classes.json --embed-model nomic-embed-text:latest --llm qwen3:4b",
           "env": {
             "OLLAMA_URL": "${OLLAMA_URL}"
           },
-          "inputs": [
-            ".cache/cookbook/blocks.json"
-          ],
-          "outputs": [
-            ".cache/cookbook/classes.json"
-          ]
+          "inputs": [".cache/cookbook/blocks.json"],
+          "inputSchema": "packages/cookbookflow/schemas/io.schema.json",
+          "outputs": [".cache/cookbook/classes.json"],
+          "outputSchema": "packages/cookbookflow/schemas/io.schema.json"
         },
         {
           "id": "cb-group",
-          "deps": [
-            "cb-classify"
-          ],
+          "deps": ["cb-classify"],
           "shell": "pnpm --filter @promethean/cookbookflow cb:03-group --in .cache/cookbook/classes.json --out .cache/cookbook/groups.json --min-sim 0.82 --max-size 12",
-          "inputs": [
-            ".cache/cookbook/classes.json"
-          ],
-          "outputs": [
-            ".cache/cookbook/groups.json"
-          ]
+          "inputs": [".cache/cookbook/classes.json"],
+          "inputSchema": "packages/cookbookflow/schemas/io.schema.json",
+          "outputs": [".cache/cookbook/groups.json"],
+          "outputSchema": "packages/cookbookflow/schemas/io.schema.json"
         },
         {
           "id": "cb-plan",
-          "deps": [
-            "cb-group"
-          ],
+          "deps": ["cb-group"],
           "shell": "pnpm --filter @promethean/cookbookflow cb:04-plan --scan .cache/cookbook/blocks.json --classes .cache/cookbook/classes.json --groups .cache/cookbook/groups.json --out .cache/cookbook/plan.json --llm qwen3:4b",
           "env": {
             "OLLAMA_URL": "${OLLAMA_URL}"
           },
-          "inputs": [
-            ".cache/cookbook/groups.json"
-          ],
-          "outputs": [
-            ".cache/cookbook/plan.json"
-          ]
+          "inputs": [".cache/cookbook/groups.json"],
+          "inputSchema": "packages/cookbookflow/schemas/io.schema.json",
+          "outputs": [".cache/cookbook/plan.json"],
+          "outputSchema": "packages/cookbookflow/schemas/io.schema.json"
         },
         {
           "id": "cb-write",
-          "deps": [
-            "cb-plan"
-          ],
+          "deps": ["cb-plan"],
           "shell": "pnpm --filter @promethean/cookbookflow cb:05-materialize --plan .cache/cookbook/plan.json --out docs/cookbook",
-          "inputs": [
-            ".cache/cookbook/plan.json"
-          ],
-          "outputs": [
-            "docs/cookbook/**/*.md"
-          ]
+          "inputs": [".cache/cookbook/plan.json"],
+          "inputSchema": "packages/cookbookflow/schemas/io.schema.json",
+          "outputs": ["docs/cookbook/**/*.md"],
+          "outputSchema": "packages/cookbookflow/schemas/io.schema.json"
         },
         {
           "id": "cb-exec",
-          "deps": [
-            "cb-write"
-          ],
+          "deps": ["cb-write"],
           "shell": "pnpm --filter @promethean/cookbookflow cb:06-exec --root docs/cookbook --out .cache/cookbook/run-results.json",
-          "inputs": [
-            "docs/cookbook/**/*.md"
-          ],
-          "outputs": [
-            ".cache/cookbook/run-results.json"
-          ]
+          "inputs": ["docs/cookbook/**/*.md"],
+          "inputSchema": "packages/cookbookflow/schemas/io.schema.json",
+          "outputs": [".cache/cookbook/run-results.json"],
+          "outputSchema": "packages/cookbookflow/schemas/io.schema.json"
         },
         {
           "id": "cb-verify",
-          "deps": [
-            "cb-exec"
-          ],
+          "deps": ["cb-exec"],
           "shell": "pnpm --filter @promethean/cookbookflow cb:07-verify --runs .cache/cookbook/run-results.json --out .cache/cookbook/verify.json --accept false",
-          "inputs": [
-            ".cache/cookbook/run-results.json"
-          ],
-          "outputs": [
-            ".cache/cookbook/verify.json"
-          ]
+          "inputs": [".cache/cookbook/run-results.json"],
+          "inputSchema": "packages/cookbookflow/schemas/io.schema.json",
+          "outputs": [".cache/cookbook/verify.json"],
+          "outputSchema": "packages/cookbookflow/schemas/io.schema.json"
         },
         {
           "id": "cb-report",
-          "deps": [
-            "cb-verify"
-          ],
+          "deps": ["cb-verify"],
           "shell": "pnpm --filter @promethean/cookbookflow cb:08-report --runs .cache/cookbook/run-results.json --verify .cache/cookbook/verify.json --out docs/agile/reports/cookbook",
-          "inputs": [
-            ".cache/cookbook/verify.json"
-          ],
-          "outputs": [
-            "docs/agile/reports/cookbook/*.md"
-          ]
+          "inputs": [".cache/cookbook/verify.json"],
+          "inputSchema": "packages/cookbookflow/schemas/io.schema.json",
+          "outputs": ["docs/agile/reports/cookbook/*.md"],
+          "outputSchema": "packages/cookbookflow/schemas/io.schema.json"
         }
       ]
     }

--- a/packages/cookbookflow/schemas/io.schema.json
+++ b/packages/cookbookflow/schemas/io.schema.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object"
+}

--- a/packages/docops/pipelines.json
+++ b/packages/docops/pipelines.json
@@ -9,116 +9,93 @@
           "env": {
             "OLLAMA_URL": "${OLLAMA_URL}"
           },
-          "inputs": [
-            "docs/unique/**/*.md"
-          ],
-          "outputs": [
-            ".cache/docops/frontmatters.json"
-          ]
+          "inputs": ["docs/unique/**/*.md"],
+          "inputSchema": "packages/docops/schemas/io.schema.json",
+          "outputs": [".cache/docops/frontmatters.json"],
+          "outputSchema": "packages/docops/schemas/io.schema.json"
         },
         {
           "id": "doc-index",
-          "deps": [
-            "doc-fm"
-          ],
+          "deps": ["doc-fm"],
           "shell": "pnpm --filter @promethean/docops doc:02-chunk-embed --root docs/unique --in .cache/docops/frontmatters.json --chunks .cache/docops/chunks.json --embeddings .cache/docops/embeddings.json --tokenizer cl100k --embed-model nomic-embed-text:latest\n",
           "env": {
             "OLLAMA_URL": "${OLLAMA_URL}"
           },
-          "inputs": [
-            "docs/unique/**/*.md",
-            ".cache/docops/frontmatters.json"
-          ],
+          "inputs": ["docs/unique/**/*.md", ".cache/docops/frontmatters.json"],
+          "inputSchema": "packages/docops/schemas/io.schema.json",
           "outputs": [
             ".cache/docops/chunks.json",
             ".cache/docops/embeddings.json"
-          ]
+          ],
+          "outputSchema": "packages/docops/schemas/io.schema.json"
         },
         {
           "id": "doc-similarity",
-          "deps": [
-            "doc-index"
-          ],
+          "deps": ["doc-index"],
           "shell": "pnpm --filter @promethean/docops doc:03-similarity --chunks .cache/docops/chunks.json --embeddings .cache/docops/embeddings.json --out .cache/docops/queries.json\n",
           "inputs": [
             ".cache/docops/chunks.json",
             ".cache/docops/embeddings.json"
           ],
-          "outputs": [
-            ".cache/docops/queries.json"
-          ]
+          "inputSchema": "packages/docops/schemas/io.schema.json",
+          "outputs": [".cache/docops/queries.json"],
+          "outputSchema": "packages/docops/schemas/io.schema.json"
         },
         {
           "id": "doc-related",
-          "deps": [
-            "doc-similarity"
-          ],
+          "deps": ["doc-similarity"],
           "shell": "pnpm --filter @promethean/docops doc:04-related --queries .cache/docops/queries.json --frontmatter .cache/docops/frontmatters.json --threshold 0.62 --out .cache/docops/related.json\n",
           "inputs": [
             ".cache/docops/queries.json",
             ".cache/docops/frontmatters.json"
           ],
-          "outputs": [
-            ".cache/docops/related.json"
-          ]
+          "inputSchema": "packages/docops/schemas/io.schema.json",
+          "outputs": [".cache/docops/related.json"],
+          "outputSchema": "packages/docops/schemas/io.schema.json"
         },
         {
           "id": "doc-references",
-          "deps": [
-            "doc-similarity"
-          ],
+          "deps": ["doc-similarity"],
           "shell": "pnpm --filter @promethean/docops doc:05-references --queries .cache/docops/queries.json --chunks .cache/docops/chunks.json --ref-threshold 0.75 --out .cache/docops/references.json\n",
-          "inputs": [
-            ".cache/docops/queries.json",
-            ".cache/docops/chunks.json"
-          ],
-          "outputs": [
-            ".cache/docops/references.json"
-          ]
+          "inputs": [".cache/docops/queries.json", ".cache/docops/chunks.json"],
+          "inputSchema": "packages/docops/schemas/io.schema.json",
+          "outputs": [".cache/docops/references.json"],
+          "outputSchema": "packages/docops/schemas/io.schema.json"
         },
         {
           "id": "doc-apply-fm",
-          "deps": [
-            "doc-related",
-            "doc-references"
-          ],
+          "deps": ["doc-related", "doc-references"],
           "shell": "pnpm --filter @promethean/docops doc:06-apply-frontmatter --root docs/unique --frontmatter .cache/docops/frontmatters.json --related .cache/docops/related.json --references .cache/docops/references.json\n",
           "inputs": [
             ".cache/docops/frontmatters.json",
             ".cache/docops/related.json",
             ".cache/docops/references.json"
           ],
-          "outputs": [
-            ".cache/docops/applied-fm.touch"
-          ]
+          "inputSchema": "packages/docops/schemas/io.schema.json",
+          "outputs": [".cache/docops/applied-fm.touch"],
+          "outputSchema": "packages/docops/schemas/io.schema.json"
         },
         {
           "id": "doc-footer",
-          "deps": [
-            "doc-apply-fm"
-          ],
+          "deps": ["doc-apply-fm"],
           "shell": "pnpm --filter @promethean/docops doc:07-write-footer --root docs/unique --references .cache/docops/references.json --related .cache/docops/related.json --style obsidian\n",
           "inputs": [
             ".cache/docops/references.json",
             ".cache/docops/related.json",
             "docs/unique/**/*.md"
           ],
-          "outputs": [
-            ".cache/docops/footer.touch"
-          ]
+          "inputSchema": "packages/docops/schemas/io.schema.json",
+          "outputs": [".cache/docops/footer.touch"],
+          "outputSchema": "packages/docops/schemas/io.schema.json"
         },
         {
           "id": "doc-rename",
-          "deps": [
-            "doc-apply-fm"
-          ],
+          "deps": ["doc-apply-fm"],
           "shell": "pnpm --filter @promethean/docops doc:08-rename --root docs/unique --frontmatter .cache/docops/frontmatters.json --out .cache/docops/renames.json\n",
-          "inputs": [
-            ".cache/docops/frontmatters.json"
-          ],
-          "outputs": [
-            ".cache/docops/renames.json"
-          ]
+          "inputs": [".cache/docops/frontmatters.json"],
+          "inputSchema": "packages/docops/schemas/io.schema.json",
+          "outputs": [".cache/docops/renames.json"],
+          "outputSchema": "packages/docops/schemas/io.schema.json"
         }
       ]
     }

--- a/packages/docops/schemas/io.schema.json
+++ b/packages/docops/schemas/io.schema.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object"
+}

--- a/packages/piper/src/types.ts
+++ b/packages/piper/src/types.ts
@@ -37,6 +37,14 @@ export const StepSchema = z
   })
   .refine((s) => !!(s.shell || s.node || s.ts || s.js), {
     message: "step must define shell|node|ts|js",
+  })
+  .refine((s) => s.inputs.length === 0 || !!s.inputSchema, {
+    message: "inputSchema required when inputs declared",
+    path: ["inputSchema"],
+  })
+  .refine((s) => s.outputs.length === 0 || !!s.outputSchema, {
+    message: "outputSchema required when outputs declared",
+    path: ["outputSchema"],
   });
 
 export const PipelineSchema = z.object({

--- a/packages/readmeflow/pipelines.json
+++ b/packages/readmeflow/pipelines.json
@@ -6,16 +6,12 @@
         {
           "id": "rm-scan",
           "shell": "pnpm --filter @promethean/readmeflow rm:01-scan --root packages",
-          "inputs": [
-            "packages/**/package.json",
-            "packages/**/tsconfig.json"
-          ]
+          "inputs": ["packages/**/package.json", "packages/**/tsconfig.json"],
+          "inputSchema": "packages/readmeflow/schemas/io.schema.json"
         },
         {
           "id": "rm-outline",
-          "deps": [
-            "rm-scan"
-          ],
+          "deps": ["rm-scan"],
           "shell": "pnpm --filter @promethean/readmeflow rm:02-outline --model qwen3:4b",
           "env": {
             "OLLAMA_URL": "${OLLAMA_URL}"
@@ -23,26 +19,19 @@
         },
         {
           "id": "rm-write",
-          "deps": [
-            "rm-outline"
-          ],
+          "deps": ["rm-outline"],
           "shell": "pnpm --filter @promethean/readmeflow rm:03-write --mermaid true",
-          "outputs": [
-            "packages/**/README.md"
-          ]
+          "outputs": ["packages/**/README.md"],
+          "outputSchema": "packages/readmeflow/schemas/io.schema.json"
         },
         {
           "id": "rm-verify",
-          "deps": [
-            "rm-write"
-          ],
+          "deps": ["rm-write"],
           "shell": "pnpm --filter @promethean/readmeflow rm:04-verify --root packages --out docs/agile/reports/readmes",
-          "inputs": [
-            "packages/**/README.md"
-          ],
-          "outputs": [
-            "docs/agile/reports/readmes/*.md"
-          ]
+          "inputs": ["packages/**/README.md"],
+          "inputSchema": "packages/readmeflow/schemas/io.schema.json",
+          "outputs": ["docs/agile/reports/readmes/*.md"],
+          "outputSchema": "packages/readmeflow/schemas/io.schema.json"
         }
       ]
     }

--- a/packages/readmeflow/schemas/io.schema.json
+++ b/packages/readmeflow/schemas/io.schema.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object"
+}

--- a/packages/semvergaurd/pipelines.json
+++ b/packages/semvergaurd/pipelines.json
@@ -9,62 +9,45 @@
           "packages/**/package.json",
           "packages/**/{src,lib}/**/*.{ts,tsx,js,jsx}"
         ],
-        "outputs": [
-          ".cache/semverguard/snapshot.json"
-        ]
+        "inputSchema": "packages/semvergaurd/schemas/io.schema.json",
+        "outputs": [".cache/semverguard/snapshot.json"],
+        "outputSchema": "packages/semvergaurd/schemas/io.schema.json"
       },
       {
         "id": "sv-diff",
-        "deps": [
-          "sv-snapshot"
-        ],
+        "deps": ["sv-snapshot"],
         "shell": "pnpm --filter @promethean/semverguard sv:02-diff --current .cache/semverguard/snapshot.json --baseline git:origin/main:.cache/semverguard/snapshot.json --out .cache/semverguard/diff.json",
-        "inputs": [
-          ".cache/semverguard/snapshot.json"
-        ],
-        "outputs": [
-          ".cache/semverguard/diff.json"
-        ]
+        "inputs": [".cache/semverguard/snapshot.json"],
+        "inputSchema": "packages/semvergaurd/schemas/io.schema.json",
+        "outputs": [".cache/semverguard/diff.json"],
+        "outputSchema": "packages/semvergaurd/schemas/io.schema.json"
       },
       {
         "id": "sv-plan",
-        "deps": [
-          "sv-diff"
-        ],
+        "deps": ["sv-diff"],
         "shell": "pnpm --filter @promethean/semverguard sv:03-plan --diff .cache/semverguard/diff.json --out .cache/semverguard/plans.json --model qwen3:4b",
-        "inputs": [
-          ".cache/semverguard/diff.json"
-        ],
-        "outputs": [
-          ".cache/semverguard/plans.json"
-        ]
+        "inputs": [".cache/semverguard/diff.json"],
+        "inputSchema": "packages/semvergaurd/schemas/io.schema.json",
+        "outputs": [".cache/semverguard/plans.json"],
+        "outputSchema": "packages/semvergaurd/schemas/io.schema.json"
       },
       {
         "id": "sv-write",
-        "deps": [
-          "sv-plan"
-        ],
+        "deps": ["sv-plan"],
         "shell": "pnpm --filter @promethean/semverguard sv:04-write --plans .cache/semverguard/plans.json --out docs/agile/tasks/semver",
-        "inputs": [
-          ".cache/semverguard/plans.json"
-        ],
-        "outputs": [
-          "docs/agile/tasks/semver/*.md"
-        ]
+        "inputs": [".cache/semverguard/plans.json"],
+        "inputSchema": "packages/semvergaurd/schemas/io.schema.json",
+        "outputs": ["docs/agile/tasks/semver/*.md"],
+        "outputSchema": "packages/semvergaurd/schemas/io.schema.json"
       },
       {
         "id": "sv-pr",
-        "deps": [
-          "sv-write"
-        ],
+        "deps": ["sv-write"],
         "shell": "pnpm --filter @promethean/semverguard sv:05-pr --plans .cache/semverguard/plans.json --root packages --mode prepare --update-dependents true --dep-range preserve",
-        "inputs": [
-          ".cache/semverguard/plans.json",
-          "packages/**/package.json"
-        ],
-        "outputs": [
-          ".cache/semverguard/pr/summary.json"
-        ]
+        "inputs": [".cache/semverguard/plans.json", "packages/**/package.json"],
+        "inputSchema": "packages/semvergaurd/schemas/io.schema.json",
+        "outputs": [".cache/semverguard/pr/summary.json"],
+        "outputSchema": "packages/semvergaurd/schemas/io.schema.json"
       }
     ]
   }

--- a/packages/semvergaurd/schemas/io.schema.json
+++ b/packages/semvergaurd/schemas/io.schema.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object"
+}

--- a/packages/testgap/pipelines.json
+++ b/packages/testgap/pipelines.json
@@ -10,67 +10,51 @@
             "packages/**/package.json",
             "packages/**/{src,lib}/**/*.{ts,tsx,js,jsx}"
           ],
-          "outputs": [
-            ".cache/testgap/exports.json"
-          ]
+          "inputSchema": "packages/testgap/schemas/io.schema.json",
+          "outputs": [".cache/testgap/exports.json"],
+          "outputSchema": "packages/testgap/schemas/io.schema.json"
         },
         {
           "id": "tg-coverage",
           "shell": "pnpm --filter @promethean/testgap tg:02-read-coverage --lcov-globs \"{coverage/lcov.info,packages/**/coverage/lcov.info}\" --out .cache/testgap/coverage.json",
-          "inputs": [
-            "coverage/lcov.info",
-            "packages/**/coverage/lcov.info"
-          ],
-          "outputs": [
-            ".cache/testgap/coverage.json"
-          ]
+          "inputs": ["coverage/lcov.info", "packages/**/coverage/lcov.info"],
+          "inputSchema": "packages/testgap/schemas/io.schema.json",
+          "outputs": [".cache/testgap/coverage.json"],
+          "outputSchema": "packages/testgap/schemas/io.schema.json"
         },
         {
           "id": "tg-map",
-          "deps": [
-            "tg-exports",
-            "tg-coverage"
-          ],
+          "deps": ["tg-exports", "tg-coverage"],
           "shell": "pnpm --filter @promethean/testgap tg:03-map-gaps --exports .cache/testgap/exports.json --coverage .cache/testgap/coverage.json --min-lines 3 --out .cache/testgap/gaps.json",
           "inputs": [
             ".cache/testgap/exports.json",
             ".cache/testgap/coverage.json"
           ],
-          "outputs": [
-            ".cache/testgap/gaps.json"
-          ]
+          "inputSchema": "packages/testgap/schemas/io.schema.json",
+          "outputs": [".cache/testgap/gaps.json"],
+          "outputSchema": "packages/testgap/schemas/io.schema.json"
         },
         {
           "id": "tg-gate",
-          "deps": [
-            "tg-map"
-          ],
+          "deps": ["tg-map"],
           "shell": "pnpm --filter @promethean/testgap tg:08-gate --gaps .cache/testgap/gaps.json --out .cache/testgap/gate.json --threshold 0.70 --metric symbols",
-          "inputs": [
-            ".cache/testgap/gaps.json"
-          ],
-          "outputs": [
-            ".cache/testgap/gate.json"
-          ]
+          "inputs": [".cache/testgap/gaps.json"],
+          "inputSchema": "packages/testgap/schemas/io.schema.json",
+          "outputs": [".cache/testgap/gate.json"],
+          "outputSchema": "packages/testgap/schemas/io.schema.json"
         },
         {
           "id": "tg-cookbook",
-          "deps": [
-            "tg-map"
-          ],
+          "deps": ["tg-map"],
           "shell": "pnpm --filter @promethean/testgap tg:04-cookbook-cross --recipes docs/cookbook/**/*.md --out .cache/testgap/cookbook.json",
-          "inputs": [
-            "docs/cookbook/**/*.md"
-          ],
-          "outputs": [
-            ".cache/testgap/cookbook.json"
-          ]
+          "inputs": ["docs/cookbook/**/*.md"],
+          "inputSchema": "packages/testgap/schemas/io.schema.json",
+          "outputs": [".cache/testgap/cookbook.json"],
+          "outputSchema": "packages/testgap/schemas/io.schema.json"
         },
         {
           "id": "tg-plan",
-          "deps": [
-            "tg-cookbook"
-          ],
+          "deps": ["tg-cookbook"],
           "shell": "pnpm --filter @promethean/testgap tg:05-plan --gaps .cache/testgap/gaps.json --cookbook .cache/testgap/cookbook.json --out .cache/testgap/plans.json --model qwen3:4b --threshold 0.5 --max-per-pkg 15",
           "env": {
             "OLLAMA_URL": "${OLLAMA_URL}"
@@ -79,35 +63,27 @@
             ".cache/testgap/gaps.json",
             ".cache/testgap/cookbook.json"
           ],
-          "outputs": [
-            ".cache/testgap/plans.json"
-          ]
+          "inputSchema": "packages/testgap/schemas/io.schema.json",
+          "outputs": [".cache/testgap/plans.json"],
+          "outputSchema": "packages/testgap/schemas/io.schema.json"
         },
         {
           "id": "tg-write",
-          "deps": [
-            "tg-plan"
-          ],
+          "deps": ["tg-plan"],
           "shell": "pnpm --filter @promethean/testgap tg:06-write --plans .cache/testgap/plans.json --out docs/agile/tasks/test-gaps",
-          "inputs": [
-            ".cache/testgap/plans.json"
-          ],
-          "outputs": [
-            "docs/agile/tasks/test-gaps/*.md"
-          ]
+          "inputs": [".cache/testgap/plans.json"],
+          "inputSchema": "packages/testgap/schemas/io.schema.json",
+          "outputs": ["docs/agile/tasks/test-gaps/*.md"],
+          "outputSchema": "packages/testgap/schemas/io.schema.json"
         },
         {
           "id": "tg-report",
-          "deps": [
-            "tg-map"
-          ],
+          "deps": ["tg-map"],
           "shell": "pnpm --filter @promethean/testgap tg:07-report --gaps .cache/testgap/gaps.json --out docs/agile/reports/test-gaps",
-          "inputs": [
-            ".cache/testgap/gaps.json"
-          ],
-          "outputs": [
-            "docs/agile/reports/test-gaps/*.md"
-          ]
+          "inputs": [".cache/testgap/gaps.json"],
+          "inputSchema": "packages/testgap/schemas/io.schema.json",
+          "outputs": ["docs/agile/reports/test-gaps/*.md"],
+          "outputSchema": "packages/testgap/schemas/io.schema.json"
         }
       ]
     }

--- a/packages/testgap/schemas/io.schema.json
+++ b/packages/testgap/schemas/io.schema.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object"
+}


### PR DESCRIPTION
## Summary
- enforce schema references in piper steps
- validate only JSON files and ensure schemas declared
- add placeholder IO schemas and references across package pipelines

## Testing
- `pnpm --filter @promethean/piper build`
- `pnpm --filter @promethean/buildfix build`
- `pnpm --filter @promethean/docops build`
- `pnpm --filter @promethean/boardrev build`
- `pnpm --filter @promethean/testgap build`
- `pnpm --filter @promethean/cookbookflow build`
- `pnpm --filter @promethean/readmeflow build`
- `pnpm --filter @promethean/codepack build` *(fails: missing script)*
- `pnpm --filter @promethean/semverguard build`
- `pnpm install`
- `pnpm --filter @promethean/piper test` *(fails: deep leaf file is visible after nested expands)*

------
https://chatgpt.com/codex/tasks/task_e_68c61b2096908324a1c366b1132b986d