### PR TITLE
feat: stabilize snapshot etags

### DIFF
--- a/packages/snapshots/ava.config.mjs
+++ b/packages/snapshots/ava.config.mjs
@@ -1,1 +1,1 @@
-export { default } from '../../../config/ava.config.base.mjs';
+export { default } from '../../config/ava.config.mjs';

--- a/packages/snapshots/src/api.ts
+++ b/packages/snapshots/src/api.ts
@@ -4,7 +4,8 @@ import type { Server } from 'http';
 import express, { type RequestHandler } from 'express';
 import rateLimit from 'express-rate-limit';
 import type { Db, Collection } from 'mongodb';
-import { sha1 } from '@promethean/utils';
+
+import { etagOf } from './etag.js';
 
 export type SnapshotApiOptions = {
     collection: string; // e.g., "processes.snapshot"
@@ -12,11 +13,6 @@ export type SnapshotApiOptions = {
     bodyLimit?: string; // default "200kb"
     maxAgeSeconds?: number; // default 5 (client cache)
 };
-
-function etagOf(doc: unknown) {
-    const s = JSON.stringify(doc);
-    return '"' + sha1(s) + '"';
-}
 
 export function getSnap(coll: Collection, keyField: string, cacheCtl: string): RequestHandler {
     return async (req, res): Promise<void> => {

--- a/packages/snapshots/src/etag.ts
+++ b/packages/snapshots/src/etag.ts
@@ -1,0 +1,51 @@
+import { sha1 } from '@promethean/utils';
+
+type JsonPrimitive = string | number | boolean | null;
+type JsonValue = JsonPrimitive | JsonArray | JsonObject;
+type JsonArray = readonly JsonValue[];
+type JsonObject = { readonly [key: string]: JsonValue };
+
+const isJsonObject = (value: JsonValue): value is JsonObject =>
+    typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const canonicalizeJsonValue = (value: JsonValue): string => {
+    if (value === null) {
+        return 'null';
+    }
+
+    if (Array.isArray(value)) {
+        const serializedItems = value.map(canonicalizeJsonValue);
+        return `[${serializedItems.join(',')}]`;
+    }
+
+    if (isJsonObject(value)) {
+        const object: JsonObject = value;
+        const sortedKeys = Object.keys(object)
+            .slice()
+            .sort((a, b) => a.localeCompare(b));
+        const serialized = sortedKeys.map((key) => {
+            const nestedValue = object[key];
+            if (nestedValue === undefined) {
+                return `${JSON.stringify(key)}:null`;
+            }
+            return `${JSON.stringify(key)}:${canonicalizeJsonValue(nestedValue)}`;
+        });
+        return `{${serialized.join(',')}}`;
+    }
+
+    return JSON.stringify(value);
+};
+
+const canonicalJsonString = (value: unknown): string => {
+    const json = JSON.stringify(value);
+    if (json === undefined) {
+        throw new TypeError('Cannot stringify value to JSON');
+    }
+    const parsed = JSON.parse(json) as JsonValue;
+    return canonicalizeJsonValue(parsed);
+};
+
+export function etagOf(doc: unknown): string {
+    const canonical = canonicalJsonString(doc);
+    return '"' + sha1(canonical) + '"';
+}

--- a/packages/snapshots/src/tests/api.test.ts
+++ b/packages/snapshots/src/tests/api.test.ts
@@ -1,6 +1,42 @@
 import test from 'ava';
 import { sha1 } from '@promethean/utils';
 
+import { etagOf } from '../etag.js';
+
 test('sha1 hashes text to hex digest', (t) => {
     t.is(sha1('test'), 'a94a8fe5ccb19ba61c4c0873d391e987982fbbd3');
+});
+
+test('etagOf sorts object keys before hashing', (t) => {
+    const shuffledDoc = { b: 2, a: 1 };
+    const orderedDoc = { a: 1, b: 2 };
+    const expected = '"' + sha1('{"a":1,"b":2}') + '"';
+
+    t.is(etagOf(shuffledDoc), expected);
+    t.is(etagOf(orderedDoc), expected);
+});
+
+test('etagOf canonicalizes nested structures', (t) => {
+    const doc = {
+        meta: { id: 'abc', created: '2024-01-01' },
+        items: [
+            { z: 1, y: 2 },
+            { b: 3, a: 4 },
+        ],
+    };
+
+    const expectedCanonical = '{"items":[{"y":2,"z":1},{"a":4,"b":3}],"meta":{"created":"2024-01-01","id":"abc"}}';
+    const expected = '"' + sha1(expectedCanonical) + '"';
+
+    t.is(etagOf(doc), expected);
+});
+
+test('etagOf matches JSON.stringify for primitives', (t) => {
+    const text = 'hello';
+    const number = 42;
+    const bool = true;
+
+    t.is(etagOf(text), '"' + sha1('"hello"') + '"');
+    t.is(etagOf(number), '"' + sha1('42') + '"');
+    t.is(etagOf(bool), '"' + sha1('true') + '"');
 });


### PR DESCRIPTION
## Summary
- extract a deterministic `etagOf` helper that canonicalizes JSON before hashing
- use the helper in the snapshot API handlers and align the package AVA config with the shared root config
- add AVA coverage for stable ETags across object key ordering, nested structures, and primitives

## Testing
- `pnpm --filter @promethean/snapshots build`
- `pnpm --filter @promethean/snapshots lint`
- `pnpm --filter @promethean/snapshots test`

## Issue
- Unable to reference an issue (gh CLI is unavailable in the container)


------
https://chatgpt.com/codex/tasks/task_e_68c8eea9f6f88324a8207b7e3b7aa2f4