### PR TITLE
boardrev: pass OLLAMA_URL through embedding and eval steps

### DIFF
--- a/packages/boardrev/pipelines.json
+++ b/packages/boardrev/pipelines.json
@@ -22,8 +22,11 @@
         },
         {
           "id": "br-index",
-          "deps": ["br-fm"],
+          "deps": ["br-fm", "OLLAMA_URL"],
           "shell": "pnpm --filter @promethean/boardrev br:03-index --globs \"{README.md,docs/**/*.md,packages/**/{src,lib}/**/*.{ts,tsx,js,jsx}}\"",
+          "env": {
+            "OLLAMA_URL": "${OLLAMA_URL}"
+          },
           "inputs": [
             "README.md",
             "docs/**/*.md",
@@ -53,6 +56,9 @@
           "id": "br-eval",
           "deps": ["br-match"],
           "shell": "pnpm --filter @promethean/boardrev br:05-eval --model qwen3:4b",
+          "env": {
+            "OLLAMA_URL": "${OLLAMA_URL}"
+          },
           "inputs": [
             ".cache/boardrev/prompts.json",
             ".cache/boardrev/context.json"


### PR DESCRIPTION
## Summary
- ensure br-index and br-eval receive `OLLAMA_URL`
- rerun lint on updated pipeline

## Testing
- `pnpm lint packages/boardrev/pipelines.json`


------
https://chatgpt.com/codex/tasks/task_e_68c71524f5ec8324988f97026c668ff7