### PR TITLE
Use LevelCache for simtasks embeddings

### DIFF
--- a/packages/simtask/package.json
+++ b/packages/simtask/package.json
@@ -20,6 +20,7 @@
     "sim:all": "pnpm sim:01-scan && pnpm sim:02-embed && pnpm sim:03-cluster && pnpm sim:04-plan && pnpm sim:05-write"
   },
   "dependencies": {
+    "@promethean/level-cache": "workspace:*",
     "@promethean/utils": "workspace:*",
     "gray-matter": "^4.0.3",
     "yaml": "^2.5.0",

--- a/packages/simtask/src/02-embed.ts
+++ b/packages/simtask/src/02-embed.ts
@@ -2,56 +2,64 @@ import { promises as fs } from "fs";
 import * as path from "path";
 import { pathToFileURL } from "url";
 
+import { openLevelCache } from "@promethean/level-cache";
 import { ollamaEmbed, parseArgs } from "@promethean/utils";
 
-import type { ScanResult, EmbeddingMap } from "./types.js";
+import type { ScanResult } from "./types.js";
 
 export type EmbedArgs = {
   "--in"?: string;
-  "--out"?: string;
+  "--out"?: string; // level cache directory
   "--embed-model"?: string;
   "--include-jsdoc"?: string;
   "--include-snippet"?: string;
 };
 
-export async function embed(args: EmbedArgs) {
+export async function embed(args: Readonly<EmbedArgs>): Promise<void> {
   const IN = path.resolve(args["--in"] ?? ".cache/simtasks/functions.json");
-  const OUT = path.resolve(args["--out"] ?? ".cache/simtasks/embeddings.json");
+  const CACHE_PATH = path.resolve(
+    args["--out"] ?? ".cache/simtasks/embeddings",
+  );
   const model = args["--embed-model"] ?? "nomic-embed-text:latest";
   const withDoc = args["--include-jsdoc"] === "true";
   const withSnippet = args["--include-snippet"] === "true";
 
-  const { functions }: ScanResult = JSON.parse(await fs.readFile(IN, "utf-8"));
-  const embeds: EmbeddingMap = {};
-
+  const { functions } = JSON.parse(
+    await fs.readFile(IN, "utf-8"),
+  ) as ScanResult;
+  const cache = await openLevelCache<number[]>({ path: CACHE_PATH });
+  const toEmbed: typeof functions = [];
   for (const f of functions) {
-    if (embeds[f.id]) continue;
-    const text = [
-      `NAME: ${f.className ? f.className + "." : ""}${f.name}`,
-      `KIND: ${f.kind}  EXPORTED: ${f.exported}`,
-      f.signature ? `SIGNATURE: ${f.signature}` : "",
-      `PACKAGE: ${f.pkgName}  FILE: ${f.fileRel}:${f.startLine}-${f.endLine}`,
-      withDoc && f.jsdoc ? `JSDOC:\n${f.jsdoc}` : "",
-      withSnippet ? `CODE:\n${f.snippet}` : "",
-    ]
-      .filter(Boolean)
-      .join("\n");
-    embeds[f.id] = await ollamaEmbed(model, text);
+    if (!(await cache.has(f.id))) toEmbed.push(f);
   }
-
-  await fs.mkdir(path.dirname(OUT), { recursive: true });
-  await fs.writeFile(OUT, JSON.stringify(embeds), "utf-8");
+  await Promise.all(
+    toEmbed.map(async (f) => {
+      const text = [
+        `NAME: ${f.className ? f.className + "." : ""}${f.name}`,
+        `KIND: ${f.kind}  EXPORTED: ${f.exported}`,
+        f.signature ? `SIGNATURE: ${f.signature}` : "",
+        `PACKAGE: ${f.pkgName}  FILE: ${f.fileRel}:${f.startLine}-${f.endLine}`,
+        withDoc && f.jsdoc ? `JSDOC:\n${f.jsdoc}` : "",
+        withSnippet ? `CODE:\n${f.snippet}` : "",
+      ]
+        .filter(Boolean)
+        .join("\n");
+      await cache.set(f.id, await ollamaEmbed(model, text));
+    }),
+  );
+  await cache.close();
   console.log(
-    `simtasks: embedded ${
-      Object.keys(embeds).length
-    } functions -> ${path.relative(process.cwd(), OUT)}`,
+    `simtasks: embedded ${toEmbed.length} functions -> ${path.relative(
+      process.cwd(),
+      CACHE_PATH,
+    )}`,
   );
 }
 
 if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
   const args = parseArgs({
     "--in": ".cache/simtasks/functions.json",
-    "--out": ".cache/simtasks/embeddings.json",
+    "--out": ".cache/simtasks/embeddings",
     "--embed-model": "nomic-embed-text:latest",
     "--include-jsdoc": "true",
     "--include-snippet": "true",

--- a/packages/simtask/src/03-cluster.ts
+++ b/packages/simtask/src/03-cluster.ts
@@ -2,13 +2,14 @@ import { promises as fs } from "fs";
 import * as path from "path";
 import { pathToFileURL } from "url";
 
+import { openLevelCache } from "@promethean/level-cache";
 import { cosine, parseArgs } from "@promethean/utils";
 
-import type { ScanResult, EmbeddingMap, Cluster } from "./types.js";
+import type { ScanResult, Cluster } from "./types.js";
 
 export type ClusterArgs = {
   "--scan"?: string;
-  "--embeds"?: string;
+  "--embeds"?: string; // level cache directory
   "--out"?: string;
   "--sim-threshold"?: string;
   "--k"?: string;
@@ -33,10 +34,10 @@ function unionFindClusters(ids: string[], edges: Array<[string, string]>) {
   return Array.from(groups.values());
 }
 
-export async function cluster(args: ClusterArgs) {
+export async function cluster(args: Readonly<ClusterArgs>): Promise<void> {
   const SCAN = path.resolve(args["--scan"] ?? ".cache/simtasks/functions.json");
-  const EMB = path.resolve(
-    args["--embeds"] ?? ".cache/simtasks/embeddings.json",
+  const CACHE_PATH = path.resolve(
+    args["--embeds"] ?? ".cache/simtasks/embeddings",
   );
   const OUT = path.resolve(args["--out"] ?? ".cache/simtasks/clusters.json");
   const TH = Number(args["--sim-threshold"] ?? "0.84");
@@ -46,45 +47,18 @@ export async function cluster(args: ClusterArgs) {
   const { functions } = JSON.parse(
     await fs.readFile(SCAN, "utf-8"),
   ) as ScanResult;
-  const embeds: EmbeddingMap = JSON.parse(await fs.readFile(EMB, "utf-8"));
+  const cache = await openLevelCache<number[]>({ path: CACHE_PATH });
+  const embeds = new Map<string, number[]>();
+  for (const f of functions) {
+    const v = await cache.get(f.id);
+    if (v) embeds.set(f.id, v);
+  }
+  await cache.close();
 
   const ids = functions.map((f) => f.id);
-  const edges: Array<[string, string]> = [];
-
-  for (const a of functions) {
-    const av = embeds[a.id]!;
-    const scores = functions
-      .filter((b) => b.id !== a.id)
-      .map((b) => ({ id: b.id, s: cosine(av, embeds[b.id]!) }))
-      .sort((x, y) => y.s - x.s)
-      .slice(0, K);
-    for (const { id, s } of scores) {
-      if (s >= TH) edges.push([a.id, id]);
-    }
-  }
-
+  const edges = buildEdges(functions, embeds, TH, K);
   const groups = unionFindClusters(ids, edges).filter((g) => g.length >= MIN);
-  const clusters: Cluster[] = groups.map((members, i) => {
-    // compute stats
-    let maxSim = 0,
-      sum = 0,
-      cnt = 0;
-    for (let x = 0; x < members.length; x++) {
-      for (let y = x + 1; y < members.length; y++) {
-        const s = cosine(embeds[members[x]!]!, embeds[members[y]!]!);
-        if (s > maxSim) maxSim = s;
-        sum += s;
-        cnt++;
-      }
-    }
-    const avg = cnt ? sum / cnt : 0;
-    return {
-      id: `cluster-${i + 1}`,
-      memberIds: members,
-      maxSim: round2(maxSim),
-      avgSim: round2(avg),
-    };
-  });
+  const clusters: Cluster[] = groups.map(clusterFromMembers(embeds));
 
   await fs.mkdir(path.dirname(OUT), { recursive: true });
   await fs.writeFile(OUT, JSON.stringify(clusters, null, 2), "utf-8");
@@ -100,10 +74,48 @@ function round2(n: number) {
   return Math.round(n * 100) / 100;
 }
 
+function buildEdges(
+  functions: ReadonlyArray<ScanResult["functions"][number]>,
+  embeds: ReadonlyMap<string, number[]>,
+  TH: number,
+  K: number,
+): Array<[string, string]> {
+  return functions.flatMap((a) => {
+    const av = embeds.get(a.id)!;
+    return functions
+      .filter((b) => b.id !== a.id)
+      .map((b) => ({ id: b.id, s: cosine(av, embeds.get(b.id)!) }))
+      .sort((x, y) => y.s - x.s)
+      .slice(0, K)
+      .filter(({ s }) => s >= TH)
+      .map(({ id }) => [a.id, id] as [string, string]);
+  });
+}
+
+const clusterFromMembers =
+  (embeds: ReadonlyMap<string, number[]>) =>
+  (members: string[], i: number): Cluster => {
+    const sims = members.flatMap((idA, idx) =>
+      members
+        .slice(idx + 1)
+        .map((idB) => cosine(embeds.get(idA)!, embeds.get(idB)!)),
+    );
+    const maxSim = round2(sims.reduce((m, s) => (s > m ? s : m), 0));
+    const avgSim = round2(
+      sims.length ? sims.reduce((sum, s) => sum + s, 0) / sims.length : 0,
+    );
+    return {
+      id: `cluster-${i + 1}`,
+      memberIds: members,
+      maxSim,
+      avgSim,
+    };
+  };
+
 if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
   const args = parseArgs({
     "--scan": ".cache/simtasks/functions.json",
-    "--embeds": ".cache/simtasks/embeddings.json",
+    "--embeds": ".cache/simtasks/embeddings",
     "--out": ".cache/simtasks/clusters.json",
     "--sim-threshold": "0.84",
     "--k": "10",

--- a/pipelines.json
+++ b/pipelines.json
@@ -90,14 +90,14 @@
             "export": "embed",
             "args": {
               "--in": ".cache/simtasks/functions.json",
-              "--out": ".cache/simtasks/embeddings.json",
+              "--out": ".cache/simtasks/embeddings",
               "--embed-model": "nomic-embed-text:latest"
             },
             "isolate": "worker"
           },
           "env": { "OLLAMA_URL": "${OLLAMA_URL}" },
           "inputs": [".cache/simtasks/functions.json"],
-          "outputs": [".cache/simtasks/embeddings.json"],
+          "outputs": [".cache/simtasks/embeddings"],
           "inputSchema": "packages/simtask/schemas/io.schema.json",
           "outputSchema": "packages/simtask/schemas/io.schema.json"
         },
@@ -109,7 +109,7 @@
             "export": "cluster",
             "args": {
               "--scan": ".cache/simtasks/functions.json",
-              "--embeds": ".cache/simtasks/embeddings.json",
+              "--embeds": ".cache/simtasks/embeddings",
               "--out": ".cache/simtasks/clusters.json",
               "--sim-threshold": "0.86",
               "--k": "12",
@@ -117,7 +117,7 @@
             },
             "isolate": "worker"
           },
-          "inputs": [".cache/simtasks/embeddings.json"],
+          "inputs": [".cache/simtasks/embeddings"],
           "outputs": [".cache/simtasks/clusters.json"],
           "inputSchema": "packages/simtask/schemas/io.schema.json",
           "outputSchema": "packages/simtask/schemas/io.schema.json"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3417,6 +3417,9 @@ importers:
 
   packages/simtask:
     dependencies:
+      '@promethean/level-cache':
+        specifier: workspace:*
+        version: link:../level-cache
       '@promethean/utils':
         specifier: workspace:*
         version: link:../utils


### PR DESCRIPTION
## Summary
- store simtasks embeddings in a LevelCache keyed by function id
- read embeddings from LevelCache during clustering
- update pipeline references and add level-cache dependency

## Testing
- `pnpm exec eslint packages/simtask/src/02-embed.ts packages/simtask/src/03-cluster.ts pipelines.json`
- `pnpm --filter @promethean/simtasks build`
- `pnpm install`


------
https://chatgpt.com/codex/tasks/task_e_68c7481f091c8324ab665616ef23dce8