### PR TITLE
feat(simtask): use level cache

### DIFF
--- a/packages/codemods/package.json
+++ b/packages/codemods/package.json
@@ -10,7 +10,7 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.json",
-    "mods:01-spec": "tsx src/01-spec.ts --scan .cache/simtasks/functions.json --clusters .cache/simtasks/clusters.json --plans .cache/simtasks/plans.json",
+    "mods:01-spec": "tsx src/01-spec.ts --scan .cache/simtasks/functions --clusters .cache/simtasks/clusters.json --plans .cache/simtasks/plans.json",
     "mods:02-generate": "tsx src/02-generate.ts",
     "mods:03-dry-run": "tsx src/03-run.ts --mode dry --root packages --report docs/agile/tasks/codemods",
     "mods:03-apply": "tsx src/03-run.ts --mode apply --root packages --report docs/agile/tasks/codemods",

--- a/packages/simtask/schemas/io.schema.json
+++ b/packages/simtask/schemas/io.schema.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object"
+}

--- a/packages/simtask/src/types.ts
+++ b/packages/simtask/src/types.ts
@@ -1,38 +1,36 @@
 export type FnKind = "function" | "arrow" | "method";
 
 export type FunctionInfo = {
-  id: string;               // stable hash
-  pkgName: string;          // from package.json name
-  pkgFolder: string;        // packages/<folder>
+  id: string; // stable hash
+  pkgName: string; // from package.json name
+  pkgFolder: string; // packages/<folder>
   fileAbs: string;
-  fileRel: string;          // repo-relative path
-  moduleRel: string;        // path inside package folder
-  name: string;             // function/variable/method name
+  fileRel: string; // repo-relative path
+  moduleRel: string; // path inside package folder
+  name: string; // function/variable/method name
   kind: FnKind;
-  className?: string;       // for methods
+  className?: string; // for methods
   exported: boolean;
   signature?: string;
   jsdoc?: string;
   startLine: number;
   endLine: number;
-  snippet: string;          // full declaration text
+  snippet: string; // full declaration text
 };
-
-export type ScanResult = { functions: FunctionInfo[] };
 
 export type EmbeddingMap = Record<string, number[]>; // id -> vector
 
 export type Cluster = {
-  id: string;           // cluster-<n>
-  memberIds: string[];  // FunctionInfo.id[]
-  maxSim: number;       // best pairwise similarity inside the cluster
-  avgSim: number;       // mean top-k similarity
+  id: string; // cluster-<n>
+  memberIds: string[]; // FunctionInfo.id[]
+  maxSim: number; // best pairwise similarity inside the cluster
+  avgSim: number; // mean top-k similarity
 };
 
 export type Plan = {
   clusterId: string;
-  title: string;        // task title
-  summary: string;      // 1-2 lines
+  title: string; // task title
+  summary: string; // 1-2 lines
   canonicalPath: string; // e.g. packages/libs/core/src/strings/format.ts
   canonicalName: string; // suggested function name
   proposedSignature?: string;

--- a/pipelines.json
+++ b/pipelines.json
@@ -78,7 +78,7 @@
             "isolate": "worker"
           },
           "inputs": ["packages/**/{src,lib}/**/*.{ts,tsx,js,jsx}"],
-          "outputs": [".cache/simtasks/functions.json"],
+          "outputs": [".cache/simtasks/functions"],
           "inputSchema": "packages/simtask/schemas/io.schema.json",
           "outputSchema": "packages/simtask/schemas/io.schema.json"
         },
@@ -89,14 +89,14 @@
             "module": "packages/simtask/dist/02-embed.js",
             "export": "embed",
             "args": {
-              "--in": ".cache/simtasks/functions.json",
+              "--in": ".cache/simtasks/functions",
               "--out": ".cache/simtasks/embeddings",
               "--embed-model": "nomic-embed-text:latest"
             },
             "isolate": "worker"
           },
           "env": { "OLLAMA_URL": "${OLLAMA_URL}" },
-          "inputs": [".cache/simtasks/functions.json"],
+          "inputs": [".cache/simtasks/functions"],
           "outputs": [".cache/simtasks/embeddings"],
           "inputSchema": "packages/simtask/schemas/io.schema.json",
           "outputSchema": "packages/simtask/schemas/io.schema.json"
@@ -108,7 +108,7 @@
             "module": "packages/simtask/dist/03-cluster.js",
             "export": "cluster",
             "args": {
-              "--scan": ".cache/simtasks/functions.json",
+              "--scan": ".cache/simtasks/functions",
               "--embeds": ".cache/simtasks/embeddings",
               "--out": ".cache/simtasks/clusters.json",
               "--sim-threshold": "0.86",
@@ -129,7 +129,7 @@
             "module": "packages/simtask/dist/04-plan.js",
             "export": "plan",
             "args": {
-              "--scan": ".cache/simtasks/functions.json",
+              "--scan": ".cache/simtasks/functions",
               "--clusters": ".cache/simtasks/clusters.json",
               "--out": ".cache/simtasks/plans.json",
               "--model": "qwen3:4b",
@@ -150,7 +150,7 @@
             "module": "packages/simtask/dist/05-write.js",
             "export": "writeTasks",
             "args": {
-              "--scan": ".cache/simtasks/functions.json",
+              "--scan": ".cache/simtasks/functions",
               "--clusters": ".cache/simtasks/clusters.json",
               "--plans": ".cache/simtasks/plans.json",
               "--out": "docs/agile/tasks"
@@ -169,10 +169,10 @@
       "steps": [
         {
           "id": "mods-simtasks",
-          "shell": "bash -lc 'if [ ! -f .cache/simtasks/functions.json ] || [ ! -f .cache/simtasks/clusters.json ] || [ ! -f .cache/simtasks/plans.json ]; then pnpm --filter @promethean/piper piper run simtasks --config pipelines.json; fi'",
+          "shell": "bash -lc 'if [ ! -d .cache/simtasks/functions ] || [ ! -f .cache/simtasks/clusters.json ] || [ ! -f .cache/simtasks/plans.json ]; then pnpm --filter @promethean/piper piper run simtasks --config pipelines.json; fi'",
           "inputs": [],
           "outputs": [
-            ".cache/simtasks/functions.json",
+            ".cache/simtasks/functions",
             ".cache/simtasks/clusters.json",
             ".cache/simtasks/plans.json"
           ],
@@ -183,7 +183,7 @@
           "deps": ["mods-simtasks"],
           "shell": "pnpm --filter @promethean/codemods mods:01-spec --tsconfig ./tsconfig.json",
           "inputs": [
-            ".cache/simtasks/functions.json",
+            ".cache/simtasks/functions",
             ".cache/simtasks/clusters.json",
             ".cache/simtasks/plans.json"
           ],


### PR DESCRIPTION
## Summary
- cache simtask scan results in LevelDB instead of JSON
- update codemods and pipelines to read from Level cache
- add missing io schema

## Testing
- `pnpm exec eslint packages/simtask/src/01-scan.ts packages/simtask/src/02-embed.ts packages/simtask/src/03-cluster.ts packages/simtask/src/04-plan.ts packages/simtask/src/05-write.ts packages/simtask/src/types.ts packages/codemods/src/01-spec.ts` *(fails: max-lines-per-function, complexity, immutable types, etc.)*
- `pnpm --filter @promethean/simtasks test`
- `pnpm --filter @promethean/codemods test`
- `pnpm install`


------
https://chatgpt.com/codex/tasks/task_e_68c75812900883248ea33765fb6a20ba