### PR TITLE
refactor: modularize voice service setup

### DIFF
--- a/packages/voice/src/index.ts
+++ b/packages/voice/src/index.ts
@@ -1,12 +1,176 @@
+import { Server } from "http";
+
 import express, { Application } from "express";
 import { Client, GatewayIntentBits, User } from "discord.js";
 import { HeartbeatClient } from "@promethean/legacy/heartbeat/index.js";
 
 import { VoiceSession } from "./voice-session.js";
 
+function setupDiscordClient(): Client {
+  const client = new Client({
+    intents: [GatewayIntentBits.Guilds, GatewayIntentBits.GuildVoiceStates],
+  });
+  client.once("ready", () => {
+    console.log("Voice service logged in");
+  });
+  return client;
+}
+
+type SessionRef = { session: VoiceSession | null };
+type WithUser = (id: string) => Promise<User>;
+
+function registerJoinRoute(
+  app: Application,
+  client: Client,
+  ctx: SessionRef,
+): void {
+  app.post("/join", async (req, res) => {
+    const { guildId, channelId } = req.body as Record<string, unknown>;
+    if (typeof guildId !== "string" || typeof channelId !== "string") {
+      return res.status(400).json({ error: "guildId and channelId required" });
+    }
+    try {
+      const guild = await client.guilds.fetch(guildId);
+      ctx.session = new VoiceSession({ guild, voiceChannelId: channelId });
+      ctx.session.start();
+      return res.json({ status: "ok" });
+    } catch (e: unknown) {
+      const message = e instanceof Error ? e.message : String(e);
+      return res.status(500).json({ error: message });
+    }
+  });
+}
+
+async function handleLeave(ctx: SessionRef): Promise<void> {
+  await ctx.session?.stop();
+  ctx.session = null;
+}
+
+function registerLeaveRoute(app: Application, ctx: SessionRef): void {
+  app.post("/leave", async (_req, res) => {
+    await handleLeave(ctx);
+    res.json({ status: "ok" });
+  });
+}
+
+function registerRecordRoutes(
+  app: Application,
+  withUser: WithUser,
+  ctx: SessionRef,
+): void {
+  app.post("/record/start", async (req, res) => {
+    if (!ctx.session) return res.status(400).json({ error: "no session" });
+    const { userId } = req.body as Record<string, unknown>;
+    if (typeof userId !== "string") {
+      return res.status(400).json({ error: "userId required" });
+    }
+    try {
+      const user = await withUser(userId);
+      await ctx.session.addSpeaker(user);
+      await ctx.session.startSpeakerRecord(user);
+      return res.json({ status: "ok" });
+    } catch (e: unknown) {
+      const message = e instanceof Error ? e.message : String(e);
+      return res.status(500).json({ error: message });
+    }
+  });
+
+  app.post("/record/stop", async (req, res) => {
+    if (!ctx.session) return res.status(400).json({ error: "no session" });
+    const { userId } = req.body as Record<string, unknown>;
+    if (typeof userId !== "string") {
+      return res.status(400).json({ error: "userId required" });
+    }
+    try {
+      const user = await withUser(userId);
+      await ctx.session.stopSpeakerRecord(user);
+      return res.json({ status: "ok" });
+    } catch (e: unknown) {
+      const message = e instanceof Error ? e.message : String(e);
+      return res.status(500).json({ error: message });
+    }
+  });
+}
+
+function registerTranscribeRoutes(
+  app: Application,
+  withUser: WithUser,
+  ctx: SessionRef,
+): void {
+  app.post("/transcribe/start", async (req, res) => {
+    if (!ctx.session) return res.status(400).json({ error: "no session" });
+    const { userId, log } = req.body as Record<string, unknown>;
+    if (typeof userId !== "string") {
+      return res.status(400).json({ error: "userId required" });
+    }
+    try {
+      const user = await withUser(userId);
+      await ctx.session.addSpeaker(user);
+      await ctx.session.startSpeakerTranscribe(user, Boolean(log));
+      return res.json({ status: "ok" });
+    } catch (e: unknown) {
+      const message = e instanceof Error ? e.message : String(e);
+      return res.status(500).json({ error: message });
+    }
+  });
+
+  app.post("/transcribe/stop", async (req, res) => {
+    if (!ctx.session) return res.status(400).json({ error: "no session" });
+    const { userId } = req.body as Record<string, unknown>;
+    if (typeof userId !== "string") {
+      return res.status(400).json({ error: "userId required" });
+    }
+    try {
+      const user = await withUser(userId);
+      await ctx.session.stopSpeakerTranscribe(user);
+      return res.json({ status: "ok" });
+    } catch (e: unknown) {
+      const message = e instanceof Error ? e.message : String(e);
+      return res.status(500).json({ error: message });
+    }
+  });
+}
+
+function registerSpeakRoute(app: Application, ctx: SessionRef): void {
+  app.post("/speak", async (req, res) => {
+    if (!ctx.session) return res.status(400).json({ error: "no session" });
+    const { text } = req.body as Record<string, unknown>;
+    if (typeof text !== "string") {
+      return res.status(400).json({ error: "text required" });
+    }
+    try {
+      await ctx.session.playVoice(text);
+      return res.json({ status: "ok" });
+    } catch (e: unknown) {
+      const message = e instanceof Error ? e.message : String(e);
+      return res.status(500).json({ error: message });
+    }
+  });
+}
+
+function registerRoutes(
+  app: Application,
+  client: Client,
+  ctx: SessionRef,
+): void {
+  const withUser: WithUser = (id) => client.users.fetch(id);
+  registerJoinRoute(app, client, ctx);
+  registerLeaveRoute(app, ctx);
+  registerRecordRoutes(app, withUser, ctx);
+  registerTranscribeRoutes(app, withUser, ctx);
+  registerSpeakRoute(app, ctx);
+}
+
+export type VoiceService = {
+  readonly app: Application;
+  readonly client: Client;
+  readonly start: (port?: number) => Promise<Server>;
+  readonly getSession: () => VoiceSession | null;
+};
+
 export function createVoiceService(
   token: string = process.env.DISCORD_TOKEN || "",
-) {
+): VoiceService {
   if (!token) {
     throw new Error("DISCORD_TOKEN env required");
   }
@@ -14,103 +178,15 @@ export function createVoiceService(
   const app: Application = express();
   app.use(express.json());
 
-  const client = new Client({
-    intents: [GatewayIntentBits.Guilds, GatewayIntentBits.GuildVoiceStates],
-  });
+  const client = setupDiscordClient();
 
-  let session: VoiceSession | null = null;
+  const ctx: { session: VoiceSession | null } = { session: null };
 
-  client.once("ready", () => {
-    console.log("Voice service logged in");
-  });
+  registerRoutes(app, client, ctx);
 
-  app.post("/join", async (req, res) => {
-    const { guildId, channelId } = req.body;
-    if (!guildId || !channelId)
-      return res.status(400).json({ error: "guildId and channelId required" });
-    try {
-      const guild = await client.guilds.fetch(guildId);
-      session = new VoiceSession({ guild, voiceChannelId: channelId });
-      session.start();
-      return res.json({ status: "ok" });
-    } catch (e: any) {
-      return res.status(500).json({ error: e.message });
-    }
-  });
-
-  app.post("/leave", (_req, res) => {
-    session?.stop();
-    session = null;
-    res.json({ status: "ok" });
-  });
-
-  async function withUser(id: string): Promise<User> {
-    return client.users.fetch(id);
-  }
-
-  app.post("/record/start", async (req, res) => {
-    if (!session) return res.status(400).json({ error: "no session" });
-    const { userId } = req.body;
-    try {
-      const user = await withUser(userId);
-      await session.addSpeaker(user);
-      await session.startSpeakerRecord(user);
-      return res.json({ status: "ok" });
-    } catch (e: any) {
-      return res.status(500).json({ error: e.message });
-    }
-  });
-
-  app.post("/record/stop", async (req, res) => {
-    if (!session) return res.status(400).json({ error: "no session" });
-    const { userId } = req.body;
-    try {
-      const user = await withUser(userId);
-      await session.stopSpeakerRecord(user);
-      return res.json({ status: "ok" });
-    } catch (e: any) {
-      return res.status(500).json({ error: e.message });
-    }
-  });
-
-  app.post("/transcribe/start", async (req, res) => {
-    if (!session) return res.status(400).json({ error: "no session" });
-    const { userId, log } = req.body;
-    try {
-      const user = await withUser(userId);
-      await session.addSpeaker(user);
-      await session.startSpeakerTranscribe(user, Boolean(log));
-      return res.json({ status: "ok" });
-    } catch (e: any) {
-      return res.status(500).json({ error: e.message });
-    }
-  });
-
-  app.post("/transcribe/stop", async (req, res) => {
-    if (!session) return res.status(400).json({ error: "no session" });
-    const { userId } = req.body;
-    try {
-      const user = await withUser(userId);
-      await session.stopSpeakerTranscribe(user);
-      return res.json({ status: "ok" });
-    } catch (e: any) {
-      return res.status(500).json({ error: e.message });
-    }
-  });
-
-  app.post("/speak", async (req, res) => {
-    if (!session) return res.status(400).json({ error: "no session" });
-    const { text } = req.body;
-    if (!text) return res.status(400).json({ error: "text required" });
-    try {
-      await session.playVoice(text);
-      return res.json({ status: "ok" });
-    } catch (e: any) {
-      return res.status(500).json({ error: e.message });
-    }
-  });
-
-  async function start(port: number = parseInt(process.env.PORT || "4000")) {
+  async function start(
+    port: number = parseInt(process.env.PORT || "4000", 10),
+  ): Promise<Server> {
     const hb = new HeartbeatClient();
     await hb.sendOnce();
     hb.start();
@@ -123,14 +199,18 @@ export function createVoiceService(
     });
   }
 
-  return { app, client, start, getSession: () => session };
+  return { app, client, start, getSession: () => ctx.session };
 }
 
 if (process.env.NODE_ENV !== "test") {
   createVoiceService()
     .start()
-    .catch((err) => {
-      console.error("Failed to start voice service", err);
+    .catch((err: unknown) => {
+      if (err instanceof Error) {
+        console.error("Failed to start voice service", err);
+      } else {
+        console.error("Failed to start voice service", String(err));
+      }
       process.exit(1);
     });
 }


### PR DESCRIPTION
## Summary
- split voice service into modular helpers for Discord client and route registration
- add explicit return types and type-safe error handling
- replace `any` with `unknown` and narrow using `instanceof Error`

## Testing
- `pnpm --filter @promethean/voice-service lint`
- `pnpm --filter @promethean/voice-service test`
- `pnpm install`

------
https://chatgpt.com/codex/tasks/task_e_68c74224ffbc8324a035ee656cdac050