### PR TITLE
feat(fsm): add parameter object helper for sequences

### DIFF
--- a/packages/fsm/HUMAN_TASK.md
+++ b/packages/fsm/HUMAN_TASK.md
@@ -1,0 +1,6 @@
+# Human Task
+
+- [ ] Publish documentation for `@promethean/fsm` to the internal knowledge base once automated docs are generated.
+- [ ] Schedule a design review to validate the FSM API ergonomics with the runtime team.
+- [ ] Capture a cookbook example that demonstrates the new `transitionMany` helper for multi-event workflows.
+- [ ] Add guidance for the `transitionManyFromParams` convenience wrapper to the knowledge base and ensure examples reflect both invocation styles.

--- a/packages/fsm/ava.config.mjs
+++ b/packages/fsm/ava.config.mjs
@@ -1,0 +1,1 @@
+export { default } from "../../config/ava.config.mjs";

--- a/packages/fsm/package.json
+++ b/packages/fsm/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@promethean/fsm",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "license": "GPL-3.0-only",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "clean": "rimraf dist",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "test": "pnpm run build && ava",
+    "lint": "pnpm exec eslint .",
+    "coverage": "pnpm run build && c8 ava",
+    "format": "pnpm exec prettier --write ."
+  },
+  "dependencies": {},
+  "devDependencies": {}
+}

--- a/packages/fsm/src/immutability.ts
+++ b/packages/fsm/src/immutability.ts
@@ -1,0 +1,11 @@
+import type { MachineSnapshot } from "./types.js";
+
+export const freezeArray = <Item>(
+  items: ReadonlyArray<Item>,
+): ReadonlyArray<Item> => Object.freeze([...items]);
+
+export const freezeSnapshot = <State extends string, Context>(
+  state: State,
+  context: Context,
+): MachineSnapshot<State, Context> =>
+  Object.freeze({ state, context }) as MachineSnapshot<State, Context>;

--- a/packages/fsm/src/index.ts
+++ b/packages/fsm/src/index.ts
@@ -1,0 +1,24 @@
+export type {
+  InitialContext,
+  MachineDefinition,
+  MachineEvent,
+  MachineSnapshot,
+  SnapshotOptions,
+  TransitionDefinition,
+  TransitionDetails,
+  TransitionForEvent,
+  TransitionManyResult,
+  TransitionManyStatus,
+  TransitionManyParams,
+  TransitionResult,
+} from "./types.js";
+
+export {
+  availableTransitions,
+  canTransition,
+  createMachine,
+  createSnapshot,
+  defineTransition,
+  transition,
+} from "./machine.js";
+export { transitionMany, transitionManyFromParams } from "./sequence.js";

