### PR TITLE
refactor tests for typings and immutability

### DIFF
--- a/packages/discord/src/tests/embedding.test.ts
+++ b/packages/discord/src/tests/embedding.test.ts
@@ -1,23 +1,28 @@
-/* eslint-disable */
 import test from "ava";
 import { RemoteEmbeddingFunction } from "@promethean/embedding";
 
-class MockBrokerClient {
-  handlers: Record<string, ((e: any) => void)[]> = {};
-  socket: { close: () => void } = { close: () => {} };
-  async connect() {
-    return;
-  }
-  subscribe(topic: string, cb: (e: any) => void) {
+type BrokerEvent = { replyTo: string; payload: { embeddings: number[][] } };
+type BrokerClientLike = {
+  connect(): Promise<void>;
+  subscribe(topic: string, cb: (e: BrokerEvent) => void): void;
+  enqueue(queue: string, payload: { items: unknown[]; replyTo: string }): void;
+  socket: { close: () => void };
+};
+
+class MockBrokerClient implements BrokerClientLike {
+  handlers: Record<string, Array<(e: BrokerEvent) => void>> = {};
+  socket = { close: () => {} };
+  async connect() {}
+  subscribe(topic: string, cb: (e: BrokerEvent) => void) {
     if (!this.handlers[topic]) this.handlers[topic] = [];
+    // eslint-disable-next-line functional/immutable-data
     this.handlers[topic]!.push(cb);
   }
-  enqueue(queue: string, payload: any) {
+  enqueue(queue: string, payload: { items: unknown[]; replyTo: string }) {
     if (queue !== "embedding.generate") return;
-    const items = payload.items || [];
-    const embeddings = items.map((_: unknown, i: number) => [i]);
+    const embeddings = payload.items.map((_, i) => [i]);
     const ev = { replyTo: payload.replyTo, payload: { embeddings } };
-    for (const cb of this.handlers["embedding.result"] || []) cb(ev);
+    (this.handlers["embedding.result"] || []).forEach((cb) => cb(ev));
   }
 }
 
@@ -27,7 +32,7 @@ test("requests embeddings via mocked broker", async (t) => {
     undefined,
     undefined,
     undefined,
-    mock as any,
+    mock as BrokerClientLike,
   );
   const result = await fn.generate(["a", "b"]);
   t.deepEqual(result, [[0], [1]]);

--- a/packages/smartgpt-bridge/src/agentSupervisor.ts
+++ b/packages/smartgpt-bridge/src/agentSupervisor.ts
@@ -56,7 +56,7 @@ export class AgentSupervisor {
     if (!fs.existsSync(logDir)) fs.mkdirSync(logDir, { recursive: true });
   }
 
-  start({
+  async start({
     prompt,
     tty: _tty = true,
     env = {},
@@ -66,7 +66,7 @@ export class AgentSupervisor {
     tty?: boolean;
     env?: Record<string, string>;
     bypassApprovals?: boolean;
-  }) {
+  }): Promise<string> {
     const id = nanoid();
     const logBuffer = new LogBuffer();
     const logfile = path.join(this.logDir, `${id}.log`);
@@ -101,7 +101,7 @@ export class AgentSupervisor {
       ];
     }
 
-    const pty = getPty();
+    const pty = await getPty();
     if (!pty) {
       throw new PtyUnavailableError();
     }

--- a/packages/smartgpt-bridge/src/routes/v0/agent.ts
+++ b/packages/smartgpt-bridge/src/routes/v0/agent.ts
@@ -80,10 +80,10 @@ export function registerAgentRoutes(fastify: any) {
           bypassApprovals,
           sandbox,
           tty,
-        } = (req.body) || {};
+        } = req.body || {};
         const mode = sandbox === "nsjail" ? "nsjail" : "default";
         const sup = getSup(fastify, mode);
-        const id = sup.start({
+        const { id } = await sup.start({
           prompt,
           env,
           bypassApprovals: Boolean(bypassApprovals),


### PR DESCRIPTION
## Summary
- add typed fetch mocks and no-store checks to docops frontend API tests
- switch SmartGPT bridge PTY loading to dynamic import and await start
- refactor Discord and UI component tests for immutable style and typed mocks

## Testing
- `pnpm --filter @promethean/docops-frontend lint`
- `pnpm --filter @promethean/docops-frontend test`
- `pnpm --filter @promethean/smartgpt-bridge lint` (fails: Unexpected any, unsafe assignments)
- `pnpm --filter @promethean/smartgpt-bridge test` (fails: 10 tests failed)
- `pnpm --filter @promethean/discord exec eslint src/tests/flow.test.ts src/tests/rest.test.ts src/tests/embedding.test.ts`
- `pnpm --filter @promethean/discord test` (fails: missing modules)
- `pnpm --filter @promethean/ui-components lint`
- `pnpm --filter @promethean/ui-components test`
- `pnpm install`

------
https://chatgpt.com/codex/tasks/task_e_68c75ea17704832495ad144cd22b41a6