### PR TITLE
refactor piper run-route test

### DIFF
--- a/packages/piper/src/tests/run-route.test.ts
+++ b/packages/piper/src/tests/run-route.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-lines-per-function */
 import * as path from "node:path";
 import { promises as fs } from "node:fs";
 
@@ -13,92 +12,100 @@ const PKG_ROOT = path.resolve(
 
 const SCHEMA = "schema-empty.json";
 
+async function writeUtf8(p: string, content: string): Promise<void> {
+  await fs.writeFile(p, content, "utf8");
+}
+
+async function setupPipeline(dir: string): Promise<string> {
+  await writeUtf8(
+    path.join(dir, "s1.js"),
+    "export default () => { console.log('one'); }\n",
+  );
+  await writeUtf8(
+    path.join(dir, "s2.js"),
+    "export default () => { console.log('two'); }\n",
+  );
+  await writeUtf8(path.join(dir, SCHEMA), JSON.stringify({ type: "object" }));
+  const cfg = {
+    pipelines: [
+      {
+        name: "p",
+        steps: [
+          {
+            id: "s1",
+            cwd: dir,
+            deps: [],
+            inputs: [],
+            outputs: [],
+            inputSchema: SCHEMA,
+            outputSchema: SCHEMA,
+            cache: "none",
+            js: { module: "./s1.js", export: "default" },
+          },
+          {
+            id: "s2",
+            cwd: dir,
+            deps: ["s1"],
+            inputs: [],
+            outputs: [],
+            inputSchema: SCHEMA,
+            outputSchema: SCHEMA,
+            cache: "none",
+            js: { module: "./s2.js", export: "default" },
+          },
+        ],
+      },
+    ],
+  };
+  const pipelinesPath = path.join(dir, "pipelines.json");
+  await writeUtf8(pipelinesPath, JSON.stringify(cfg, null, 2));
+  return pipelinesPath;
+}
+
+async function startDevUi(pipelinesPath: string) {
+  return startProcessWithPort({
+    cmd: "node",
+    args: [
+      path.join(PKG_ROOT, "dist/dev-ui.js"),
+      "--config",
+      pipelinesPath,
+      "--port",
+      ":PORT",
+    ],
+    cwd: PKG_ROOT,
+    ready: {
+      kind: "http",
+      url: "http://localhost:PORT/health",
+      timeoutMs: 60_000,
+    },
+    port: { mode: "free" },
+    baseUrlTemplate: (p) => `http://127.0.0.1:${p}/`,
+  });
+}
+
+function assertPipelineSuccess(
+  t: { readonly true: (value: unknown) => void },
+  text: string,
+): void {
+  t.true(text.includes("s1 one"));
+  t.true(text.includes("s2 two"));
+  t.true(text.includes("EXIT s2 0"));
+}
+
 test.serial("dev-ui runs full pipeline via /api/run", async (t) => {
   const tmpParent = path.join(PKG_ROOT, "test-tmp");
   await fs.mkdir(tmpParent, { recursive: true });
   const dir = await fs.mkdtemp(path.join(tmpParent, "piper-"));
-  try {
-    await fs.writeFile(
-      path.join(dir, "s1.js"),
-      "export default () => { console.log('one'); }\n",
-      "utf8",
-    );
-    await fs.writeFile(
-      path.join(dir, "s2.js"),
-      "export default () => { console.log('two'); }\n",
-      "utf8",
-    );
-    await fs.writeFile(
-      path.join(dir, SCHEMA),
-      JSON.stringify({ type: "object" }),
-      "utf8",
-    );
-    const cfg = {
-      pipelines: [
-        {
-          name: "p",
-          steps: [
-            {
-              id: "s1",
-              cwd: dir,
-              deps: [],
-              inputs: [],
-              outputs: [],
-              inputSchema: SCHEMA,
-              outputSchema: SCHEMA,
-              cache: "none",
-              js: { module: "./s1.js", export: "default" },
-            },
-            {
-              id: "s2",
-              cwd: dir,
-              deps: ["s1"],
-              inputs: [],
-              outputs: [],
-              inputSchema: SCHEMA,
-              outputSchema: SCHEMA,
-              cache: "none",
-              js: { module: "./s2.js", export: "default" },
-            },
-          ],
-        },
-      ],
-    };
-    const pipelinesPath = path.join(dir, "pipelines.json");
-    await fs.writeFile(pipelinesPath, JSON.stringify(cfg, null, 2), "utf8");
-
-    const { stop, baseUrl } = await startProcessWithPort({
-      cmd: "node",
-      args: [
-        path.join(PKG_ROOT, "dist/dev-ui.js"),
-        "--config",
-        pipelinesPath,
-        "--port",
-        ":PORT",
-      ],
-      cwd: PKG_ROOT,
-      ready: {
-        kind: "http",
-        url: "http://localhost:PORT/health",
-        timeoutMs: 60_000,
-      },
-      port: { mode: "free" },
-      baseUrlTemplate: (p) => `http://127.0.0.1:${p}/`,
-    });
-
-    try {
-      const q = new URLSearchParams({ pipeline: "p" });
-      const res = await fetch(`${baseUrl}api/run?${q.toString()}`);
-      t.is(res.status, 200);
-      const text = await res.text();
-      t.true(text.includes("s1 one"));
-      t.true(text.includes("s2 two"));
-      t.true(text.includes("EXIT s2 0"));
-    } finally {
-      await stop();
-    }
-  } finally {
+  t.teardown(async () => {
     await shutdown().catch(() => {});
     await fs.rm(dir, { recursive: true, force: true });
-  }
+  });
+  const pipelinesPath = await setupPipeline(dir);
+  const { stop, baseUrl } = await startDevUi(pipelinesPath);
+  t.teardown(stop);
+  const q = new URLSearchParams({ pipeline: "p" });
+  const res = await fetch(`${baseUrl}api/run?${q.toString()}`);
+  t.is(res.status, 200);
+  const text = await res.text();
+  assertPipelineSuccess(t, text);
 });


### PR DESCRIPTION
## Summary
- streamline piper run-route test with helper functions
- remove max-lines-per-function disable comment

## Testing
- `pnpm exec eslint packages/piper/src/tests/run-route.test.ts`
- `pnpm --filter @promethean/piper test` *(fails: TimeoutError in frontend hmr.state.test.ts)*
- `pnpm install`


------
https://chatgpt.com/codex/tasks/task_e_68c75e9b0d14832499cea90e03e75576