### PR TITLE
Handle JSON parse errors in piper validation

### DIFF
--- a/packages/piper/src/runner.ts
+++ b/packages/piper/src/runner.ts
@@ -55,7 +55,14 @@ async function validateFiles(
   const validate = ajv.compile(schema);
   for (const f of jsonFiles) {
     const absFile = path.resolve(cwd, f);
-    const data = JSON.parse(await fs.readFile(absFile, "utf-8"));
+    let data: unknown;
+    try {
+      const raw = await fs.readFile(absFile, "utf-8");
+      data = JSON.parse(raw);
+    } catch (e: unknown) {
+      const msg = e instanceof Error ? e.message : String(e);
+      throw new Error(`failed to parse JSON file ${f}: ${msg}`);
+    }
     const ok = validate(data);
     if (!ok) {
       throw new Error(

--- a/packages/piper/src/tests/input-parse-error.test.ts
+++ b/packages/piper/src/tests/input-parse-error.test.ts
@@ -1,0 +1,70 @@
+import * as fs from "fs/promises";
+import * as path from "path";
+
+import test from "ava";
+
+import { runPipeline, StepError } from "../runner.js";
+
+async function withTmp(fn: (dir: string) => Promise<void>) {
+  const dir = path.join(
+    process.cwd(),
+    "test-tmp",
+    String(Date.now()) + "-" + Math.random().toString(36).slice(2),
+  );
+  await fs.mkdir(dir, { recursive: true });
+  try {
+    await fn(dir);
+  } finally {
+    await fs.rm(dir, { recursive: true, force: true });
+  }
+}
+
+test.serial("validateFiles includes path on JSON parse error", async (t) => {
+  await withTmp(async (dir) => {
+    const prevCwd = process.cwd();
+    process.chdir(dir);
+    try {
+      await fs.writeFile("bad.json", "{not json", "utf8");
+      await fs.writeFile(
+        "schema.json",
+        JSON.stringify({ type: "object" }),
+        "utf8",
+      );
+      const cfg = {
+        pipelines: [
+          {
+            name: "demo",
+            steps: [
+              {
+                id: "noop",
+                cwd: ".",
+                deps: [],
+                inputs: ["bad.json"],
+                inputSchema: "schema.json",
+                outputs: [],
+                cache: "content",
+                shell: "echo hi",
+              },
+            ],
+          },
+        ],
+      };
+      await fs.writeFile(
+        "pipelines.json",
+        JSON.stringify(cfg, null, 2),
+        "utf8",
+      );
+      const err = await t.throwsAsync(
+        () =>
+          runPipeline("pipelines.json", "demo", {
+            concurrency: 1,
+            contentHash: true,
+          }),
+        { instanceOf: StepError },
+      );
+      t.true(err?.message.includes("bad.json"));
+    } finally {
+      process.chdir(prevCwd);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- handle invalid JSON files in piper's `validateFiles` by throwing an error that includes file path
- add regression test ensuring the offending path is mentioned when input JSON parsing fails

## Testing
- `pnpm lint:diff`
- `pnpm --filter @promethean/piper test` *(fails: file-tree lazy loads and caches directory contents)*
- `pnpm install` *(fails: packages/embedding build)*

------
https://chatgpt.com/codex/tasks/task_e_68c7433f59d48324886541dd5ccded4e