### PR TITLE
refactor(piper): modularize HotWrapper and accessors

### DIFF
--- a/packages/piper/src/frontend/forward.ts
+++ b/packages/piper/src/frontend/forward.ts
@@ -1,0 +1,48 @@
+export function forwardMethods(
+  wrapper: { [k: string]: unknown },
+  impl: { [k: string]: unknown },
+): void {
+  const keys = ["render", "getHotState", "setHotState"];
+  for (const k of keys) {
+    const fn = (impl as Record<string, unknown>)?.[k];
+    if (typeof fn === "function") {
+      (wrapper as Record<string, unknown>)[k] = function (
+        this: unknown,
+        ...args: unknown[]
+      ) {
+        return (fn as (...xs: unknown[]) => unknown).apply(this, args);
+      } as unknown;
+    }
+  }
+}
+
+export function forwardAccessors(
+  wrapper: Record<string, unknown>,
+  impl: Record<string, unknown>,
+  Impl: { prototype?: unknown },
+): void {
+  try {
+    const hasData =
+      Object.prototype.hasOwnProperty.call(Impl.prototype || {}, "data") ||
+      "data" in impl;
+    if (hasData) {
+      Object.defineProperty(wrapper, "data", {
+        configurable: true,
+        enumerable: true,
+        get: () => {
+          if ("data" in impl) {
+            return impl["data"];
+          }
+          return undefined;
+        },
+        set: (v: unknown) => {
+          if ("data" in impl) {
+            impl["data"] = v;
+          }
+        },
+      });
+    }
+  } catch {
+    // Best-effort; lack of accessor forwarding should not break element creation.
+  }
+}

--- a/packages/piper/src/frontend/hmr.ts
+++ b/packages/piper/src/frontend/hmr.ts
@@ -1,14 +1,20 @@
-// Simple hot-reload registry for web components that preserves state when possible.
-// Components can optionally implement getHotState(): unknown and setHotState(state: unknown): void.
+// Simple hot-reload registry for web components that preserves state when
+// possible. Components can optionally implement getHotState(): unknown and
+// setHotState(state: unknown): void.
 
