### PR TITLE
feat(discord): allow embed config override

### DIFF
--- a/packages/discord/config/providers.yml
+++ b/packages/discord/config/providers.yml
@@ -1,0 +1,16 @@
+providers:
+  - provider: discord
+    tenant: duck
+    credentials:
+      bot_token: ${DISCORD_TOKEN_DUCK}
+      app_id: "123456789012345678"
+    allow:
+      spaces: ["111111111111111111"]
+      users: ["*"]
+      kinds: ["message", "attachment"]
+    storage:
+      mongo_db: "promethean_discord_duck"
+      chroma_ns: "discord__duck"
+    rate:
+      max_concurrent: 8
+      bucket_overrides: {}

--- a/packages/discord/src/message-embedder/index.ts
+++ b/packages/discord/src/message-embedder/index.ts
@@ -1,10 +1,24 @@
-import { fileBackedRegistry } from "@promethean/platform";
+import {
+  fileBackedRegistry,
+  type ProviderRegistry,
+} from "@promethean/platform";
 import { makeChromaWrapper } from "@promethean/migrations/chroma.js";
 import { makeDeterministicEmbedder } from "@promethean/migrations/embedder.js";
 
-export async function embedMessage(evt: any) {
+type EmbedMessageEvent = {
+  readonly provider: string;
+  readonly tenant: string;
+  readonly message_id: string;
+  readonly space_urn: string;
+  readonly text: string;
+};
+
+export async function embedMessage(
+  evt: Readonly<EmbedMessageEvent>,
+  cfg?: { readonly registry?: ProviderRegistry; readonly configPath?: string },
+): Promise<{ readonly ns: string; readonly id: string } | null> {
   if (!evt.text || !evt.text.trim()) return null;
-  const reg = fileBackedRegistry();
+  const reg = cfg?.registry ?? fileBackedRegistry(cfg?.configPath);
   const tenantCfg = await reg.get(evt.provider, evt.tenant);
   const ns = `${tenantCfg.storage.chroma_ns}__messages`;
   const dim = Number(process.env.EMBEDDING_DIM || "1536");

--- a/packages/discord/src/tests/message-embedder.test.ts
+++ b/packages/discord/src/tests/message-embedder.test.ts
@@ -1,18 +1,32 @@
+import path from "node:path";
+
 import test from "ava";
 import { embedMessage } from "@promethean/discord";
+
+type EmbedEvt = {
+  readonly provider: string;
+  readonly tenant: string;
+  readonly message_id: string;
+  readonly space_urn: string;
+  readonly text: string;
+};
 
 test("embeds text into provider+tenant namespace", async (t) => {
   process.env.DISCORD_TOKEN_DUCK = "test";
   process.env.EMBEDDING_DIM = "16";
-  const out = await embedMessage({
-    message_id: "m1",
-    author_urn: "urn:discord:user:duck:u1",
-    space_urn: "urn:discord:space:duck:c1",
-    text: "hello",
-    created_at: new Date().toISOString(),
-    provider: "discord",
-    tenant: "duck",
-  } as any);
+  const cfg = path.join(process.cwd(), "config", "providers.yml");
+  const out = await embedMessage(
+    {
+      message_id: "m1",
+      author_urn: "urn:discord:user:duck:u1",
+      space_urn: "urn:discord:space:duck:c1",
+      text: "hello",
+      created_at: new Date().toISOString(),
+      provider: "discord",
+      tenant: "duck",
+    } as EmbedEvt,
+    { configPath: cfg },
+  );
   t.truthy(out);
   t.regex(out!.ns, /discord__duck/);
 });


### PR DESCRIPTION
## Summary
- allow embedMessage to take an injected registry or provider config path
- supply providers.yml fixture and pass its path in embed tests

## Testing
- `pnpm --filter @promethean/discord test`
- `pnpm install`


------
https://chatgpt.com/codex/tasks/task_e_68c73fb281748324adbfcbffab4d2f02