### PR TITLE
feat(boardrev): cache repo index and embeddings

### DIFF
--- a/packages/boardrev/package.json
+++ b/packages/boardrev/package.json
@@ -24,12 +24,14 @@
   },
   "dependencies": {
     "@promethean/utils": "workspace:*",
+    "@promethean/level-cache": "workspace:*",
     "globby": "^14.0.2",
     "gray-matter": "^4.0.3",
     "yaml": "^2.5.0",
     "zod": "^3.23.8"
   },
   "devDependencies": {
+    "esmock": "^2.7.3",
     "tsx": "^4.19.2"
   }
 }

--- a/packages/boardrev/src/03-index-repo.ts
+++ b/packages/boardrev/src/03-index-repo.ts
@@ -3,28 +3,31 @@ import * as path from "path";
 import { promises as fs } from "fs";
 
 import { globby } from "globby";
-import { ollamaEmbed, parseArgs, writeText } from "@promethean/utils";
+import { openLevelCache, type Cache } from "@promethean/level-cache";
+import { ollamaEmbed, parseArgs } from "@promethean/utils";
 
-import type { RepoDoc, Embeddings } from "./types.js";
+import type { RepoDoc } from "./types.js";
 
 export async function indexRepo({
   globs,
   maxBytes,
   maxLines,
   embedModel,
-  outIndex,
-  outEmb,
+  cache,
 }: Readonly<{
   globs: string;
   maxBytes: number;
   maxLines: number;
   embedModel: string;
-  outIndex: string;
-  outEmb: string;
+  cache: string;
 }>) {
   const files = await globby(globs.split(",").map((s) => s.trim()));
-  const index: RepoDoc[] = [];
-  const embeddings: Embeddings = {};
+  const db = await openLevelCache<unknown>({
+    path: path.resolve(cache),
+  });
+  const docCache = db.withNamespace("idx") as Cache<RepoDoc>;
+  const embCache = db.withNamespace("emb") as Cache<number[]>;
+  let indexed = 0;
 
   for (const f of files) {
     const st = await fs.stat(f);
@@ -32,23 +35,21 @@ export async function indexRepo({
     const raw = await fs.readFile(f, "utf-8");
     const excerpt = raw.split(/\r?\n/).slice(0, maxLines).join("\n");
     const kind = /\.(md|mdx)$/i.test(f) ? "doc" : "code";
-    index.push({ path: f.replace(/\\/g, "/"), size: st.size, kind, excerpt });
-  }
-
-  for (const d of index) {
-    const key = d.path;
-    if (!embeddings[key]) {
-      const text = `PATH: ${d.path}\nKIND: ${d.kind}\n---\n${d.excerpt}`;
-      embeddings[key] = await ollamaEmbed(embedModel, text);
+    const doc: RepoDoc = {
+      path: f.replace(/\\/g, "/"),
+      size: st.size,
+      kind,
+      excerpt,
+    };
+    await docCache.set(doc.path, doc);
+    if (!(await embCache.has(doc.path))) {
+      const text = `PATH: ${doc.path}\nKIND: ${doc.kind}\n---\n${doc.excerpt}`;
+      await embCache.set(doc.path, await ollamaEmbed(embedModel, text));
     }
+    indexed++;
   }
-
-  await writeText(
-    path.resolve(outIndex),
-    JSON.stringify({ docs: index }, null, 2),
-  );
-  await writeText(path.resolve(outEmb), JSON.stringify(embeddings));
-  console.log(`boardrev: indexed ${index.length} repo docs`);
+  await db.close();
+  console.log(`boardrev: indexed ${indexed} repo docs`);
 }
 
 if (import.meta.main) {
@@ -58,16 +59,14 @@ if (import.meta.main) {
     "--max-bytes": "200000",
     "--max-lines": "400",
     "--embed-model": "nomic-embed-text:latest",
-    "--out-index": ".cache/boardrev/repo-index.json",
-    "--out-emb": ".cache/boardrev/repo-embeddings.json",
+    "--cache": ".cache/boardrev/repo-cache",
   });
   indexRepo({
     globs: args["--globs"],
     maxBytes: Number(args["--max-bytes"]),
     maxLines: Number(args["--max-lines"]),
     embedModel: args["--embed-model"],
-    outIndex: args["--out-index"],
-    outEmb: args["--out-emb"],
+    cache: args["--cache"],
   }).catch((e) => {
     console.error(e);
     process.exit(1);

--- a/packages/boardrev/src/test/cache.test.ts
+++ b/packages/boardrev/src/test/cache.test.ts
@@ -1,0 +1,94 @@
+import { promises as fs } from "fs";
+import * as os from "os";
+import * as path from "path";
+
+import test from "ava";
+import esmock from "esmock";
+import { openLevelCache } from "@promethean/level-cache";
+
+async function tmpdir(): Promise<string> {
+  return fs.mkdtemp(path.join(os.tmpdir(), "boardrev-cache-"));
+}
+
+async function stubUtils() {
+  const utils = await import("@promethean/utils");
+  const stub: Readonly<typeof utils> = {
+    ...utils,
+    ollamaEmbed: async () => [1, 1],
+  };
+  return stub;
+}
+
+test("indexRepo writes docs and embeddings to level cache", async (t) => {
+  const dir = await tmpdir();
+  const cacheDir = path.join(dir, "cache");
+  const file = path.join(dir, "README.md");
+  await fs.writeFile(file, "hello\nworld");
+
+  const stub = await stubUtils();
+  const mod = await esmock<typeof import("../03-index-repo.js")>(
+    new URL("../03-index-repo.js", import.meta.url).pathname,
+    { "@promethean/utils": stub },
+  );
+  const { indexRepo } = mod;
+  await indexRepo({
+    globs: file,
+    maxBytes: 1000,
+    maxLines: 10,
+    embedModel: "x",
+    cache: cacheDir,
+  });
+
+  const cache = await openLevelCache<unknown>({ path: cacheDir });
+  const docs = cache.withNamespace("idx");
+  const emb = cache.withNamespace("emb");
+  const key = file.replace(/\\/g, "/");
+  t.truthy(await docs.get(key));
+  t.deepEqual(await emb.get(key), [1, 1]);
+  await cache.close();
+});
+
+test("matchContext reads from level cache", async (t) => {
+  const dir = await tmpdir();
+  const cacheDir = path.join(dir, "cache");
+  const file = path.join(dir, "README.md");
+  await fs.writeFile(file, "hello\nworld");
+  const stub = await stubUtils();
+  const mod1 = await esmock<typeof import("../03-index-repo.js")>(
+    new URL("../03-index-repo.js", import.meta.url).pathname,
+    { "@promethean/utils": stub },
+  );
+  const { indexRepo } = mod1;
+  await indexRepo({
+    globs: file,
+    maxBytes: 1000,
+    maxLines: 10,
+    embedModel: "x",
+    cache: cacheDir,
+  });
+  const mod2 = await esmock<typeof import("../04-match-context.js")>(
+    new URL("../04-match-context.js", import.meta.url).pathname,
+    { "@promethean/utils": stub },
+  );
+  const { matchContext } = mod2;
+  const tasksDir = path.join(dir, "tasks");
+  await fs.mkdir(tasksDir);
+  const taskFile = path.join(tasksDir, "task.md");
+  await fs.writeFile(
+    taskFile,
+    "---\ntitle: t\nstatus: todo\npriority: P1\n---\nbody\n",
+  );
+  const outFile = path.join(dir, "out.json");
+  await matchContext({
+    tasks: tasksDir,
+    cache: cacheDir,
+    embedModel: "x",
+    k: 1,
+    out: outFile,
+  });
+  const out = JSON.parse(await fs.readFile(outFile, "utf-8")) as {
+    contexts?: { hits?: { path: string }[] }[];
+  };
+  const hitPath = out.contexts?.[0]?.hits?.[0]?.path;
+  t.is(hitPath, file.replace(/\\/g, "/"));
+});

--- a/pipelines.json
+++ b/pipelines.json
@@ -377,8 +377,7 @@
               "maxBytes": 200000,
               "maxLines": 400,
               "embedModel": "nomic-embed-text:latest",
-              "outIndex": ".cache/boardrev/repo-index.json",
-              "outEmb": ".cache/boardrev/repo-embeddings.json"
+              "cache": ".cache/boardrev/repo-cache"
             },
             "isolate": "worker"
           },
@@ -388,10 +387,7 @@
             "docs/**/*.md",
             "packages/**/{src,lib}/**/*.{ts,tsx,js,jsx}"
           ],
-          "outputs": [
-            ".cache/boardrev/repo-index.json",
-            ".cache/boardrev/repo-embeddings.json"
-          ],
+          "outputs": [".cache/boardrev/repo-cache"],
           "inputSchema": "packages/boardrev/schemas/io.schema.json",
           "outputSchema": "packages/boardrev/schemas/io.schema.json"
         },
@@ -403,19 +399,14 @@
             "export": "matchContext",
             "args": {
               "tasks": "docs/agile/tasks",
-              "index": ".cache/boardrev/repo-index.json",
-              "emb": ".cache/boardrev/repo-embeddings.json",
+              "cache": ".cache/boardrev/repo-cache",
               "embedModel": "nomic-embed-text:latest",
               "k": 8,
               "out": ".cache/boardrev/context.json"
             },
             "isolate": "worker"
           },
