### PR TITLE
feat(piper): log stderr on failed steps

### DIFF
--- a/packages/piper/src/runner.ts
+++ b/packages/piper/src/runner.ts
@@ -309,6 +309,15 @@ export async function runPipeline(
         return attemptRun(nextAttempt);
       })(0);
 
+      if (execRes.code !== 0) {
+        const parts = [
+          `[piper] step ${s.id} failed with exit code ${execRes.code}`,
+        ];
+        if (execRes.stderr) parts.push(`stderr:\n${execRes.stderr}`);
+        if (execRes.stdout) parts.push(`stdout:\n${execRes.stdout}`);
+        console.error(parts.join("\n"));
+      }
+
       const endedAt = new Date().toISOString();
       const outHashAfter = s.outputs.length
         ? await fingerprintFromGlobs(

--- a/packages/piper/src/tests/error-logging.test.ts
+++ b/packages/piper/src/tests/error-logging.test.ts
@@ -1,0 +1,74 @@
+import * as fs from "fs/promises";
+import * as path from "path";
+
+import test from "ava";
+
+import { runPipeline } from "../runner.js";
+
+async function withTmp(fn: (dir: string) => Promise<void>) {
+  const dir = path.join(
+    process.cwd(),
+    "test-tmp",
+    String(Date.now()) + "-" + Math.random().toString(36).slice(2),
+  );
+  await fs.mkdir(dir, { recursive: true });
+  try {
+    await fn(dir);
+  } finally {
+    await fs.rm(dir, { recursive: true, force: true });
+  }
+}
+
+test("failing steps log stderr once", async (t) => {
+  await withTmp(async (dir) => {
+    const prevCwd = process.cwd();
+    process.chdir(dir);
+    try {
+      const cfg = {
+        pipelines: [
+          {
+            name: "demo",
+            steps: [
+              {
+                id: "bad",
+                cwd: ".",
+                deps: [],
+                inputs: [],
+                outputs: [],
+                cache: "content",
+                retry: 1,
+                shell: "sh -c 'echo out; echo err >&2; exit 1'",
+              },
+            ],
+          },
+        ],
+      };
+      const pipelinesPath = path.join(dir, "pipelines.json");
+      await fs.writeFile(pipelinesPath, JSON.stringify(cfg, null, 2), "utf8");
+
+      const logs: string[] = [];
+      const origError = console.error;
+      console.error = (...args: unknown[]) => {
+        logs.push(args.join(" "));
+      };
+      try {
+        await t.throwsAsync(
+          () =>
+            runPipeline(pipelinesPath, "demo", {
+              concurrency: 1,
+              contentHash: true,
+            }),
+          { instanceOf: Error },
+        );
+      } finally {
+        console.error = origError;
+      }
+
+      t.is(logs.length, 1);
+      t.true(logs[0]?.includes("err"));
+      t.true(logs[0]?.includes("out"));
+    } finally {
+      process.chdir(prevCwd);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- log step stderr/stdout once when a step exits non-zero
- test that failing steps emit stderr output once

## Testing
- `pnpm lint packages/piper/src/runner.ts packages/piper/src/tests/error-logging.test.ts`
- `pnpm --filter @promethean/piper test -- --match 'failing steps log stderr once'`
- `pnpm install`


------
https://chatgpt.com/codex/tasks/task_e_68c730d05bd883249efd53276fa5ccff