### PR TITLE
feat(frontend-service): disable fastify static reply decoration

### DIFF
--- a/packages/frontend-service/src/index.ts
+++ b/packages/frontend-service/src/index.ts
@@ -1,27 +1,30 @@
-import Fastify from "fastify";
-import fastifyStatic from "@fastify/static";
-import { fileURLToPath } from "node:url";
-import path from "node:path";
 import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import fastifyStatic from "@fastify/static";
+import Fastify, { type FastifyInstance } from "fastify";
 import {
-  registerHealthRoute,
   registerDiagnosticsRoute,
+  registerHealthRoute,
 } from "@promethean/web-utils";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
-async function mountFrontends(app: any) {
+async function mountFrontends(app: Readonly<FastifyInstance>): Promise<void> {
   const repoRoot = path.resolve(__dirname, "..", "..", "..");
   const packagesDir = path.join(repoRoot, "packages");
   const dirs = fs.readdirSync(packagesDir, { withFileTypes: true });
 
-  for (const dir of dirs) {
-    if (!dir.isDirectory()) continue;
+  dirs.forEach((dir) => {
+    if (!dir.isDirectory()) return;
     const pkgPath = path.join(packagesDir, dir.name);
     const pkgJsonPath = path.join(pkgPath, "package.json");
-    if (!fs.existsSync(pkgJsonPath)) continue;
-    const pkg = JSON.parse(fs.readFileSync(pkgJsonPath, "utf8"));
+    if (!fs.existsSync(pkgJsonPath)) return;
+    const pkg = JSON.parse(fs.readFileSync(pkgJsonPath, "utf8")) as unknown as {
+      name?: string;
+    };
     const name: string = pkg.name ?? dir.name;
     const prefix = name.startsWith("@promethean/") ? name.split("/")[1] : name;
     const distFrontend = path.join(pkgPath, "dist", "frontend");
@@ -31,6 +34,7 @@ async function mountFrontends(app: any) {
       app.register(fastifyStatic, {
         root: distFrontend,
         prefix: `/${prefix}/`,
+        decorateReply: false,
       });
     }
 
@@ -38,16 +42,25 @@ async function mountFrontends(app: any) {
       app.register(fastifyStatic, {
         root: staticDir,
         prefix: `/${prefix}/static/`,
+        decorateReply: false,
       });
     }
-  }
+  });
 }
 
-export async function createServer() {
+export async function createServer(): Promise<FastifyInstance> {
   const app = Fastify();
   await mountFrontends(app);
-  await registerHealthRoute(app, { serviceName: "frontend-service" });
-  await registerDiagnosticsRoute(app, { serviceName: "frontend-service" });
+  const healthRoute = registerHealthRoute as (
+    app: FastifyInstance,
+    opts: { readonly serviceName: string },
+  ) => Promise<void>;
+  const diagnosticsRoute = registerDiagnosticsRoute as (
+    app: FastifyInstance,
+    opts: { readonly serviceName: string },
+  ) => Promise<void>;
+  await healthRoute(app, { serviceName: "frontend-service" });
+  await diagnosticsRoute(app, { serviceName: "frontend-service" });
   await app.ready();
   return app;
 }

--- a/packages/frontend-service/src/tests/server.test.ts
+++ b/packages/frontend-service/src/tests/server.test.ts
@@ -1,4 +1,5 @@
 import test from "ava";
+
 import { createServer } from "../index.js";
 
 async function build() {
@@ -18,8 +19,16 @@ test("diagnostics route responds", async (t) => {
   t.is(res.statusCode, 200);
 });
 
-test("serves existing frontend assets", async (t) => {
+test("serves piper frontend asset", async (t) => {
   const app = await build();
   const res = await app.inject("/piper/main.js");
   t.is(res.statusCode, 200);
+});
+
+["llm-chat-frontend", "smart-chat-frontend"].forEach((pkg) => {
+  test(`serves static asset for ${pkg}`, async (t) => {
+    const app = await build();
+    const res = await app.inject(`/${pkg}/static/index.html`);
+    t.is(res.statusCode, 200);
+  });
 });


### PR DESCRIPTION
## Summary
- disable reply decoration when mounting frontend static assets to avoid conflicts
- test serving assets from piper and multiple frontend packages

## Testing
- `pnpm exec eslint packages/frontend-service/src/index.ts packages/frontend-service/src/tests/server.test.ts`
- `pnpm --filter @promethean/frontend-service test`
- `pnpm install` *(postinstall reported some package build failures)*

------
https://chatgpt.com/codex/tasks/task_e_68c73f9a17508324ac99016320bafd0d