### PR TITLE
refactor: run semverguard via js worker

### DIFF
--- a/packages/semverguard/pipelines.json
+++ b/packages/semverguard/pipelines.json
@@ -4,7 +4,15 @@
     "steps": [
       {
         "id": "sv-snapshot",
-        "shell": "pnpm --filter @promethean/semverguard sv:01-snapshot --root packages --tsconfig ./tsconfig.json --out .cache/semverguard/snapshot.json",
+        "js": {
+          "module": "scripts/piper-semverguard.mjs",
+          "export": "snapshot",
+          "args": {
+            "root": "packages",
+            "tsconfig": "./tsconfig.json",
+            "out": ".cache/semverguard/snapshot.json"
+          }
+        },
         "inputs": [
           "packages/**/package.json",
           "packages/**/{src,lib}/**/*.{ts,tsx,js,jsx}"
@@ -16,7 +24,15 @@
       {
         "id": "sv-diff",
         "deps": ["sv-snapshot"],
-        "shell": "pnpm --filter @promethean/semverguard sv:02-diff --current .cache/semverguard/snapshot.json --baseline git:origin/main:.cache/semverguard/snapshot.json --out .cache/semverguard/diff.json",
+        "js": {
+          "module": "scripts/piper-semverguard.mjs",
+          "export": "diff",
+          "args": {
+            "current": ".cache/semverguard/snapshot.json",
+            "baseline": "git:origin/main:.cache/semverguard/snapshot.json",
+            "out": ".cache/semverguard/diff.json"
+          }
+        },
         "inputs": [".cache/semverguard/snapshot.json"],
         "inputSchema": "packages/semverguard/schemas/io.schema.json",
         "outputs": [".cache/semverguard/diff.json"],
@@ -25,7 +41,15 @@
       {
         "id": "sv-plan",
         "deps": ["sv-diff"],
-        "shell": "pnpm --filter @promethean/semverguard sv:03-plan --diff .cache/semverguard/diff.json --out .cache/semverguard/plans.json --model qwen3:4b",
+        "js": {
+          "module": "scripts/piper-semverguard.mjs",
+          "export": "plan",
+          "args": {
+            "diff": ".cache/semverguard/diff.json",
+            "out": ".cache/semverguard/plans.json",
+            "model": "qwen3:4b"
+          }
+        },
         "inputs": [".cache/semverguard/diff.json"],
         "inputSchema": "packages/semverguard/schemas/io.schema.json",
         "outputs": [".cache/semverguard/plans.json"],
@@ -34,7 +58,14 @@
       {
         "id": "sv-write",
         "deps": ["sv-plan"],
-        "shell": "pnpm --filter @promethean/semverguard sv:04-write --plans .cache/semverguard/plans.json --out docs/agile/tasks/semver",
+        "js": {
+          "module": "scripts/piper-semverguard.mjs",
+          "export": "write",
+          "args": {
+            "plans": ".cache/semverguard/plans.json",
+            "out": "docs/agile/tasks/semver"
+          }
+        },
         "inputs": [".cache/semverguard/plans.json"],
         "inputSchema": "packages/semverguard/schemas/io.schema.json",
         "outputs": ["docs/agile/tasks/semver/*.md"],
@@ -43,7 +74,17 @@
       {
         "id": "sv-pr",
         "deps": ["sv-write"],
-        "shell": "pnpm --filter @promethean/semverguard sv:05-pr --plans .cache/semverguard/plans.json --root packages --mode prepare --update-dependents true --dep-range preserve",
+        "js": {
+          "module": "scripts/piper-semverguard.mjs",
+          "export": "pr",
+          "args": {
+            "plans": ".cache/semverguard/plans.json",
+            "root": "packages",
+            "mode": "prepare",
+            "updateDependents": true,
+            "depRange": "preserve"
+          }
+        },
         "inputs": [".cache/semverguard/plans.json", "packages/**/package.json"],
         "inputSchema": "packages/semverguard/schemas/io.schema.json",
         "outputs": [".cache/semverguard/pr/summary.json"],

--- a/pipelines.json
+++ b/pipelines.json
@@ -168,54 +168,95 @@
       "steps": [
         {
           "id": "sv-snapshot",
-          "shell": "pnpm --filter @promethean/semverguard sv:01-snapshot --root packages --tsconfig ./tsconfig.json --out .cache/semverguard/snapshot.json",
+          "js": {
+            "module": "scripts/piper-semverguard.mjs",
+            "export": "snapshot",
+            "args": {
+              "root": "packages",
+              "tsconfig": "./tsconfig.json",
+              "out": ".cache/semverguard/snapshot.json"
+            }
+          },
           "inputs": [
             "packages/**/package.json",
             "packages/**/{src,lib}/**/*.{ts,tsx,js,jsx}"
           ],
           "outputs": [".cache/semverguard/snapshot.json"],
-          "inputSchema": "packages/semvergaurd/schemas/io.schema.json",
-          "outputSchema": "packages/semvergaurd/schemas/io.schema.json"
+          "inputSchema": "packages/semverguard/schemas/io.schema.json",
+          "outputSchema": "packages/semverguard/schemas/io.schema.json"
         },
         {
           "id": "sv-diff",
           "deps": ["sv-snapshot"],
-          "shell": "pnpm --filter @promethean/semverguard sv:02-diff --current .cache/semverguard/snapshot.json --baseline git:origin/main:.cache/semverguard/snapshot.json --out .cache/semverguard/diff.json",
+          "js": {
+            "module": "scripts/piper-semverguard.mjs",
+            "export": "diff",
+            "args": {
+              "current": ".cache/semverguard/snapshot.json",
+              "baseline": "git:origin/main:.cache/semverguard/snapshot.json",
+              "out": ".cache/semverguard/diff.json"
+            }
+          },
           "inputs": [".cache/semverguard/snapshot.json"],
           "outputs": [".cache/semverguard/diff.json"],
-          "inputSchema": "packages/semvergaurd/schemas/io.schema.json",
-          "outputSchema": "packages/semvergaurd/schemas/io.schema.json"
+          "inputSchema": "packages/semverguard/schemas/io.schema.json",
+          "outputSchema": "packages/semverguard/schemas/io.schema.json"
         },
         {
           "id": "sv-plan",
           "deps": ["sv-diff"],
-          "shell": "pnpm --filter @promethean/semverguard sv:03-plan --diff .cache/semverguard/diff.json --out .cache/semverguard/plans.json --model qwen3:4b",
+          "js": {
+            "module": "scripts/piper-semverguard.mjs",
+            "export": "plan",
+            "args": {
+              "diff": ".cache/semverguard/diff.json",
+              "out": ".cache/semverguard/plans.json",
+              "model": "qwen3:4b"
+            }
+          },
           "env": { "OLLAMA_URL": "${OLLAMA_URL}" },
           "inputs": [".cache/semverguard/diff.json"],
           "outputs": [".cache/semverguard/plans.json"],
-          "inputSchema": "packages/semvergaurd/schemas/io.schema.json",
-          "outputSchema": "packages/semvergaurd/schemas/io.schema.json"
+          "inputSchema": "packages/semverguard/schemas/io.schema.json",
+          "outputSchema": "packages/semverguard/schemas/io.schema.json"
         },
         {
           "id": "sv-write",
           "deps": ["sv-plan"],
-          "shell": "pnpm --filter @promethean/semverguard sv:04-write --plans .cache/semverguard/plans.json --out docs/agile/tasks/semver",
+          "js": {
+            "module": "scripts/piper-semverguard.mjs",
+            "export": "write",
+            "args": {
+              "plans": ".cache/semverguard/plans.json",
+              "out": "docs/agile/tasks/semver"
+            }
+          },
           "inputs": [".cache/semverguard/plans.json"],
           "outputs": ["docs/agile/tasks/semver/*.md"],
-          "inputSchema": "packages/semvergaurd/schemas/io.schema.json",
-          "outputSchema": "packages/semvergaurd/schemas/io.schema.json"
+          "inputSchema": "packages/semverguard/schemas/io.schema.json",
+          "outputSchema": "packages/semverguard/schemas/io.schema.json"
         },
         {
           "id": "sv-pr",
           "deps": ["sv-write"],
-          "shell": "pnpm --filter @promethean/semverguard sv:05-pr --plans .cache/semverguard/plans.json --root packages --mode prepare --update-dependents true --dep-range preserve",
+          "js": {
+            "module": "scripts/piper-semverguard.mjs",
+            "export": "pr",
+            "args": {
+              "plans": ".cache/semverguard/plans.json",
+              "root": "packages",
+              "mode": "prepare",
+              "updateDependents": true,
+              "depRange": "preserve"
+            }
+          },
           "inputs": [
             ".cache/semverguard/plans.json",
             "packages/**/package.json"
           ],
           "outputs": [".cache/semverguard/pr/summary.json"],
-          "inputSchema": "packages/semvergaurd/schemas/io.schema.json",
-          "outputSchema": "packages/semvergaurd/schemas/io.schema.json"
+          "inputSchema": "packages/semverguard/schemas/io.schema.json",
+          "outputSchema": "packages/semverguard/schemas/io.schema.json"
         }
       ]
     },

--- a/scripts/piper-semverguard.mjs
+++ b/scripts/piper-semverguard.mjs
@@ -1,0 +1,102 @@
+import { spawn } from "node:child_process";
+
+function run(command, args) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, { stdio: "inherit" });
+    child.on("close", (code) => {
+      if (code === 0) resolve();
+      else
+        reject(
+          new Error(`${command} ${args.join(" ")} exited with code ${code}`),
+        );
+    });
+  });
+}
+
+export async function snapshot(opts = {}) {
+  const root = opts.root ?? "packages";
+  const tsconfig = opts.tsconfig ?? "./tsconfig.json";
+  const out = opts.out ?? ".cache/semverguard/snapshot.json";
+  await run("pnpm", [
+    "--filter",
+    "@promethean/semverguard",
+    "sv:01-snapshot",
+    "--root",
+    root,
+    "--tsconfig",
+    tsconfig,
+    "--out",
+    out,
+  ]);
+}
+
+export async function diff(opts = {}) {
+  const current = opts.current ?? ".cache/semverguard/snapshot.json";
+  const baseline = opts.baseline ?? ".cache/semverguard/baseline.json";
+  const out = opts.out ?? ".cache/semverguard/diff.json";
+  await run("pnpm", [
+    "--filter",
+    "@promethean/semverguard",
+    "sv:02-diff",
+    "--current",
+    current,
+    "--baseline",
+    baseline,
+    "--out",
+    out,
+  ]);
+}
+
+export async function plan(opts = {}) {
+  const diff = opts.diff ?? ".cache/semverguard/diff.json";
+  const out = opts.out ?? ".cache/semverguard/plans.json";
+  const model = opts.model ?? "qwen3:4b";
+  await run("pnpm", [
+    "--filter",
+    "@promethean/semverguard",
+    "sv:03-plan",
+    "--diff",
+    diff,
+    "--out",
+    out,
+    "--model",
+    model,
+  ]);
+}
+
+export async function write(opts = {}) {
+  const plans = opts.plans ?? ".cache/semverguard/plans.json";
+  const out = opts.out ?? "docs/agile/tasks/semver";
+  await run("pnpm", [
+    "--filter",
+    "@promethean/semverguard",
+    "sv:04-write",
+    "--plans",
+    plans,
+    "--out",
+    out,
+  ]);
+}
+
+export async function pr(opts = {}) {
+  const plans = opts.plans ?? ".cache/semverguard/plans.json";
+  const root = opts.root ?? "packages";
+  const mode = opts.mode ?? "prepare";
+  const updateDependents = String(opts.updateDependents ?? true);
+  const depRange = opts.depRange ?? "preserve";
+  await run("pnpm", [
+    "--filter",
+    "@promethean/semverguard",
+    "sv:05-pr",
+    "--plans",
+    plans,
+    "--root",
+    root,
+    "--mode",
+    mode,
+    "--update-dependents",
+    updateDependents,
+    "--dep-range",
+    depRange,
+  ]);
+}


### PR DESCRIPTION
## Summary
- route semverguard pipeline steps through JS worker wrappers
- invoke semverguard snapshot/diff/plan/write/pr steps with pnpm in a worker
- update pipeline configs to use the new JS worker module

## Testing
- `pnpm exec eslint scripts/piper-semverguard.mjs`
- `pnpm --filter @promethean/semverguard build`
- `pnpm --filter @promethean/piper build`
- `pnpm install`

------
https://chatgpt.com/codex/tasks/task_e_68c73183677083249d067c11a18c91b4