### PR TITLE
chore: reuse shared file walker

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14385,7 +14385,7 @@ snapshots:
 
   axios@1.11.0:
     dependencies:
-      follow-redirects: 1.15.11(debug@4.4.3)
+      follow-redirects: 1.15.11(debug@4.3.7)
       form-data: 4.0.4
       proxy-from-env: 1.1.0
     transitivePeerDependencies:
@@ -16777,7 +16777,7 @@ snapshots:
   http-proxy@1.18.1:
     dependencies:
       eventemitter3: 4.0.7
-      follow-redirects: 1.15.11(debug@4.4.3)
+      follow-redirects: 1.15.11(debug@4.3.7)
       requires-port: 1.0.0
     transitivePeerDependencies:
       - debug

--- a/scripts/rewrite-imports.mjs
+++ b/scripts/rewrite-imports.mjs
@@ -1,12 +1,14 @@
 #!/usr/bin/env node
 import { promises as fs } from "node:fs";
 import path from "node:path";
+import { listFilesRec } from "@promethean/utils";
 
 const WRITE = process.argv.includes("--write");
 const REPO = process.cwd();
 const PKG_ROOTS = ["shared/ts"];
 const SRC_DIR_NAME = "src";
 const exts = [".ts", ".tsx", ".mts", ".cts", ".js", ".mjs", ".cjs"];
+const EXT_SET = new Set(exts);
 
 async function exists(p) {
   try {
@@ -18,33 +20,6 @@ async function exists(p) {
 }
 async function readJSON(p) {
   return JSON.parse(await fs.readFile(p, "utf8"));
-}
-
-async function* walkDirs(root, depth = 2) {
-  if (depth < 0) return;
-  const entries = await fs
-    .readdir(root, { withFileTypes: true })
-    .catch(() => []);
-  for (const e of entries) {
-    if (!e.isDirectory()) continue;
-    const p = path.join(root, e.name);
-    yield p;
-    yield* walkDirs(p, depth - 1);
-  }
-}
-
-async function* walkFiles(dir) {
-  const entries = await fs
-    .readdir(dir, { withFileTypes: true })
-    .catch(() => []);
-  for (const e of entries) {
-    const p = path.join(dir, e.name);
-    if (e.isDirectory()) {
-      yield* walkFiles(p);
-    } else if (exts.some((x) => p.endsWith(x))) {
-      yield p;
-    }
-  }
 }
 
 function parseMatches(code) {
@@ -75,9 +50,10 @@ async function collectPackages() {
   for (const root of PKG_ROOTS) {
     const abs = path.join(REPO, root);
     if (!(await exists(abs))) continue;
-    for await (const d of walkDirs(abs, 1)) {
-      const pj = path.join(d, "package.json");
-      if (!(await exists(pj))) continue;
+    const files = await listFilesRec(abs, new Set([".json"]));
+    for (const pj of files) {
+      if (path.basename(pj) !== "package.json") continue;
+      const d = path.dirname(pj);
       const pkg = await readJSON(pj);
       const src = path.join(d, SRC_DIR_NAME);
       if (!(await exists(src))) continue;
@@ -103,7 +79,8 @@ async function main() {
   let total = 0;
 
   for (const pkg of pkgs) {
-    for await (const f of await walkFiles(pkg.src)) {
+    const files = await listFilesRec(pkg.src, EXT_SET);
+    for (const f of files) {
       let code = await fs.readFile(f, "utf8");
       let changed = 0;
 


### PR DESCRIPTION
## Summary
- expose a shared `listFilesRec` file walker from `@promethean/utils`
- replace custom directory walkers in build scripts with the shared utility

## Testing
- `pnpm --filter @promethean/utils test`
- `pnpm install`


------
https://chatgpt.com/codex/tasks/task_e_68c74037d3c8832482ef522bf4ef5baa