### PR TITLE
refactor: modularize outline helpers

### DIFF
--- a/packages/readmeflow/src/02-outline.ts
+++ b/packages/readmeflow/src/02-outline.ts
@@ -5,7 +5,7 @@ import { z } from "zod";
 import { openLevelCache } from "@promethean/level-cache";
 import { parseArgs, ollamaJSON } from "@promethean/utils";
 
-import type { ScanOut, Outline, OutlinesFile } from "./types.js";
+import type { ScanOut, Outline, OutlinesFile, PkgInfo } from "./types.js";
 
 const OutlineSchema = z.object({
   title: z.string().min(1),
@@ -17,99 +17,102 @@ const OutlineSchema = z.object({
   badges: z.array(z.string()).optional(),
 });
 
-// eslint-disable-next-line max-lines-per-function, complexity, sonarjs/cognitive-complexity
+type Prompts = { readonly sys: string; readonly user: string };
+
+export function buildPrompts(pkg: Readonly<PkgInfo>): Prompts {
+  const sys = [
+    "You write tight, practical READMEs for dev tools. Use short sections and code blocks when useful.",
+    "Return ONLY JSON: { title, tagline, includeTOC?, sections:[{heading, body}], badges?[] }",
+    "Prefer concise install, quickstart, CLI/API usage, configuration, and troubleshooting.",
+  ].join("\n");
+
+  const user = [
+    `PACKAGE: ${pkg.name} v${pkg.version}`,
+    `DESC: ${pkg.description ?? "(none)"}`,
+    `HAS_TS: ${pkg.hasTsConfig}`,
+    `BIN: ${Object.keys(pkg.bin ?? {}).join(", ") || "(none)"}`,
+    `SCRIPTS: ${
+      Object.keys(pkg.scripts ?? {})
+        .slice(0, 8)
+        .join(", ") || "(none)"
+    }`,
+    `INTERNAL_DEPS: ${pkg.workspaceDeps.join(", ") || "(none)"}`,
+    "",
+    "If the package is a CLI, include a 'Commands' section with examples.",
+    "If it's a library, include a 'Quickstart' import/usage snippet.",
+    "If the repo uses Piper pipelines, mention how to run the relevant pipeline.",
+  ].join("\n");
+
+  return { sys, user };
+}
+
+export async function fetchOutline(
+  pkg: Readonly<PkgInfo>,
+  model = "qwen3:4b",
+): Promise<Readonly<Outline>> {
+  const { sys, user } = buildPrompts(pkg);
+  const obj = await ollamaJSON(
+    model,
+    `SYSTEM:\n${sys}\n\nUSER:\n${user}`,
+  ).catch(() => ({
+    title: pkg.name,
+    tagline: pkg.description ?? "",
+    includeTOC: true,
+    sections: [
+      {
+        heading: "Install",
+        body: `\`\`\`bash\npnpm -w add -D ${pkg.name}\n\`\`\``,
+      },
+      { heading: "Quickstart", body: "```ts\n// usage example\n```" },
+      {
+        heading: "Commands",
+        body:
+          Object.keys(pkg.scripts ?? {})
+            .map((k) => `- \`${k}\``)
+            .join("\n") || "N/A",
+      },
+    ],
+  }));
+  const parsed = OutlineSchema.safeParse(obj);
+  const outlineRaw = parsed.success
+    ? parsed.data
+    : {
+        title: pkg.name,
+        tagline: pkg.description ?? "",
+        includeTOC: true,
+        sections: [
+          { heading: "Install", body: `pnpm add ${pkg.name}` },
+          { heading: "Usage", body: "(coming soon)" },
+          { heading: "License", body: "GPLv3" },
+        ],
+      };
+
+  return {
+    name: pkg.name,
+    title: outlineRaw.title,
+    tagline: outlineRaw.tagline,
+    includeTOC: outlineRaw.includeTOC,
+    sections: outlineRaw.sections,
+    ...(outlineRaw.badges?.length ? { badges: outlineRaw.badges } : {}),
+  };
+}
+
 export async function outline(
-  options: { cache?: string; model?: string } = {},
+  options: Readonly<{ cache?: string; model?: string }> = {},
 ): Promise<void> {
   const cache = await openLevelCache<ScanOut | OutlinesFile>({
     path: path.resolve(options.cache ?? ".cache/readmes"),
   });
   const scan = (await cache.get("scan")) as ScanOut;
-  // eslint-disable-next-line functional/no-let
-  let outlines: Record<string, Outline> = {};
 
-  for (const pkg of scan.packages) {
-    const sys = [
-      "You write tight, practical READMEs for dev tools. Use short sections and code blocks when useful.",
-      "Return ONLY JSON: { title, tagline, includeTOC?, sections:[{heading, body}], badges?[] }",
-      "Prefer concise install, quickstart, CLI/API usage, configuration, and troubleshooting.",
-    ].join("\n");
+  const outlines = await scan.packages.reduce<
+    Promise<Record<string, Readonly<Outline>>>
+  >(async (accP, pkg) => {
+    const acc = await accP;
+    const outlinePkg = await fetchOutline(pkg, options.model);
+    return { ...acc, [pkg.name]: outlinePkg };
+  }, Promise.resolve({}));
 
-    const user = [
-      `PACKAGE: ${pkg.name} v${pkg.version}`,
-      `DESC: ${pkg.description ?? "(none)"}`,
-      `HAS_TS: ${pkg.hasTsConfig}`,
-      `BIN: ${Object.keys(pkg.bin ?? {}).join(", ") || "(none)"}`,
-      `SCRIPTS: ${
-        Object.keys(pkg.scripts ?? {})
-          .slice(0, 8)
-          .join(", ") || "(none)"
-      }`,
-      `INTERNAL_DEPS: ${pkg.workspaceDeps.join(", ") || "(none)"}`,
-      "",
-      "If the package is a CLI, include a 'Commands' section with examples.",
-      "If it's a library, include a 'Quickstart' import/usage snippet.",
-      "If the repo uses Piper pipelines, mention how to run the relevant pipeline.",
-    ].join("\n");
-
-    // eslint-disable-next-line functional/no-let
-    let obj: unknown;
-    try {
-      obj = await ollamaJSON(
-        options.model ?? "qwen3:4b",
-        `SYSTEM:\n${sys}\n\nUSER:\n${user}`,
-      );
-    } catch {
-      obj = {
-        title: pkg.name,
-        tagline: pkg.description ?? "",
-        includeTOC: true,
-        sections: [
-          {
-            heading: "Install",
-            body: `\`\`\`bash\npnpm -w add -D ${pkg.name}\n\`\`\``,
-          },
-          {
-            heading: "Quickstart",
-            body: "```ts\n// usage example\n```",
-          },
-          {
-            heading: "Commands",
-            body:
-              Object.keys(pkg.scripts ?? {})
-                .map((k) => `- \`${k}\``)
-                .join("\n") || "N/A",
-          },
-        ],
-      };
-    }
-    const parsed = OutlineSchema.safeParse(obj);
-    const outlineRaw = parsed.success
-      ? parsed.data
-      : {
-          title: pkg.name,
-          tagline: pkg.description ?? "",
-          includeTOC: true,
-          sections: [
-            { heading: "Install", body: `pnpm add ${pkg.name}` },
-            { heading: "Usage", body: "(coming soon)" },
-            { heading: "License", body: "GPLv3" },
-          ],
-        };
-
-    // eslint-disable-next-line functional/prefer-immutable-types
-    const outline: Outline = {
-      name: pkg.name,
-      title: outlineRaw.title,
-      tagline: outlineRaw.tagline,
-      includeTOC: outlineRaw.includeTOC,
-      sections: outlineRaw.sections,
-      ...(outlineRaw.badges?.length ? { badges: outlineRaw.badges } : {}),
-    };
-
-    outlines = { ...outlines, [pkg.name]: outline };
-  }
-  // eslint-disable-next-line functional/prefer-immutable-types
   const out: OutlinesFile = { plannedAt: new Date().toISOString(), outlines };
   await cache.set("outlines", out);
   await cache.close();


### PR DESCRIPTION
## Summary
- refactor outline generation with buildPrompts and fetchOutline helpers
- collect outlines via reduce instead of mutation
- drop unnecessary eslint disable comment

## Testing
- `pnpm exec eslint packages/readmeflow/src/02-outline.ts`
- `pnpm --filter @promethean/readmeflow test`
- `pnpm install`


------
https://chatgpt.com/codex/tasks/task_e_68c75a827bf483248f121f607ca6811f