### PR TITLE
feat: add frontend service

### DIFF
--- a/packages/frontend-service/README.md
+++ b/packages/frontend-service/README.md
@@ -1,0 +1,15 @@
+# Frontend Service
+
+Serves compiled frontend assets from Promethean packages under a single Fastify instance.
+
+## Usage
+
+```bash
+pnpm --filter @promethean/frontend-service start
+```
+
+This will start a server on port `4500`. Each package that contains a `dist/frontend` or `static` directory is mounted under a path matching the package name.
+
+Example: `http://localhost:4500/piper/` serves the Piper frontend.
+
+Health and diagnostics endpoints are available at `/health` and `/diagnostics`.

--- a/packages/frontend-service/ava.config.mjs
+++ b/packages/frontend-service/ava.config.mjs
@@ -1,0 +1,1 @@
+export { default } from "../../config/ava.config.mjs";

--- a/packages/frontend-service/package.json
+++ b/packages/frontend-service/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@promethean/web-utils",
+  "name": "@promethean/frontend-service",
   "version": "0.0.1",
   "private": true,
   "type": "module",
@@ -21,19 +21,17 @@
     "build": "tsc",
     "clean": "rimraf dist",
     "typecheck": "tsc -p tsconfig.json --noEmit",
-    "test": "pnpm run build && ava --config ../../config/ava.config.mjs",
+    "test": "pnpm run build && ava",
     "lint": "pnpm exec eslint .",
-    "coverage": "pnpm run build && c8 ava --config ../../config/ava.config.mjs",
-    "format": "pnpm exec prettier --write ."
+    "coverage": "pnpm run build && c8 ava",
+    "format": "pnpm exec prettier --write .",
+    "prestart": "pnpm run build",
+    "start": "node dist/index.js"
   },
   "module": "dist/index.js",
   "dependencies": {
-    "cheerio": "1.0.0-rc.12",
-    "zod": "3.23.8",
-    "@xenova/transformers": "2.17.2",
-    "@promethean/fs": "workspace:*"
-  },
-  "devDependencies": {
-    "fastify": "5.3.2"
+    "fastify": "5.3.2",
+    "@fastify/static": "8.2.0",
+    "@promethean/web-utils": "workspace:*"
   }
 }

--- a/packages/frontend-service/project.json
+++ b/packages/frontend-service/project.json
@@ -1,0 +1,34 @@
+{
+  "name": "@promethean/frontend-service",
+  "root": "packages/frontend-service",
+  "sourceRoot": "packages/frontend-service/src",
+  "targets": {
+    "build": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "tsc -b"
+      },
+      "outputs": ["{projectRoot}/dist"]
+    },
+    "typecheck": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "tsc -p tsconfig.json --noEmit"
+      }
+    },
+    "test": {
+      "executor": "nx:run-commands",
+      "dependsOn": ["build"],
+      "options": {
+        "command": "ava"
+      }
+    },
+    "lint": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "eslint ."
+      }
+    }
+  },
+  "tags": ["scope:packages"]
+}

--- a/packages/frontend-service/src/index.ts
+++ b/packages/frontend-service/src/index.ts
@@ -1,0 +1,62 @@
+import Fastify from "fastify";
+import fastifyStatic from "@fastify/static";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+import fs from "node:fs";
+import {
+  registerHealthRoute,
+  registerDiagnosticsRoute,
+} from "@promethean/web-utils";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+async function mountFrontends(app: any) {
+  const repoRoot = path.resolve(__dirname, "..", "..", "..");
+  const packagesDir = path.join(repoRoot, "packages");
+  const dirs = fs.readdirSync(packagesDir, { withFileTypes: true });
+
+  for (const dir of dirs) {
+    if (!dir.isDirectory()) continue;
+    const pkgPath = path.join(packagesDir, dir.name);
+    const pkgJsonPath = path.join(pkgPath, "package.json");
+    if (!fs.existsSync(pkgJsonPath)) continue;
+    const pkg = JSON.parse(fs.readFileSync(pkgJsonPath, "utf8"));
+    const name: string = pkg.name ?? dir.name;
+    const prefix = name.startsWith("@promethean/") ? name.split("/")[1] : name;
+    const distFrontend = path.join(pkgPath, "dist", "frontend");
+    const staticDir = path.join(pkgPath, "static");
+
+    if (fs.existsSync(distFrontend)) {
+      app.register(fastifyStatic, {
+        root: distFrontend,
+        prefix: `/${prefix}/`,
+      });
+    }
+
+    if (fs.existsSync(staticDir)) {
+      app.register(fastifyStatic, {
+        root: staticDir,
+        prefix: `/${prefix}/static/`,
+      });
+    }
+  }
+}
+
+export async function createServer() {
+  const app = Fastify();
+  await mountFrontends(app);
+  await registerHealthRoute(app, { serviceName: "frontend-service" });
+  await registerDiagnosticsRoute(app, { serviceName: "frontend-service" });
+  await app.ready();
+  return app;
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  const port = Number(process.env.PORT ?? 4500);
+  const server = await createServer();
+  server.listen({ port, host: "0.0.0.0" }).catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
+}

