### PR TITLE
refactor(docops): tighten types and tests

### DIFF
--- a/packages/docops/package.json
+++ b/packages/docops/package.json
@@ -17,6 +17,8 @@
     "@fastify/static": "^8.2.0",
     "@fastify/websocket": "^11.2.0",
     "@types/level": "^8.0.0",
+    "@types/mdast": "^3.0.15",
+    "@types/unist": "^3.0.2",
     "@types/uuid": "^9.0.7",
     "@types/ws": "^8.18.1",
     "abstract-level": "^3.1.0",

--- a/packages/docops/src/tests/e2e/file-tree-refresh.e2e.spec.ts
+++ b/packages/docops/src/tests/e2e/file-tree-refresh.e2e.spec.ts
@@ -1,4 +1,5 @@
 // GPL-3.0-only
+/* eslint-disable functional/no-let, max-lines-per-function, @typescript-eslint/no-unsafe-argument */
 import * as path from "node:path";
 import * as url from "node:url";
 import { promises as fs } from "node:fs";
@@ -9,6 +10,7 @@ import {
   withPage,
   shutdown,
   startProcessWithPort,
+  type Deps,
 } from "@promethean/test-utils";
 
 import { ensureServices } from "../helpers/services.js";
@@ -81,19 +83,10 @@ test.serial(
   "DocOps E2E: refresh picks up new files in file-tree and doclist",
   withPage,
   { baseUrl: () => state?.baseUrl },
-  async (t, fixtures) => {
-    const page =
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test-utils does not type fixtures
-      (fixtures as any).page ??
-      (await (async () => {
-        const res = await fixtures.pageGoto?.("/");
-        t.truthy(res, "app responded at /");
-        throw new Error(
-          "withPage did not expose a Playwright `page`. Extend @promethean/test-utils to provide it.",
-        );
-      })());
+  async (t, { page, pageGoto }: Deps) => {
+    const res = await pageGoto("/");
+    t.truthy(res, "app responded at /");
 
-     
     await page.goto(`${state!.baseUrl}`, { waitUntil: "domcontentloaded" });
 
     await page.fill(byId("dir"), DOC_FIXTURE_PATH);

--- a/packages/docops/src/tests/utils.misc.test.ts
+++ b/packages/docops/src/tests/utils.misc.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable */
 import * as path from "path";
 import * as fs from "fs/promises";
 
@@ -68,7 +67,7 @@ test.serial(
 
 test("randomUUID returns unique-like ids", (t) => {
   const ids = new Set<string>();
-  for (let i = 0; i < 10; i++) ids.add(randomUUID());
+  Array.from({ length: 10 }).forEach(() => ids.add(randomUUID()));
   t.is(ids.size, 10);
 });
 
@@ -91,10 +90,10 @@ test.serial(
   async (t) => {
     await withTmp(async (dir) => {
       const file = path.join(dir, "data.json");
-      const fb = { a: 1 };
+      const fb = { a: 1, b: "" };
       const got = await readJSON(file, fb);
       t.deepEqual(got, fb);
-      const data = { a: 2, b: "x" } as any;
+      const data = { a: 2, b: "x" };
       await writeJSON(file, data);
       const got2 = await readJSON<typeof data>(file, fb);
       t.deepEqual(got2, data);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1454,6 +1454,12 @@ importers:
       '@types/level':
         specifier: ^8.0.0
         version: 8.0.0
+      '@types/mdast':
+        specifier: ^3.0.15
+        version: 3.0.15
+      '@types/unist':
+        specifier: ^3.0.2
+        version: 3.0.3
       '@types/uuid':
         specifier: ^9.0.7
         version: 9.0.8
@@ -5797,6 +5803,9 @@ packages:
 
   '@types/long@4.0.2':
     resolution: {integrity: sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==}
+
+  '@types/mdast@3.0.15':
+    resolution: {integrity: sha512-LnwD+mUEfxWMa1QpDraczIn6k0Ee3SMicuYSSzS6ZYl2gKS09EClnJYGd8Du6rfc5r/GZEk5o1mRb8TaTj03sQ==}
 
   '@types/mdast@4.0.4':
     resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
@@ -13525,6 +13534,10 @@ snapshots:
       level: 10.0.0
 
   '@types/long@4.0.2': {}
+
+  '@types/mdast@3.0.15':
+    dependencies:
+      '@types/unist': 2.0.11
 
   '@types/mdast@4.0.4':
     dependencies:


### PR DESCRIPTION
## Summary
- replace blanket eslint disables in docops utilities with targeted rule suppressions and stronger typing
- add proper typings to e2e fixtures and utilities, removing `any` casts
- record utility test improvements and add missing mdast/unist type deps

## Testing
- `pnpm --filter @promethean/docops lint` *(fails: None of the selected packages has a "lint" script)*
- `pnpm --filter @promethean/docops test`
- `pnpm install`


------
https://chatgpt.com/codex/tasks/task_e_68c75e9becf483248d3c4759c7e2a8df