### PR TITLE
buildfix: add build step and tsx scripts

### DIFF
--- a/packages/buildfix/package.json
+++ b/packages/buildfix/package.json
@@ -12,10 +12,10 @@
     "build": "tsc -p tsconfig.json",
     "clean": "rimraf dist .cache && tsc -b --clean",
     "typecheck": "tsc -p tsconfig.json --noEmit",
-    "bf:01-errors": "node ./dist/01-errors.js",
-    "bf:02-iterate": "node ./dist/02-iterate.js",
-    "bf:03-report": "node ./dist/03-report.js",
-    "bf:all": "pnpm build && pnpm bf:01-errors && pnpm bf:02-iterate && pnpm bf:03-report",
+    "bf:01-errors": "tsx ./src/01-errors.ts",
+    "bf:02-iterate": "tsx ./src/02-iterate.ts",
+    "bf:03-report": "tsx ./src/03-report.ts",
+    "bf:all": "pnpm bf:01-errors && pnpm bf:02-iterate && pnpm bf:03-report",
     "test": "pnpm build && ava",
     "test:unit": "pnpm build && ava \"dist/tests/**/*.js\" \"!dist/tests/integration/**/*.js\"",
     "test:integration": "pnpm build && ava \"dist/tests/integration/**/*.js\"",
@@ -28,5 +28,7 @@
     "ts-morph": "22.0.0",
     "zod": "3.23.8"
   },
-  "devDependencies": {}
+  "devDependencies": {
+    "tsx": "^4.20.3"
+  }
 }

--- a/pipelines.json
+++ b/pipelines.json
@@ -301,7 +301,17 @@
       "name": "buildfix",
       "steps": [
         {
+          "id": "bf-build",
+          "shell": "pnpm --filter @promethean/buildfix build",
+          "inputs": [
+            "packages/buildfix/tsconfig.json",
+            "packages/buildfix/src/**/*"
+          ],
+          "outputs": ["packages/buildfix/dist/**"]
+        },
+        {
           "id": "bf-errors",
+          "deps": ["bf-build"],
           "shell": "pnpm --filter @promethean/buildfix bf:01-errors --tsconfig tsconfig.json --out .cache/buildfix/errors.json",
           "inputs": [
             "tsconfig.json",
@@ -311,7 +321,7 @@
         },
         {
           "id": "bf-iterate",
-          "deps": ["bf-errors"],
+          "deps": ["bf-build", "bf-errors"],
           "shell": "pnpm --filter @promethean/buildfix bf:02-iterate --errors .cache/buildfix/errors.json --out .cache/buildfix --model qwen3:4b --max-cycles 5 --git per-error --commit-on always --branch-prefix buildfix --remote origin --push false --use-gh false --rollback-on-regress true\n",
           "env": {
             "OLLAMA_URL": "${OLLAMA_URL}"
@@ -329,7 +339,7 @@
         },
         {
           "id": "bf-report",
-          "deps": ["bf-iterate"],
+          "deps": ["bf-build", "bf-iterate"],
           "shell": "pnpm --filter @promethean/buildfix bf:03-report --summary .cache/buildfix/summary.json --history-root .cache/buildfix/history --out docs/agile/reports/buildfix",
           "inputs": [".cache/buildfix/summary.json"],
           "outputs": ["docs/agile/reports/buildfix/*.md"]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -464,6 +464,10 @@ importers:
       zod:
         specifier: 3.23.8
         version: 3.23.8
+    devDependencies:
+      tsx:
+        specifier: ^4.20.3
+        version: 4.20.3
 
   packages/cephalon:
     dependencies:


### PR DESCRIPTION
## Summary
- ensure buildfix pipeline builds before running analysis steps
- run buildfix scripts via tsx directly on source files

## Testing
- `pnpm --filter @promethean/buildfix test`
- `pnpm piper run buildfix --config packages/buildfix/pipelines.json` *(fails: step bf-iterate exited 1)*

------
https://chatgpt.com/codex/tasks/task_e_68c71e732c2c8324903d3e6fd40e6c08