### PR TITLE
feat: centralize json helpers

### DIFF
--- a/packages/buildfix/src/utils.ts
+++ b/packages/buildfix/src/utils.ts
@@ -4,7 +4,7 @@ import * as path from "path";
 import { pathToFileURL } from "url";
 
 import { Project } from "ts-morph";
-export { sha1 } from "@promethean/utils";
+export { sha1, readJSON, writeJSON } from "@promethean/utils";
 
 export const OLLAMA_URL = process.env.OLLAMA_URL ?? "http://localhost:11434";
 
@@ -73,23 +73,6 @@ export async function tsc(tsconfig: string) {
   const text = out + "\n" + err;
   const diags = parseTsc(text);
   return { ok: code === 0, text, diags };
-}
-
-export async function ensureDir(p: string) {
-  await fs.mkdir(p, { recursive: true });
-}
-
-export async function writeJSON(p: string, data: any) {
-  await ensureDir(path.dirname(p));
-  await fs.writeFile(p, JSON.stringify(data, null, 2), "utf-8");
-}
-
-export async function readJSON<T>(p: string): Promise<T | undefined> {
-  try {
-    return JSON.parse(await fs.readFile(p, "utf-8"));
-  } catch {
-    return undefined;
-  }
 }
 
 export async function importSnippet(snippetPath: string) {

--- a/packages/codemods/src/utils.ts
+++ b/packages/codemods/src/utils.ts
@@ -1,20 +1,8 @@
-import { promises as fs } from "fs";
 import * as path from "path";
+export { readJSON, writeJSON } from "@promethean/utils";
 
 import { SourceFile, SyntaxKind } from "ts-morph";
 import { globby } from "globby";
-
-export async function readJSON<T>(p: string, fallback: T): Promise<T> {
-  try {
-    return JSON.parse(await fs.readFile(p, "utf-8")) as T;
-  } catch {
-    return fallback;
-  }
-}
-export async function writeJSON(p: string, data: any) {
-  await fs.mkdir(path.dirname(p), { recursive: true });
-  await fs.writeFile(p, JSON.stringify(data, null, 2), "utf-8");
-}
 
 export async function listCodeFiles(root: string) {
   const patterns = [

--- a/packages/cookbookflow/src/utils.ts
+++ b/packages/cookbookflow/src/utils.ts
@@ -1,8 +1,5 @@
-import { promises as fs } from "fs";
-import * as path from "path";
 import { execFile as _execFile } from "child_process";
-
-import { slug } from "@promethean/utils";
+export { slug, readMaybe, writeJSON, writeText } from "@promethean/utils";
 
 export function parseArgs<T extends Record<string, string>>(def: T): T {
   const out: Record<string, string> = { ...def };
@@ -18,23 +15,6 @@ export function parseArgs<T extends Record<string, string>>(def: T): T {
   }
   return out as T;
 }
-export async function readMaybe(p: string) {
-  try {
-    return await fs.readFile(p, "utf-8");
-  } catch {
-    return undefined;
-  }
-}
-export async function writeJSON(p: string, data: any) {
-  await fs.mkdir(path.dirname(p), { recursive: true });
-  await fs.writeFile(p, JSON.stringify(data, null, 2), "utf-8");
-}
-export async function writeText(p: string, s: string) {
-  await fs.mkdir(path.dirname(p), { recursive: true });
-  await fs.writeFile(p, s, "utf-8");
-}
-
-export { slug };
 export function sha1(s: string) {
   let h = 2166136261 >>> 0;
   for (let i = 0; i < s.length; i++) {
@@ -58,7 +38,7 @@ export async function execShell(cmd: string, args: string[], cwd: string) {
         { cwd, maxBuffer: 1024 * 1024 * 64, env: { ...process.env } },
         (err, stdout, stderr) => {
           resolve({
-            code: err ? ((err as any).code ?? 1) : 0,
+            code: err ? (err as any).code ?? 1 : 0,
             stdout: String(stdout),
             stderr: String(stderr),
           });

--- a/packages/docops/src/utils.ts
+++ b/packages/docops/src/utils.ts
@@ -15,6 +15,8 @@ export {
   stripGeneratedSections,
   START_MARK,
   END_MARK,
+  readJSON,
+  writeJSON,
 } from "@promethean/utils";
 
 export const OLLAMA_URL = process.env.OLLAMA_URL ?? "http://localhost:11434";
@@ -56,20 +58,6 @@ export function extnamePrefer(originalPath: string): string {
 
 export function dedupe<T>(arr: T[]): T[] {
   return Array.from(new Set(arr));
-}
-
-export async function readJSON<T>(file: string, fallback: T): Promise<T> {
-  try {
-    const s = await fs.readFile(file, "utf-8");
-    return JSON.parse(s) as T;
-  } catch {
-    return fallback;
-  }
-}
-
-export async function writeJSON(file: string, data: any) {
-  await fs.mkdir(path.dirname(file), { recursive: true });
-  await fs.writeFile(file, JSON.stringify(data, null, 2), "utf-8");
 }
 
 export function frontToYAML(front: Front): string {

--- a/packages/semverguard/src/utils.ts
+++ b/packages/semverguard/src/utils.ts
@@ -1,5 +1,5 @@
-import { promises as fs } from "fs";
 import * as path from "path";
+export { readJSON, writeJSON } from "@promethean/utils";
 
 export function parseArgs(def: Record<string, string>) {
   const out = { ...def };
@@ -14,17 +14,6 @@ export function parseArgs(def: Record<string, string>) {
     out[k] = v;
   }
   return out as Record<string, string>;
-}
-export async function readJSON<T>(p: string): Promise<T | undefined> {
-  try {
-    return JSON.parse(await fs.readFile(p, "utf-8")) as T;
-  } catch {
-    return undefined;
-  }
-}
-export async function writeJSON(p: string, data: any) {
-  await fs.mkdir(path.dirname(p), { recursive: true });
-  await fs.writeFile(p, JSON.stringify(data, null, 2), "utf-8");
 }
 
 export function rel(abs: string) {

--- a/packages/sonarflow/src/utils.ts
+++ b/packages/sonarflow/src/utils.ts
@@ -1,6 +1,4 @@
-import { promises as fs } from "fs";
-import * as path from "path";
-export { sha1 } from "@promethean/utils";
+export { sha1, readJSON, writeJSON } from "@promethean/utils";
 
 export function parseArgs(
   defaults: Readonly<Record<string, string>>,
@@ -14,19 +12,6 @@ export function parseArgs(
     },
     { ...defaults },
   );
-}
-
-export async function writeJSON(p: string, data: unknown): Promise<void> {
-  await fs.mkdir(path.dirname(p), { recursive: true });
-  await fs.writeFile(p, JSON.stringify(data, null, 2), "utf-8");
-}
-
-export async function readJSON<T>(p: string): Promise<T | undefined> {
-  try {
-    return JSON.parse(await fs.readFile(p, "utf-8")) as T;
-  } catch {
-    return undefined;
-  }
 }
 
 export const SONAR_URL = process.env.SONAR_HOST_URL ?? "http://localhost:9000";

--- a/packages/symdocs/src/02-docs.ts
+++ b/packages/symdocs/src/02-docs.ts
@@ -3,7 +3,7 @@ import * as path from "path";
 import { fileURLToPath } from "url";
 
 import { z } from "zod";
-import { ollamaJSON } from "@promethean/utils";
+import { ollamaJSON, readJSON } from "@promethean/utils";
 
 import { parseArgs, sha1 } from "./utils.js";
 import type { DocDraft, DocMap, ScanResult } from "./types.js";
@@ -142,14 +142,6 @@ export async function runDocs(opts: DocsOptions = {}) {
       outPath,
     )}`,
   );
-}
-
-async function readJSON(p: string): Promise<any | undefined> {
-  try {
-    return JSON.parse(await fs.readFile(p, "utf-8"));
-  } catch {
-    return undefined;
-  }
 }
 
 if (process.argv[1] === fileURLToPath(import.meta.url)) {

--- a/packages/testgap/src/utils.ts
+++ b/packages/testgap/src/utils.ts
@@ -1,46 +1,10 @@
-import { promises as fs } from "fs";
-import * as path from "path";
-export const OLLAMA_URL = process.env.OLLAMA_URL ?? "http://localhost:11434";
-
-export async function writeJSON(p: string, data: any) {
-  await fs.mkdir(path.dirname(p), { recursive: true });
-  await fs.writeFile(p, JSON.stringify(data, null, 2), "utf-8");
-}
-export async function readJSON<T>(p: string): Promise<T> {
-  return JSON.parse(await fs.readFile(p, "utf-8"));
-}
-export async function readMaybe(p: string) {
-  try {
-    return await fs.readFile(p, "utf-8");
-  } catch {
-    return undefined;
-  }
-}
-export async function ollamaJSON(model: string, prompt: string) {
-  const res = await fetch(`${OLLAMA_URL}/api/generate`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({
-      model,
-      prompt,
-      stream: false,
-      options: { temperature: 0 },
-      format: "json",
-    }),
-  });
-  if (!res.ok) throw new Error(`ollama ${res.status}`);
-  const data: any = await res.json();
-  const raw =
-    typeof data.response === "string"
-      ? data.response
-      : JSON.stringify(data.response);
-  return JSON.parse(
-    raw
-      .replace(/```json\s*/g, "")
-      .replace(/```\s*$/g, "")
-      .trim(),
-  );
-}
+export {
+  writeJSON,
+  readJSON,
+  readMaybe,
+  OLLAMA_URL,
+  ollamaJSON,
+} from "@promethean/utils";
 export function rel(p: string) {
   return p.replace(process.cwd().replace(/\\/g, "/") + "/", "");
 }

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -15,6 +15,7 @@ export { listFilesRec } from "./list-files-rec.js";
 export { OLLAMA_URL, ollamaEmbed, ollamaJSON } from "./ollama.js";
 export { readText, writeText, readMaybe } from "./files.js";
 export { sha1 } from "./hash.js";
+export { readJSON, writeJSON } from "./json.js";
 export {
   stripGeneratedSections,
   START_MARK,

--- a/packages/utils/src/json.ts
+++ b/packages/utils/src/json.ts
@@ -1,0 +1,18 @@
+import { promises as fs } from "fs";
+import path from "path";
+
+export async function readJSON<T>(
+  p: string,
+  fallback?: T,
+): Promise<T | undefined> {
+  try {
+    return JSON.parse(await fs.readFile(p, "utf-8")) as T;
+  } catch {
+    return fallback;
+  }
+}
+
+export async function writeJSON(p: string, data: unknown): Promise<void> {
+  await fs.mkdir(path.dirname(p), { recursive: true });
+  await fs.writeFile(p, JSON.stringify(data, null, 2), "utf-8");
+}

--- a/packages/utils/src/tests/json.test.ts
+++ b/packages/utils/src/tests/json.test.ts
@@ -1,0 +1,28 @@
+import * as path from "path";
+import * as fs from "fs/promises";
+import test from "ava";
+
+import { readJSON, writeJSON } from "../json.js";
+
+async function tmpFile(name: string) {
+  const dir = path.join(process.cwd(), "test-tmp", Date.now().toString());
+  await fs.mkdir(dir, { recursive: true });
+  return { dir, file: path.join(dir, name) };
+}
+
+test("readJSON returns fallback for missing", async (t) => {
+  const { file, dir } = await tmpFile("missing.json");
+  const fb = { a: 1 };
+  const res = await readJSON<typeof fb>(file, fb);
+  t.deepEqual(res, fb);
+  await fs.rm(dir, { recursive: true, force: true });
+});
+
+test("writeJSON writes data and readJSON reads it", async (t) => {
+  const { file, dir } = await tmpFile("data.json");
+  const data = { x: 1 };
+  await writeJSON(file, data);
+  const got = await readJSON<typeof data>(file);
+  t.deepEqual(got, data);
+  await fs.rm(dir, { recursive: true, force: true });
+});


### PR DESCRIPTION
## Summary
- add readJSON/writeJSON utilities to @promethean/utils
- replace package-specific JSON helpers with shared versions
- add tests for new helpers

## Testing
- `pnpm --filter @promethean/utils test`
- `pnpm --filter @promethean/semverguard test`
- `pnpm --filter @promethean/codemods test`
- `pnpm --filter @promethean/cookbookflow test`
- `pnpm --filter @promethean/buildfix test`
- `pnpm --filter @promethean/testgap test`
- `pnpm --filter @promethean/docops test`
- `pnpm --filter @promethean/sonarflow test`
- `pnpm --filter @promethean/symdocs test`
- `pnpm install`


------
https://chatgpt.com/codex/tasks/task_e_68c7402f3a9c83249da1eed2fdb21f38