### PR TITLE
refactor buildfix pipeline to use js worker

### DIFF
--- a/packages/buildfix/pipelines.json
+++ b/packages/buildfix/pipelines.json
@@ -16,7 +16,15 @@
         },
         {
           "id": "bf-errors",
-          "shell": "pnpm --filter @promethean/buildfix bf:01-errors --tsconfig tsconfig.json --out .cache/buildfix/errors.json",
+          "deps": ["bf-build"],
+          "js": {
+            "module": "packages/buildfix/dist/01-errors.js",
+            "isolate": "worker",
+            "args": {
+              "tsconfig": "tsconfig.json",
+              "out": ".cache/buildfix/errors.json"
+            }
+          },
           "inputs": [
             "tsconfig.json",
             "packages/**/{src,lib}/**/*.{ts,tsx,js,jsx}"
@@ -28,7 +36,23 @@
         {
           "id": "bf-iterate",
           "deps": ["bf-build", "bf-errors"],
-          "shell": "pnpm --filter @promethean/buildfix bf:02-iterate --errors .cache/buildfix/errors.json --out .cache/buildfix --model qwen3:4b --max-cycles 5 --git per-error --commit-on always --branch-prefix buildfix --remote origin --push false --use-gh false --rollback-on-regress true",
+          "js": {
+            "module": "packages/buildfix/dist/02-iterate.js",
+            "isolate": "worker",
+            "args": {
+              "errors": ".cache/buildfix/errors.json",
+              "out": ".cache/buildfix",
+              "model": "qwen3:4b",
+              "maxCycles": 5,
+              "git": "per-error",
+              "commitOn": "always",
+              "branchPrefix": "buildfix",
+              "remote": "origin",
+              "push": false,
+              "useGh": false,
+              "rollbackOnRegress": true
+            }
+          },
           "env": {
             "OLLAMA_URL": "${OLLAMA_URL}"
           },
@@ -48,8 +72,15 @@
         {
           "id": "bf-report",
           "deps": ["bf-build", "bf-iterate"],
-
-          "shell": "pnpm --filter @promethean/buildfix bf:03-report --summary .cache/buildfix/summary.json --history-root .cache/buildfix/history --out docs/agile/reports/buildfix",
+          "js": {
+            "module": "packages/buildfix/dist/03-report.js",
+            "isolate": "worker",
+            "args": {
+              "summary": ".cache/buildfix/summary.json",
+              "historyRoot": ".cache/buildfix/history",
+              "out": "docs/agile/reports/buildfix"
+            }
+          },
           "inputs": [".cache/buildfix/summary.json"],
           "inputSchema": "packages/buildfix/schemas/io.schema.json",
           "outputs": ["docs/agile/reports/buildfix/*.md"],

--- a/packages/buildfix/src/02-iterate.ts
+++ b/packages/buildfix/src/02-iterate.ts
@@ -2,9 +2,16 @@ import * as path from "path";
 import { promises as fs } from "fs";
 
 import { parseArgs } from "@promethean/utils";
+import { fileURLToPath } from "node:url";
 
 import { writeJSON, readJSON, applySnippetToProject } from "./utils.js";
-import type { ErrorList, History, Attempt, Summary } from "./types.js";
+import type {
+  ErrorList,
+  History,
+  Attempt,
+  Summary,
+  BuildError,
+} from "./types.js";
 import { requestPlan, writePlanFile } from "./iter/plan.js";
 import { materializeSnippet } from "./iter/dsl.js";
 import { buildAndJudge } from "./iter/eval.js";
@@ -18,49 +25,47 @@ import {
   rollbackWorktree,
 } from "./iter/git.js";
 
-const args = parseArgs({
-  "--errors": ".cache/buildfix/errors.json",
-  "--out": ".cache/buildfix",
-  "--model": "qwen3:4b",
-  "--max-cycles": "5",
-  "--only-code": "",
-  "--only-file": "",
-  "--tsconfig": "",
-  // git
-  "--git": "off", // off | per-error
-  "--commit-on": "always", // always | success
-  "--branch-prefix": "buildfix",
-  "--remote": "origin",
-  "--push": "false",
-  "--use-gh": "false",
-  // rollback
-  "--rollback-on-regress": "true", // if after error count > before, undo worktree changes
-});
+export type IterateOptions = {
+  readonly errors?: string;
+  readonly out?: string;
+  readonly model?: string;
+  readonly maxCycles?: number;
+  readonly onlyCode?: string;
+  readonly onlyFile?: string;
+  readonly tsconfig?: string;
+  readonly git?: string;
+  readonly commitOn?: "always" | "success";
+  readonly branchPrefix?: string;
+  readonly remote?: string;
+  readonly push?: boolean;
+  readonly useGh?: boolean;
+  readonly rollbackOnRegress?: boolean;
+};
 
-function makeBranch(err: any) {
+function makeBranch(err: BuildError, branchPrefix: string): string {
   const fileSlug = err.file
     .replace(process.cwd() + path.sep, "")
     .replace(/[\/\\\.]/g, "-");
-  return sanitizeBranch(
-    `${args["--branch-prefix"]}/${err.code}/${fileSlug}/${err.line}`,
-  );
+  return sanitizeBranch(`${branchPrefix}/${err.code}/${fileSlug}/${err.line}`);
 }
 
-async function main() {
-  const errors = await readJSON<ErrorList>(path.resolve(args["--errors"]));
+export async function run(opts: IterateOptions = {}): Promise<void> {
+  const errors = await readJSON<ErrorList>(
+    path.resolve(opts.errors ?? ".cache/buildfix/errors.json"),
+  );
   if (!errors) throw new Error("errors.json not found");
-  const tsconfig = args["--tsconfig"] || errors.tsconfig;
-  const onlyCode = (args["--only-code"] || "").trim();
-  const onlyFile = (args["--only-file"] || "").trim();
-  const maxCycles = Number(args["--max-cycles"]);
-  const OUT = path.resolve(args["--out"]);
+  const tsconfig = opts.tsconfig || errors.tsconfig;
+  const onlyCode = (opts.onlyCode ?? "").trim();
+  const onlyFile = (opts.onlyFile ?? "").trim();
+  const maxCycles = opts.maxCycles ?? 5;
+  const OUT = path.resolve(opts.out ?? ".cache/buildfix");
 
-  const useGit = args["--git"] !== "off" && (await isGitRepo());
-  const commitOn = (args["--commit-on"] as "always" | "success") || "always";
-  const remote = args["--remote"];
-  const push = args["--push"] === "true";
-  const useGh = args["--use-gh"] === "true";
-  const doRollback = args["--rollback-on-regress"] === "true";
+  const useGit = opts.git !== "off" && (await isGitRepo());
+  const commitOn = opts.commitOn || "always";
+  const remote = opts.remote || "origin";
+  const push = opts.push ?? false;
+  const useGh = opts.useGh ?? false;
+  const doRollback = opts.rollbackOnRegress ?? true;
 
   const todo = errors.errors.filter(
     (e) =>
@@ -86,8 +91,8 @@ async function main() {
     };
 
     let branch: string | undefined;
-    if (useGit && args["--git"] === "per-error") {
-      branch = makeBranch(err);
+    if (useGit && opts.git === "per-error") {
+      branch = makeBranch(err, opts.branchPrefix || "buildfix");
       await ensureBranch(branch);
     }
 
@@ -107,7 +112,7 @@ async function main() {
       // 1) Plan
       let plan;
       try {
-        plan = await requestPlan(args["--model"], err, history);
+        plan = await requestPlan(opts.model ?? "qwen3:4b", err, history);
       } catch (e) {
         console.error(`✖ plan failed for ${err.key}:`, e);
         break;
@@ -226,7 +231,42 @@ async function main() {
   );
 }
 
-main().catch((e) => {
-  console.error(e);
-  process.exit(1);
-});
+export default run;
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  const args = parseArgs({
+    "--errors": ".cache/buildfix/errors.json",
+    "--out": ".cache/buildfix",
+    "--model": "qwen3:4b",
+    "--max-cycles": "5",
+    "--only-code": "",
+    "--only-file": "",
+    "--tsconfig": "",
+    "--git": "off",
+    "--commit-on": "always",
+    "--branch-prefix": "buildfix",
+    "--remote": "origin",
+    "--push": "false",
+    "--use-gh": "false",
+    "--rollback-on-regress": "true",
+  });
+  run({
+    errors: args["--errors"],
+    out: args["--out"],
+    model: args["--model"],
+    maxCycles: Number(args["--max-cycles"]),
+    onlyCode: args["--only-code"],
+    onlyFile: args["--only-file"],
+    tsconfig: args["--tsconfig"],
+    git: args["--git"],
+    commitOn: args["--commit-on"] as "always" | "success",
+    branchPrefix: args["--branch-prefix"],
+    remote: args["--remote"],
+    push: args["--push"] === "true",
+    useGh: args["--use-gh"] === "true",
+    rollbackOnRegress: args["--rollback-on-regress"] === "true",
+  }).catch((e) => {
+    console.error(e);
+    process.exit(1);
+  });
+}

--- a/packages/buildfix/src/03-report.ts
+++ b/packages/buildfix/src/03-report.ts
@@ -2,27 +2,32 @@ import * as path from "path";
 import { promises as fs } from "fs";
 
 import { parseArgs } from "@promethean/utils";
+import { fileURLToPath } from "node:url";
 
 import { readJSON } from "./utils.js";
 import type { Summary, History } from "./types.js";
 
-const args = parseArgs({
-  "--history-root": ".cache/buildfix/history",
-  "--summary": ".cache/buildfix/summary.json",
-  "--out": "docs/agile/reports/buildfix",
-});
+export type ReportOptions = {
+  readonly historyRoot?: string;
+  readonly summary?: string;
+  readonly out?: string;
+};
 
-async function main() {
-  const sum = await readJSON<Summary>(path.resolve(args["--summary"]));
+export async function run(opts: ReportOptions = {}): Promise<void> {
+  const sum = await readJSON<Summary>(
+    path.resolve(opts.summary ?? ".cache/buildfix/summary.json"),
+  );
   if (!sum) throw new Error("summary not found");
 
-  await fs.mkdir(path.resolve(args["--out"]), { recursive: true });
+  const outDir = path.resolve(opts.out ?? "docs/agile/reports/buildfix");
+  await fs.mkdir(outDir, { recursive: true });
   const ts = new Date().toISOString().replace(/[:.]/g, "-");
-  const out = path.join(args["--out"], `buildfix-${ts}.md`);
+  const out = path.join(outDir, `buildfix-${ts}.md`);
 
+  const histRoot = path.resolve(opts.historyRoot ?? ".cache/buildfix/history");
   const rows = await Promise.all(
-    sum.items.map(async (it: { key: string; resolved: any; attempts: any }) => {
-      const hp = path.join(args["--history-root"], it.key, "history.json");
+    sum.items.map(async (it: Summary["items"][number]) => {
+      const hp = path.join(histRoot, it.key, "history.json");
       const hist = await readJSON<History>(hp);
       const last = hist?.attempts.at(-1);
       return `| \`${it.key}\` | ${it.resolved ? "✅" : "❌"} | ${
@@ -46,13 +51,26 @@ async function main() {
 
   await fs.writeFile(out, md, "utf-8");
   await fs.writeFile(
-    path.join(args["--out"], "README.md"),
+    path.join(outDir, "README.md"),
     `# Buildfix Reports\n\n- [Latest](${path.basename(out)})\n`,
   );
   console.log(`buildfix: report → ${path.relative(process.cwd(), out)}`);
 }
 
-main().catch((e) => {
-  console.error(e);
-  process.exit(1);
-});
+export default run;
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  const args = parseArgs({
+    "--history-root": ".cache/buildfix/history",
+    "--summary": ".cache/buildfix/summary.json",
+    "--out": "docs/agile/reports/buildfix",
+  });
+  run({
+    historyRoot: args["--history-root"],
+    summary: args["--summary"],
+    out: args["--out"],
+  }).catch((e) => {
+    console.error(e);
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
## Summary
- expose buildfix steps as callable functions for worker execution
- run buildfix pipeline with JS worker steps in Piper

## Testing
- `pnpm exec eslint packages/buildfix/src/01-errors.ts packages/buildfix/src/02-iterate.ts packages/buildfix/src/03-report.ts packages/buildfix/pipelines.json` (fails: functional rules and complexity warnings)
- `pnpm --filter @promethean/buildfix test`
- `pnpm --filter @promethean/piper build`
- `pnpm install`


------
https://chatgpt.com/codex/tasks/task_e_68c731b566b08324a90eb93a7dc82793