### PR TITLE
refactor(symdocs): use level cache

### DIFF
--- a/packages/symdocs/package.json
+++ b/packages/symdocs/package.json
@@ -17,11 +17,11 @@
     "symdocs:all": "pnpm symdocs:01-scan && pnpm symdocs:02-docs && pnpm symdocs:03-write"
   },
   "dependencies": {
+    "@promethean/level-cache": "workspace:*",
     "@promethean/utils": "workspace:*",
     "gray-matter": "^4.0.3",
     "yaml": "^2.5.0",
-    "zod": "^3.23.8",
-    "@promethean/utils": "workspace:*"
+    "zod": "^3.23.8"
   },
   "devDependencies": {
     "tsx": "^4.19.2"

--- a/packages/symdocs/tsconfig.json
+++ b/packages/symdocs/tsconfig.json
@@ -8,5 +8,5 @@
     "exactOptionalPropertyTypes": false
   },
   "include": ["src/**/*"],
-  "references": []
+  "references": [{ "path": "../level-cache" }]
 }

--- a/pipelines.json
+++ b/pipelines.json
@@ -12,7 +12,7 @@
             "isolate": "worker"
           },
           "inputs": ["packages/**/{src,lib}/**/*.{ts,tsx,js,jsx}"],
-          "outputs": [".cache/symdocs/symbols.json"],
+          "outputs": [".cache/symdocs.level"],
           "inputSchema": "packages/symdocs/schemas/io.schema.json",
           "outputSchema": "packages/symdocs/schemas/io.schema.json"
         },
@@ -26,8 +26,8 @@
             "isolate": "worker"
           },
           "env": { "OLLAMA_URL": "${OLLAMA_URL}" },
-          "inputs": [".cache/symdocs/symbols.json"],
-          "outputs": [".cache/symdocs/docs.json"],
+          "inputs": [".cache/symdocs.level"],
+          "outputs": [".cache/symdocs.level"],
           "inputSchema": "packages/symdocs/schemas/io.schema.json",
           "outputSchema": "packages/symdocs/schemas/io.schema.json"
         },
@@ -40,7 +40,7 @@
             "args": { "out": "docs/packages", "granularity": "module" },
             "isolate": "worker"
           },
-          "inputs": [".cache/symdocs/docs.json"],
+          "inputs": [".cache/symdocs.level"],
           "outputs": ["docs/packages/**/**/*.md"],
           "inputSchema": "packages/symdocs/schemas/io.schema.json",
           "outputSchema": "packages/symdocs/schemas/io.schema.json"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3741,6 +3741,9 @@ importers:
 
   packages/symdocs:
     dependencies:
+      '@promethean/level-cache':
+        specifier: workspace:*
+        version: link:../level-cache
       '@promethean/utils':
         specifier: workspace:*
         version: link:../utils


### PR DESCRIPTION
## Summary
- persist symbol scan results and generated docs in LevelCache
- load symdocs write and graph stages from LevelCache instead of JSON files
- update pipeline and configuration for LevelCache storage

## Testing
- `pnpm exec eslint packages/symdocs/src/01-scan.ts packages/symdocs/src/02-docs.ts packages/symdocs/src/03-write.ts packages/symdocs/src/04-graph.ts pipelines.json`
- `pnpm --filter @promethean/symdocs build`
- `pnpm install`

------
https://chatgpt.com/codex/tasks/task_e_68c75be161b48324a526a2d508b9bbce