--- a/packages/fsm/src/machine.ts
+++ b/packages/fsm/src/machine.ts
@@ -1,0 +1,300 @@
+import type {
+  InitialContext,
+  MachineDefinition,
+  MachineEvent,
+  MachineSnapshot,
+  SnapshotOptions,
+  TransitionDefinition,
+  TransitionDetails,
+  TransitionForEvent,
+  TransitionResult,
+} from "./types.js";
+import { freezeArray, freezeSnapshot } from "./immutability.js";
+const resolveInitialContext = <Context>(
+  initial: InitialContext<Context>,
+): Context =>
+  typeof initial === "function" ? (initial as () => Context)() : initial;
+
+export const createMachine = <
+  State extends string,
+  Events extends Record<string, unknown>,
+  Context,
+>(
+  definition: MachineDefinition<State, Events, Context>,
+): MachineDefinition<State, Events, Context> => ({
+  initialState: definition.initialState,
+  initialContext: definition.initialContext,
+  transitions: freezeArray(definition.transitions),
+});
+
+export const defineTransition = <
+  State extends string,
+  Events extends Record<string, unknown>,
+  Context,
+>(
+  transition: TransitionDefinition<State, Events, Context>,
+): TransitionDefinition<State, Events, Context> => transition;
+
+export const createSnapshot = <
+  State extends string,
+  Events extends Record<string, unknown>,
+  Context,
+>(
+  definition: MachineDefinition<State, Events, Context>,
+  options?: SnapshotOptions<State, Context>,
+): MachineSnapshot<State, Context> => {
+  const state = options?.state ?? definition.initialState;
+  const context =
+    options?.context ?? resolveInitialContext(definition.initialContext);
+  return freezeSnapshot(state, context);
+};
+
+const isMatchingTransition = <
+  State extends string,
+  Events extends Record<string, unknown>,
+  Context,
+  EventType extends keyof Events & string,
+>(
+  transition: TransitionDefinition<State, Events, Context>,
+  snapshot: MachineSnapshot<State, Context>,
+  event: MachineEvent<Events, EventType>,
+): transition is TransitionForEvent<State, Events, Context, EventType> =>
+  transition.from === snapshot.state && transition.event === event.type;
+
+const findMatchingTransitions = <
+  State extends string,
+  Events extends Record<string, unknown>,
+  Context,
+  EventType extends keyof Events & string,
+>(
+  definition: MachineDefinition<State, Events, Context>,
+  snapshot: MachineSnapshot<State, Context>,
+  event: MachineEvent<Events, EventType>,
+): ReadonlyArray<TransitionForEvent<State, Events, Context, EventType>> =>
+  freezeArray(
+    definition.transitions.filter(
+      (
+        transition,
+      ): transition is TransitionForEvent<State, Events, Context, EventType> =>
+        isMatchingTransition(transition, snapshot, event),
+    ),
+  );
+
+const buildDetails = <
+  State extends string,
+  Events extends Record<string, unknown>,
+  Context,
+  EventType extends keyof Events & string,
+>(
+  snapshot: MachineSnapshot<State, Context>,
+  transition: TransitionForEvent<State, Events, Context, EventType>,
+  event: MachineEvent<Events, EventType>,
+): TransitionDetails<State, Events, Context, EventType> => ({
+  from: snapshot.state,
+  to: transition.to,
+  context: snapshot.context,
+  event,
+});
+
+type CandidateEvaluation<
+  State extends string,
+  Events extends Record<string, unknown>,
+  Context,
+  EventType extends keyof Events & string,
+> =
+  | Readonly<{
+      readonly status: "transitioned";
+      readonly transition: TransitionForEvent<
+        State,
+        Events,
+        Context,
+        EventType
+      >;
+      readonly details: TransitionDetails<State, Events, Context, EventType>;
+      readonly snapshot: MachineSnapshot<State, Context>;
+    }>
+  | Readonly<{
+      readonly status: "guard-rejected";
+      readonly transition: TransitionForEvent<
+        State,
+        Events,
+        Context,
+        EventType
+      >;
+      readonly details: TransitionDetails<State, Events, Context, EventType>;
+    }>;
+
+const evaluateCandidate = <
+  State extends string,
+  Events extends Record<string, unknown>,
+  Context,
+  EventType extends keyof Events & string,
+>(
+  candidate: TransitionForEvent<State, Events, Context, EventType>,
+  snapshot: MachineSnapshot<State, Context>,
+  event: MachineEvent<Events, EventType>,
+): CandidateEvaluation<State, Events, Context, EventType> => {
+  const details = buildDetails(snapshot, candidate, event);
+  const guardPasses = candidate.guard ? candidate.guard(details) : true;
+
+  if (!guardPasses) {
+    return {
+      status: "guard-rejected",
+      transition: candidate,
+      details,
+    };
+  }
+
+  const nextContext = candidate.reducer
+    ? candidate.reducer(details)
+    : snapshot.context;
+
+  return {
+    status: "transitioned",
+    transition: candidate,
+    details,
+    snapshot: freezeSnapshot(candidate.to, nextContext),
+  };
+};
+
+const findTransitioned = <
+  State extends string,
+  Events extends Record<string, unknown>,
+  Context,
+  EventType extends keyof Events & string,
+>(
+  evaluations: ReadonlyArray<
+    CandidateEvaluation<State, Events, Context, EventType>
+  >,
+):
+  | Extract<
+      CandidateEvaluation<State, Events, Context, EventType>,
+      { readonly status: "transitioned" }
+    >
+  | undefined =>
+  evaluations.find(
+    (
+      evaluation,
+    ): evaluation is Extract<
+      CandidateEvaluation<State, Events, Context, EventType>,
+      { readonly status: "transitioned" }
+    > => evaluation.status === "transitioned",
+  );
+
+const findGuardRejection = <
+  State extends string,
+  Events extends Record<string, unknown>,
+  Context,
+  EventType extends keyof Events & string,
+>(
+  evaluations: ReadonlyArray<
+    CandidateEvaluation<State, Events, Context, EventType>
+  >,
+):
+  | Extract<
+      CandidateEvaluation<State, Events, Context, EventType>,
+      { readonly status: "guard-rejected" }
+    >
+  | undefined =>
+  evaluations.find(
+    (
+      evaluation,
+    ): evaluation is Extract<
+      CandidateEvaluation<State, Events, Context, EventType>,
+      { readonly status: "guard-rejected" }
+    > => evaluation.status === "guard-rejected",
+  );
+
+const resolveEvaluations = <
+  State extends string,
+  Events extends Record<string, unknown>,
+  Context,
+  EventType extends keyof Events & string,
+>(
+  evaluations: ReadonlyArray<
+    CandidateEvaluation<State, Events, Context, EventType>
+  >,
+  snapshot: MachineSnapshot<State, Context>,
+  event: MachineEvent<Events, EventType>,
+): TransitionResult<State, Events, Context, EventType> => {
+  const successful = findTransitioned(evaluations);
+
+  if (successful) {
+    return {
+      status: "transitioned",
+      snapshot: successful.snapshot,
+      event,
+      transition: successful.transition,
+      details: successful.details,
+    };
+  }
+
+  const rejection = findGuardRejection(evaluations);
+
+  if (rejection) {
+    return {
+      status: "guard-rejected",
+      snapshot,
+      event,
+      transition: rejection.transition,
+      details: rejection.details,
+    };
+  }
+
+  return { status: "no-transition", snapshot, event };
+};
+
+export const transition = <
+  State extends string,
+  Events extends Record<string, unknown>,
+  Context,
+  EventType extends keyof Events & string,
+>(
+  definition: MachineDefinition<State, Events, Context>,
+  snapshot: MachineSnapshot<State, Context>,
+  event: MachineEvent<Events, EventType>,
+): TransitionResult<State, Events, Context, EventType> => {
+  const candidates = findMatchingTransitions(definition, snapshot, event);
+  if (candidates.length === 0) {
+    return { status: "no-transition", snapshot, event };
+  }
+
+  const evaluations = candidates.map((candidate) =>
+    evaluateCandidate(candidate, snapshot, event),
+  );
+
+  return resolveEvaluations(evaluations, snapshot, event);
+};
+
+export const availableTransitions = <
+  State extends string,
+  Events extends Record<string, unknown>,
+  Context,
+>(
+  definition: MachineDefinition<State, Events, Context>,
+  snapshot: MachineSnapshot<State, Context>,
+): ReadonlyArray<TransitionDefinition<State, Events, Context>> =>
+  freezeArray(
+    definition.transitions.filter(
+      (transition) => transition.from === snapshot.state,
+    ),
+  );
+
+export const canTransition = <
+  State extends string,
+  Events extends Record<string, unknown>,
+  Context,
+  EventType extends keyof Events & string,
+>(
+  definition: MachineDefinition<State, Events, Context>,
+  snapshot: MachineSnapshot<State, Context>,
+  event: MachineEvent<Events, EventType>,
+): boolean =>
+  findMatchingTransitions(definition, snapshot, event).some((candidate) => {
+    if (!candidate.guard) {
+      return true;
+    }
+
+    const details = buildDetails(snapshot, candidate, event);
+    return candidate.guard(details);
+  });

