### PR TITLE
test: add schema references

### DIFF
--- a/packages/piper/src/tests/error-logging.test.ts
+++ b/packages/piper/src/tests/error-logging.test.ts
@@ -5,6 +5,8 @@ import test from "ava";
 
 import { runPipeline } from "../runner.js";
 
+const SCHEMA = "schema-empty.json";
+
 async function withTmp(fn: (dir: string) => Promise<void>) {
   const dir = path.join(
     process.cwd(),
@@ -12,6 +14,11 @@ async function withTmp(fn: (dir: string) => Promise<void>) {
     String(Date.now()) + "-" + Math.random().toString(36).slice(2),
   );
   await fs.mkdir(dir, { recursive: true });
+  await fs.writeFile(
+    path.join(dir, SCHEMA),
+    JSON.stringify({ type: "object" }),
+    "utf8",
+  );
   try {
     await fn(dir);
   } finally {
@@ -35,6 +42,8 @@ test("failing steps log stderr once", async (t) => {
                 deps: [],
                 inputs: [],
                 outputs: [],
+                inputSchema: SCHEMA,
+                outputSchema: SCHEMA,
                 cache: "content",
                 retry: 1,
                 shell: "sh -c 'echo out; echo err >&2; exit 1'",

--- a/packages/piper/src/tests/frontend/devui.runjs.args.test.ts
+++ b/packages/piper/src/tests/frontend/devui.runjs.args.test.ts
@@ -11,6 +11,8 @@ const PKG_ROOT = path.resolve(
   "..",
 );
 
+const SCHEMA = "schema-empty.json";
+
 // Ensure dev-ui runs JS steps with arg.* without creating a TS step
 // that would otherwise crash the runner.
 test.serial("dev-ui runs JS step with args", async (t) => {
@@ -21,6 +23,11 @@ test.serial("dev-ui runs JS step with args", async (t) => {
     await fs.writeFile(
       path.join(dir, "step.js"),
       "export default ({name}) => { console.log('hello '+name); }\n",
+      "utf8",
+    );
+    await fs.writeFile(
+      path.join(dir, SCHEMA),
+      JSON.stringify({ type: "object" }),
       "utf8",
     );
     const cfg = {
@@ -34,6 +41,8 @@ test.serial("dev-ui runs JS step with args", async (t) => {
               deps: [],
               inputs: [],
               outputs: [],
+              inputSchema: SCHEMA,
+              outputSchema: SCHEMA,
               cache: "content",
               js: { module: "./step.js", export: "default" },
             },

--- a/packages/piper/src/tests/hash.test.ts
+++ b/packages/piper/src/tests/hash.test.ts
@@ -5,6 +5,8 @@ import test, { ExecutionContext } from "ava";
 
 import { fingerprintFromGlobs, stepFingerprint } from "../hash.js";
 
+const SCHEMA = "schema-empty.json";
+
 async function withTmp(
   _t: ExecutionContext<unknown>,
   fn: {
@@ -19,6 +21,11 @@ async function withTmp(
     String(Date.now()) + "-" + Math.random().toString(36).slice(2),
   );
   await fs.mkdir(dir, { recursive: true });
+  await fs.writeFile(
+    path.join(dir, SCHEMA),
+    JSON.stringify({ type: "object" }),
+    "utf8",
+  );
   try {
     await fn(dir);
   } finally {
@@ -65,6 +72,8 @@ test("stepFingerprint covers inputs and config", async (t) => {
       inputs: ["a.txt"],
       outputs: [],
       cache: "content",
+      inputSchema: SCHEMA,
+      outputSchema: SCHEMA,
     };
 
     const fp1 = await stepFingerprint(step, dir, true);
@@ -92,6 +101,8 @@ test("stepFingerprint includes js step config", async (t) => {
       inputs: [],
       outputs: [],
       cache: "content",
+      inputSchema: SCHEMA,
+      outputSchema: SCHEMA,
       js: { module: "./a.js", export: "default", args: { x: 1 } },
     };
     const fp1 = await stepFingerprint(base, dir, true);

--- a/packages/piper/src/tests/js-step.test.ts
+++ b/packages/piper/src/tests/js-step.test.ts
@@ -7,6 +7,8 @@ import { sleep } from "@promethean/utils";
 import { runPipeline } from "../runner.js";
 import { runJSFunction } from "../fsutils.js";
 
+const SCHEMA = "schema-empty.json";
+
 async function withTmp(fn: (dir: string) => Promise<void>) {
   const parent = path.join(process.cwd(), "test-tmp");
   await fs.mkdir(parent, { recursive: true });
@@ -14,6 +16,11 @@ async function withTmp(fn: (dir: string) => Promise<void>) {
   const prevCwd = process.cwd();
   process.chdir(dir);
   try {
+    await fs.writeFile(
+      path.join(dir, SCHEMA),
+      JSON.stringify({ type: "object" }),
+      "utf8",
+    );
     await fn(dir);
     // small grace period for any async file watchers/flushes
     await sleep(50);
@@ -45,6 +52,8 @@ test.serial("runPipeline executes js + shell steps (make → cat)", async (t) =>
               deps: [],
               inputs: [],
               outputs: ["out.txt"],
+              inputSchema: SCHEMA,
+              outputSchema: SCHEMA,
               cache: "content",
               js: {
                 module: "./lib.js",
@@ -58,6 +67,8 @@ test.serial("runPipeline executes js + shell steps (make → cat)", async (t) =>
               deps: ["make"],
               inputs: ["out.txt"],
               outputs: ["out2.txt"],
+              inputSchema: SCHEMA,
+              outputSchema: SCHEMA,
               cache: "content",
               shell: "cat out.txt > out2.txt",
             },
@@ -97,6 +108,8 @@ test.serial("JS steps isolate process.env when run concurrently", async (t) => {
               deps: [],
               inputs: [],
               outputs: ["a.txt"],
+              inputSchema: SCHEMA,
+              outputSchema: SCHEMA,
               cache: "content",
               env: { V: "1" },
               js: {
@@ -111,6 +124,8 @@ test.serial("JS steps isolate process.env when run concurrently", async (t) => {
               deps: [],
               inputs: [],
               outputs: ["b.txt"],
+              inputSchema: SCHEMA,
+              outputSchema: SCHEMA,
               cache: "content",
               env: { V: "2" },
               js: {
@@ -176,6 +191,8 @@ test.serial(
                 deps: [],
                 inputs: [],
                 outputs: [],
+                inputSchema: SCHEMA,
+                outputSchema: SCHEMA,
                 cache: "none",
                 timeoutMs: 100,
                 env: { LEAK: "1" },
@@ -187,6 +204,8 @@ test.serial(
                 deps: [],
                 inputs: [],
                 outputs: [],
+                inputSchema: SCHEMA,
+                outputSchema: SCHEMA,
                 cache: "none",
                 js: { module: "./after.js" },
               },
@@ -245,6 +264,8 @@ test.serial(
                 deps: [],
                 inputs: [],
                 outputs: [],
+                inputSchema: SCHEMA,
+                outputSchema: SCHEMA,
                 cache: "none",
                 timeoutMs: 10,
                 env: { TEST_VAR: "changed" },
@@ -284,6 +305,8 @@ test.serial("worker js step: crash rejects instead of hanging", async (t) => {
               deps: [],
               inputs: [],
               outputs: [],
+              inputSchema: SCHEMA,
+              outputSchema: SCHEMA,
               cache: "content",
               js: { module: "./bad.js", isolate: "worker" },
             },
@@ -317,6 +340,8 @@ test.serial("worker js step: export name is respected (one/two)", async (t) => {
               deps: [],
               inputs: [],
               outputs: [],
+              inputSchema: SCHEMA,
+              outputSchema: SCHEMA,
               cache: "content",
               js: { module: "./mod.js", export: "one", isolate: "worker" },
             },
@@ -326,6 +351,8 @@ test.serial("worker js step: export name is respected (one/two)", async (t) => {
               deps: ["a"],
               inputs: [],
               outputs: [],
+              inputSchema: SCHEMA,
+              outputSchema: SCHEMA,
               cache: "content",
               js: { module: "./mod.js", export: "two", isolate: "worker" },
             },
@@ -374,6 +401,8 @@ test.serial(
                 deps: [],
                 inputs: [],
                 outputs: [],
+                inputSchema: SCHEMA,
+                outputSchema: SCHEMA,
                 cache: "content",
                 js: { module: "./mod.js", isolate: "worker" },
               },
@@ -430,6 +459,8 @@ test.serial(
                 deps: [],
                 inputs: [],
                 outputs: [],
+                inputSchema: SCHEMA,
+                outputSchema: SCHEMA,
                 cache: "content",
                 ...(timeoutMs ? { timeoutMs } : {}),
                 ...(env ? { env } : {}),

--- a/packages/piper/src/tests/retry.test.ts
+++ b/packages/piper/src/tests/retry.test.ts
@@ -5,6 +5,8 @@ import test from "ava";
 
 import { runPipeline } from "../runner.js";
 
+const SCHEMA = "schema-empty.json";
+
 async function withTmp(fn: (dir: string) => Promise<void>) {
   const dir = path.join(
     process.cwd(),
@@ -12,6 +14,11 @@ async function withTmp(fn: (dir: string) => Promise<void>) {
     String(Date.now()) + "-" + Math.random().toString(36).slice(2),
   );
   await fs.mkdir(dir, { recursive: true });
+  await fs.writeFile(
+    path.join(dir, SCHEMA),
+    JSON.stringify({ type: "object" }),
+    "utf8",
+  );
   try {
     await fn(dir);
   } finally {
@@ -35,6 +42,8 @@ test("runPipeline retries failed steps", async (t) => {
                 deps: [],
                 inputs: [],
                 outputs: [],
+                inputSchema: SCHEMA,
+                outputSchema: SCHEMA,
                 cache: "content",
                 retry: 1,
                 shell:

--- a/packages/piper/src/tests/run-route.test.ts
+++ b/packages/piper/src/tests/run-route.test.ts
@@ -11,6 +11,8 @@ const PKG_ROOT = path.resolve(
   "..",
 );
 
+const SCHEMA = "schema-empty.json";
+
 test.serial("dev-ui runs full pipeline via /api/run", async (t) => {
   const tmpParent = path.join(PKG_ROOT, "test-tmp");
   await fs.mkdir(tmpParent, { recursive: true });
@@ -26,6 +28,11 @@ test.serial("dev-ui runs full pipeline via /api/run", async (t) => {
       "export default () => { console.log('two'); }\n",
       "utf8",
     );
+    await fs.writeFile(
+      path.join(dir, SCHEMA),
+      JSON.stringify({ type: "object" }),
+      "utf8",
+    );
     const cfg = {
       pipelines: [
         {
@@ -37,6 +44,8 @@ test.serial("dev-ui runs full pipeline via /api/run", async (t) => {
               deps: [],
               inputs: [],
               outputs: [],
+              inputSchema: SCHEMA,
+              outputSchema: SCHEMA,
               cache: "none",
               js: { module: "./s1.js", export: "default" },
             },
@@ -46,6 +55,8 @@ test.serial("dev-ui runs full pipeline via /api/run", async (t) => {
               deps: ["s1"],
               inputs: [],
               outputs: [],
+              inputSchema: SCHEMA,
+              outputSchema: SCHEMA,
               cache: "none",
               js: { module: "./s2.js", export: "default" },
             },

--- a/packages/piper/src/tests/runner.test.ts
+++ b/packages/piper/src/tests/runner.test.ts
@@ -5,6 +5,8 @@ import test from "ava";
 
 import { runPipeline, StepError } from "../runner.js";
 
+const SCHEMA = "schema-empty.json";
+
 async function withTmp(fn: { (dir: any): Promise<void>; (arg0: string): any }) {
   const dir = path.join(
     process.cwd(),
@@ -12,6 +14,11 @@ async function withTmp(fn: { (dir: any): Promise<void>; (arg0: string): any }) {
     String(Date.now()) + "-" + Math.random().toString(36).slice(2),
   );
   await fs.mkdir(dir, { recursive: true });
+  await fs.writeFile(
+    path.join(dir, SCHEMA),
+    JSON.stringify({ type: "object" }),
+    "utf8",
+  );
   try {
     await fn(dir);
   } finally {
@@ -37,6 +44,8 @@ test.serial(
                   deps: [],
                   inputs: [],
                   outputs: ["out.txt"],
+                  inputSchema: SCHEMA,
+                  outputSchema: SCHEMA,
                   cache: "content",
                   shell: "echo hello > out.txt",
                 },
@@ -46,6 +55,8 @@ test.serial(
                   deps: ["make"],
                   inputs: ["out.txt"],
                   outputs: ["out2.txt"],
+                  inputSchema: SCHEMA,
+                  outputSchema: SCHEMA,
                   cache: "content",
                   shell: "cat out.txt > out2.txt",
                 },
@@ -114,6 +125,8 @@ test.serial(
                   deps: [],
                   inputs: [],
                   outputs: ["a.txt"],
+                  inputSchema: SCHEMA,
+                  outputSchema: SCHEMA,
                   cache: "content",
                   shell: "echo A > a.txt",
                 },
@@ -123,6 +136,8 @@ test.serial(
                   deps: ["make"],
                   inputs: ["a.txt"],
                   outputs: ["b.txt"],
+                  inputSchema: SCHEMA,
+                  outputSchema: SCHEMA,
                   cache: "content",
                   // Force a non-zero exit to simulate failure
                   shell: "sh -c 'echo err >&2; echo will-fail; exit 2'",
@@ -133,6 +148,8 @@ test.serial(
                   deps: ["boom"],
                   inputs: ["b.txt"],
                   outputs: ["c.txt"],
+                  inputSchema: SCHEMA,
+                  outputSchema: SCHEMA,
                   cache: "content",
                   shell: "cat b.txt > c.txt",
                 },
@@ -219,6 +236,8 @@ test.serial("runPipeline detects cyclic dependencies", async (t) => {
                 deps: ["c"], // cycle back from c
                 inputs: [],
                 outputs: ["a.txt"],
+                inputSchema: SCHEMA,
+                outputSchema: SCHEMA,
                 cache: "content",
                 shell: "echo A > a.txt",
               },
@@ -228,6 +247,8 @@ test.serial("runPipeline detects cyclic dependencies", async (t) => {
                 deps: ["a"],
                 inputs: ["a.txt"],
                 outputs: ["b.txt"],
+                inputSchema: SCHEMA,
+                outputSchema: SCHEMA,
                 cache: "content",
                 shell: "cat a.txt > b.txt",
               },
@@ -237,6 +258,8 @@ test.serial("runPipeline detects cyclic dependencies", async (t) => {
                 deps: ["b"],
                 inputs: ["b.txt"],
                 outputs: ["c.txt"],
+                inputSchema: SCHEMA,
+                outputSchema: SCHEMA,
                 cache: "content",
                 shell: "cat b.txt > c.txt",
               },
@@ -280,6 +303,8 @@ test.serial(
                   deps: [],
                   inputs: ["nonexistent.txt"], // declared but not produced
                   outputs: ["out.txt"],
+                  inputSchema: SCHEMA,
+                  outputSchema: SCHEMA,
                   cache: "content",
                   shell: "cat nonexistent.txt > out.txt",
                 },
@@ -330,6 +355,8 @@ test.serial(
                   deps: [],
                   inputs: [],
                   outputs: ["x.txt"],
+                  inputSchema: SCHEMA,
+                  outputSchema: SCHEMA,
                   cache: "content",
                   shell: "echo X > x.txt",
                 },
@@ -339,6 +366,8 @@ test.serial(
                   deps: [],
                   inputs: [],
                   outputs: ["y.txt"],
+                  inputSchema: SCHEMA,
+                  outputSchema: SCHEMA,
                   cache: "content",
                   shell: "echo Y > y.txt",
                 },
@@ -348,6 +377,8 @@ test.serial(
                   deps: ["make1", "make2"],
                   inputs: ["x.txt", "y.txt"],
                   outputs: ["z.txt"],
+                  inputSchema: SCHEMA,
+                  outputSchema: SCHEMA,
                   cache: "content",
                   shell: "cat x.txt y.txt > z.txt",
                 },

--- a/packages/piper/src/tests/runner.worker.smoke.test.ts
+++ b/packages/piper/src/tests/runner.worker.smoke.test.ts
@@ -6,6 +6,8 @@ import { sleep } from "@promethean/utils";
 
 import { runPipeline } from "../runner.js";
 
+const SCHEMA = "schema-empty.json";
+
 async function withTmp(fn: (dir: string) => Promise<void>) {
   const parent = path.join(process.cwd(), "test-tmp");
   await fs.mkdir(parent, { recursive: true });
@@ -13,6 +15,11 @@ async function withTmp(fn: (dir: string) => Promise<void>) {
   const prevCwd = process.cwd();
   process.chdir(dir);
   try {
+    await fs.writeFile(
+      path.join(dir, SCHEMA),
+      JSON.stringify({ type: "object" }),
+      "utf8",
+    );
     await fn(dir);
     await sleep(50);
   } finally {
@@ -45,6 +52,8 @@ test.serial("js step (worker isolate) basic smoke", async (t) => {
               deps: [],
               inputs: [],
               outputs: [],
+              inputSchema: SCHEMA,
+              outputSchema: SCHEMA,
               cache: "content",
               env: { WENV: "X" },
               js: { module: "./m.js", isolate: "worker", args: { msg: "ok" } },


### PR DESCRIPTION
## Summary
- add minimal JSON schema files to piper tests
- reference schema files in step configs

## Testing
- `pnpm exec eslint packages/piper/src/tests/error-logging.test.ts packages/piper/src/tests/frontend/devui.runjs.args.test.ts packages/piper/src/tests/hash.test.ts packages/piper/src/tests/js-step.test.ts packages/piper/src/tests/retry.test.ts packages/piper/src/tests/run-route.test.ts packages/piper/src/tests/runner.test.ts packages/piper/src/tests/runner.worker.smoke.test.ts` *(fails: many lint errors)*
- `pnpm --filter @promethean/piper test` *(fails: TimeoutError: page.waitForFunction: Timeout 30000ms exceeded)*
- `pnpm install`


------
https://chatgpt.com/codex/tasks/task_e_68c73fb9ed6883249c44c77e38939265