### PR TITLE
fix: resolve discord test types

### DIFF
--- a/packages/discord/src/tests/embedding.test.ts
+++ b/packages/discord/src/tests/embedding.test.ts
@@ -1,5 +1,6 @@
 import test from "ava";
 import { RemoteEmbeddingFunction } from "@promethean/embedding";
+import type { BrokerClient } from "@promethean/legacy/brokerClient.js";
 
 type BrokerEvent = { replyTo: string; payload: { embeddings: number[][] } };
 type BrokerClientLike = {
@@ -32,7 +33,7 @@ test("requests embeddings via mocked broker", async (t) => {
     undefined,
     undefined,
     undefined,
-    mock as BrokerClientLike,
+    mock as unknown as BrokerClient,
   );
   const result = await fn.generate(["a", "b"]);
   t.deepEqual(result, [[0], [1]]);

--- a/packages/discord/src/tests/flow.test.ts
+++ b/packages/discord/src/tests/flow.test.ts
@@ -1,5 +1,6 @@
-import test from "ava";
 import path from "node:path";
+
+import test from "ava";
 import { InMemoryEventBus } from "@promethean/event/memory.js";
 import {
   GatewayPublisher,
@@ -14,59 +15,62 @@ type EmbedEvt = {
   readonly message_id: string;
   readonly space_urn: string;
   readonly text: string;
+  readonly attachments?: Array<{ id: string }>;
 };
 // fallback mock: real package unavailable
 async function embedAttachments(evt: { attachments?: Array<{ id: string }> }) {
   return { ids: evt.attachments?.map((a) => a.id) ?? [] };
 }
 
+const provider = "discord";
+const tenant = "duck";
+const normTopic = `promethean.p.${provider}.t.${tenant}.events.SocialMessageCreated`;
+const raw = {
+  id: "m1",
+  author: { id: "u1" },
+  channel_id: "c1",
+  content: "hi",
+  attachments: [
+    {
+      id: "a1",
+      url: "https://cdn/1",
+      content_type: "image/png",
+      size: 12,
+      hash: "h",
+    },
+  ],
+  timestamp: new Date().toISOString(),
+};
+
 test("end-to-end: raw -> normalized -> index + embed", async (t) => {
+  // eslint-disable-next-line functional/immutable-data
   process.env.DISCORD_TOKEN_DUCK = "x";
+  // eslint-disable-next-line functional/immutable-data
   process.env.EMBEDDING_DIM = "8";
   const bus = new InMemoryEventBus();
   const pub = new GatewayPublisher(bus);
-  const provider = "discord";
-  const tenant = "duck";
-  const normTopic = `promethean.p.${provider}.t.${tenant}.events.SocialMessageCreated`;
 
-  let seen = { indexed: 0, attachments: 0, embeddedMsg: 0, embeddedAtt: 0 };
-  await bus.subscribe(normTopic, "workers", async (e) => {
-    const evt = e.payload as EmbedEvt;
-    const msg = await indexMessage(evt);
-    const atts = await indexAttachments(evt);
-    const cfg = path.join(process.cwd(), "config", "providers.yml");
-    const em = await embedMessage(evt, { configPath: cfg });
-    const ea = await embedAttachments(evt);
-    seen = {
-      indexed: seen.indexed + (msg ? 1 : 0),
-      attachments: seen.attachments + atts.length,
-      embeddedMsg: seen.embeddedMsg + (em ? 1 : 0),
-      embeddedAtt: seen.embeddedAtt + (ea.ids?.length ?? 0),
-    };
+  const done = new Promise<void>(async (resolve) => {
+    await (bus as unknown as InMemoryEventBus).subscribe(
+      normTopic,
+      "workers",
+      async (e: unknown) => {
+        const evt = (e as { payload: EmbedEvt }).payload;
+        const msg = await indexMessage(evt);
+        const atts = (await indexAttachments(evt)) as ReadonlyArray<unknown>;
+        const cfg = path.join(process.cwd(), "config", "providers.yml");
+        const em = await embedMessage(evt, { configPath: cfg });
+        const ea = await embedAttachments(evt);
+        t.truthy(msg);
+        t.is(atts.length, 1);
+        t.truthy(em);
+        t.is(ea.ids.length, 1);
+        resolve();
+      },
+    );
   });
 
-  const raw = {
-    id: "m1",
-    author: { id: "u1" },
-    channel_id: "c1",
-    content: "hi",
-    attachments: [
-      {
-        id: "a1",
-        url: "https://cdn/1",
-        content_type: "image/png",
-        size: 12,
-        hash: "h",
-      },
-    ],
-    timestamp: new Date().toISOString(),
-  };
   await pub.publishRaw(provider, tenant, raw);
   await pub.publishNormalized(provider, tenant, raw);
-  await new Promise((r) => setTimeout(r, 0));
-
-  t.is(seen.indexed, 1);
-  t.is(seen.attachments, 1);
-  t.is(seen.embeddedMsg, 1);
-  t.is(seen.embeddedAtt, 1);
+  await done;
 });


### PR DESCRIPTION
## Summary
- align embedding broker mock with BrokerClient interface
- add attachment typing and refactor flow test

## Testing
- `pnpm --filter @promethean/discord build`
- `pnpm --filter @promethean/discord test`
- `pnpm install`


------
https://chatgpt.com/codex/tasks/task_e_68c76a4be1648324820abcd8614e7f28