### PR TITLE
refactor(semverguard): use levelcache

### DIFF
--- a/packages/semverguard/package.json
+++ b/packages/semverguard/package.json
@@ -23,7 +23,8 @@
     "ts-morph": "^22.0.0",
     "yaml": "^2.5.0",
     "zod": "^3.23.8",
-    "@promethean/utils": "workspace:*"
+    "@promethean/utils": "workspace:*",
+    "@promethean/level-cache": "workspace:*"
   },
   "devDependencies": {
     "tsx": "^4.19.2"

--- a/packages/semverguard/pipelines.json
+++ b/packages/semverguard/pipelines.json
@@ -10,7 +10,8 @@
           "args": {
             "root": "packages",
             "tsconfig": "./tsconfig.json",
-            "out": ".cache/semverguard/snapshot.json"
+            "cache": ".cache/semverguard",
+            "ns": "snapshot"
           }
         },
         "inputs": [
@@ -18,7 +19,7 @@
           "packages/**/{src,lib}/**/*.{ts,tsx,js,jsx}"
         ],
         "inputSchema": "packages/semverguard/schemas/io.schema.json",
-        "outputs": [".cache/semverguard/snapshot.json"],
+        "outputs": [],
         "outputSchema": "packages/semverguard/schemas/io.schema.json"
       },
       {
@@ -28,14 +29,15 @@
           "module": "scripts/piper-semverguard.mjs",
           "export": "diff",
           "args": {
-            "current": ".cache/semverguard/snapshot.json",
-            "baseline": "git:origin/main:.cache/semverguard/snapshot.json",
-            "out": ".cache/semverguard/diff.json"
+            "cache": ".cache/semverguard",
+            "currentNs": "snapshot",
+            "baselineNs": "baseline",
+            "diffNs": "diff"
           }
         },
-        "inputs": [".cache/semverguard/snapshot.json"],
+        "inputs": [],
         "inputSchema": "packages/semverguard/schemas/io.schema.json",
-        "outputs": [".cache/semverguard/diff.json"],
+        "outputs": [],
         "outputSchema": "packages/semverguard/schemas/io.schema.json"
       },
       {
@@ -45,14 +47,16 @@
           "module": "scripts/piper-semverguard.mjs",
           "export": "plan",
           "args": {
-            "diff": ".cache/semverguard/diff.json",
-            "out": ".cache/semverguard/plans.json",
+            "cache": ".cache/semverguard",
+            "diffNs": "diff",
+            "planNs": "plan",
             "model": "qwen3:4b"
           }
         },
-        "inputs": [".cache/semverguard/diff.json"],
+        "env": { "OLLAMA_URL": "${OLLAMA_URL}" },
+        "inputs": [],
         "inputSchema": "packages/semverguard/schemas/io.schema.json",
-        "outputs": [".cache/semverguard/plans.json"],
+        "outputs": [],
         "outputSchema": "packages/semverguard/schemas/io.schema.json"
       },
       {
@@ -62,11 +66,12 @@
           "module": "scripts/piper-semverguard.mjs",
           "export": "write",
           "args": {
-            "plans": ".cache/semverguard/plans.json",
+            "cache": ".cache/semverguard",
+            "planNs": "plan",
             "out": "docs/agile/tasks/semver"
           }
         },
-        "inputs": [".cache/semverguard/plans.json"],
+        "inputs": [],
         "inputSchema": "packages/semverguard/schemas/io.schema.json",
         "outputs": ["docs/agile/tasks/semver/*.md"],
         "outputSchema": "packages/semverguard/schemas/io.schema.json"
@@ -78,14 +83,15 @@
           "module": "scripts/piper-semverguard.mjs",
           "export": "pr",
           "args": {
-            "plans": ".cache/semverguard/plans.json",
+            "cache": ".cache/semverguard",
+            "planNs": "plan",
             "root": "packages",
             "mode": "prepare",
             "updateDependents": true,
             "depRange": "preserve"
           }
         },
-        "inputs": [".cache/semverguard/plans.json", "packages/**/package.json"],
+        "inputs": ["packages/**/package.json"],
         "inputSchema": "packages/semverguard/schemas/io.schema.json",
         "outputs": [".cache/semverguard/pr/summary.json"],
         "outputSchema": "packages/semverguard/schemas/io.schema.json"

