### PR TITLE
refactor(docops): streamline chunk creation

### DIFF
--- a/packages/docops/src/utils.ts
+++ b/packages/docops/src/utils.ts
@@ -123,22 +123,24 @@ export function parseMarkdownChunks(markdown: string): Chunk[] {
       const raw = node.type === "code" ? node.value || "" : extractText(node);
       const trimmed = (raw || "").trim();
       if (!trimmed) return;
-      const kind = node.type === "code" ? "code" : "text";
-      for (const s of sentenceSplit(trimmed, 1200)) {
-        const base: any = {
-          id: "",
-          docUuid: "",
-          docPath: "",
-          startLine: pos.start.line,
-          startCol: pos.start.column,
-          endLine: pos.end.line,
-          endCol: pos.end.column,
-          text: s,
-          kind,
-        };
-        if (currentHeading) base.title = currentHeading;
-        chunks.push(base as Chunk);
-      }
+      const kind: Chunk["kind"] = node.type === "code" ? "code" : "text";
+      chunks.push(
+        ...sentenceSplit(trimmed, 1200).map(
+          (s) =>
+            ({
+              id: "",
+              docUuid: "",
+              docPath: "",
+              startLine: pos.start.line,
+              startCol: pos.start.column,
+              endLine: pos.end.line,
+              endCol: pos.end.column,
+              text: s,
+              kind,
+              ...(currentHeading ? { title: currentHeading } : {}),
+            }) as Chunk,
+        ),
+      );
     }
   });
 


### PR DESCRIPTION
## Summary
- streamline `parseMarkdownChunks` by mapping sentences and pushing in one call

## Testing
- `pnpm exec eslint packages/docops/src/utils.ts`
- `pnpm lint:diff`
- `pnpm --filter @promethean/docops test`
- `pnpm install`


------
https://chatgpt.com/codex/tasks/task_e_68c839ae58cc83249059a50b525fd11d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined internal markdown chunk processing for improved maintainability and type safety.
  * Ensures consistent handling of chunk metadata and titles while preserving existing behavior.
  * No changes to user-visible features or outputs.
  * No modifications to public APIs; integrations continue to work as before.
  * No action required from users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->