--- a/packages/fsm/src/sequence.ts
+++ b/packages/fsm/src/sequence.ts
@@ -1,0 +1,147 @@
+import { freezeArray } from "./immutability.js";
+import { transition } from "./machine.js";
+import type {
+  MachineDefinition,
+  MachineEvent,
+  MachineSnapshot,
+  TransitionManyParams,
+  TransitionManyResult,
+  TransitionResult,
+} from "./types.js";
+
+/* eslint-disable @typescript-eslint/prefer-readonly-parameter-types --
+   Tuple and reducer parameters use readonly inputs, but the rule does not
+   detect the immutability guarantees from our aliases. */
+
+type SequenceAccumulator<
+  State extends string,
+  Events extends Record<string, unknown>,
+  Context,
+> = Readonly<{
+  readonly snapshot: MachineSnapshot<State, Context>;
+  readonly results: ReadonlyArray<TransitionResult<State, Events, Context>>;
+  readonly halted: boolean;
+}>;
+
+type SequenceEvaluation<
+  State extends string,
+  Events extends Record<string, unknown>,
+  Context,
+> = Readonly<{
+  readonly finalSnapshot: MachineSnapshot<State, Context>;
+  readonly results: ReadonlyArray<TransitionResult<State, Events, Context>>;
+  readonly halted: boolean;
+}>;
+
+type TransitionManyArgs<
+  State extends string,
+  Events extends Record<string, unknown>,
+  Context,
+> = readonly [
+  definition: MachineDefinition<State, Events, Context>,
+  snapshot: MachineSnapshot<State, Context>,
+  events: ReadonlyArray<MachineEvent<Events>>,
+];
+
+const evaluateSequence = <
+  State extends string,
+  Events extends Record<string, unknown>,
+  Context,
+>(
+  definition: MachineDefinition<State, Events, Context>,
+  snapshot: MachineSnapshot<State, Context>,
+  events: ReadonlyArray<MachineEvent<Events>>,
+): SequenceEvaluation<State, Events, Context> => {
+  const initialAccumulator: SequenceAccumulator<State, Events, Context> = {
+    snapshot,
+    results: [],
+    halted: false,
+  };
+
+  const finalAccumulator = events.reduce<
+    SequenceAccumulator<State, Events, Context>
+  >(
+    (
+      current: Readonly<SequenceAccumulator<State, Events, Context>>,
+      event: Readonly<MachineEvent<Events>>,
+    ) => {
+      if (current.halted) {
+        return current;
+      }
+
+      const result = transition(definition, current.snapshot, event);
+      const nextSnapshot =
+        result.status === "transitioned" ? result.snapshot : current.snapshot;
+
+      return {
+        snapshot: nextSnapshot,
+        results: [...current.results, result],
+        halted: result.status !== "transitioned",
+      };
+    },
+    initialAccumulator,
+  );
+
+  return {
+    finalSnapshot: finalAccumulator.snapshot,
+    results: finalAccumulator.results,
+    halted: finalAccumulator.halted,
+  };
+};
+
+const summariseSequence = <
+  State extends string,
+  Events extends Record<string, unknown>,
+  Context,
+>(
+  events: ReadonlyArray<MachineEvent<Events>>,
+  evaluation: SequenceEvaluation<State, Events, Context>,
+): TransitionManyResult<State, Events, Context> => {
+  const status: TransitionManyResult<State, Events, Context>["status"] =
+    events.length === 0
+      ? "no-events"
+      : evaluation.halted
+        ? "halted"
+        : "complete";
+
+  return {
+    status,
+    snapshot: evaluation.finalSnapshot,
+    results: freezeArray(evaluation.results),
+  };
+};
+
+const runSequence = <
+  State extends string,
+  Events extends Record<string, unknown>,
+  Context,
+>(
+  definition: MachineDefinition<State, Events, Context>,
+  snapshot: MachineSnapshot<State, Context>,
+  events: ReadonlyArray<MachineEvent<Events>>,
+): TransitionManyResult<State, Events, Context> =>
+  summariseSequence(events, evaluateSequence(definition, snapshot, events));
+
+export function transitionMany<
+  State extends string,
+  Events extends Record<string, unknown>,
+  Context,
+>(
+  ...[definition, snapshot, events]: TransitionManyArgs<State, Events, Context>
+): TransitionManyResult<State, Events, Context> {
+  return runSequence(definition, snapshot, events);
+}
+
+export const transitionManyFromParams = <
+  State extends string,
+  Events extends Record<string, unknown>,
+  Context,
+>({
+  definition,
+  snapshot,
+  events,
+}: TransitionManyParams<State, Events, Context>): TransitionManyResult<
+  State,
+  Events,
+  Context
+> => runSequence(definition, snapshot, events);