--- a/pipelines.json
+++ b/pipelines.json
@@ -246,14 +246,15 @@
             "args": {
               "root": "packages",
               "tsconfig": "./tsconfig.json",
-              "out": ".cache/semverguard/snapshot.json"
+              "cache": ".cache/semverguard",
+              "ns": "snapshot"
             }
           },
           "inputs": [
             "packages/**/package.json",
             "packages/**/{src,lib}/**/*.{ts,tsx,js,jsx}"
           ],
-          "outputs": [".cache/semverguard/snapshot.json"],
+          "outputs": [],
           "inputSchema": "packages/semverguard/schemas/io.schema.json",
           "outputSchema": "packages/semverguard/schemas/io.schema.json"
         },
@@ -264,13 +265,14 @@
             "module": "scripts/piper-semverguard.mjs",
             "export": "diff",
             "args": {
-              "current": ".cache/semverguard/snapshot.json",
-              "baseline": "git:origin/main:.cache/semverguard/snapshot.json",
-              "out": ".cache/semverguard/diff.json"
+              "cache": ".cache/semverguard",
+              "currentNs": "snapshot",
+              "baselineNs": "baseline",
+              "diffNs": "diff"
             }
           },
-          "inputs": [".cache/semverguard/snapshot.json"],
-          "outputs": [".cache/semverguard/diff.json"],
+          "inputs": [],
+          "outputs": [],
           "inputSchema": "packages/semverguard/schemas/io.schema.json",
           "outputSchema": "packages/semverguard/schemas/io.schema.json"
         },
@@ -281,14 +283,15 @@
             "module": "scripts/piper-semverguard.mjs",
             "export": "plan",
             "args": {
-              "diff": ".cache/semverguard/diff.json",
-              "out": ".cache/semverguard/plans.json",
+              "cache": ".cache/semverguard",
+              "diffNs": "diff",
+              "planNs": "plan",
               "model": "qwen3:4b"
             }
           },
           "env": { "OLLAMA_URL": "${OLLAMA_URL}" },
-          "inputs": [".cache/semverguard/diff.json"],
-          "outputs": [".cache/semverguard/plans.json"],
+          "inputs": [],
+          "outputs": [],
           "inputSchema": "packages/semverguard/schemas/io.schema.json",
           "outputSchema": "packages/semverguard/schemas/io.schema.json"
         },
@@ -299,11 +302,12 @@
             "module": "scripts/piper-semverguard.mjs",
             "export": "write",
             "args": {
-              "plans": ".cache/semverguard/plans.json",
+              "cache": ".cache/semverguard",
+              "planNs": "plan",
               "out": "docs/agile/tasks/semver"
             }
           },
-          "inputs": [".cache/semverguard/plans.json"],
+          "inputs": [],
           "outputs": ["docs/agile/tasks/semver/*.md"],
           "inputSchema": "packages/semverguard/schemas/io.schema.json",
           "outputSchema": "packages/semverguard/schemas/io.schema.json"
@@ -315,17 +319,15 @@
             "module": "scripts/piper-semverguard.mjs",
             "export": "pr",
             "args": {
-              "plans": ".cache/semverguard/plans.json",
+              "cache": ".cache/semverguard",
+              "planNs": "plan",
               "root": "packages",
               "mode": "prepare",
               "updateDependents": true,
               "depRange": "preserve"
             }
           },
-          "inputs": [
-            ".cache/semverguard/plans.json",
-            "packages/**/package.json"
-          ],
+          "inputs": ["packages/**/package.json"],
           "outputs": [".cache/semverguard/pr/summary.json"],
           "inputSchema": "packages/semverguard/schemas/io.schema.json",
           "outputSchema": "packages/semverguard/schemas/io.schema.json"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3407,6 +3407,9 @@ importers:
 
   packages/semverguard:
     dependencies:
+      '@promethean/level-cache':
+        specifier: workspace:*
+        version: link:../level-cache
       '@promethean/utils':
         specifier: workspace:*
         version: link:../utils

