### PR TITLE
refactor: run sonarflow via piper worker pipeline

### DIFF
--- a/packages/sonarflow/pipeline.json
+++ b/packages/sonarflow/pipeline.json
@@ -1,0 +1,98 @@
+{
+  "pipelines": [
+    {
+      "name": "sonar",
+      "steps": [
+        {
+          "id": "sonar-scan",
+          "cwd": ".",
+          "shell": "sonar-scanner && touch .cache/sonar/scan.touch",
+          "env": {
+            "SONAR_HOST_URL": "${SONAR_HOST_URL}",
+            "SONAR_TOKEN": "${SONAR_TOKEN}",
+            "SONAR_PROJECT_KEY": "${SONAR_PROJECT_KEY}"
+          },
+          "inputs": [
+            "packages/**/{src,lib}/**/*.{ts,tsx,js,jsx}",
+            "sonar-project.properties"
+          ],
+          "outputs": [".cache/sonar/scan.touch"],
+          "inputSchema": "packages/sonarflow/schemas/io.schema.json",
+          "outputSchema": "packages/sonarflow/schemas/io.schema.json"
+        },
+        {
+          "id": "sonar-fetch",
+          "deps": ["sonar-scan"],
+          "cwd": "packages/sonarflow",
+          "env": {
+            "SONAR_HOST_URL": "${SONAR_HOST_URL}",
+            "SONAR_TOKEN": "${SONAR_TOKEN}",
+            "SONAR_PROJECT_KEY": "${SONAR_PROJECT_KEY}"
+          },
+          "js": {
+            "module": "dist/02-fetch.js",
+            "export": "default",
+            "args": {
+              "project": "${SONAR_PROJECT_KEY}",
+              "out": ".cache/sonar/issues.json",
+              "statuses": "OPEN,REOPENED,CONFIRMED",
+              "types": "BUG,VULNERABILITY,CODE_SMELL,SECURITY_HOTSPOT",
+              "severities": "BLOCKER,CRITICAL,MAJOR,MINOR,INFO",
+              "pageSize": 500
+            },
+            "isolate": "worker"
+          },
+          "inputs": [],
+          "outputs": [".cache/sonar/issues.json"],
+          "outputSchema": "packages/sonarflow/schemas/io.schema.json"
+        },
+        {
+          "id": "sonar-plan",
+          "deps": ["sonar-fetch"],
+          "cwd": "packages/sonarflow",
+          "env": {
+            "OLLAMA_URL": "${OLLAMA_URL}"
+          },
+          "js": {
+            "module": "dist/03-plan.js",
+            "export": "default",
+            "args": {
+              "input": ".cache/sonar/issues.json",
+              "output": ".cache/sonar/plans.json",
+              "groupBy": "rule+prefix",
+              "prefixDepth": 2,
+              "minGroup": 2,
+              "model": "qwen3:4b"
+            },
+            "isolate": "worker"
+          },
+          "inputs": [".cache/sonar/issues.json"],
+          "outputs": [".cache/sonar/plans.json"],
+          "inputSchema": "packages/sonarflow/schemas/io.schema.json",
+          "outputSchema": "packages/sonarflow/schemas/io.schema.json"
+        },
+        {
+          "id": "sonar-write",
+          "deps": ["sonar-plan"],
+          "cwd": "packages/sonarflow",
+          "js": {
+            "module": "dist/04-write.js",
+            "export": "default",
+            "args": {
+              "input": ".cache/sonar/plans.json",
+              "out": "docs/agile/tasks/sonar",
+              "status": "todo",
+              "assignee": "",
+              "label": "sonarqube,quality,remediation"
+            },
+            "isolate": "worker"
+          },
+          "inputs": [".cache/sonar/plans.json"],
+          "outputs": ["docs/agile/tasks/sonar/*.md"],
+          "inputSchema": "packages/sonarflow/schemas/io.schema.json",
+          "outputSchema": "packages/sonarflow/schemas/io.schema.json"
+        }
+      ]
+    }
+  ]
+}

--- a/packages/sonarflow/schemas/io.schema.json
+++ b/packages/sonarflow/schemas/io.schema.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object"
+}

