### PR TITLE
docs: describe automation pipelines

### DIFF
--- a/docs/agile/tasks/Review pipeline documentation.md
+++ b/docs/agile/tasks/Review pipeline documentation.md
@@ -1,0 +1,27 @@
+---
+uuid: 9f621ec3-91d2-42cf-a8af-b1eafe7c4041
+title: review pipeline documentation in README
+status: todo
+priority: P3
+labels: []
+created_at: '2025-09-18T19:28:54Z'
+---
+## 🛠️ Task: Review pipeline documentation in README
+
+### Context
+- The root README now lists every pipeline defined in `pipelines.json` with step summaries.
+- Future changes to `pipelines.json` need manual confirmation so the README stays accurate.
+
+### Definition of Done
+- [ ] Compare the README pipeline section against the current `pipelines.json` contents.
+- [ ] Update descriptions, environment notes, or step listings if the pipeline config changes.
+- [ ] Record any follow-up issues that arise from mismatches.
+
+### Suggested Plan
+1. Diff `pipelines.json` against the last documented state.
+2. Regenerate or adjust the README summaries as needed.
+3. Flag large behavioural changes to the automation owner.
+
+### References
+- `README.md` (Automation pipelines section)
+- `pipelines.json`


### PR DESCRIPTION
## Summary
- add an Automation pipelines section to the root README so every configured flow in `pipelines.json` is documented with its intent and step sequence
- add a follow-up task reminding operators to keep the README pipeline inventory aligned with future `pipelines.json` changes

## Testing
- `pnpm lint:diff` *(fails: existing lint errors in unrelated packages; see run output for details)*

------
https://chatgpt.com/codex/tasks/task_e_68cc5c6a38d0832497ec20710a91fec5