### PR TITLE
refactor: simplify docops collect with Array.fromAsync

### DIFF
--- a/packages/docops/src/db.ts
+++ b/packages/docops/src/db.ts
@@ -1,8 +1,16 @@
+/// <reference lib="esnext" />
+
 // src/db.ts
 import { Level } from "level";
 import type { AbstractSublevel } from "abstract-level";
 
 import type { Chunk, QueryHit } from "./types.js";
+
+declare global {
+  interface ArrayConstructor {
+    fromAsync<T>(iterable: Iterable<T> | AsyncIterable<T>): Promise<T[]>;
+  }
+}
 
 export type DBs = {
   root: Level<string, unknown>;
@@ -103,8 +111,4 @@ export const withDb = async <R>(
 };
 
 export const collect = <T>(xs: Iterable<T> | AsyncIterable<T>) =>
-  (async () => {
-    const out: T[] = [];
-    for await (const x of xs as any) out.push(x);
-    return out;
-  })();
+  Array.fromAsync(xs as any);


### PR DESCRIPTION
## Summary
- refactor docops collect to use Array.fromAsync
- add global Array.fromAsync declaration

## Testing
- `pnpm --filter @promethean/docops test`
- `pnpm install`
- `pnpm lint:diff` *(fails: ESLint errors in packages/docops/src/db.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68c839af461c8324a260e6e07fcc5e22

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined asynchronous data collection using modern platform capabilities for improved maintainability.
* **Performance**
  * Minor improvements to efficiency when aggregating data, potentially reducing processing time in some scenarios.
* **Compatibility**
  * Improved alignment with newer runtime features to enhance forward-compatibility without changing existing behavior.
* **Chores**
  * Internal typings updated to reflect modern APIs; no changes to public interfaces or user workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->