--- a/scripts/piper-semverguard.mjs
+++ b/scripts/piper-semverguard.mjs
@@ -16,7 +16,8 @@ function run(command, args) {
 export async function snapshot(opts = {}) {
   const root = opts.root ?? "packages";
   const tsconfig = opts.tsconfig ?? "./tsconfig.json";
-  const out = opts.out ?? ".cache/semverguard/snapshot.json";
+  const cache = opts.cache ?? ".cache/semverguard";
+  const ns = opts.ns ?? "snapshot";
   await run("pnpm", [
     "--filter",
     "@promethean/semverguard",
@@ -25,61 +26,73 @@ export async function snapshot(opts = {}) {
     root,
     "--tsconfig",
     tsconfig,
-    "--out",
-    out,
+    "--cache",
+    cache,
+    "--ns",
+    ns,
   ]);
 }
 
 export async function diff(opts = {}) {
-  const current = opts.current ?? ".cache/semverguard/snapshot.json";
-  const baseline = opts.baseline ?? ".cache/semverguard/baseline.json";
-  const out = opts.out ?? ".cache/semverguard/diff.json";
+  const cache = opts.cache ?? ".cache/semverguard";
+  const currentNs = opts.currentNs ?? "snapshot";
+  const baselineNs = opts.baselineNs ?? "baseline";
+  const diffNs = opts.diffNs ?? "diff";
   await run("pnpm", [
     "--filter",
     "@promethean/semverguard",
     "sv:02-diff",
-    "--current",
-    current,
-    "--baseline",
-    baseline,
-    "--out",
-    out,
+    "--cache",
+    cache,
+    "--current-ns",
+    currentNs,
+    "--baseline-ns",
+    baselineNs,
+    "--diff-ns",
+    diffNs,
   ]);
 }
 
 export async function plan(opts = {}) {
-  const diff = opts.diff ?? ".cache/semverguard/diff.json";
-  const out = opts.out ?? ".cache/semverguard/plans.json";
+  const cache = opts.cache ?? ".cache/semverguard";
+  const diffNs = opts.diffNs ?? "diff";
+  const planNs = opts.planNs ?? "plan";
   const model = opts.model ?? "qwen3:4b";
   await run("pnpm", [
     "--filter",
     "@promethean/semverguard",
     "sv:03-plan",
-    "--diff",
-    diff,
-    "--out",
-    out,
+    "--cache",
+    cache,
+    "--diff-ns",
+    diffNs,
+    "--plan-ns",
+    planNs,
     "--model",
     model,
   ]);
 }
 
 export async function write(opts = {}) {
-  const plans = opts.plans ?? ".cache/semverguard/plans.json";
+  const cache = opts.cache ?? ".cache/semverguard";
+  const planNs = opts.planNs ?? "plan";
   const out = opts.out ?? "docs/agile/tasks/semver";
   await run("pnpm", [
     "--filter",
     "@promethean/semverguard",
     "sv:04-write",
-    "--plans",
-    plans,
+    "--cache",
+    cache,
+    "--plan-ns",
+    planNs,
     "--out",
     out,
   ]);
 }
 
 export async function pr(opts = {}) {
-  const plans = opts.plans ?? ".cache/semverguard/plans.json";
+  const cache = opts.cache ?? ".cache/semverguard";
+  const planNs = opts.planNs ?? "plan";
   const root = opts.root ?? "packages";
   const mode = opts.mode ?? "prepare";
   const updateDependents = String(opts.updateDependents ?? true);
@@ -88,8 +101,10 @@ export async function pr(opts = {}) {
     "--filter",
     "@promethean/semverguard",
     "sv:05-pr",
-    "--plans",
-    plans,
+    "--cache",
+    cache,
+    "--plan-ns",
+    planNs,
     "--root",
     root,
     "--mode",


### PR DESCRIPTION
## Summary
- switch semverguard stages from JSON files to LevelCache namespaces
- update semverguard pipelines and orchestration scripts for cache usage
- add LevelCache dependency

## Testing
- `pnpm lint:diff` *(fails: numerous pre-existing lint errors across packages)*
- `pnpm --filter @promethean/semverguard build`
- `pnpm install`


------
https://chatgpt.com/codex/tasks/task_e_68c75be1f09083249e3c52f13f9d4479