### PR TITLE
feat: add OLLAMA env for board review

### DIFF
--- a/pipelines.json
+++ b/pipelines.json
@@ -210,6 +210,9 @@
           "id": "br-eval",
           "deps": ["br-match"],
           "shell": "pnpm --filter @promethean/boardrev br:05-eval --model qwen3:4b",
+          "env": {
+            "OLLAMA_URL": "${OLLAMA_URL}"
+          },
           "inputs": [
             ".cache/boardrev/prompts.json",
             ".cache/boardrev/context.json"


### PR DESCRIPTION
## Summary
- ensure board-review eval step forwards OLLAMA_URL

## Testing
- `pnpm lint:diff` *(fails: 1586 problems, 606 errors)*
- `pnpm --filter @promethean/boardrev test`
- `pnpm piper run board-review --config packages/boardrev/pipelines.json` *(fails: unknown step OLLAMA_URL)*
- `pnpm install`


------
https://chatgpt.com/codex/tasks/task_e_68c71e8e38fc8324bc47150fb559a141