### PR TITLE
docs: replace serve:sites references with frontend service

### DIFF
--- a/docs/services/smartgpt-bridge-dashboard.md
+++ b/docs/services/smartgpt-bridge-dashboard.md
@@ -19,8 +19,8 @@ The dashboard at `/` is now generated from the live OpenAPI spec exposed by the 
     - `pnpm -C services/ts/smartgpt-bridge start`
 2. Start the proxy service:
     - `pnpm -C services/js/proxy start`
-3. Serve frontends:
-    - `pnpm serve:sites`
+3. Start the frontend service:
+    - `pnpm --filter @promethean/frontend-service dev`
 4. Open the dashboard:
     - http://localhost:4500/smartgpt-dashboard/
 5. (Optional) Paste your bearer token and click Save to enable protected routes.

--- a/packages/llm/README.md
+++ b/packages/llm/README.md
@@ -14,7 +14,7 @@ manager is missing):
 
 POST `/generate` with JSON containing `prompt`, `context` and optional `format` to receive the generated reply.
 
-Serve the chat interface via `pnpm serve:sites` and open `http://localhost:4500/llm-chat/` to try it in your browser.
+Start the `frontend-service` with `pnpm --filter @promethean/frontend-service dev` and open `http://localhost:4500/llm-chat/` to try it in your browser.
 
 ## Configuration
 

--- a/packages/smartgpt-bridge/README.md
+++ b/packages/smartgpt-bridge/README.md
@@ -43,7 +43,7 @@ export AGENT_RESTORE_ON_START=true             # load past agents as historical 
 npm i
 npm start
 # http://0.0.0.0:3210/openapi.json
-# Dashboard now served via `pnpm serve:sites`:
+# Dashboard now served via `frontend-service`:
 #   http://localhost:4500/smartgpt-dashboard/
 ```
 

--- a/sites/README.md
+++ b/sites/README.md
@@ -1,6 +1,6 @@
 # Sites
 
-This directory collects all frontend code for Promethean. Each subfolder contains a standalone HTML/JS frontend served by a shared static file server.
+This directory collects all frontend code for Promethean. Each subfolder contains a standalone HTML/JS frontend served by the `frontend-service`.
 
 Current frontends:
 
@@ -9,7 +9,7 @@ Current frontends:
 - `markdown-graph` – Force-directed visualization of markdown link graphs.
 - `health-dashboard` – Realtime viewer of heartbeat metrics from Promethean services.
 
-Run `pnpm serve:sites` from the repo root and visit `http://localhost:4500/<site>/` to view a frontend. Future agents should place any web UI or dashboard code here.
+Run `pnpm --filter @promethean/frontend-service dev` from the repo root and visit `http://localhost:4500/<site>/` to view a frontend. Future agents should place any web UI or dashboard code here.
 
 All network requests from these frontends are routed through the proxy service at `http://localhost:8080`. For example:
 

--- a/sites/markdown-graph/README.md
+++ b/sites/markdown-graph/README.md
@@ -1,3 +1,3 @@
 # Markdown Link Graph
 
-`graph.html` renders the markdown link graph produced by the `markdown_graph` service. Run `pnpm serve:sites` and open `http://localhost:4500/markdown-graph/graph.html` while the service is running to explore the connected documents in a force-directed view.
+`graph.html` renders the markdown link graph produced by the `markdown_graph` service. Start the `frontend-service` with `pnpm --filter @promethean/frontend-service dev` and open `http://localhost:4500/markdown-graph/graph.html` while the service is running to explore the connected documents in a force-directed view.


### PR DESCRIPTION
## Summary
- replace deprecated `serve:sites` directions with new `frontend-service`
- adjust smartgpt bridge and LLM READMEs to point to `frontend-service`
- update smartgpt bridge dashboard docs to start `frontend-service`

## Testing
- `pnpm lint:diff`
- `pnpm --filter @promethean/llm test`
- `pnpm --filter @promethean/smartgpt-bridge test` *(fails: Fastify swagger plugin version mismatch)*
- `pnpm install`


------
https://chatgpt.com/codex/tasks/task_e_68c735968610832489d48335ce61044d