### PR TITLE
Refactor docops chunk splitting

### DIFF
--- a/packages/docops/src/utils.ts
+++ b/packages/docops/src/utils.ts
@@ -96,14 +96,13 @@ export function parseMarkdownChunks(markdown: string): Chunk[] {
       } else buf = (buf ? buf + " " : "") + p;
     }
     if (buf) chunks.push(buf.trim());
-    const final: string[] = [];
-    for (const c of chunks) {
-      if (c.length <= maxLen) final.push(c);
-      else
-        for (let i = 0; i < c.length; i += maxLen)
-          final.push(c.slice(i, i + maxLen));
-    }
-    return final;
+    return chunks.flatMap((c) =>
+      c.length <= maxLen
+        ? [c]
+        : Array.from({ length: Math.ceil(c.length / maxLen) }, (_, i) =>
+            c.slice(i * maxLen, (i + 1) * maxLen),
+          ),
+    );
   }
 
   visit(ast, (node: any) => {


### PR DESCRIPTION
## Summary
- replace the nested chunk splitting loops in `sentenceSplit` with a `flatMap`/`Array.from` implementation
- preserve the chunk output while simplifying the code path

## Testing
- pnpm exec eslint packages/docops/src/utils.ts
- pnpm --filter @promethean/docops test
- pnpm install

------
https://chatgpt.com/codex/tasks/task_e_68c839ad47f48324870b1f6a0a6909f0