--- a/packages/fsm/src/tests/machine.test.ts
+++ b/packages/fsm/src/tests/machine.test.ts
@@ -1,0 +1,311 @@
+import test from "ava";
+
+import {
+  availableTransitions,
+  canTransition,
+  createMachine,
+  createSnapshot,
+  defineTransition,
+  transition,
+  transitionMany,
+  transitionManyFromParams,
+  type MachineDefinition,
+  type MachineEvent,
+  type MachineSnapshot,
+  type TransitionResult,
+} from "../index.js";
+
+type WorkflowState = "idle" | "running" | "completed";
+
+type WorkflowEvents = {
+  start: { readonly increment: number };
+  finish: { readonly summary: string };
+  reset: undefined;
+};
+
+type WorkflowContext = Readonly<{
+  readonly count: number;
+  readonly history: ReadonlyArray<string>;
+}>;
+
+const createWorkflowMachine = (): MachineDefinition<
+  WorkflowState,
+  WorkflowEvents,
+  WorkflowContext
+> =>
+  createMachine<WorkflowState, WorkflowEvents, WorkflowContext>({
+    initialState: "idle",
+    initialContext: (): WorkflowContext => ({
+      count: 0,
+      history: [] as ReadonlyArray<string>,
+    }),
+    transitions: [
+      defineTransition<WorkflowState, WorkflowEvents, WorkflowContext>({
+        from: "idle",
+        to: "running",
+        event: "start",
+        reducer: ({ context, event }): WorkflowContext => ({
+          count: context.count + event.payload.increment,
+          history: [...context.history, `started:${event.payload.increment}`],
+        }),
+      }),
+      defineTransition<WorkflowState, WorkflowEvents, WorkflowContext>({
+        from: "running",
+        to: "completed",
+        event: "finish",
+        guard: ({ event }) => event.payload.summary.length > 0,
+        reducer: ({ context, event }): WorkflowContext => ({
+          count: context.count,
+          history: [...context.history, `finished:${event.payload.summary}`],
+        }),
+      }),
+      defineTransition<WorkflowState, WorkflowEvents, WorkflowContext>({
+        from: "completed",
+        to: "idle",
+        event: "reset",
+        reducer: ({ context }): WorkflowContext => ({
+          count: 0,
+          history: context.history,
+        }),
+      }),
+    ],
+  });
+
+test("creates independent snapshots with the initial configuration", (t) => {
+  const machine = createWorkflowMachine();
+  const first = createSnapshot(machine);
+  const second = createSnapshot(machine);
+
+  t.deepEqual(first, {
+    state: "idle",
+    context: { count: 0, history: [] },
+  });
+  t.deepEqual(second, first);
+  t.not(first, second);
+});
+
+test("applies transitions and reducers immutably", (t) => {
+  const machine = createWorkflowMachine();
+  const initial = createSnapshot(machine);
+  const startEvent: MachineEvent<WorkflowEvents, "start"> = {
+    type: "start",
+    payload: { increment: 2 },
+  };
+
+  const startResult = transition(machine, initial, startEvent);
+  t.is(startResult.status, "transitioned");
+
+  const runningSnapshot = (
+    startResult as Extract<
+      TransitionResult<WorkflowState, WorkflowEvents, WorkflowContext>,
+      { readonly status: "transitioned" }
+    >
+  ).snapshot;
+
+  t.deepEqual(runningSnapshot, {
+    state: "running",
+    context: { count: 2, history: ["started:2"] },
+  });
+  t.deepEqual(initial, {
+    state: "idle",
+    context: { count: 0, history: [] },
+  });
+
+  const finishEvent: MachineEvent<WorkflowEvents, "finish"> = {
+    type: "finish",
+    payload: { summary: "ok" },
+  };
+
+  const finishResult = transition(machine, runningSnapshot, finishEvent);
+  t.is(finishResult.status, "transitioned");
+  t.deepEqual(
+    (
+      finishResult as Extract<
+        TransitionResult<WorkflowState, WorkflowEvents, WorkflowContext>,
+        { readonly status: "transitioned" }
+      >
+    ).snapshot,
+    {
+      state: "completed",
+      context: { count: 2, history: ["started:2", "finished:ok"] },
+    },
+  );
+});
+
+test("prevents transitions when guards reject the event", (t) => {
+  const machine = createWorkflowMachine();
+  const runningSnapshot = Object.freeze({
+    state: "running" as WorkflowState,
+    context: { count: 4, history: ["started:4"] as ReadonlyArray<string> },
+  }) as MachineSnapshot<WorkflowState, WorkflowContext>;
+  const finishEvent: MachineEvent<WorkflowEvents, "finish"> = {
+    type: "finish",
+    payload: { summary: "" },
+  };
+
+  const result = transition(machine, runningSnapshot, finishEvent);
+  if (result.status !== "guard-rejected") {
+    t.fail(`Expected guard rejection, received ${result.status}`);
+    return;
+  }
+
+  t.deepEqual(result.snapshot, runningSnapshot);
+  t.deepEqual(result.details, {
+    from: "running",
+    to: "completed",
+    context: runningSnapshot.context,
+    event: finishEvent,
+  });
+});
+
+test("returns no-transition when no candidate exists", (t) => {
+  const machine = createWorkflowMachine();
+  const snapshot = createSnapshot(machine);
+  const finishEvent: MachineEvent<WorkflowEvents, "finish"> = {
+    type: "finish",
+    payload: { summary: "done" },
+  };
+
+  const result = transition(machine, snapshot, finishEvent);
+  t.is(result.status, "no-transition");
+  t.deepEqual(result.snapshot, snapshot);
+});
+
+test("lists available transitions for the current state", (t) => {
+  const machine = createWorkflowMachine();
+  const runningSnapshot = Object.freeze({
+    state: "running" as WorkflowState,
+    context: { count: 1, history: ["started:1"] as ReadonlyArray<string> },
+  }) as MachineSnapshot<WorkflowState, WorkflowContext>;
+
+  const transitions = availableTransitions(machine, runningSnapshot);
+  t.deepEqual(
+    transitions.map((item) => item.event),
+    ["finish"],
+  );
+});
+
+test("canTransition respects guard logic", (t) => {
+  const machine = createWorkflowMachine();
+  const runningSnapshot = Object.freeze({
+    state: "running" as WorkflowState,
+    context: { count: 1, history: ["started:1"] as ReadonlyArray<string> },
+  }) as MachineSnapshot<WorkflowState, WorkflowContext>;
+
+  const goodEvent: MachineEvent<WorkflowEvents, "finish"> = {
+    type: "finish",
+    payload: { summary: "great" },
+  };
+  const badEvent: MachineEvent<WorkflowEvents, "finish"> = {
+    type: "finish",
+    payload: { summary: "" },
+  };
+
+  t.true(canTransition(machine, runningSnapshot, goodEvent));
+  t.false(canTransition(machine, runningSnapshot, badEvent));
+});
+
+test("snapshot options override defaults", (t) => {
+  const machine = createWorkflowMachine();
+  const customSnapshot = createSnapshot(machine, {
+    state: "completed",
+    context: { count: 10, history: ["custom"] },
+  });
+
+  t.deepEqual(customSnapshot, {
+    state: "completed",
+    context: { count: 10, history: ["custom"] },
+  });
+});
+
+test("transitionMany processes a sequence until completion", (t) => {
+  const machine = createWorkflowMachine();
+  const initial = createSnapshot(machine);
+  const startEvent: MachineEvent<WorkflowEvents, "start"> = {
+    type: "start",
+    payload: { increment: 1 },
+  };
+  const finishEvent: MachineEvent<WorkflowEvents, "finish"> = {
+    type: "finish",
+    payload: { summary: "done" },
+  };
+
+  const sequence = transitionMany(machine, initial, [startEvent, finishEvent]);
+
+  t.is(sequence.status, "complete");
+  t.true(Object.isFrozen(sequence.results));
+  t.is(sequence.results.length, 2);
+  t.deepEqual(sequence.snapshot, {
+    state: "completed",
+    context: { count: 1, history: ["started:1", "finished:done"] },
+  });
+});
+
+test("transitionMany halts on guard rejection and preserves the snapshot", (t) => {
+  const machine = createWorkflowMachine();
+  const initial = createSnapshot(machine);
+  const startEvent: MachineEvent<WorkflowEvents, "start"> = {
+    type: "start",
+    payload: { increment: 3 },
+  };
+  const rejectedFinish: MachineEvent<WorkflowEvents, "finish"> = {
+    type: "finish",
+    payload: { summary: "" },
+  };
+  const resetEvent: MachineEvent<WorkflowEvents, "reset"> = {
+    type: "reset",
+    payload: undefined,
+  };
+
+  const events: ReadonlyArray<MachineEvent<WorkflowEvents>> = [
+    startEvent,
+    rejectedFinish,
+    resetEvent,
+  ];
+  const sequence = transitionMany(machine, initial, events);
+
+  t.is(sequence.status, "halted");
+  t.is(sequence.results.length, 2);
+  t.deepEqual(
+    sequence.results.map((result) => result.status),
+    ["transitioned", "guard-rejected"],
+  );
+
+  const transitioned = sequence.results[0] as Extract<
+    TransitionResult<WorkflowState, WorkflowEvents, WorkflowContext>,
+    { readonly status: "transitioned" }
+  >;
+
+  t.deepEqual(sequence.snapshot, transitioned.snapshot);
+});
+
+test("transitionMany reports no events when the sequence is empty", (t) => {
+  const machine = createWorkflowMachine();
+  const initial = createSnapshot(machine);
+
+  const sequence = transitionMany(machine, initial, []);
+
+  t.is(sequence.status, "no-events");
+  t.deepEqual(sequence.snapshot, initial);
+  t.deepEqual(sequence.results, []);
+  t.true(Object.isFrozen(sequence.results));
+});
+
+test("transitionManyFromParams mirrors the tuple signature", (t) => {
+  const machine = createWorkflowMachine();
+  const initial = createSnapshot(machine);
+  const events: ReadonlyArray<MachineEvent<WorkflowEvents>> = [
+    { type: "start", payload: { increment: 5 } },
+    { type: "finish", payload: { summary: "wrapped" } },
+  ];
+
+  const tupleResult = transitionMany(machine, initial, events);
+  const paramsResult = transitionManyFromParams({
+    definition: machine,
+    snapshot: initial,
+    events,
+  });
+
+  t.deepEqual(paramsResult, tupleResult);
+  t.true(Object.isFrozen(paramsResult.results));
+});

