### PR TITLE
chore: ensure codemods run after simtasks

### DIFF
--- a/docs/notes/promethean-ci-cd-pipeline.md
+++ b/docs/notes/promethean-ci-cd-pipeline.md
@@ -104,8 +104,22 @@ pipelines:
 
   - name: codemods
     steps:
+      - id: mods-simtasks
+        inputs: []
+        outputs:
+          [
+            ".cache/simtasks/functions.json",
+            ".cache/simtasks/clusters.json",
+            ".cache/simtasks/plans.json",
+          ]
       - id: mods-spec
-        inputs: [".cache/simtasks/{functions,clusters,plans}.json"]
+        deps: ["mods-simtasks"]
+        inputs:
+          [
+            ".cache/simtasks/functions.json",
+            ".cache/simtasks/clusters.json",
+            ".cache/simtasks/plans.json",
+          ]
         outputs: [".cache/codemods/specs.json"]
       - id: mods-generate
         deps: ["mods-spec"]

--- a/pipelines.json
+++ b/pipelines.json
@@ -79,9 +79,24 @@
       "name": "codemods",
       "steps": [
         {
+          "id": "mods-simtasks",
+          "shell": "bash -lc 'if [ ! -f .cache/simtasks/functions.json ] || [ ! -f .cache/simtasks/clusters.json ] || [ ! -f .cache/simtasks/plans.json ]; then pnpm --filter @promethean/piper piper run simtasks --config pipelines.json; fi'",
+          "inputs": [],
+          "outputs": [
+            ".cache/simtasks/functions.json",
+            ".cache/simtasks/clusters.json",
+            ".cache/simtasks/plans.json"
+          ]
+        },
+        {
           "id": "mods-spec",
+          "deps": ["mods-simtasks"],
           "shell": "pnpm --filter @promethean/codemods mods:01-spec --tsconfig ./tsconfig.json",
-          "inputs": [".cache/simtasks/{functions,clusters,plans}.json"],
+          "inputs": [
+            ".cache/simtasks/functions.json",
+            ".cache/simtasks/clusters.json",
+            ".cache/simtasks/plans.json"
+          ],
           "outputs": [".cache/codemods/specs.json"]
         },
         {


### PR DESCRIPTION
## Summary
- ensure codemods pipeline runs simtasks first when cache is missing
- document codemods' simtasks prerequisite

## Testing
- `pnpm --filter @promethean/piper test` *(fails: outputSchema required when outputs declared)*
- `pnpm --filter @promethean/codemods test`
- `pnpm --filter @promethean/simtasks test`
- `pnpm --filter @promethean/piper exec piper run codemods --config ../../pipelines.json` *(fails: pipelines config invalid: inputSchema/outputSchema required)*
- `pnpm lint:diff` *(fails: ESLint missing jiti library and many lint errors)*
- `pnpm install`


------
https://chatgpt.com/codex/tasks/task_e_68c71e7fbd008324af991adc4709720b