--- a/packages/sonarflow/src/03-plan.ts
+++ b/packages/sonarflow/src/03-plan.ts
@@ -1,3 +1,5 @@
+import { pathToFileURL } from "url";
+import { promises as fs } from "fs";
 import { z } from "zod";
 import { ollamaJSON } from "@promethean/utils";
 
@@ -16,14 +18,14 @@ import type {
   SonarIssue,
 } from "./types.js";
 
-const args = parseArgs({
-  "--in": ".cache/sonar/issues.json",
-  "--out": ".cache/sonar/plans.json",
-  "--group-by": "rule+prefix", // "rule" | "prefix" | "rule+prefix"
-  "--prefix-depth": "2",
-  "--min-group": "2",
-  "--model": "qwen3:4b",
-});
+export type PlanOpts = {
+  input: string;
+  output: string;
+  groupBy: string;
+  prefixDepth: number;
+  minGroup: number;
+  model: string;
+};
 
 const TaskSchema = z.object({
   title: z.string().min(1),
@@ -49,24 +51,24 @@ function bundleTitle(k: string) {
   return parts.join(" • ");
 }
 
-async function main() {
-  const inPath = String(args["--in"]);
-  const outPath = String(args["--out"]);
-  const model = String(args["--model"]);
+export async function plan(opts: PlanOpts) {
+  const inPath = opts.input;
+  const outPath = opts.output;
+  const model = opts.model;
 
   const { issues, project } = JSON.parse(
-    await (await fetch("file://" + process.cwd() + "/" + inPath)).text(),
+    await fs.readFile(inPath, "utf-8"),
   ) as FetchPayload;
 
-  const depth = Number(args["--prefix-depth"]);
-  const mode = String(args["--group-by"]);
+  const depth = opts.prefixDepth;
+  const mode = opts.groupBy;
   const groups = new Map<string, SonarIssue[]>();
   for (const it of issues) {
     const k = bundleKey(it, mode, depth);
     (groups.get(k) ?? groups.set(k, []).get(k)!).push(it);
   }
 
-  const min = Number(args["--min-group"]);
+  const min = opts.minGroup;
   const bundles: IssueBundle[] = [];
   for (const [k, arr] of groups) {
     if (arr.length < min) continue;
@@ -96,7 +98,6 @@ async function main() {
 
   const tasks: PlanTask[] = [];
   for (const b of bundles) {
-    // Prepare compact context for LLM
     const bullets = b.issues
       .slice(0, 30)
       .map((i) => {
@@ -135,7 +136,6 @@ async function main() {
       const parsed = TaskSchema.safeParse(obj);
       if (!parsed.success) throw new Error("invalid LLM JSON");
     } catch {
-      // Fallback
       obj = {
         title: `[${b.severityTop}] ${b.title}`,
         summary: `Address ${b.issues.length} SonarQube finding(s) related to ${
@@ -188,7 +188,26 @@ async function main() {
   console.log(`sonarflow: planned ${tasks.length} tasks → ${outPath}`);
 }
 
-main().catch((e) => {
-  console.error(e);
-  process.exit(1);
-});
+if (import.meta.url === pathToFileURL(process.argv[1]!).href) {
+  const args = parseArgs({
+    "--in": ".cache/sonar/issues.json",
+    "--out": ".cache/sonar/plans.json",
+    "--group-by": "rule+prefix",
+    "--prefix-depth": "2",
+    "--min-group": "2",
+    "--model": "qwen3:4b",
+  });
+  plan({
+    input: String(args["--in"]),
+    output: String(args["--out"]),
+    groupBy: String(args["--group-by"]),
+    prefixDepth: Number(args["--prefix-depth"]),
+    minGroup: Number(args["--min-group"]),
+    model: String(args["--model"]),
+  }).catch((e) => {
+    console.error(e);
+    process.exit(1);
+  });
+}
+
+export default plan;


### PR DESCRIPTION
## Summary
- expose sonarflow fetch/plan/write as callable functions
- run sonarflow steps in a new piper pipeline using JS worker isolation

## Testing
- `pnpm lint packages/sonarflow/src/02-fetch.ts packages/sonarflow/src/03-plan.ts packages/sonarflow/src/04-write.ts`
- `pnpm --filter @promethean/sonarflow build`
- `pnpm install`


------
https://chatgpt.com/codex/tasks/task_e_68c7319dec008324b971674e7d00ff88