### PR TITLE
feat(piper): expand env placeholders

### DIFF
--- a/packages/piper/src/runner.ts
+++ b/packages/piper/src/runner.ts
@@ -30,6 +30,23 @@ import { loadState, saveState, RunState, type Step } from "./lib/state.js";
 import { renderReport } from "./lib/report.js";
 import { emitEvent, type PiperEvent } from "./lib/events.js";
 
+function expandEnvVars(
+  env: Readonly<Record<string, string>>,
+): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const [k, v] of Object.entries(env)) {
+    const match = /^\$\{(\w+)\}$/.exec(v);
+    if (match) {
+      const key = match[1]!;
+      const actual = process.env[key];
+      if (actual !== undefined) out[k] = actual;
+    } else {
+      out[k] = v;
+    }
+  }
+  return out;
+}
+
 type ValidateFn = {
   (data: unknown): boolean;
   errors?: unknown;
@@ -98,7 +115,12 @@ async function readConfig(p: string): Promise<PiperFile> {
   if (!parsed.success) {
     throw new Error("pipelines config invalid: " + parsed.error.message);
   }
-  return parsed.data;
+  return {
+    pipelines: parsed.data.pipelines.map((p) => ({
+      ...p,
+      steps: p.steps.map((s) => ({ ...s, env: expandEnvVars(s.env) })),
+    })),
+  };
 }
 
 function shouldSkip(
@@ -314,7 +336,7 @@ export async function runPipeline(
               return await runJSModule(s, cwd, envMerged, fp, s.timeoutMs);
             } catch (e: unknown) {
               const stderr =
-                e instanceof Error ? e.stack ?? e.message : String(e);
+                e instanceof Error ? (e.stack ?? e.message) : String(e);
               return { code: 1, stdout: "", stderr } as const;
             } finally {
               if (needJsLock) jsSem.release();

--- a/packages/piper/src/tests/env-expand.test.ts
+++ b/packages/piper/src/tests/env-expand.test.ts
@@ -1,0 +1,46 @@
+import { promises as fs } from "fs";
+import os from "os";
+import path from "path";
+import test from "ava";
+import { runPipeline } from "../runner.js";
+
+// Verify that ${VAR} placeholders in step.env are replaced with process.env values
+
+test("expands env placeholders", async (t) => {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "piper-env-"));
+  const mod =
+    "import { promises as fs } from 'fs';\nexport async function run({ file }) { await fs.writeFile(file, process.env.X ?? '', 'utf8'); }\n";
+  await fs.writeFile(path.join(dir, "envmod.js"), mod, "utf8");
+  const cfg = {
+    pipelines: [
+      {
+        name: "demo",
+        steps: [
+          {
+            id: "s",
+            js: {
+              module: "./envmod.js",
+              export: "run",
+              args: { file: "out.txt" },
+            },
+            env: { X: "${X}" },
+            inputs: [],
+            outputs: ["out.txt"],
+          },
+        ],
+      },
+    ],
+  };
+  await fs.writeFile(
+    path.join(dir, "pipelines.json"),
+    JSON.stringify(cfg, null, 2),
+    "utf8",
+  );
+  const orig = process.env.X;
+  process.env.X = "ok";
+  await runPipeline(path.join(dir, "pipelines.json"), "demo", {});
+  const out = await fs.readFile(path.join(dir, "out.txt"), "utf8");
+  t.is(out, "ok");
+  if (orig === undefined) delete process.env.X;
+  else process.env.X = orig;
+});


### PR DESCRIPTION
## Summary
- expand `${VAR}` placeholders in step.env during pipeline config load
- cover env substitution with a new runner test

## Testing
- `pnpm exec eslint packages/piper/src/runner.ts packages/piper/src/tests/env-expand.test.ts` *(fails: many lint warnings)*
- `pnpm --filter @promethean/piper test` *(fails: TimeoutError, 4 tests failed)*
- `pnpm --filter @promethean/piper build`
- `OLLAMA_URL=http://localhost:11434 pnpm exec piper run simtasks` *(fails: module not found)*
- `pnpm install`


------
https://chatgpt.com/codex/tasks/task_e_68c75e8d68c48324b1caa395be73a2dd