-          "inputs": [
-            "docs/agile/tasks/**/*.md",
-            ".cache/boardrev/repo-index.json",
-            ".cache/boardrev/repo-embeddings.json"
-          ],
+          "inputs": ["docs/agile/tasks/**/*.md", ".cache/boardrev/repo-cache"],
           "outputs": [".cache/boardrev/context.json"],
           "inputSchema": "packages/boardrev/schemas/io.schema.json",
           "outputSchema": "packages/boardrev/schemas/io.schema.json"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -432,6 +432,9 @@ importers:
 
   packages/boardrev:
     dependencies:
+      '@promethean/level-cache':
+        specifier: workspace:*
+        version: link:../level-cache
       '@promethean/utils':
         specifier: workspace:*
         version: link:../utils
@@ -448,6 +451,9 @@ importers:
         specifier: ^3.23.8
         version: 3.25.76
     devDependencies:
+      esmock:
+        specifier: ^2.7.3
+        version: 2.7.3
       tsx:
         specifier: ^4.19.2
         version: 4.20.3


### PR DESCRIPTION
## Summary
- persist repo document metadata and embeddings in LevelCache
- fetch repo context from LevelCache rather than JSON files
- test LevelCache integration for indexing and matching

## Testing
- `pnpm exec eslint packages/boardrev/src/03-index-repo.ts packages/boardrev/src/04-match-context.ts packages/boardrev/src/test/cache.test.ts packages/boardrev/package.json pipelines.json`
- `pnpm --filter @promethean/boardrev test`
- `pnpm install`

------
https://chatgpt.com/codex/tasks/task_e_68c7481e48308324a0ddb9424b29aa93