### PR TITLE
feat(utils): centralize sha1 hashing helper

### DIFF
--- a/packages/buildfix/src/utils.ts
+++ b/packages/buildfix/src/utils.ts
@@ -4,17 +4,9 @@ import * as path from "path";
 import { pathToFileURL } from "url";
 
 import { Project } from "ts-morph";
+export { sha1 } from "@promethean/utils";
 
 export const OLLAMA_URL = process.env.OLLAMA_URL ?? "http://localhost:11434";
-
-export function sha1(s: string) {
-  let h = 2166136261 >>> 0;
-  for (let i = 0; i < s.length; i++) {
-    h ^= s.charCodeAt(i);
-    h = Math.imul(h, 16777619);
-  }
-  return "h" + h.toString(16);
-}
 
 export async function run(
   cmd: string,
@@ -26,7 +18,7 @@ export async function run(
       { cwd, maxBuffer: 1024 * 1024 * 64, env: { ...process.env } },
       (e, stdout, stderr) => {
         res({
-          code: e ? ((e as any).code ?? 1) : 0,
+          code: e ? (e as any).code ?? 1 : 0,
           out: String(stdout),
           err: String(stderr),
         });
@@ -153,7 +145,7 @@ export async function git(cmd: string, cwd = process.cwd()) {
         { cwd, maxBuffer: 1024 * 1024 * 64, env: { ...process.env } },
         (e, stdout, stderr) => {
           resolve({
-            code: e ? ((e as any).code ?? 1) : 0,
+            code: e ? (e as any).code ?? 1 : 0,
             out: String(stdout).trim(),
             err: String(stderr).trim(),
           });

--- a/packages/codepack/package.json
+++ b/packages/codepack/package.json
@@ -12,11 +12,12 @@
     "code:all": "pnpm code:01-extract && pnpm code:02-embed && pnpm code:03-cluster && pnpm code:04-name && pnpm code:05-materialize"
   },
   "dependencies": {
+    "@promethean/fs": "workspace:*",
+    "@promethean/utils": "workspace:*",
     "gray-matter": "4.0.3",
     "remark-parse": "11.0.0",
     "unified": "11.0.4",
     "unist-util-visit": "5.0.0",
-    "zod": "3.23.8",
-    "@promethean/fs": "workspace:*"
+    "zod": "3.23.8"
   }
 }

--- a/packages/codepack/src/utils.ts
+++ b/packages/codepack/src/utils.ts
@@ -4,8 +4,8 @@ import matter from "gray-matter";
 import { unified } from "unified";
 import remarkParse from "remark-parse";
 import { visit } from "unist-util-visit";
-import * as crypto from "crypto";
 import { ensureDir } from "@promethean/fs";
+export { sha1 } from "@promethean/utils";
 
 export { ensureDir };
 
@@ -37,10 +37,6 @@ export async function listFilesRec(root: string, exts: Set<string>) {
   return out.filter((p) =>
     exts.size ? exts.has(path.extname(p).toLowerCase()) : true,
   );
-}
-
-export function sha1(s: string): string {
-  return crypto.createHash("sha1").update(s).digest("hex");
 }
 
 export function cosine(a: number[], b: number[]) {

--- a/packages/piper/src/hash.ts
+++ b/packages/piper/src/hash.ts
@@ -2,14 +2,11 @@ import { promises as fs } from "fs";
 import type { Stats } from "fs";
 import * as path from "path";
 import * as crypto from "crypto";
+import { sha1 } from "@promethean/utils";
 import { pathToFileURL, fileURLToPath } from "url";
 
 import { globby } from "globby";
 import { init, parse } from "es-module-lexer";
-
-export function sha1(s: string) {
-  return crypto.createHash("sha1").update(s).digest("hex");
-}
 
 export async function fingerprintFromGlobs(
   globs: string[],

--- a/packages/simtask/package.json
+++ b/packages/simtask/package.json
@@ -20,6 +20,7 @@
     "sim:all": "pnpm sim:01-scan && pnpm sim:02-embed && pnpm sim:03-cluster && pnpm sim:04-plan && pnpm sim:05-write"
   },
   "dependencies": {
+    "@promethean/utils": "workspace:*",
     "gray-matter": "^4.0.3",
     "yaml": "^2.5.0",
     "zod": "^3.23.8"

--- a/packages/simtask/src/utils.ts
+++ b/packages/simtask/src/utils.ts
@@ -1,6 +1,6 @@
 import { promises as fs } from "fs";
 import * as path from "path";
-import * as crypto from "crypto";
+export { sha1 } from "@promethean/utils";
 
 import * as ts from "typescript";
 
@@ -49,10 +49,6 @@ export async function listFilesRec(root: string, exts: Set<string>) {
   }
   await walk(root);
   return out;
-}
-
-export function sha1(s: string) {
-  return crypto.createHash("sha1").update(s).digest("hex");
 }
 
 export function relFromRepo(abs: string) {

--- a/packages/sonarflow/src/utils.js
+++ b/packages/sonarflow/src/utils.js
@@ -1,6 +1,6 @@
 import { promises as fs } from "fs";
 import * as path from "path";
-import * as crypto from "crypto";
+export { sha1 } from "@promethean/utils";
 export function parseArgs(defaults) {
   const out = { ...defaults };
   const a = process.argv.slice(2);
@@ -11,9 +11,6 @@ export function parseArgs(defaults) {
     out[k] = v;
   }
   return out;
-}
-export function sha1(s) {
-  return crypto.createHash("sha1").update(s).digest("hex");
 }
 export async function writeJSON(p, data) {
   await fs.mkdir(path.dirname(p), { recursive: true });

--- a/packages/sonarflow/src/utils.ts
+++ b/packages/sonarflow/src/utils.ts
@@ -1,6 +1,6 @@
 import { promises as fs } from "fs";
 import * as path from "path";
-import * as crypto from "crypto";
+export { sha1 } from "@promethean/utils";
 
 export function parseArgs(
   defaults: Readonly<Record<string, string>>,
@@ -14,10 +14,6 @@ export function parseArgs(
     },
     { ...defaults },
   );
-}
-
-export function sha1(s: string): string {
-  return crypto.createHash("sha1").update(s).digest("hex");
 }
 
 export async function writeJSON(p: string, data: unknown): Promise<void> {

--- a/packages/symdocs/package.json
+++ b/packages/symdocs/package.json
@@ -17,6 +17,7 @@
     "symdocs:all": "pnpm symdocs:01-scan && pnpm symdocs:02-docs && pnpm symdocs:03-write"
   },
   "dependencies": {
+    "@promethean/utils": "workspace:*",
     "gray-matter": "^4.0.3",
     "yaml": "^2.5.0",
     "zod": "^3.23.8"

--- a/packages/symdocs/src/utils.ts
+++ b/packages/symdocs/src/utils.ts
@@ -1,6 +1,6 @@
 import { promises as fs } from "fs";
 import * as path from "path";
-import * as crypto from "crypto";
+export { sha1 } from "@promethean/utils";
 
 import * as ts from "typescript";
 
@@ -40,10 +40,6 @@ export async function listFilesRec(
   }
   await walk(root);
   return out.filter((p) => exts.has(path.extname(p).toLowerCase()));
-}
-
-export function sha1(s: string): string {
-  return crypto.createHash("sha1").update(s).digest("hex");
 }
 
 export function relFromRepo(abs: string): string {

--- a/packages/utils/src/hash.ts
+++ b/packages/utils/src/hash.ts
@@ -1,0 +1,8 @@
+import { createHash } from "node:crypto";
+
+/**
+ * Compute the SHA-1 hash of the given text and return the hex digest.
+ */
+export function sha1(text: string): string {
+  return createHash("sha1").update(text).digest("hex");
+}

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -6,3 +6,4 @@ export { retry } from "./retry.js";
 export type { RetryOptions } from "./retry.js";
 export { slug } from "./slug.js";
 export { parseArgs } from "./parse-args.js";
+export { sha1 } from "./hash.js";

--- a/packages/utils/src/tests/hash.test.ts
+++ b/packages/utils/src/tests/hash.test.ts
@@ -1,0 +1,7 @@
+import test from "ava";
+
+import { sha1 } from "../hash.js";
+
+test("sha1 hashes text to hex digest", (t) => {
+  t.is(sha1("test"), "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3");
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -745,6 +745,9 @@ importers:
       '@promethean/fs':
         specifier: workspace:*
         version: link:../fs
+      '@promethean/utils':
+        specifier: workspace:*
+        version: link:../utils
       gray-matter:
         specifier: 4.0.3
         version: 4.0.3
@@ -3313,6 +3316,9 @@ importers:
 
   packages/simtask:
     dependencies:
+      '@promethean/utils':
+        specifier: workspace:*
+        version: link:../utils
       gray-matter:
         specifier: ^4.0.3
         version: 4.0.3
@@ -3606,6 +3612,9 @@ importers:
 
   packages/symdocs:
     dependencies:
+      '@promethean/utils':
+        specifier: workspace:*
+        version: link:../utils
       gray-matter:
         specifier: ^4.0.3
         version: 4.0.3
@@ -14169,7 +14178,7 @@ snapshots:
 
   axios@1.11.0:
     dependencies:
-      follow-redirects: 1.15.11(debug@4.4.1)
+      follow-redirects: 1.15.11(debug@4.3.7)
       form-data: 4.0.4
       proxy-from-env: 1.1.0
     transitivePeerDependencies:
@@ -16541,7 +16550,7 @@ snapshots:
   http-proxy@1.18.1:
     dependencies:
       eventemitter3: 4.0.7
-      follow-redirects: 1.15.11(debug@4.4.1)
+      follow-redirects: 1.15.11(debug@4.3.7)
       requires-port: 1.0.0
     transitivePeerDependencies:
       - debug


### PR DESCRIPTION
## Summary
- add shared `sha1` helper and export it from `@promethean/utils`
- replace ad-hoc `sha1` implementations in simtasks, piper, symdocs, codepack, buildfix, and sonarflow
- declare `@promethean/utils` dependency where needed

## Testing
- `pnpm --filter @promethean/utils test`
- `pnpm --filter @promethean/simtasks build`
- `pnpm --filter @promethean/piper test` *(fails: TimeoutError)*
- `pnpm --filter @promethean/piper build`
- `pnpm --filter @promethean/symdocs build`
- `pnpm --filter @promethean/codepack code:01-extract -- --dir ../../docs` *(fails: YAMLException)*
- `pnpm --filter @promethean/buildfix test`
- `pnpm --filter @promethean/sonarflow build`
- `pnpm install`


------
https://chatgpt.com/codex/tasks/task_e_68c61a6c1a7083249bdbe1019a934772