### PR TITLE
refactor: simplify pending change detection

### DIFF
--- a/packages/markdown/src/sync.ts
+++ b/packages/markdown/src/sync.ts
@@ -133,13 +133,12 @@ export async function syncBoardStatuses(board: MarkdownBoard, opts: SyncOptions)
 }
 
 export function detectPendingChanges(board: MarkdownBoard, opts: SyncOptions): boolean {
-    for (const col of board.listColumns()) {
+    return board.listColumns().some((col) => {
         const status = headerToStatus(col.name);
-        for (const card of board.listCards(col.name)) {
-            if (cardNeedsStatusUpdate(card, status) || cardNeedsLink(card, opts.createMissingTasks)) return true;
-        }
-    }
-    return false;
+        return board
+            .listCards(col.name)
+            .some((card) => cardNeedsStatusUpdate(card, status) || cardNeedsLink(card, opts.createMissingTasks));
+    });
 }
 
 export async function applyUpdates(board: MarkdownBoard, opts: SyncOptions): Promise<boolean> {


### PR DESCRIPTION
## Summary
- refactor detectPendingChanges to use Array.some for status/link checks

## Testing
- `pnpm exec eslint packages/markdown/src/sync.ts` *(fails: many pre-existing lint errors)*
- `pnpm --filter @promethean/markdown test` *(fails: Couldn’t find any files to test)*
- `pnpm install`


------
https://chatgpt.com/codex/tasks/task_e_68c839a7e88c8324a0b346b32328ba25