--- a/packages/frontend-service/src/tests/server.test.ts
+++ b/packages/frontend-service/src/tests/server.test.ts
@@ -1,0 +1,25 @@
+import test from "ava";
+import { createServer } from "../index.js";
+
+async function build() {
+  const app = await createServer();
+  return app;
+}
+
+test("health route responds", async (t) => {
+  const app = await build();
+  const res = await app.inject("/health");
+  t.is(res.statusCode, 200);
+});
+
+test("diagnostics route responds", async (t) => {
+  const app = await build();
+  const res = await app.inject("/diagnostics");
+  t.is(res.statusCode, 200);
+});
+
+test("serves existing frontend assets", async (t) => {
+  const app = await build();
+  const res = await app.inject("/piper/main.js");
+  t.is(res.statusCode, 200);
+});

--- a/packages/frontend-service/tsconfig.json
+++ b/packages/frontend-service/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../config/tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "composite": true,
+    "declaration": true
+  },
+  "include": ["src/**/*"],
+  "references": []
+}

--- a/packages/web-utils/src/core.ts
+++ b/packages/web-utils/src/core.ts
@@ -3,32 +3,51 @@
  */
 
 // Avoid hard dependency on fastify types; accept any-compatible instances
-import type { z } from 'zod';
+import type { z } from "zod";
 
 export type HealthCheckResponse = {
-    status: 'healthy' | 'unhealthy';
-    timestamp: string;
-    service: string;
+  status: "healthy" | "unhealthy";
+  timestamp: string;
+  service: string;
 };
 
-export function createHealthCheck(serviceName: string = 'promethean-service') {
-    return (): HealthCheckResponse => ({
-        status: 'healthy',
-        timestamp: new Date().toISOString(),
-        service: serviceName,
-    });
+export function createHealthCheck(serviceName: string = "promethean-service") {
+  return (): HealthCheckResponse => ({
+    status: "healthy",
+    timestamp: new Date().toISOString(),
+    service: serviceName,
+  });
 }
 
-export async function registerHealthRoute(fastify: any, options: { serviceName?: string }) {
-    const healthCheck = createHealthCheck(options.serviceName);
+export async function registerHealthRoute(
+  fastify: any,
+  options: { serviceName?: string },
+) {
+  const healthCheck = createHealthCheck(options.serviceName);
 
-    fastify.get('/health', async () => {
-        return healthCheck();
-    });
+  fastify.get("/health", async () => {
+    return healthCheck();
+  });
+}
+
+export async function registerDiagnosticsRoute(
+  fastify: any,
+  options: { serviceName?: string } = {},
+) {
+  const service = options.serviceName ?? "promethean-service";
+
+  fastify.get("/diagnostics", async () => {
+    return {
+      service,
+      timestamp: new Date().toISOString(),
+      uptime: process.uptime(),
+      memory: process.memoryUsage(),
+    };
+  });
 }
 
 export function createValidationHandler<T extends z.ZodSchema>(schema: T) {
-    return (data: unknown): z.infer<T> => {
-        return schema.parse(data);
-    };
+  return (data: unknown): z.infer<T> => {
+    return schema.parse(data);
+  };
 }

--- a/packages/web-utils/src/tests/core.test.ts
+++ b/packages/web-utils/src/tests/core.test.ts
@@ -1,0 +1,27 @@
+import test from "ava";
+import Fastify from "fastify";
+
+import { registerHealthRoute, registerDiagnosticsRoute } from "../core.js";
+
+test("health route returns healthy status", async (t) => {
+  const app = Fastify();
+  await registerHealthRoute(app, { serviceName: "test-service" });
+  await app.ready();
+  const res = await app.inject("/health");
+  t.is(res.statusCode, 200);
+  const body = res.json();
+  t.is(body.status, "healthy");
+  t.is(body.service, "test-service");
+});
+
+test("diagnostics route exposes runtime info", async (t) => {
+  const app = Fastify();
+  await registerDiagnosticsRoute(app, { serviceName: "test-service" });
+  await app.ready();
+  const res = await app.inject("/diagnostics");
+  t.is(res.statusCode, 200);
+  const body = res.json();
+  t.is(body.service, "test-service");
+  t.truthy(body.uptime);
+  t.truthy(body.memory);
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1862,6 +1862,18 @@ importers:
         specifier: ^3.4.2
         version: 3.6.2
 
+  packages/frontend-service:
+    dependencies:
+      '@fastify/static':
+        specifier: 8.2.0
+        version: 8.2.0
+      '@promethean/web-utils':
+        specifier: workspace:*
+        version: link:../web-utils
+      fastify:
+        specifier: 5.0.0
+        version: 5.0.0
+
   packages/fs:
     dependencies:
       '@promethean/stream':
@@ -4053,6 +4065,10 @@ importers:
       zod:
         specifier: 3.23.8
         version: 3.23.8
+    devDependencies:
+      fastify:
+        specifier: 5.0.0
+        version: 5.0.0
 
   packages/worker:
     dependencies:


### PR DESCRIPTION
## Summary
- add diagnostics route utility
- create frontend service to serve compiled frontends with health/diagnostics

## Testing
- `pnpm lint:diff`
- `pnpm --filter @promethean/web-utils test`
- `pnpm --filter @promethean/frontend-service test`
- `pnpm install`


------
https://chatgpt.com/codex/tasks/task_e_68c7358f1ec483249026b0885f57bb5c