### PR TITLE
feat(piper): support commented JSON schemas

### DIFF
--- a/packages/piper/package.json
+++ b/packages/piper/package.json
@@ -22,20 +22,21 @@
     }
   },
   "dependencies": {
-    "@promethean/level-cache": "workspace:*",
-    "@promethean/utils": "workspace:*",
-    "chokidar": "3.6.0",
-    "globby": "14.0.2",
-    "zod": "3.23.8",
-    "@promethean/fs": "workspace:*",
-    "es-module-lexer": "1.5.1",
-    "fastify": "5.3.2",
-    "@fastify/static": "8.2.0",
     "@fastify/rate-limit": "10.3.0",
+    "@fastify/static": "8.2.0",
     "@fastify/swagger": "9.5.1",
     "@fastify/swagger-ui": "5.2.3",
+    "@promethean/fs": "workspace:*",
+    "@promethean/level-cache": "workspace:*",
+    "@promethean/ui-components": "workspace:*",
+    "@promethean/utils": "workspace:*",
     "ajv": "8.17.1",
-    "@promethean/ui-components": "workspace:*"
+    "chokidar": "3.6.0",
+    "es-module-lexer": "1.5.1",
+    "fastify": "5.3.2",
+    "globby": "14.0.2",
+    "jsonc-parser": "3.3.1",
+    "zod": "3.23.8"
   },
   "devDependencies": {
     "@promethean/test-utils": "workspace:*",

--- a/packages/piper/src/tests/jsonc.test.ts
+++ b/packages/piper/src/tests/jsonc.test.ts
@@ -1,0 +1,80 @@
+import * as fs from "fs/promises";
+import * as path from "path";
+
+import test from "ava";
+import { sleep } from "@promethean/utils";
+
+import { runPipeline } from "../runner.js";
+
+const schema = `{
+  // require compilerOptions.strict
+  "type": "object",
+  "required": ["compilerOptions"],
+  "properties": {
+    "compilerOptions": {
+      "type": "object",
+      "required": ["strict"],
+      "properties": { "strict": { "type": "boolean" } }
+    },
+  },
+}`;
+
+const tsconfig = `{
+  // comment inside tsconfig
+  "compilerOptions": {
+    "strict": true,
+  }
+}`;
+
+const cfg = {
+  pipelines: [
+    {
+      name: "demo",
+      steps: [
+        {
+          id: "s1",
+          shell: "cp tsconfig.json out.json",
+          inputs: ["tsconfig.json"],
+          outputs: ["out.json"],
+          inputSchema: "tsconfig.schema.json",
+          outputSchema: "tsconfig.schema.json",
+        },
+      ],
+    },
+  ],
+};
+
+async function withTmp(fn: (dir: string) => Promise<void>) {
+  const dir = path.join(
+    process.cwd(),
+    "test-tmp",
+    String(Date.now()) + "-" + Math.random().toString(36).slice(2),
+  );
+  await fs.mkdir(dir, { recursive: true });
+  try {
+    await fn(dir);
+  } finally {
+    await sleep(25);
+    await fs.rm(dir, { recursive: true, force: true });
+  }
+}
+
+test("parses commented tsconfig", async (t) => {
+  await withTmp(async (dir) => {
+    const prev = process.cwd();
+    process.chdir(dir);
+    try {
+      await fs.writeFile("tsconfig.schema.json", schema, "utf8");
+      await fs.writeFile("tsconfig.json", tsconfig, "utf8");
+      await fs.writeFile(
+        "pipelines.json",
+        JSON.stringify(cfg, null, 2),
+        "utf8",
+      );
+      const res = await runPipeline("pipelines.json", "demo", {});
+      t.is(res[0]?.exitCode, 0);
+    } finally {
+      process.chdir(prev);
+    }
+  });
+});

--- a/packages/piper/src/types.ts
+++ b/packages/piper/src/types.ts
@@ -38,14 +38,24 @@ export const StepSchema = z
   .refine((s) => !!(s.shell || s.node || s.ts || s.js), {
     message: "step must define shell|node|ts|js",
   })
-  .refine((s) => s.inputs.length === 0 || !!s.inputSchema, {
-    message: "inputSchema required when inputs declared",
-    path: ["inputSchema"],
-  })
-  .refine((s) => s.outputs.length === 0 || !!s.outputSchema, {
-    message: "outputSchema required when outputs declared",
-    path: ["outputSchema"],
-  });
+  .refine(
+    (s) =>
+      s.inputs.every((i) => !i.toLowerCase().endsWith(".json")) ||
+      !!s.inputSchema,
+    {
+      message: "inputSchema required when inputs declared",
+      path: ["inputSchema"],
+    },
+  )
+  .refine(
+    (s) =>
+      s.outputs.every((o) => !o.toLowerCase().endsWith(".json")) ||
+      !!s.outputSchema,
+    {
+      message: "outputSchema required when outputs declared",
+      path: ["outputSchema"],
+    },
+  );
 
 export const PipelineSchema = z.object({
   name: z.string().min(1),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2986,6 +2986,9 @@ importers:
       globby:
         specifier: 14.0.2
         version: 14.0.2
+      jsonc-parser:
+        specifier: 3.3.1
+        version: 3.3.1
       zod:
         specifier: 3.23.8
         version: 3.23.8
@@ -8992,6 +8995,9 @@ packages:
 
   jsonc-parser@3.2.0:
     resolution: {integrity: sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==}
+
+  jsonc-parser@3.3.1:
+    resolution: {integrity: sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==}
 
   jsonfile@6.2.0:
     resolution: {integrity: sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==}
@@ -17555,6 +17561,8 @@ snapshots:
   json5@2.2.3: {}
 
   jsonc-parser@3.2.0: {}
+
+  jsonc-parser@3.3.1: {}
 
   jsonfile@6.2.0:
     dependencies:


### PR DESCRIPTION
## Summary
- parse JSON files and schemas with `jsonc-parser`
- allow schema requirements only for JSON inputs/outputs
- add test for commented tsconfig parsing

## Testing
- `pnpm exec eslint packages/piper/src/runner.ts packages/piper/src/tests/jsonc.test.ts packages/piper/src/types.ts` *(fails: Function 'shouldSkip' has too many parameters, Async function 'runPipeline' has too many lines, Async arrow function has too many lines, Refactor this function to reduce its Cognitive Complexity from 37 to the 15 allowed, Unexpected let, Async arrow function has too many lines, Refactor this function to reduce its Cognitive Complexity from 18 to the 15 allowed, File has too many lines)*
- `pnpm --filter @promethean/piper test` *(fails: tests › frontend › devui.runjs.args › dev-ui runs JS step with args, tests › frontend › filetree.lazy-cache › file-tree lazy loads and caches directory contents, tests › frontend › hmr.state › hot reload keeps component input state)*
- `pnpm install`


------
https://chatgpt.com/codex/tasks/task_e_68c7433e914883249ec7e88f9735c1d0