### PR TITLE
feat: add eslint task pipeline

### DIFF
--- a/pipelines.json
+++ b/pipelines.json
@@ -22,10 +22,14 @@
           "js": {
             "module": "scripts/piper-symdocs.mjs",
             "export": "docs",
-            "args": { "model": "qwen3:4b" },
+            "args": {
+              "model": "qwen3:4b"
+            },
             "isolate": "worker"
           },
-          "env": { "OLLAMA_URL": "${OLLAMA_URL}" },
+          "env": {
+            "OLLAMA_URL": "${OLLAMA_URL}"
+          },
           "inputs": [".cache/symdocs/symbols.json"],
           "outputs": [".cache/symdocs/docs.json"],
           "inputSchema": "packages/symdocs/schemas/io.schema.json",
@@ -37,7 +41,10 @@
           "js": {
             "module": "scripts/piper-symdocs.mjs",
             "export": "write",
-            "args": { "out": "docs/packages", "granularity": "module" },
+            "args": {
+              "out": "docs/packages",
+              "granularity": "module"
+            },
             "isolate": "worker"
           },
           "inputs": [".cache/symdocs/docs.json"],
@@ -95,7 +102,9 @@
             },
             "isolate": "worker"
           },
-          "env": { "OLLAMA_URL": "${OLLAMA_URL}" },
+          "env": {
+            "OLLAMA_URL": "${OLLAMA_URL}"
+          },
           "inputs": [".cache/simtasks/functions.json"],
           "outputs": [".cache/simtasks/embeddings"],
           "inputSchema": "packages/simtask/schemas/io.schema.json",
@@ -137,7 +146,9 @@
             },
             "isolate": "worker"
           },
-          "env": { "OLLAMA_URL": "${OLLAMA_URL}" },
+          "env": {
+            "OLLAMA_URL": "${OLLAMA_URL}"
+          },
           "inputs": [".cache/simtasks/clusters.json"],
           "outputs": [".cache/simtasks/plans.json"],
           "inputSchema": "packages/simtask/schemas/io.schema.json",
@@ -286,7 +297,9 @@
               "model": "qwen3:4b"
             }
           },
-          "env": { "OLLAMA_URL": "${OLLAMA_URL}" },
+          "env": {
+            "OLLAMA_URL": "${OLLAMA_URL}"
+          },
           "inputs": [".cache/semverguard/diff.json"],
           "outputs": [".cache/semverguard/plans.json"],
           "inputSchema": "packages/semverguard/schemas/io.schema.json",
@@ -385,7 +398,9 @@
             },
             "isolate": "worker"
           },
-          "env": { "OLLAMA_URL": "${OLLAMA_URL}" },
+          "env": {
+            "OLLAMA_URL": "${OLLAMA_URL}"
+          },
           "inputs": [
             "README.md",
             "docs/**/*.md",
@@ -429,7 +444,9 @@
             },
             "isolate": "worker"
           },
-          "env": { "OLLAMA_URL": "${OLLAMA_URL}" },
+          "env": {
+            "OLLAMA_URL": "${OLLAMA_URL}"
+          },
           "inputs": [
             ".cache/boardrev/prompts.json",
             ".cache/boardrev/context.json"
@@ -498,7 +515,6 @@
             "OLLAMA_URL": "${OLLAMA_URL}"
           },
           "shell": "pnpm --filter @promethean/sonarflow sonar:plan --in .cache/sonar/issues.json --out .cache/sonar/plans.json --group-by rule+prefix --prefix-depth 2 --min-group 2 --model qwen3:4b",
-          "env": { "OLLAMA_URL": "${OLLAMA_URL}" },
           "inputs": [".cache/sonar/issues.json"],
           "outputs": [".cache/sonar/plans.json"],
           "inputSchema": "packages/sonarflow/schemas/io.schema.json",
@@ -522,7 +538,10 @@
           "id": "rm-scan",
           "js": {
             "module": "packages/readmeflow/dist/01-scan.js",
-            "args": { "root": "packages", "cache": ".cache/readmes" },
+            "args": {
+              "root": "packages",
+              "cache": ".cache/readmes"
+            },
             "isolate": "worker"
           },
           "inputs": ["packages/**/package.json", "packages/**/tsconfig.json"],
@@ -533,7 +552,10 @@
           "deps": ["rm-scan"],
           "js": {
             "module": "packages/readmeflow/dist/02-outline.js",
-            "args": { "cache": ".cache/readmes", "model": "qwen3:4b" },
+            "args": {
+              "cache": ".cache/readmes",
+              "model": "qwen3:4b"
+            },
             "isolate": "worker"
           },
           "env": {
@@ -545,7 +567,10 @@
           "deps": ["rm-outline"],
           "js": {
             "module": "packages/readmeflow/dist/03-write.js",
-            "args": { "cache": ".cache/readmes", "mermaid": true },
+            "args": {
+              "cache": ".cache/readmes",
+              "mermaid": true
+            },
             "isolate": "worker"
           },
           "outputs": ["packages/**/README.md"],
@@ -829,6 +854,38 @@
           "outputs": [],
           "inputSchema": "packages/docops/schemas/io.schema.json",
           "outputSchema": "packages/docops/schemas/io.schema.json"
+        }
+      ]
+    },
+    {
+      "name": "eslint-tasks",
+      "steps": [
+        {
+          "id": "eslint-report",
+          "shell": "pnpm exec eslint packages --format json > .cache/eslint/report.json",
+          "inputs": ["packages/**/{src,lib}/**/*.{ts,tsx,js,jsx}"],
+          "outputs": [".cache/eslint/report.json"],
+          "outputSchema": "scripts/eslint.schema.json"
+        },
+        {
+          "id": "eslint-tasks",
+          "deps": ["eslint-report"],
+          "js": {
+            "module": "scripts/piper-eslint-tasks.mjs",
+            "export": "tasks",
+            "args": {
+              "report": ".cache/eslint/report.json",
+              "outDir": "docs/agile/tasks",
+              "model": "qwen3:4b"
+            },
+            "isolate": "worker"
+          },
+          "env": {
+            "OLLAMA_URL": "${OLLAMA_URL}"
+          },
+          "inputs": [".cache/eslint/report.json"],
+          "inputSchema": "scripts/eslint.schema.json",
+          "outputs": ["docs/agile/tasks/*.md"]
         }
       ]
     }

