### PR TITLE
refactor: run symdocs via piper js workers

### DIFF
--- a/pipelines.json
+++ b/pipelines.json
@@ -6,7 +6,11 @@
         {
           "id": "symdocs-scan",
           "cwd": ".",
-          "shell": "pnpm --filter @promethean/symdocs symdocs:01-scan",
+          "js": {
+            "module": "scripts/piper-symdocs.mjs",
+            "export": "scan",
+            "isolate": "worker"
+          },
           "inputs": ["packages/**/{src,lib}/**/*.{ts,tsx,js,jsx}"],
           "outputs": [".cache/symdocs/symbols.json"],
           "inputSchema": "packages/symdocs/schemas/io.schema.json",
@@ -15,7 +19,12 @@
         {
           "id": "symdocs-docs",
           "deps": ["symdocs-scan"],
-          "shell": "pnpm --filter @promethean/symdocs symdocs:02-docs --model qwen3:4b",
+          "js": {
+            "module": "scripts/piper-symdocs.mjs",
+            "export": "docs",
+            "args": { "model": "qwen3:4b" },
+            "isolate": "worker"
+          },
           "env": { "OLLAMA_URL": "${OLLAMA_URL}" },
           "inputs": [".cache/symdocs/symbols.json"],
           "outputs": [".cache/symdocs/docs.json"],
@@ -25,7 +34,12 @@
         {
           "id": "symdocs-write",
           "deps": ["symdocs-docs"],
-          "shell": "pnpm --filter @promethean/symdocs symdocs:03-write --out docs/packages --granularity module",
+          "js": {
+            "module": "scripts/piper-symdocs.mjs",
+            "export": "write",
+            "args": { "out": "docs/packages", "granularity": "module" },
+            "isolate": "worker"
+          },
           "inputs": [".cache/symdocs/docs.json"],
           "outputs": ["docs/packages/**/**/*.md"],
           "inputSchema": "packages/symdocs/schemas/io.schema.json",
@@ -34,7 +48,11 @@
         {
           "id": "symdocs-graph",
           "deps": ["symdocs-scan"],
-          "shell": "pnpm --filter @promethean/symdocs symdocs:04-graph",
+          "js": {
+            "module": "scripts/piper-symdocs.mjs",
+            "export": "graph",
+            "isolate": "worker"
+          },
           "inputs": [
             "packages/**/package.json",
             "packages/**/{src,lib}/**/*.{ts,tsx,js,jsx}"

--- a/scripts/piper-symdocs.mjs
+++ b/scripts/piper-symdocs.mjs
@@ -1,0 +1,29 @@
+import { spawn } from 'node:child_process';
+
+export async function scan(args = {}) {
+  const { runScan } = await import('../packages/symdocs/dist/01-scan.js');
+  await runScan(args);
+}
+
+export async function docs(args = {}) {
+  const { runDocs } = await import('../packages/symdocs/dist/02-docs.js');
+  await runDocs(args);
+}
+
+export async function write(args = {}) {
+  const { runWrite } = await import('../packages/symdocs/dist/03-write.js');
+  await runWrite(args);
+}
+
+export async function graph() {
+  await new Promise((resolve, reject) => {
+    const proc = spawn('pnpm', ['--filter', '@promethean/symdocs', 'symdocs:04-graph'], {
+      stdio: 'inherit',
+    });
+    proc.on('close', (code) => {
+      if (code === 0) resolve();
+      else reject(new Error(`symdocs:04-graph exited with code ${code}`));
+    });
+    proc.on('error', reject);
+  });
+}


### PR DESCRIPTION
## Summary
- expose symdocs scan/docs/write steps as callable functions
- run symdocs pipeline steps via piper JS workers
- add piper wrapper for symdocs steps

## Testing
- `pnpm exec eslint packages/symdocs/src/01-scan.ts packages/symdocs/src/02-docs.ts packages/symdocs/src/03-write.ts scripts/piper-symdocs.mjs` *(fails: many lint errors)*
- `pnpm --filter @promethean/symdocs build`
- `pnpm --filter @promethean/piper build`
- `pnpm install`


------
https://chatgpt.com/codex/tasks/task_e_68c731594be88324b003c245e1a889fc