### PR TITLE
refactor: remove eslint disables

### DIFF
--- a/packages/codemods/package.json
+++ b/packages/codemods/package.json
@@ -21,7 +21,8 @@
     "globby": "^14.0.2",
     "ts-morph": "^22.0.0",
     "yaml": "^2.5.0",
-    "@promethean/utils": "workspace:*"
+    "@promethean/utils": "workspace:*",
+    "@promethean/level-cache": "workspace:*"
   },
   "devDependencies": {
     "tsx": "^4.19.2"

--- a/packages/codemods/src/01-spec.ts
+++ b/packages/codemods/src/01-spec.ts
@@ -69,7 +69,7 @@ function buildParamMap(canon: string[], dup: string[]): number[] {
 
 async function main() {
   const scanCache = await openLevelCache<Fn[]>({ path: path.resolve(scan) });
-  const scanFns = (await scanCache.get("functions")) ?? [];
+  const scanFns = (await scanCache.get("functions")) ?? ([] as Fn[]);
   await scanCache.close();
   const byId = new Map<string, Fn>(scanFns.map((f) => [f.id, f]));
   const clustersData = await readJSON<Cluster[]>(path.resolve(clusters), []);

--- a/packages/cookbookflow/src/04-plan.ts
+++ b/packages/cookbookflow/src/04-plan.ts
@@ -1,4 +1,3 @@
-/* eslint-disable */
 import { promises as fs } from "fs";
 import * as path from "path";
 
@@ -68,7 +67,7 @@ async function main() {
       })
       .join("\n\n");
 
-    let obj: any;
+    let obj: unknown;
     try {
       obj = await ollamaJSON(
         args["--llm"],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -789,6 +789,9 @@ importers:
 
   packages/codemods:
     dependencies:
+      '@promethean/level-cache':
+        specifier: workspace:*
+        version: link:../level-cache
       '@promethean/utils':
         specifier: workspace:*
         version: link:../utils


### PR DESCRIPTION
## Summary
- tighten snapshot API types and drop global eslint disables
- replace `any` in codemod runner with typed unknown imports and diff parts
- add generics and safer typing to sonarflow fetch, simtask scan, cookbookflow utilities, and testgap writer

## Testing
- `pnpm --filter @promethean/snapshots test`
- `pnpm --filter @promethean/codemods build`
- `pnpm --filter @promethean/sonarflow build`
- `pnpm --filter @promethean/simtasks build`
- `pnpm --filter @promethean/cookbookflow build`
- `pnpm --filter @promethean/testgap build`
- `pnpm install`

------
https://chatgpt.com/codex/tasks/task_e_68c75e9d7420832491f1ab19545062c6