### PR TITLE
chore(voice): include tests in tsconfig

### DIFF
--- a/packages/voice/package.json
+++ b/packages/voice/package.json
@@ -5,8 +5,8 @@
   "main": "dist/index.js",
   "scripts": {
     "build": "tsc",
-    "test": "cross-env TS_NODE_TRANSPILE_ONLY=1 ava --config ../../../config/ava.config.mjs \"src/tests/**/*.ts\"",
-    "coverage": "cross-env TS_NODE_TRANSPILE_ONLY=1 c8 ava \"src/tests/**/*.ts\"",
+    "test": "cross-env TS_NODE_TRANSPILE_ONLY=1 ava --config ../../../config/ava.config.mjs \"tests/**/*.ts\" \"src/tests/**/*.ts\"",
+    "coverage": "cross-env TS_NODE_TRANSPILE_ONLY=1 c8 ava \"tests/**/*.ts\" \"src/tests/**/*.ts\"",
     "lint": "pnpm exec eslint . || true",
     "format": "pnpm exec prettier --write ."
   },
@@ -29,6 +29,7 @@
       "ts": "module"
     },
     "files": [
+      "tests/**/*.ts",
       "src/tests/**/*.ts"
     ],
     "nodeArguments": [

--- a/packages/voice/tsconfig.eslint.json
+++ b/packages/voice/tsconfig.eslint.json
@@ -1,3 +1,4 @@
 {
-  "extends": "./tsconfig.json"
+  "extends": "./tsconfig.json",
+  "include": ["src/**/*.ts", "tests/**/*.ts"]
 }

--- a/packages/voice/tsconfig.json
+++ b/packages/voice/tsconfig.json
@@ -4,5 +4,5 @@
     "outDir": "dist",
     "rootDir": "src"
   },
-  "include": ["src/**/*.ts"]
+  "include": ["src/**/*.ts", "tests/**/*.ts"]
 }


### PR DESCRIPTION
## Summary
- add voice tests to tsconfig include and eslint config
- expand voice test scripts to cover root-level tests

## Testing
- `pnpm exec eslint packages/voice/tsconfig.json packages/voice/tsconfig.eslint.json packages/voice/package.json`
- `pnpm --filter @promethean/voice-service test` *(fails: ERR_PACKAGE_PATH_NOT_EXPORTED / Promethean legacy and Discord mock errors)*
- `pnpm install`


------
https://chatgpt.com/codex/tasks/task_e_68c74229ae648324b1543dbe94179e52