### PR TITLE
feat: cache dedupe plan in leveldb

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@promethean/piper": "workspace:*",
     "@promethean/pm2-helpers": "workspace:*",
     "@promethean/utils": "workspace:*",
+    "@promethean/level-cache": "workspace:*",
     "@promethean/health-dashboard-frontend": "workspace:*",
     "@promethean/llm-chat-frontend": "workspace:*",
     "@promethean/markdown-graph-frontend": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,6 +25,9 @@ importers:
       '@promethean/legacy':
         specifier: workspace:*
         version: link:packages/legacy
+      '@promethean/level-cache':
+        specifier: workspace:*
+        version: link:packages/level-cache
       '@promethean/llm-chat-frontend':
         specifier: workspace:*
         version: link:packages/llm-chat-frontend

--- a/scripts/dedupe-versions-plan.mjs
+++ b/scripts/dedupe-versions-plan.mjs
@@ -1,0 +1,32 @@
+import { writeFile } from "fs/promises";
+import { join, resolve } from "path";
+import { openLevelCache } from "@promethean/level-cache";
+
+const args = process.argv.slice(2);
+const KEY = args[0];
+const OUT = args[1];
+
+if (!KEY) {
+  console.error(
+    "Usage: node scripts/dedupe-versions-plan.mjs <key> [out.json]",
+  );
+  process.exit(1);
+}
+
+const CACHE_PATH = join(process.cwd(), ".cache", "dedupe-versions");
+const cache = await openLevelCache({ path: CACHE_PATH });
+const plan = await cache.get(KEY);
+await cache.close();
+
+if (!plan) {
+  console.error(`No plan found for key ${KEY}`);
+  process.exit(1);
+}
+
+const json = JSON.stringify(plan, null, 2);
+if (OUT) {
+  await writeFile(resolve(OUT), json);
+  console.log(`Wrote plan to ${OUT}`);
+} else {
+  console.log(json);
+}

--- a/tests/scripts/dedupe-versions-plan.test.js
+++ b/tests/scripts/dedupe-versions-plan.test.js
@@ -1,0 +1,51 @@
+import test from "ava";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import { openLevelCache } from "@promethean/level-cache";
+
+const run = (args, options = {}) => {
+  const res = spawnSync("node", args, {
+    cwd: path.resolve("."),
+    encoding: "utf8",
+    ...options,
+  });
+  if (res.status !== 0) throw new Error(res.stderr || res.stdout);
+  return res;
+};
+
+test("dedupe-versions caches plan and read command retrieves it", async (t) => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "dedupe-"));
+  fs.writeFileSync(path.join(tmp, "a.md"), "one");
+  fs.writeFileSync(path.join(tmp, "a v2.md"), "two");
+  const board = path.join(tmp, "board.md");
+  fs.writeFileSync(board, "- [ ] [[a]]");
+  const key = `test-${Date.now()}`;
+
+  run([
+    "scripts/dedupe-versions.mjs",
+    tmp,
+    "--plan",
+    key,
+    "--ext",
+    "md",
+    "--board",
+    board,
+  ]);
+
+  const cachePath = path.join(process.cwd(), ".cache", "dedupe-versions");
+  const cache = await openLevelCache({ path: cachePath });
+  const plan = await cache.get(key);
+  await cache.close();
+  t.truthy(plan);
+  t.is(plan[0].drops.length, 1);
+
+  const out = run(["scripts/dedupe-versions-plan.mjs", key]);
+  const parsed = JSON.parse(out.stdout);
+  t.deepEqual(parsed, plan);
+
+  const cache2 = await openLevelCache({ path: cachePath });
+  await cache2.del(key);
+  await cache2.close();
+});


### PR DESCRIPTION
## Summary
- cache dedupe-versions change plans in LevelCache keyed by run id
- add cli to read cached plans
- cover plan caching with a new test

## Testing
- `pnpm --filter @promethean/level-cache test`
- `pnpm coverage tests/scripts/dedupe-versions-plan.test.js`
- `pnpm install`

------
https://chatgpt.com/codex/tasks/task_e_68c75be34ea48324b417d3cd489c8f65