### PR TITLE
chore: ignore dist directories in ESLint

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -8,8 +8,16 @@ import ava from "eslint-plugin-ava";
 
 export default [
   {
+    ignores: [
+      "**/dist/**",
+      "**/.cache/**",
+      "./scripts/**",
+      "./templates/**",
+      "./eslint.config.ts",
+    ],
+  },
+  {
     files: ["**/*.{ts,tsx}"],
-    ignores: ["**/dist/**", "**/.cache/**", "./scripts/**", "./templates/**"],
     languageOptions: {
       parser: tsParser,
       parserOptions: {


### PR DESCRIPTION
## Summary
- prevent ESLint from scanning generated `dist` output by moving ignore patterns to a top-level block and ignoring the config file itself

## Testing
- `pnpm exec eslint packages/piper/dist/index.js`
- `pnpm --filter @promethean/piper build`
- `pnpm lint:diff` *(fails: 625 problems)*
- `pnpm install`


------
https://chatgpt.com/codex/tasks/task_e_68c74228bcec8324a9d78d80f191d0c7