### PR TITLE
chore: update fastify plugins

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,7 +102,10 @@
     "overrides": {
       "fastify": "5.0.0",
       "@fastify/static": "8.2.0",
-      "@fastify/websocket": "11.2.0"
+      "@fastify/websocket": "11.2.0",
+      "@fastify/rate-limit": "10.3.0",
+      "@fastify/swagger": "9.5.1",
+      "@fastify/swagger-ui": "5.2.3"
     }
   }
 }

--- a/packages/smartgpt-bridge/package.json
+++ b/packages/smartgpt-bridge/package.json
@@ -20,8 +20,8 @@
   },
   "dependencies": {
     "@fastify/rate-limit": "^10.3.0",
-    "@fastify/swagger": "^8.15.0",
-    "@fastify/swagger-ui": "^1.10.2",
+    "@fastify/swagger": "^9.5.1",
+    "@fastify/swagger-ui": "^5.2.3",
     "@promethean/embedding": "workspace:*",
     "@promethean/fs": "workspace:*",
     "@promethean/persistence": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ overrides:
   fastify: 5.0.0
   '@fastify/static': 8.2.0
   '@fastify/websocket': 11.2.0
+  '@fastify/rate-limit': 10.3.0
+  '@fastify/swagger': 9.5.1
+  '@fastify/swagger-ui': 5.2.3
 
 importers:
 
@@ -3436,14 +3439,14 @@ importers:
   packages/smartgpt-bridge:
     dependencies:
       '@fastify/rate-limit':
-        specifier: ^10.3.0
+        specifier: 10.3.0
         version: 10.3.0
       '@fastify/swagger':
-        specifier: ^8.15.0
-        version: 8.15.0
+        specifier: 9.5.1
+        version: 9.5.1
       '@fastify/swagger-ui':
-        specifier: ^1.10.2
-        version: 1.10.2
+        specifier: 5.2.3
+        version: 5.2.3
       '@promethean/embedding':
         specifier: workspace:*
         version: link:../embedding
@@ -4996,14 +4999,8 @@ packages:
   '@fastify/static@8.2.0':
     resolution: {integrity: sha512-PejC/DtT7p1yo3p+W7LiUtLMsV8fEvxAK15sozHy9t8kwo5r0uLYmhV/inURmGz1SkHZFz/8CNtHLPyhKcx4SQ==}
 
-  '@fastify/swagger-ui@1.10.2':
-    resolution: {integrity: sha512-f2mRqtblm6eRAFQ3e8zSngxVNEtiYY7rISKQVjPA++ZsWc5WYlPVTb6Bx0G/zy0BIoucNqDr/Q2Vb/kTYkOq1A==}
-
   '@fastify/swagger-ui@5.2.3':
     resolution: {integrity: sha512-e7ivEJi9EpFcxTONqICx4llbpB2jmlI+LI1NQ/mR7QGQnyDOqZybPK572zJtcdHZW4YyYTBHcP3a03f1pOh0SA==}
-
-  '@fastify/swagger@8.15.0':
-    resolution: {integrity: sha512-zy+HEEKFqPMS2sFUsQU5X0MHplhKJvWeohBwTCkBAJA/GDYGLGUWQaETEhptiqxK7Hs0fQB9B4MDb3pbwIiCwA==}
 
   '@fastify/swagger@9.5.1':
     resolution: {integrity: sha512-EGjYLA7vDmCPK7XViAYMF6y4+K3XUy5soVTVxsyXolNe/Svb4nFQxvtuQvvoQb2Gzc9pxiF3+ZQN/iZDHhKtTg==}
@@ -7974,9 +7971,6 @@ packages:
   fast-uri@3.1.0:
     resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
 
-  fastify-plugin@4.5.1:
-    resolution: {integrity: sha512-stRHYGeuqpEZTL1Ef0Ovr2ltazUT9g844X5z/zEBFLG8RYlpDiOCIG+ATvYEp+/zmc7sN29mcIMp8gvYplYPIQ==}
-
   fastify-plugin@5.0.1:
     resolution: {integrity: sha512-HCxs+YnRaWzCl+cWRYFnHmeRFyR5GVnJTAaCJQiYzQSDwK9MgJdyAsuL3nh0EWRCYMgQ5MeziymvmAhUHYHDUQ==}
 
@@ -8957,10 +8951,6 @@ packages:
 
   json-schema-ref-resolver@2.0.1:
     resolution: {integrity: sha512-HG0SIB9X4J8bwbxCbnd5FfPEbcXAJYTi1pBJeP/QPON+w8ovSME8iRG+ElHNxZNX2Qh6eYn1GdzJFS4cDFfx0Q==}
-
-  json-schema-resolver@2.0.0:
-    resolution: {integrity: sha512-pJ4XLQP4Q9HTxl6RVDLJ8Cyh1uitSs0CzDBAz1uoJ4sRD/Bk7cFSXL1FUXDW3zJ7YnfliJx6eu8Jn283bpZ4Yg==}
-    engines: {node: '>=10'}
 
   json-schema-resolver@3.0.0:
     resolution: {integrity: sha512-HqMnbz0tz2DaEJ3ntsqtx3ezzZyDE7G56A/pPY/NGmrPu76UzsWquOpHFRAf5beTNXoH2LU5cQePVvRli1nchA==}
@@ -12394,14 +12384,6 @@ snapshots:
       fastq: 1.19.1
       glob: 11.0.3
 
-  '@fastify/swagger-ui@1.10.2':
-    dependencies:
-      '@fastify/static': 8.2.0
-      fastify-plugin: 4.5.1
-      openapi-types: 12.1.3
-      rfdc: 1.4.1
-      yaml: 2.8.1
-
   '@fastify/swagger-ui@5.2.3':
     dependencies:
       '@fastify/static': 8.2.0
@@ -12409,16 +12391,6 @@ snapshots:
       openapi-types: 12.1.3
       rfdc: 1.4.1
       yaml: 2.8.1
-
-  '@fastify/swagger@8.15.0':
-    dependencies:
-      fastify-plugin: 4.5.1
-      json-schema-resolver: 2.0.0
-      openapi-types: 12.1.3
-      rfdc: 1.4.1
-      yaml: 2.8.1
-    transitivePeerDependencies:
-      - supports-color
 
   '@fastify/swagger@9.5.1':
     dependencies:
@@ -14385,7 +14357,7 @@ snapshots:
 
   axios@1.11.0:
     dependencies:
-      follow-redirects: 1.15.11(debug@4.4.3)
+      follow-redirects: 1.15.11(debug@4.3.7)
       form-data: 4.0.4
       proxy-from-env: 1.1.0
     transitivePeerDependencies:
@@ -16305,8 +16277,6 @@ snapshots:
 
   fast-uri@3.1.0: {}
 
-  fastify-plugin@4.5.1: {}
-
   fastify-plugin@5.0.1: {}
 
   fastify@5.0.0:
@@ -16777,7 +16747,7 @@ snapshots:
   http-proxy@1.18.1:
     dependencies:
       eventemitter3: 4.0.7
-      follow-redirects: 1.15.11(debug@4.4.3)
+      follow-redirects: 1.15.11(debug@4.3.7)
       requires-port: 1.0.0
     transitivePeerDependencies:
       - debug
@@ -17520,14 +17490,6 @@ snapshots:
   json-schema-ref-resolver@2.0.1:
     dependencies:
       dequal: 2.0.3
-
-  json-schema-resolver@2.0.0:
-    dependencies:
-      debug: 4.4.3
-      rfdc: 1.4.1
-      uri-js: 4.4.1
-    transitivePeerDependencies:
-      - supports-color
 
   json-schema-resolver@3.0.0:
     dependencies:


### PR DESCRIPTION
## Summary
- align Fastify plugins with Fastify v5
- record Fastify plugin overrides in workspace config

## Testing
- `pnpm --filter @promethean/smartgpt-bridge test` *(fails: Promise returned by test never resolved, but no Fastify plugin version mismatches)*
- `pnpm install` *(fails: packages/utils build: Failed)*

------
https://chatgpt.com/codex/tasks/task_e_68c73fab555c8324b820c351ba1e1ee9