--- a/scripts/eslint.schema.json
+++ b/scripts/eslint.schema.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "array"
+}

--- a/scripts/piper-eslint-tasks.mjs
+++ b/scripts/piper-eslint-tasks.mjs
@@ -1,0 +1,95 @@
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { spawn } from "node:child_process";
+
+async function runEslint(target = "packages") {
+  return new Promise((resolve, reject) => {
+    const proc = spawn("pnpm", ["exec", "eslint", target, "--format", "json"], {
+      stdio: ["ignore", "pipe", "inherit"],
+    });
+    let out = "";
+    proc.stdout.on("data", (d) => {
+      out += d.toString();
+    });
+    proc.on("close", (code) => {
+      if (code === 0 || code === 1) {
+        resolve(out);
+      } else {
+        reject(new Error(`eslint exited with code ${code}`));
+      }
+    });
+    proc.on("error", reject);
+  });
+}
+
+async function ollamaSuggest(model, prompt) {
+  const url = process.env.OLLAMA_URL;
+  if (!url) return "No suggestion available.";
+  try {
+    const res = await fetch(`${url}/api/generate`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ model, prompt, stream: false }),
+    });
+    const json = await res.json();
+    return typeof json.response === "string"
+      ? json.response.trim()
+      : "No suggestion available.";
+  } catch {
+    return "No suggestion available.";
+  }
+}
+
+export async function tasks(args = {}) {
+  const reportPath = args.report ?? ".cache/eslint/report.json";
+  const outDir = args.outDir ?? "docs/agile/tasks";
+  const model = args.model ?? "qwen3:4b";
+
+  let reportRaw;
+  try {
+    reportRaw = await fs.readFile(reportPath, "utf8");
+  } catch {
+    reportRaw = await runEslint();
+    await fs.mkdir(path.dirname(reportPath), { recursive: true });
+    await fs.writeFile(reportPath, reportRaw);
+  }
+
+  const results = JSON.parse(reportRaw);
+  await fs.mkdir(outDir, { recursive: true });
+
+  for (const file of results) {
+    const { filePath, messages } = file;
+    if (!messages?.length) continue;
+    let source;
+    try {
+      source = await fs.readFile(filePath, "utf8");
+    } catch {
+      continue;
+    }
+    const lines = source.split(/\r?\n/);
+    for (const msg of messages) {
+      const { line, endLine, ruleId, message, severity } = msg;
+      const start = Math.max(0, (line ?? 1) - 3);
+      const end = Math.min(lines.length, (endLine ?? line ?? 1) + 2);
+      const context = lines.slice(start, end).join("\n");
+      const suggestion = await ollamaSuggest(
+        model,
+        `ESLint ${severity === 2 ? "error" : "warning"} ${
+          ruleId ?? ""
+        } in ${filePath}:${line}.\nMessage: ${message}.\nContext:\n${context}\nProvide a concise fix or guidance.`,
+      );
+      const rel = path.relative(process.cwd(), filePath);
+      const title = `Resolve ${ruleId ?? "lint issue"} in ${rel}:${line}`;
+      const body = `#Todo\n\n## 🛠️ Task: ${title}\n\nESLint ${
+        severity === 2 ? "error" : "warning"
+      }: ${message}\n\n### 💡 Suggestion\n${suggestion}\n\n---\n\n## 🎯 Goals\n- [ ] Fix ${
+        ruleId ?? "lint issue"
+      }\n\n---\n\n## 📦 Requirements\n- [ ] ESLint passes for ${rel}\n\n---\n\n## 📋 Subtasks\n- [ ] Address the ${
+        severity === 2 ? "error" : "warning"
+      } in ${rel}\n\n---\n`;
+      const slug = `${rel.replace(/[^a-zA-Z0-9]/g, "_")}_${line}.md`;
+      const outPath = path.join(outDir, slug);
+      await fs.writeFile(outPath, body);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add piper script to turn ESLint findings into task files with LLM suggestions
- wire up `eslint-tasks` pipeline steps for report generation and task creation

## Testing
- `pnpm exec eslint scripts/piper-eslint-tasks.mjs`
- `pnpm --filter @promethean/piper test` *(fails: TimeoutError: page.waitForFunction: Timeout 30000ms exceeded.)*
- `pnpm install`


------
https://chatgpt.com/codex/tasks/task_e_68c759c738b48324927e91f8bc78f31c