### PR TITLE
feat(piper): include stderr and command details when steps fail

### DIFF
--- a/packages/piper/src/runner.ts
+++ b/packages/piper/src/runner.ts
@@ -110,6 +110,42 @@ function shouldSkip(
   return { skip: false, reason: "" };
 }
 
+export class StepError extends Error {
+  stepId: string;
+  command: string;
+  exitCode: number | null | undefined;
+  stderr: string | undefined;
+  stdout: string | undefined;
+
+  constructor(step: PiperStep, result: StepResult) {
+    const command = (() => {
+      if (step.shell) return `shell: ${step.shell}`;
+      if (step.node) return `node: ${step.node}`;
+      if (step.ts) return `ts: ${step.ts.module}`;
+      if (step.js) return `js: ${step.js.module}`;
+      return "unknown";
+    })();
+    const parts = [
+      `step ${step.id} failed with exit code ${result.exitCode}`,
+      `command: ${command}`,
+    ];
+    if (result.stderr) parts.push(`stderr: ${result.stderr.trim()}`);
+    if (result.stdout) {
+      const out =
+        result.stdout.length > 200
+          ? `${result.stdout.slice(0, 200)}...`
+          : result.stdout;
+      parts.push(`stdout: ${out.trim()}`);
+    }
+    super(parts.join("\n"));
+    this.stepId = step.id;
+    this.command = command;
+    this.exitCode = result.exitCode;
+    this.stderr = result.stderr;
+    this.stdout = result.stdout;
+  }
+}
+
 export async function runPipeline(
   configPath: string,
   pipelineName: string,
@@ -122,6 +158,7 @@ export async function runPipeline(
   const pipeline = cfg.pipelines.find((p) => p.name === pipelineName);
   if (!pipeline) throw new Error(`pipeline '${pipelineName}' not found`);
   const steps = topoSort(pipeline.steps);
+  const stepMap = new Map(steps.map((s) => [s.id, s]));
   const state = await loadState(pipeline.name);
   const emit = opts.emit ?? emitEvent;
 
@@ -358,6 +395,8 @@ export async function runPipeline(
     (r) => !r.skipped && typeof r.exitCode === "number" && r.exitCode !== 0,
   );
   if (failed) {
+    const step = stepMap.get(failed.id);
+    if (step) throw new StepError(step, failed);
     throw new Error(
       `step ${failed.id} failed with exit code ${failed.exitCode}`,
     );


### PR DESCRIPTION
## Summary
- throw a StepError with command, stderr and stdout for failed steps
- surface failure details in runner tests

## Testing
- `pnpm exec eslint packages/piper/src/runner.ts packages/piper/src/tests/runner.test.ts` *(fails: many pre-existing lint errors)*
- `pnpm --filter @promethean/piper test` *(fails: TimeoutError in frontend tests)*


------
https://chatgpt.com/codex/tasks/task_e_68c730cec45c832496f09fbba9cb41ac