### PR TITLE
feat: centralize file existence util

### DIFF
--- a/packages/codepack/src/05-materialize.ts
+++ b/packages/codepack/src/05-materialize.ts
@@ -1,6 +1,7 @@
 // src/05-materialize.ts
 import { promises as fs } from "fs";
 import * as path from "path";
+import { fileExists } from "@promethean/utils/fs.js";
 import { parseArgs, ensureDir } from "./utils.js";
 import type { BlockManifest, NamePlan } from "./types.js";
 
@@ -15,15 +16,6 @@ function safeJoin(...parts: string[]) {
   const p = path.join(...parts).replace(/\\/g, "/");
   if (p.includes("..")) throw new Error("refusing to write paths with ..");
   return p;
-}
-
-async function exists(p: string) {
-  try {
-    await fs.stat(p);
-    return true;
-  } catch {
-    return false;
-  }
 }
 
 async function main() {
@@ -73,12 +65,12 @@ async function main() {
 
       // avoid clobbering existing files: append -1, -2,...
       let outPath = target;
-      if (await exists(outPath)) {
+      if (await fileExists(outPath)) {
         const ext = path.extname(target);
         const base = path.basename(target, ext);
         const dir = path.dirname(target);
         let i = 1;
-        while (await exists(path.join(dir, `${base}-${i}${ext}`))) i++;
+        while (await fileExists(path.join(dir, `${base}-${i}${ext}`))) i++;
         outPath = path.join(dir, `${base}-${i}${ext}`);
       }
 

--- a/packages/docops/tsconfig.json
+++ b/packages/docops/tsconfig.json
@@ -14,6 +14,9 @@
     },
     {
       "path": "../docops-frontend"
+    },
+    {
+      "path": "../utils"
     }
   ]
 }

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -14,6 +14,16 @@
     "./dist/*": "./dist/*",
     "./*": "./dist/*"
   },
+  "typesVersions": {
+    "*": {
+      "fs": [
+        "dist/fs.d.ts"
+      ],
+      "*": [
+        "dist/*"
+      ]
+    }
+  },
   "files": [
     "dist"
   ],

--- a/packages/utils/src/fs.ts
+++ b/packages/utils/src/fs.ts
@@ -1,0 +1,12 @@
+import { promises as fs } from "node:fs";
+
+/**
+ * Check if a file or directory exists.
+ * @param p Path to the file or directory.
+ * @returns True if the path exists, false otherwise.
+ */
+export const fileExists = (p: string): Promise<boolean> =>
+  fs
+    .stat(p)
+    .then(() => true)
+    .catch(() => false);

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -20,3 +20,4 @@ export {
   START_MARK,
   END_MARK,
 } from "./strip-generated-sections.js";
+export { fileExists } from "./fs.js";

--- a/packages/utils/src/tests/fileExists.test.ts
+++ b/packages/utils/src/tests/fileExists.test.ts
@@ -1,0 +1,16 @@
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import test from "ava";
+
+import { fileExists } from "../fs.js";
+
+test("fileExists detects existing and missing files", async (t) => {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "file-exists-"));
+  const file = path.join(dir, "temp.txt");
+  await fs.writeFile(file, "hi", "utf8");
+
+  t.true(await fileExists(file));
+  t.false(await fileExists(path.join(dir, "missing.txt")));
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14385,7 +14385,7 @@ snapshots:
 
   axios@1.11.0:
     dependencies:
-      follow-redirects: 1.15.11(debug@4.4.3)
+      follow-redirects: 1.15.11(debug@4.3.7)
       form-data: 4.0.4
       proxy-from-env: 1.1.0
     transitivePeerDependencies:
@@ -16777,7 +16777,7 @@ snapshots:
   http-proxy@1.18.1:
     dependencies:
       eventemitter3: 4.0.7
-      follow-redirects: 1.15.11(debug@4.4.3)
+      follow-redirects: 1.15.11(debug@4.3.7)
       requires-port: 1.0.0
     transitivePeerDependencies:
       - debug

--- a/scripts/fix-bins.js
+++ b/scripts/fix-bins.js
@@ -3,20 +3,12 @@
  * Walk all workspace packages, read their package.json, find "bin" entries,
  * and chmod +x each target. Cross-platform (no shx), minimal deps.
  */
