### PR TITLE
feat(smartgpt-bridge): cache bootstrap state

### DIFF
--- a/packages/smartgpt-bridge/README.md
+++ b/packages/smartgpt-bridge/README.md
@@ -250,11 +250,11 @@ If auth is enabled, paste a bearer token in the token box and Save. The UI store
 
 ### Indexer bootstrap + incremental cursor
 
-- On first launch, the service enters "bootstrap" mode and enumerates files once.
-- Progress is saved to `logs/indexer/<ROOT_PATH_SAFE>/bootstrap.json` so restarts resume from the last processed file.
-- While bootstrapping, status includes `{ bootstrap: { total, cursor, remaining } }`.
-- After finishing, it switches to `indexed` mode and, on subsequent starts, performs an incremental scan to enqueue only new/changed files and purge removed files.
-- To force a full rebuild, delete the corresponding `bootstrap.json` and restart.
+  - On first launch, the service enters "bootstrap" mode and enumerates files once.
+  - Progress is cached under `.cache/smartgpt-bridge` keyed by root path so restarts resume from the last processed file.
+  - While bootstrapping, status includes `{ bootstrap: { total, cursor, remaining } }`.
+  - After finishing, it switches to `indexed` mode and, on subsequent starts, performs an incremental scan to enqueue only new/changed files and purge removed files.
+  - To force a full rebuild, clear the cached state for that root path and restart.
 
 ## Funnel for Custom GPT
 

--- a/packages/smartgpt-bridge/package.json
+++ b/packages/smartgpt-bridge/package.json
@@ -24,6 +24,7 @@
     "@fastify/swagger-ui": "^5.2.3",
     "@promethean/embedding": "workspace:*",
     "@promethean/fs": "workspace:*",
+    "@promethean/level-cache": "workspace:*",
     "@promethean/persistence": "workspace:*",
     "@promethean/utils": "workspace:*",
     "ajv-formats": "^3.0.1",

--- a/packages/smartgpt-bridge/src/tests/integration/indexer.incremental.test.ts
+++ b/packages/smartgpt-bridge/src/tests/integration/indexer.incremental.test.ts
@@ -86,7 +86,9 @@ test.serial(
     t.is(s1.mode, "indexed");
     const stateFile = await loadBootstrapState(ROOT);
     t.truthy(stateFile);
-    t.true(["indexed", "bootstrap"].includes(stateFile.mode));
+    if (stateFile) {
+      t.true(["indexed", "bootstrap"].includes(stateFile.mode ?? ""));
+    }
 
     // Clear call history for incremental phase
     col.upserts = [];

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3453,6 +3453,9 @@ importers:
       '@promethean/fs':
         specifier: workspace:*
         version: link:../fs
+      '@promethean/level-cache':
+        specifier: workspace:*
+        version: link:../level-cache
       '@promethean/persistence':
         specifier: workspace:*
         version: link:../persistence


### PR DESCRIPTION
## Summary
- replace bootstrap file persistence with LevelCache
- document new cache-based bootstrap state
- adjust incremental indexer test for optional state

## Testing
- `pnpm exec eslint packages/smartgpt-bridge/src/indexerState.ts`
- `pnpm --filter @promethean/smartgpt-bridge test` *(fails: Promise returned by test never resolved)*
- `pnpm install`


------
https://chatgpt.com/codex/tasks/task_e_68c748223bc4832497d6382541efdeee