### PR TITLE
fix: build before testing file indexer and harden ignore normalization

### DIFF
--- a/packages/file-indexer/project.json
+++ b/packages/file-indexer/project.json
@@ -20,6 +20,7 @@
     },
     "test": {
       "executor": "nx:run-commands",
+      "dependsOn": ["build"],
       "options": {
         "command": "ava",
         "cwd": "packages/file-indexer"

--- a/packages/file-indexer/src/runtime.ts
+++ b/packages/file-indexer/src/runtime.ts
@@ -293,16 +293,38 @@ function normalizeIgnoreSegments(
   return Array.from(ignoreDirs)
     .map((value) => value?.trim())
     .filter(isNonEmpty)
-    .map((value) => value.replace(/[\\/]+$/, ""))
+    .map(trimTrailingSeparators)
     .filter(isNonEmpty)
     .map((value) =>
       path.isAbsolute(value) ? path.relative(root, value) : value,
     )
-    .map((value) => value.replace(/^[.\\/]+/, ""))
+    .map(trimLeadingDotsAndSeparators)
     .filter(isNonEmpty)
     .map((value) => path.normalize(value))
     .filter((value) => value.length > 0 && !value.startsWith(".."))
     .map((value) => value.split(path.sep).filter(Boolean));
+}
+
+function trimTrailingSeparators(value: string): string {
+  if (value.length === 0) {
+    return value;
+  }
+  const code = value.charCodeAt(value.length - 1);
+  if (code === 47 || code === 92) {
+    return trimTrailingSeparators(value.slice(0, -1));
+  }
+  return value;
+}
+
+function trimLeadingDotsAndSeparators(value: string): string {
+  if (value.length === 0) {
+    return value;
+  }
+  const code = value.charCodeAt(0);
+  if (code === 46 || code === 47 || code === 92) {
+    return trimLeadingDotsAndSeparators(value.slice(1));
+  }
+  return value;
 }
 
 function isNonEmpty(value: string | undefined | null): value is string {


### PR DESCRIPTION
## Summary
- add the @promethean/file-indexer workspace package that composes `listFilesRec` with directory filtering, callback hooks, batching, and progress reporting
- factor shared traversal helpers into a runtime module and document usage and options in a package README
- cover core behaviors with tests for ignore directories, extension filtering, batching, and content loading
- ensure the Nx `test` target depends on `build` so TypeScript is compiled before AVA runs
- replace ignore-directory normalization regexes with recursive helpers to avoid the CodeQL ReDoS warning

## Testing
- pnpm --filter @promethean/file-indexer build
- pnpm --filter @promethean/file-indexer test

------
https://chatgpt.com/codex/tasks/task_e_68c8e46c24748324b11b3ba588ca20c2