### PR TITLE
feat(utils): retry ollama embedding on server busy

### DIFF
--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -12,7 +12,7 @@ export { relFromRepo } from "./path.js";
 export { cosine } from "./cosine.js";
 export { getJsDocText, getNodeText, posToLine } from "./ts-ast.js";
 export { listFilesRec } from "./list-files-rec.js";
-export { OLLAMA_URL, ollamaEmbed, ollamaJSON } from "./ollama.js";
+export { OLLAMA_URL, ollamaEmbed, ollamaJSON, OllamaError } from "./ollama.js";
 export { readText, writeText, readMaybe } from "./files.js";
 export { sha1 } from "./hash.js";
 export {

--- a/packages/utils/src/tests/ollama.test.ts
+++ b/packages/utils/src/tests/ollama.test.ts
@@ -3,10 +3,13 @@ import test from "ava";
 import { OLLAMA_URL, ollamaEmbed, ollamaJSON } from "../ollama.js";
 
 // simple fetch mock helper
-function mockFetch(res: Response) {
+function mockFetch(res: () => Response) {
   const orig = globalThis.fetch;
-  globalThis.fetch = (async () => res) as any;
+  // eslint-disable-next-line functional/immutable-data
+  globalThis.fetch = (async (_input: RequestInfo | URL, _init?: RequestInit) =>
+    res()) as unknown as typeof fetch;
   return () => {
+    // eslint-disable-next-line functional/immutable-data
     globalThis.fetch = orig;
   };
 }
@@ -15,26 +18,43 @@ test("OLLAMA_URL has default", (t) => {
   t.is(OLLAMA_URL, process.env.OLLAMA_URL ?? "http://localhost:11434");
 });
 
-test("ollamaEmbed returns embedding", async (t) => {
+test.serial("ollamaEmbed returns embedding", async (t) => {
   const restore = mockFetch(
-    new Response(JSON.stringify({ embedding: [1, 2, 3] }), { status: 200 }),
+    () =>
+      new Response(JSON.stringify({ embedding: [1, 2, 3] }), { status: 200 }),
   );
   const emb = await ollamaEmbed("m", "text");
   t.deepEqual(emb, [1, 2, 3]);
   restore();
 });
 
-test("ollamaJSON parses response", async (t) => {
+test.serial("ollamaEmbed retries and fails after max attempts", async (t) => {
+  // eslint-disable-next-line functional/prefer-immutable-types
+  const calls: number[] = [];
+  const restore = mockFetch(() => {
+    // eslint-disable-next-line functional/immutable-data
+    calls.push(1);
+    return new Response("busy", { status: 503 });
+  });
+  await t.throwsAsync(() => ollamaEmbed("m", "text"), {
+    message: /ollama embeddings 503/,
+  });
+  t.is(calls.length, 3);
+  restore();
+});
+
+test.serial("ollamaJSON parses response", async (t) => {
   const restore = mockFetch(
-    new Response(JSON.stringify({ response: '{"a":1}' }), { status: 200 }),
+    () =>
+      new Response(JSON.stringify({ response: '{"a":1}' }), { status: 200 }),
   );
   const obj = await ollamaJSON("m", "p");
   t.deepEqual(obj, { a: 1 });
   restore();
 });
 
-test("ollamaJSON throws on error", async (t) => {
-  const restore = mockFetch(new Response("fail", { status: 500 }));
+test.serial("ollamaJSON throws on error", async (t) => {
+  const restore = mockFetch(() => new Response("fail", { status: 500 }));
   await t.throwsAsync(() => ollamaJSON("m", "p"), {
     message: /ollama generate 500/,
   });


### PR DESCRIPTION
## Summary
- add OllamaError and retry logic to ollamaEmbed
- re-export OllamaError from utils index
- cover embed retry behavior with new serial tests

## Testing
- `pnpm exec eslint packages/utils/src/ollama.ts packages/utils/src/index.ts packages/utils/src/tests/ollama.test.ts`
- `pnpm --filter @promethean/utils test`
- `pnpm install`


------
https://chatgpt.com/codex/tasks/task_e_68c76325f7288324ac268f1c6686e8da