### PR TITLE
Adjust docops pipeline to process staged inbox content

### DIFF
--- a/pipelines.json
+++ b/pipelines.json
@@ -745,19 +745,26 @@
       "name": "docops",
       "steps": [
         {
+          "id": "doc-stage",
+          "shell": "if [ -d inbox ]; then mkdir -p labeled && rsync -a inbox/ labeled/; else echo 'doc-stage: inbox directory missing' >&2; fi",
+          "inputs": ["inbox/**/*"],
+          "outputs": ["labeled/**/*"]
+        },
+        {
           "id": "doc-fm",
+          "deps": ["doc-stage"],
           "js": {
             "module": "scripts/piper-docops.mjs",
             "export": "frontmatter",
             "args": {
-              "dir": "docs/unique",
+              "dir": "labeled",
               "genModel": "qwen3:4b"
             }
           },
           "env": {
             "OLLAMA_URL": "${OLLAMA_URL}"
           },
-          "inputs": ["docs/unique/**/*.md"],
+          "inputs": ["labeled/**/*.md"],
           "outputs": [],
           "inputSchema": "packages/docops/schemas/io.schema.json",
           "outputSchema": "packages/docops/schemas/io.schema.json"
@@ -769,7 +776,7 @@
             "module": "scripts/piper-docops.mjs",
             "export": "embed",
             "args": {
-              "dir": "docs/unique",
+              "dir": "labeled",
               "embedModel": "nomic-embed-text:latest",
               "collection": "docs"
             }
@@ -777,7 +784,7 @@
           "env": {
             "OLLAMA_URL": "${OLLAMA_URL}"
           },
-          "inputs": ["docs/unique/**/*.md"],
+          "inputs": ["labeled/**/*.md"],
           "outputs": [],
           "inputSchema": "packages/docops/schemas/io.schema.json",
           "outputSchema": "packages/docops/schemas/io.schema.json"
@@ -809,12 +816,12 @@
             "module": "scripts/piper-docops.mjs",
             "export": "relations",
             "args": {
-              "dir": "docs/unique",
+              "dir": "labeled",
               "docThreshold": 0.78,
               "refThreshold": 0.6
             }
           },
-          "inputs": ["docs/unique/**/*.md"],
+          "inputs": ["labeled/**/*.md"],
           "outputs": [],
           "inputSchema": "packages/docops/schemas/io.schema.json",
           "outputSchema": "packages/docops/schemas/io.schema.json"
@@ -826,13 +833,13 @@
             "module": "scripts/piper-docops.mjs",
             "export": "footers",
             "args": {
-              "dir": "docs/unique",
+              "dir": "labeled",
               "anchorStyle": "block",
               "includeRelated": true,
               "includeSources": true
             }
           },
-          "inputs": ["docs/unique/**/*.md"],
+          "inputs": ["labeled/**/*.md"],
           "outputs": [],
           "inputSchema": "packages/docops/schemas/io.schema.json",
           "outputSchema": "packages/docops/schemas/io.schema.json"
@@ -844,10 +851,10 @@
             "module": "scripts/piper-docops.mjs",
             "export": "rename",
             "args": {
-              "dir": "docs/unique"
+              "dir": "labeled"
             }
           },
-          "inputs": ["docs/unique/**/*.md"],
+          "inputs": ["labeled/**/*.md"],
           "outputs": [],
           "inputSchema": "packages/docops/schemas/io.schema.json",
           "outputSchema": "packages/docops/schemas/io.schema.json"


### PR DESCRIPTION
## Summary
- add a staging step that copies the inbox directory into labeled before the docops steps run
- point the docops processing steps at the staged labeled directory so inputs remain untouched

## Testing
- not run (configuration-only change)


------
https://chatgpt.com/codex/tasks/task_e_68cc5c4047708324953c46d6d393fde3