-const { promises: fs } = require("fs");
-const path = require("path");
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { fileExists } from "@promethean/utils/fs";
 
 async function readJSON(p) {
   return JSON.parse(await fs.readFile(p, "utf8"));
-}
-
-async function exists(p) {
-  try {
-    await fs.access(p);
-    return true;
-  } catch {
-    return false;
-  }
 }
 
 async function chmodX(p) {
@@ -30,7 +22,7 @@ async function chmodX(p) {
 
 async function fixPackage(pkgDir) {
   const pkgPath = path.join(pkgDir, "package.json");
-  if (!(await exists(pkgPath))) return;
+  if (!(await fileExists(pkgPath))) return;
   const pkg = await readJSON(pkgPath);
   if (!pkg.bin) return;
 
@@ -38,7 +30,7 @@ async function fixPackage(pkgDir) {
 
   for (const rel of bins) {
     const abs = path.join(pkgDir, rel);
-    if (await exists(abs)) {
+    if (await fileExists(abs)) {
       // ensure shebang exists (best effort, don’t mutate if missing)
       // You can enforce shebang by uncommenting the block below.
       // const content = await fs.readFile(abs, 'utf8');
@@ -56,7 +48,7 @@ async function main() {
   // Simpler: walk ./packages/* (adjust if your layout differs).
   const root = process.cwd();
   const pkgsRoot = path.join(root, "packages");
-  if (!(await exists(pkgsRoot))) return;
+  if (!(await fileExists(pkgsRoot))) return;
 
   const entries = await fs.readdir(pkgsRoot, { withFileTypes: true });
   for (const ent of entries) {

--- a/scripts/rewrite-imports.mjs
+++ b/scripts/rewrite-imports.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import { promises as fs } from "node:fs";
 import path from "node:path";
+import { fileExists } from "@promethean/utils/fs";
 
 const WRITE = process.argv.includes("--write");
 const REPO = process.cwd();
@@ -8,14 +9,6 @@ const PKG_ROOTS = ["shared/ts"];
 const SRC_DIR_NAME = "src";
 const exts = [".ts", ".tsx", ".mts", ".cts", ".js", ".mjs", ".cjs"];
 
-async function exists(p) {
-  try {
-    await fs.stat(p);
-    return true;
-  } catch {
-    return false;
-  }
-}
 async function readJSON(p) {
   return JSON.parse(await fs.readFile(p, "utf8"));
 }
@@ -74,13 +67,13 @@ async function collectPackages() {
   const pkgs = [];
   for (const root of PKG_ROOTS) {
     const abs = path.join(REPO, root);
-    if (!(await exists(abs))) continue;
+    if (!(await fileExists(abs))) continue;
     for await (const d of walkDirs(abs, 1)) {
       const pj = path.join(d, "package.json");
-      if (!(await exists(pj))) continue;
+      if (!(await fileExists(pj))) continue;
       const pkg = await readJSON(pj);
       const src = path.join(d, SRC_DIR_NAME);
-      if (!(await exists(src))) continue;
+      if (!(await fileExists(src))) continue;
       pkgs.push({ name: pkg.name, dir: d, src });
     }
   }
@@ -109,7 +102,7 @@ async function main() {
 
       for (const m of parseMatches(code)) {
         for (const cand of resolveCandidates(f, m.spec)) {
-          if (!(await exists(cand))) continue;
+          if (!(await fileExists(cand))) continue;
           const owner = findOwner(cand, pkgs);
           if (owner && owner.name !== pkg.name) {
             const newSpec = owner.name; // e.g. @promethean/agent


### PR DESCRIPTION
## Summary
- add shared `fileExists` helper to `@promethean/utils`
- refactor scripts to reuse `fileExists`
- simplify docops rename flow with shared util

## Testing
- `pnpm exec eslint packages/utils/src/fs.ts packages/utils/src/index.ts packages/utils/src/tests/fileExists.test.ts scripts/fix-bins.js scripts/nx-doctor.js scripts/rewrite-imports.mjs scripts/wire-references.mjs packages/docops/src/06-rename.ts packages/codepack/src/05-materialize.ts` *(fails: Parsing error: /workspace/promethean/packages/codepack/src/05-materialize.ts was not found by the project service...)*
- `pnpm --filter @promethean/utils test`
- `pnpm --filter @promethean/codepack test`
- `pnpm --filter @promethean/docops test`
- `pnpm install`


------
https://chatgpt.com/codex/tasks/task_e_68c7402c2a588324a45d13213fcfb113