### PR TITLE
Refactor chroma wrapper state updates

### DIFF
--- a/docs/agile/tasks/expand-functional-loop-refactors.md
+++ b/docs/agile/tasks/expand-functional-loop-refactors.md
@@ -1,0 +1,32 @@
+---
+uuid: f6c39654-1e09-4741-9aeb-bdb200cc7216
+title: Expand functional loop refactors across repository
+status: todo
+priority: P3
+labels:
+  - refactor
+  - functional-style
+created_at: '2025-09-18T19:29:29Z'
+---
+#Todo
+
+# Description
+Document and schedule additional refactors that replace imperative loops with functional primitives (e.g., map, filter, reduce) in packages that still rely on mutable iteration.
+
+## Goals
+- Identify the highest-impact modules where loop refactors would improve readability and composability.
+- Capture any dependencies or blockers that require human coordination.
+- Provide clear acceptance criteria so future agents or maintainers can implement the changes confidently.
+
+## Requirements
+- Survey at least three packages that still rely heavily on imperative loops.
+- Record example locations with file paths and explain why a functional approach would help.
+- Note any tests or benchmarks that must be run after refactoring.
+
+## Subtasks
+- [ ] Audit loop-heavy modules and prioritize candidates for refactoring.
+- [ ] Outline expected functional transformations (map/filter/reduce/etc.) for each candidate.
+- [ ] Confirm testing strategy with the owning team or update documentation with required checks.
+
+## Comments
+Use this section for async coordination notes and links to relevant code reviews or discussions.

--- a/packages/embedding/src/chroma.ts
+++ b/packages/embedding/src/chroma.ts
@@ -1,27 +1,51 @@
-type UpsertItem = {
+type UpsertItem = Readonly<{
   id: string;
-  embedding: number[];
-  metadata?: Record<string, any>;
+  embedding: ReadonlyArray<number>;
+  metadata?: Readonly<Record<string, unknown>>;
   document?: string;
-};
+}>;
 
-export type ChromaConfig = {
+export type ChromaConfig = Readonly<{
   url: string; // CHROMA_URL
   prefix?: string; // collection prefix e.g., prom_
   collection: string; // logical collection name
   embeddingDim: number; // guard
-};
+}>;
 
 export type ChromaWrapper = {
   ensureCollection(): Promise<void>;
-  upsert(items: UpsertItem[]): Promise<void>;
-  delete(ids: string[]): Promise<void>;
+  upsert(items: ReadonlyArray<UpsertItem>): Promise<void>;
+  delete(ids: ReadonlyArray<string>): Promise<void>;
   count(): Promise<number>;
 };
 
+class StateRef {
+  static readonly #store = new WeakMap<
+    StateRef,
+    ReadonlyMap<string, UpsertItem>
+  >();
+
+  constructor() {
+    StateRef.#store.set(this, new Map<string, UpsertItem>());
+  }
+
+  get(): ReadonlyMap<string, UpsertItem> {
+    return StateRef.#store.get(this)!;
+  }
+
+  update(
+    updater: (
+      current: ReadonlyArray<readonly [string, UpsertItem]>,
+    ) => ReadonlyArray<readonly [string, UpsertItem]>,
+  ): void {
+    const nextEntries = updater([...this.get().entries()]);
+    StateRef.#store.set(this, new Map(nextEntries));
+  }
+}
+
 export function makeChromaWrapper(cfg: ChromaConfig): ChromaWrapper {
   // Minimal, adapter-agnostic wrapper. Replace internals with real chromadb client as needed.
-  const state = new Map<string, UpsertItem>(); // in-memory stub fallback
+  const stateRef = new StateRef();
   return {
     async ensureCollection() {
       // In a real client: create/get collection, validate metadata embeddingDim
@@ -29,14 +53,18 @@ export function makeChromaWrapper(cfg: ChromaConfig): ChromaWrapper {
       if (!cfg.collection || !cfg.embeddingDim)
         throw new Error("Invalid ChromaConfig");
     },
-    async upsert(items: UpsertItem[]) {
-      for (const it of items) state.set(it.id, it);
+    async upsert(items: ReadonlyArray<UpsertItem>) {
+      stateRef.update((current) => [
+        ...current,
+        ...items.map((it) => [it.id, it] as const),
+      ]);
     },
-    async delete(ids: string[]) {
-      for (const id of ids) state.delete(id);
+    async delete(ids: ReadonlyArray<string>) {
+      const toDelete = new Set(ids);
+      stateRef.update((current) => current.filter(([id]) => !toDelete.has(id)));
     },
     async count() {
-      return state.size;
+      return stateRef.get().size;
     },
   };
 }


### PR DESCRIPTION
## Summary
- replace the chroma wrapper's in-memory mutation loops with functional stateRef updates
- tighten readonly typing on Chroma data structures to reinforce immutable usage
- add an agile task to track further loop-to-functional refactors for human follow-up

## Testing
- pnpm --filter @promethean/embedding build

> Note: Unable to reference a GitHub issue because the `gh` CLI is unavailable in this environment.


------
https://chatgpt.com/codex/tasks/task_e_68cc5af8117c8324ae2ecc0c369bfe70