--- a/packages/fsm/src/types.ts
+++ b/packages/fsm/src/types.ts
@@ -1,0 +1,127 @@
+export type MachineEvent<
+  Events extends Record<string, unknown>,
+  Type extends keyof Events & string = keyof Events & string,
+> = Readonly<{
+  readonly type: Type;
+  readonly payload: Events[Type];
+}>;
+
+export type MachineSnapshot<State extends string, Context> = Readonly<{
+  readonly state: State;
+  readonly context: Context;
+}>;
+
+export type SnapshotOptions<State extends string, Context> = Readonly<{
+  readonly state?: State;
+  readonly context?: Context;
+}>;
+
+export type InitialContext<Context> = Context | (() => Context);
+
+export type TransitionDetails<
+  State extends string,
+  Events extends Record<string, unknown>,
+  Context,
+  EventType extends keyof Events & string,
+> = Readonly<{
+  readonly from: State;
+  readonly to: State;
+  readonly context: Context;
+  readonly event: MachineEvent<Events, EventType>;
+}>;
+
+export type TransitionDefinition<
+  State extends string,
+  Events extends Record<string, unknown>,
+  Context,
+> = {
+  [EventType in keyof Events & string]: Readonly<{
+    readonly from: State;
+    readonly to: State;
+    readonly event: EventType;
+    readonly guard?: (
+      details: TransitionDetails<State, Events, Context, EventType>,
+    ) => boolean;
+    readonly reducer?: (
+      details: TransitionDetails<State, Events, Context, EventType>,
+    ) => Context;
+  }>;
+}[keyof Events & string];
+
+export type TransitionForEvent<
+  State extends string,
+  Events extends Record<string, unknown>,
+  Context,
+  EventType extends keyof Events & string,
+> = Extract<
+  TransitionDefinition<State, Events, Context>,
+  { readonly event: EventType }
+>;
+
+export type MachineDefinition<
+  State extends string,
+  Events extends Record<string, unknown>,
+  Context,
+> = Readonly<{
+  readonly initialState: State;
+  readonly initialContext: InitialContext<Context>;
+  readonly transitions: readonly TransitionDefinition<State, Events, Context>[];
+}>;
+
+export type TransitionResult<
+  State extends string,
+  Events extends Record<string, unknown>,
+  Context,
+  EventType extends keyof Events & string = keyof Events & string,
+> =
+  | Readonly<{
+      readonly status: "transitioned";
+      readonly snapshot: MachineSnapshot<State, Context>;
+      readonly event: MachineEvent<Events, EventType>;
+      readonly transition: TransitionForEvent<
+        State,
+        Events,
+        Context,
+        EventType
+      >;
+      readonly details: TransitionDetails<State, Events, Context, EventType>;
+    }>
+  | Readonly<{
+      readonly status: "guard-rejected";
+      readonly snapshot: MachineSnapshot<State, Context>;
+      readonly event: MachineEvent<Events, EventType>;
+      readonly transition: TransitionForEvent<
+        State,
+        Events,
+        Context,
+        EventType
+      >;
+      readonly details: TransitionDetails<State, Events, Context, EventType>;
+    }>
+  | Readonly<{
+      readonly status: "no-transition";
+      readonly snapshot: MachineSnapshot<State, Context>;
+      readonly event: MachineEvent<Events, EventType>;
+    }>;
+
+export type TransitionManyStatus = "no-events" | "complete" | "halted";
+
+export type TransitionManyResult<
+  State extends string,
+  Events extends Record<string, unknown>,
+  Context,
+> = Readonly<{
+  readonly status: TransitionManyStatus;
+  readonly snapshot: MachineSnapshot<State, Context>;
+  readonly results: ReadonlyArray<TransitionResult<State, Events, Context>>;
+}>;
+
+export type TransitionManyParams<
+  State extends string,
+  Events extends Record<string, unknown>,
+  Context,
+> = {
+  readonly definition: MachineDefinition<State, Events, Context>;
+  readonly snapshot: MachineSnapshot<State, Context>;
+  readonly events: ReadonlyArray<MachineEvent<Events>>;
+};

--- a/packages/fsm/tsconfig.json
+++ b/packages/fsm/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../config/tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "composite": true,
+    "declaration": true
+  },
+  "include": ["src/**/*"],
+  "references": []
+}


### PR DESCRIPTION
## Summary
- refactor the sequence runner to share evaluation helpers and support parameter-object inputs
- expose the new `transitionManyFromParams` helper and cover it in the machine tests
- queue a human follow-up to document the additional invocation option for multi-event workflows

## Testing
- pnpm --filter @promethean/fsm build
- pnpm --filter @promethean/fsm test
- pnpm exec eslint packages/fsm/src/sequence.ts packages/fsm/src/index.ts packages/fsm/src/tests/machine.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68cc58d858f4832495f8e78d8899bc34