### PR TITLE
fix piper pipeline schemas

### DIFF
--- a/pipelines.json
+++ b/pipelines.json
@@ -107,7 +107,8 @@
             ".cache/simtasks/functions.json",
             ".cache/simtasks/clusters.json",
             ".cache/simtasks/plans.json"
-          ]
+          ],
+          "outputSchema": "packages/simtask/schemas/io.schema.json"
         },
         {
           "id": "mods-spec",
@@ -395,7 +396,9 @@
             "packages/buildfix/tsconfig.json",
             "packages/buildfix/src/**/*"
           ],
-          "outputs": ["packages/buildfix/dist/**"]
+          "outputs": ["packages/buildfix/dist/**"],
+          "inputSchema": "packages/buildfix/schemas/io.schema.json",
+          "outputSchema": "packages/buildfix/schemas/io.schema.json"
         },
         {
           "id": "bf-errors",


### PR DESCRIPTION
## Summary
- add missing output schema for codemods pipeline step
- include input/output schemas for buildfix build step

## Testing
- `pnpm lint:diff` *(fails: 1881 problems across repository)*
- `pnpm exec piper run symdocs --config pipelines.json --dry`
- `pnpm install`


------
https://chatgpt.com/codex/tasks/task_e_68c72a1280a483249d237af37663d90f