### PR TITLE
feat: cache cephalon inner state

### DIFF
--- a/packages/cephalon/package.json
+++ b/packages/cephalon/package.json
@@ -7,8 +7,8 @@
   "scripts": {
     "build": "tsc -b",
     "start": "node dist/index.js",
-    "test": "pnpm run build && SKIP_NETWORK_TESTS=1 ava --config ../../../config/ava.config.mjs tests/smoke.test.js --node-arguments='--enable-source-maps'",
-    "coverage": "pnpm run build && SKIP_NETWORK_TESTS=1 c8 ava --config ../../../config/ava.config.mjs tests/smoke.test.js --node-arguments='--enable-source-maps'",
+    "test": "pnpm run build && SKIP_NETWORK_TESTS=1 ava --config ../../../config/ava.config.mjs \"tests/**/*.test.js\" --node-arguments='--enable-source-maps'",
+    "coverage": "pnpm run build && SKIP_NETWORK_TESTS=1 c8 ava --config ../../../config/ava.config.mjs \"tests/**/*.test.js\" --node-arguments='--enable-source-maps'",
     "build:check": "tsc --noEmit --incremental false -p .",
     "deploy": "pnpm run build && node --env-file=../../.env dist/util/deploy.js",
     "lint": "pnpm exec eslint . || true",
@@ -32,6 +32,7 @@
     "@discordjs/voice": "^0.18.0",
     "@promethean/agent-ecs": "workspace:*",
     "@promethean/embedding": "workspace:*",
+    "@promethean/level-cache": "workspace:*",
     "@promethean/legacy": "workspace:*",
     "@promethean/llm": "workspace:*",
     "@promethean/persistence": "workspace:*",

--- a/packages/cephalon/src/agent/index.ts
+++ b/packages/cephalon/src/agent/index.ts
@@ -44,6 +44,7 @@ import {
   generateInnerState as generateInnerStateFn,
   think as thinkFn,
   updateInnerState as updateInnerStateFn,
+  loadInnerState as loadInnerStateFn,
 } from "./innerState.js";
 import { SpeechArbiter, TurnManager } from "./speechCoordinator.js";
 
@@ -116,6 +117,7 @@ export class AIAgent extends EventEmitter {
     this.turnManager.on("turn", (id: number) =>
       this.speechArbiter.setTurnId(id),
     );
+    void this.loadInnerState();
   }
   speak = speakAction;
   storeAgentMessage = storeAgentMessageAction;
@@ -131,6 +133,7 @@ export class AIAgent extends EventEmitter {
   generateInnerState = generateInnerStateFn;
   think = thinkFn;
   updateInnerState = updateInnerStateFn;
+  loadInnerState = loadInnerStateFn;
 
   /** external VAD should call this with raw activity booleans frequently */
   public updateVad(rawActive: boolean) {

--- a/packages/cephalon/tests/innerState.test.js
+++ b/packages/cephalon/tests/innerState.test.js
@@ -1,0 +1,40 @@
+import test from "ava";
+import { rm } from "node:fs/promises";
+import { openLevelCache } from "@promethean/level-cache";
+import { loadInnerState, updateInnerState } from "../dist/agent/innerState.js";
+import { defaultState } from "../dist/prompts.js";
+
+const CACHE_PATH = ".cache/cephalon.level";
+let STATE_KEY = "Agent-inner-state";
+try {
+  const env = await import("@promethean/legacy/env.js");
+  if (typeof env.AGENT_NAME === "string") {
+    STATE_KEY = `${env.AGENT_NAME}-inner-state`;
+  }
+} catch {}
+
+test.beforeEach(async () => {
+  await rm(CACHE_PATH, { recursive: true, force: true });
+});
+
+test.afterEach.always(async () => {
+  await rm(CACHE_PATH, { recursive: true, force: true });
+});
+
+test("loadInnerState returns default when cache empty", async (t) => {
+  const agent = { innerState: {} };
+  await loadInnerState.call(agent);
+  t.deepEqual(agent.innerState, defaultState);
+  const cache = await openLevelCache({ path: CACHE_PATH });
+  const stored = await cache.get(STATE_KEY);
+  await cache.close();
+  t.deepEqual(stored, defaultState);
+});
+
+test("updateInnerState persists and load retrieves", async (t) => {
+  const agent = { innerState: defaultState };
+  await updateInnerState.call(agent, { currentMood: "happy" });
+  const agent2 = { innerState: {} };
+  await loadInnerState.call(agent2);
+  t.is(agent2.innerState.currentMood, "happy");
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -516,6 +516,9 @@ importers:
       '@promethean/legacy':
         specifier: workspace:*
         version: link:../legacy
+      '@promethean/level-cache':
+        specifier: workspace:*
+        version: link:../level-cache
       '@promethean/llm':
         specifier: workspace:*
         version: link:../llm


### PR DESCRIPTION
## Summary
- persist cephalon inner state in LevelCache using a unique key
- load agent inner state from LevelCache on startup
- add LevelCache dependency and tests for inner state persistence

## Testing
- `pnpm --filter @promethean/cephalon test` *(fails: Cannot find module '@promethean/agent-ecs', '@promethean/voice-service')*
- `pnpm -r --filter @promethean/cephalon^... build` *(fails: packages/voice build: File ...tests/dummy.test.ts is not under 'rootDir')*
- `pnpm install`


------
https://chatgpt.com/codex/tasks/task_e_68c748216fbc83248f5ae95c9524c90f