### PR TITLE
refactor: collect code blocks with promise.all

### DIFF
--- a/packages/codepack/src/01-extract.ts
+++ b/packages/codepack/src/01-extract.ts
@@ -1,10 +1,17 @@
 // src/01-extract.ts
 import { promises as fs } from "fs";
 import * as path from "path";
+
 import matter from "gray-matter";
-import { parseArgs, relPath, sha1 } from "./utils.js";
-import { extractCodeBlocksWithContext, detectFilenameHint } from "./utils.js";
 import { listFilesRec } from "@promethean/utils";
+
+import {
+  parseArgs,
+  relPath,
+  sha1,
+  extractCodeBlocksWithContext,
+  detectFilenameHint,
+} from "./utils.js";
 import type { BlockManifest, CodeBlock } from "./types.js";
 
 const args = parseArgs({
@@ -21,33 +28,35 @@ const OUT = path.resolve(args["--out"]);
 
 async function main() {
   const files = await listFilesRec(ROOT, EXTS);
-  const blocks: CodeBlock[] = [];
+  const blocks = (
+    await Promise.all(
+      files.map(async (f) => {
+        const raw = await fs.readFile(f, "utf-8");
+        const { content } = matter(raw); // ignore frontmatter, operate on content
+        const found = extractCodeBlocksWithContext(content);
+        const rel = relPath(ROOT, f);
 
-  for (const f of files) {
-    const raw = await fs.readFile(f, "utf-8");
-    const { content } = matter(raw); // ignore frontmatter, operate on content
-    const found = extractCodeBlocksWithContext(content);
-    const rel = relPath(ROOT, f);
-
-    found.forEach((b, idx) => {
-      const id = sha1([f, b.startLine, b.endLine, sha1(b.value)].join("|"));
-      blocks.push({
-        id,
-        srcPath: f,
-        relPath: rel,
-        lang: b.lang,
-        startLine: b.startLine,
-        endLine: b.endLine,
-        code: b.value,
-        contextBefore: b.beforeText,
-        contextAfter: b.afterText,
-        hintedName: detectFilenameHint(b),
-      });
-    });
-  }
+        return found.map((b) => {
+          const id = sha1([f, b.startLine, b.endLine, sha1(b.value)].join("|"));
+          return {
+            id,
+            srcPath: f,
+            relPath: rel,
+            lang: b.lang,
+            startLine: b.startLine,
+            endLine: b.endLine,
+            code: b.value,
+            contextBefore: b.beforeText,
+            contextAfter: b.afterText,
+            hintedName: detectFilenameHint(b),
+          } satisfies CodeBlock;
+        });
+      }),
+    )
+  ).flat();
 
   await fs.mkdir(path.dirname(OUT), { recursive: true });
-  const manifest: BlockManifest = { blocks };
+  const manifest = { blocks } as const satisfies BlockManifest;
   await fs.writeFile(OUT, JSON.stringify(manifest, null, 2), "utf-8");
   console.log(
     `extracted ${blocks.length} code blocks -> ${path.relative(


### PR DESCRIPTION
## Summary
- streamline extraction by mapping files concurrently and flattening code block results
- ensure manifest typed immutable via `satisfies`

## Testing
- `pnpm exec eslint packages/codepack/src/01-extract.ts --max-warnings=0`
- `pnpm --filter @promethean/codepack test`
- `pnpm install`


------
https://chatgpt.com/codex/tasks/task_e_68c839a2cff4832499a7171c4f17c72b