### PR TITLE
chore: clean symdocs pipeline env

### DIFF
--- a/pipelines.json
+++ b/pipelines.json
@@ -6,7 +6,7 @@
         {
           "id": "symdocs-scan",
           "cwd": ".",
-          "shell": "pnpm --filter @promethean/symdocs symdocs:01-scan --root packages --tsconfig ./config/tsconfig.base.json",
+          "shell": "pnpm --filter @promethean/symdocs symdocs:01-scan",
           "inputs": ["packages/**/{src,lib}/**/*.{ts,tsx,js,jsx}"],
           "outputs": [".cache/symdocs/symbols.json"]
         },
@@ -14,6 +14,7 @@
           "id": "symdocs-docs",
           "deps": ["symdocs-scan"],
           "shell": "pnpm --filter @promethean/symdocs symdocs:02-docs --model qwen3:4b",
+          "env": { "OLLAMA_URL": "${OLLAMA_URL}" },
           "inputs": [".cache/symdocs/symbols.json"],
           "outputs": [".cache/symdocs/docs.json"]
         },


### PR DESCRIPTION
## Summary
- drop redundant root/tsconfig flags from symdocs-scan
- allow symdocs-docs to read OLLAMA_URL from environment

## Testing
- `pnpm --filter @promethean/symdocs build`
- `pnpm --filter @promethean/piper build`
- `pnpm lint:diff` *(fails: ESLint reports hundreds of repository-wide errors)*
- `pnpm exec piper run symdocs` *(fails: step symdocs-scan exit code 1)*
- `pnpm install`


------
https://chatgpt.com/codex/tasks/task_e_68c71e8af404832495ec7104f56291c2