-type HotLike = {
+import { forwardMethods } from "./forward.js";
+import { HotWrapper } from "./hot-wrapper.js";
+
+export type HotLike = {
   render?: () => void;
   getHotState?: () => unknown;
   setHotState?: (s: unknown) => void;
 };
-type ImplCtor<T extends HotLike = HotLike> = new () => T;
-type HotElement<T extends HotLike = HotLike> = HTMLElement & { __impl?: T };
-type HotRegistry<T extends HotLike = HotLike> = {
+export type ImplCtor<T extends HotLike = HotLike> = new () => T;
+export type HotElement<T extends HotLike = HotLike> = HTMLElement & {
+  __impl?: T;
+};
+export type HotRegistry<T extends HotLike = HotLike> = {
   components: Map<string, ImplCtor<T>>;
   instances: Map<string, Set<HotElement<T>>>;
   register: (name: string, impl: ImplCtor<T>) => void;
@@ -37,24 +43,6 @@ function ensureHot<T extends HotLike = HotLike>(): HotRegistry<T> {
   return w.__PIPER_HOT;
 }
 
-function forwardMethods(
-  wrapper: { [k: string]: unknown },
-  impl: { [k: string]: unknown },
-) {
-  const keys = ["render", "getHotState", "setHotState"];
-  for (const k of keys) {
-    const fn = (impl as Record<string, unknown>)?.[k];
-    if (typeof fn === "function") {
-      (wrapper as Record<string, unknown>)[k] = function (
-        this: unknown,
-        ...args: unknown[]
-      ) {
-        return (fn as (...xs: unknown[]) => unknown).apply(this, args);
-      } as unknown;
-    }
-  }
-}
-
 function replaceInstance<T extends HotLike>(
   inst: HotElement<T>,
   Impl: ImplCtor<T>,
@@ -79,103 +67,18 @@ function replaceInstance<T extends HotLike>(
   }
 }
 
-/* eslint-disable-next-line max-lines-per-function */
 export function registerHotElement<T extends HotLike = HotLike>(
   name: string,
   Impl: ImplCtor<T>,
 ): void {
   const hot = ensureHot<T>();
   if (!customElements.get(name)) {
-    class HotWrapper extends HTMLElement {
-      __impl: InstanceType<typeof Impl> | undefined;
-      constructor() {
-        super();
-        const impl = new Impl();
-        this.__impl = impl;
-        // Ensure Impl methods (render/state) are callable from wrapper context
-        forwardMethods(
-          this as unknown as Record<string, unknown>,
-          impl as unknown as Record<string, unknown>,
-        );
-
-        // Forward common property accessors (not just methods). At minimum, proxy
-        // a `data` accessor if the implementation supports it so callers like
-        // `el.data = { ... }` configure the underlying component.
-        try {
-          const hasData =
-            Object.prototype.hasOwnProperty.call(
-              (Impl as unknown as { prototype?: unknown }).prototype || {},
-              "data",
-            ) || "data" in (impl as unknown as Record<string, unknown>);
-          if (hasData) {
-            Object.defineProperty(this, "data", {
-              configurable: true,
-              enumerable: true,
-              get: () => {
-                const t: unknown = this.__impl;
-                if (
-                  t &&
-                  typeof t === "object" &&
-                  "data" in (t as Record<string, unknown>)
-                ) {
-                  return (t as Record<string, unknown>)["data"];
-                }
-                return undefined;
-              },
-              set: (v: unknown) => {
-                const t: unknown = this.__impl;
-                if (
-                  t &&
-                  typeof t === "object" &&
-                  "data" in (t as Record<string, unknown>)
-                ) {
-                  (t as Record<string, unknown>)["data"] = v;
-                }
-              },
-            });
-          }
-        } catch {
-          // Best-effort; lack of accessor forwarding should not break element creation.
-        }
-      }
-      connectedCallback(): void {
-        const set = hot.instances.get(name) ?? new Set<HotElement<T>>();
-        set.add(this as unknown as HotElement<T>);
-        hot.instances.set(name, set);
-        (
-          this.__impl as unknown as { connectedCallback?: () => void }
-        )?.connectedCallback?.call(this);
-      }
-      disconnectedCallback(): void {
-        (
-          this.__impl as unknown as { disconnectedCallback?: () => void }
-        )?.disconnectedCallback?.call(this);
-        const set = hot.instances.get(name);
-        if (set) set.delete(this as unknown as HotElement<T>);
-      }
-      attributeChangedCallback(
-        attrName: string,
-        oldVal: unknown,
-        newVal: unknown,
-      ): void {
-        (
-          this.__impl as unknown as {
-            attributeChangedCallback?: (
-              a: string,
-              o: unknown,
-              n: unknown,
-            ) => void;
-          }
-        )?.attributeChangedCallback?.call(this, attrName, oldVal, newVal);
-      }
-      static get observedAttributes() {
-        return (
-          (Impl as unknown as { observedAttributes?: string[] })
-            .observedAttributes || []
-        );
-      }
-    }
-    customElements.define(name, HotWrapper);
+    class HW extends HotWrapper<T> {}
+    (HW as typeof HotWrapper<T>).Impl = Impl;
+    (HW as typeof HotWrapper<HotLike>).hot =
+      hot as unknown as HotRegistry<HotLike>;
+    (HW as typeof HotWrapper<T>).elementName = name;
+    customElements.define(name, HW);
   }
   hot.register(name, Impl);
 }

--- a/packages/piper/src/frontend/hot-wrapper.ts
+++ b/packages/piper/src/frontend/hot-wrapper.ts
@@ -1,0 +1,69 @@
+import { forwardMethods, forwardAccessors } from "./forward.js";
+import type { HotLike, ImplCtor, HotElement, HotRegistry } from "./hmr.js";
+
+export class HotWrapper<T extends HotLike = HotLike> extends HTMLElement {
+  static hot: HotRegistry<HotLike>;
+  static elementName: string;
+  static Impl: ImplCtor<HotLike>;
+
+  __impl: InstanceType<ImplCtor<T>> | undefined;
+
+  constructor() {
+    super();
+    const ctor = this.constructor as typeof HotWrapper<T>;
+    const Impl = ctor.Impl as ImplCtor<T>;
+    const impl = new Impl();
+    this.__impl = impl;
+    forwardMethods(
+      this as unknown as Record<string, unknown>,
+      impl as unknown as Record<string, unknown>,
+    );
+    forwardAccessors(
+      this as unknown as Record<string, unknown>,
+      impl as unknown as Record<string, unknown>,
+      Impl as unknown as { prototype?: unknown },
+    );
+  }
+
+  connectedCallback(): void {
+    const ctor = this.constructor as typeof HotWrapper<T>;
+    const set =
+      ctor.hot.instances.get(ctor.elementName) ?? new Set<HotElement<T>>();
+    set.add(this as unknown as HotElement<T>);
+    ctor.hot.instances.set(ctor.elementName, set);
+    (
+      this.__impl as unknown as { connectedCallback?: () => void }
+    )?.connectedCallback?.call(this);
+  }
+
+  disconnectedCallback(): void {
+    const ctor = this.constructor as typeof HotWrapper<T>;
+    (
+      this.__impl as unknown as { disconnectedCallback?: () => void }
+    )?.disconnectedCallback?.call(this);
+    const set = ctor.hot.instances.get(ctor.elementName);
+    if (set) set.delete(this as unknown as HotElement<T>);
+  }
+
+  attributeChangedCallback(
+    attrName: string,
+    oldVal: unknown,
+    newVal: unknown,
+  ): void {
+    (
+      this.__impl as unknown as {
+        attributeChangedCallback?: (a: string, o: unknown, n: unknown) => void;
+      }
+    )?.attributeChangedCallback?.call(this, attrName, oldVal, newVal);
+  }
+
+  static get observedAttributes(): string[] {
+    return (
+      (
+        (this as unknown as typeof HotWrapper<HotLike>).Impl as unknown as {
+          observedAttributes?: string[];
+        }
+      ).observedAttributes || []
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- extract HotWrapper into its own module
- share accessor-forwarding via new forwardAccessors utility
- streamline registerHotElement and remove max-lines-per-function suppression

## Testing
- `pnpm --filter @promethean/piper lint` *(fails: None of the selected packages has a "lint" script)*
- `pnpm --filter @promethean/piper test` *(fails: TimeoutError in hmr.state.test.ts)*
- `pnpm install`


------
https://chatgpt.com/codex/tasks/task_e_68c7295f06108324a87fc17b455c8f17