### PR TITLE
chore: run tests before coverage

### DIFF
--- a/packages/testgap/pipelines.json
+++ b/packages/testgap/pipelines.json
@@ -15,7 +15,12 @@
           "outputSchema": "packages/testgap/schemas/io.schema.json"
         },
         {
+          "id": "tg-tests",
+          "shell": "pnpm -w -r test -- --coverage"
+        },
+        {
           "id": "tg-coverage",
+          "deps": ["tg-tests"],
           "shell": "pnpm --filter @promethean/testgap tg:02-read-coverage --lcov-globs \"{coverage/lcov.info,packages/**/coverage/lcov.info}\" --out .cache/testgap/coverage.json",
           "inputs": ["coverage/lcov.info", "packages/**/coverage/lcov.info"],
           "inputSchema": "packages/testgap/schemas/io.schema.json",

--- a/pipelines.json
+++ b/pipelines.json
@@ -349,7 +349,12 @@
           "outputs": [".cache/testgap/exports.json"]
         },
         {
+          "id": "tg-tests",
+          "shell": "pnpm -w -r test -- --coverage"
+        },
+        {
           "id": "tg-coverage",
+          "deps": ["tg-tests"],
           "shell": "pnpm --filter @promethean/testgap tg:02-read-coverage --lcov-globs \"{coverage/lcov.info,packages/**/coverage/lcov.info}\" --out .cache/testgap/coverage.json",
           "inputs": ["coverage/lcov.info", "packages/**/coverage/lcov.info"],
           "outputs": [".cache/testgap/coverage.json"]


### PR DESCRIPTION
## Summary
- run workspace tests with coverage before reading coverage data in test-gap pipeline
- gate coverage step on successful test execution

## Testing
- `pnpm lint:diff` *(fails: file ignored/no jiti library)*
- `pnpm --filter @promethean/testgap test`
- `pnpm piper run test-gap --config packages/testgap/pipelines.json` *(fails: step tg-coverage failed with exit code 1)*
- `pnpm install`


------
https://chatgpt.com/codex/tasks/task_e_68c71e7aa2608324851c6f561e7de808