### PR TITLE
feat: add ollama chat handler

### DIFF
--- a/docs/tasks/verify-ollama-handler.md
+++ b/docs/tasks/verify-ollama-handler.md
@@ -1,0 +1,16 @@
+# Task: Verify Ollama Chat Handler Integration
+
+## Summary
+Ensure the new Ollama-backed chat completion handler interoperates with a live Ollama instance and produces OpenAI-compatible responses.
+
+## Steps
+1. Provision or reuse an Ollama runtime with the target model already pulled (e.g. `ollama pull llama3`).
+2. Start the OpenAI-compliant server with the Ollama handler enabled. Create a short bootstrap script (for example `scripts/openai-server/start-ollama.mjs`) that imports `createOpenAICompliantServer` and `createOllamaChatCompletionHandler`, then listens on `0.0.0.0:3000`. Run it after building the package:
+   ```bash
+   pnpm --filter @promethean/openai-server run build
+   node scripts/openai-server/start-ollama.mjs
+   ```
+   > Pass `OLLAMA_BASE_URL` if the server is not on `http://127.0.0.1:11434`.
+3. Send a chat completion request using `curl` or the dashboard and confirm the queue processes it successfully.
+4. Capture the JSON response and verify it matches the OpenAI schema (id/object/choices/usage fields present).
+5. File a report with logs, model version, and sample response in the deployment notes folder.

--- a/docs/tasks/verify-openai-server-deployment.md
+++ b/docs/tasks/verify-openai-server-deployment.md
@@ -1,0 +1,20 @@
+## 🛠️ Description
+
+Set up a staging deployment for `@promethean/openai-server` and validate it
+behind the shared Fastify gateway. The automated tests cover the queue and API
+shape, but we still need human confirmation that the Swagger UI renders and the
+web component dashboard behaves correctly in a browser.
+
+## 📦 Requirements
+- Provision the service using the new package and expose `/v1/chat/completions`,
+  `/queue/snapshot`, `/docs`, and `/openapi.json`.
+- Confirm that `/queue/snapshot` updates live while posting chat completion
+  requests.
+- Capture screenshots of the Swagger UI and dashboard for docs.
+
+## ✅ Acceptance Criteria
+- Deployment URL circulated in `#promethean-platform`.
+- Screenshots archived under `docs/ui` with descriptive filenames.
+- Manual validation notes stored alongside the deployment checklist.
+
+#infrastructure #manual-validation

--- a/packages/openai-server/README.md
+++ b/packages/openai-server/README.md
@@ -1,0 +1,47 @@
+# @promethean/openai-server
+
+A Fastify-based web server that exposes an OpenAI-compatible chat completions API.
+It queues incoming requests, processes them using a configurable handler, and
+exposes monitoring endpoints plus generated OpenAPI documentation.
+
+## Features
+
+- **OpenAI-compatible**: Implements `/v1/chat/completions` with request/response
+  schemas aligned to the OpenAI HTTP API.
+- **Queue-backed**: Uses a functional, immutable task queue with configurable
+  concurrency and detailed metrics.
+- **Observability**: Provides `/queue/snapshot`, `/health`, and auto-generated
+  `/openapi.json` plus Swagger UI at `/docs`.
+- **Web UI**: Ships with a Web Component dashboard served via `@fastify/static`.
+- **Ollama integration**: Includes a ready-made handler that bridges Ollama's
+  `/api/chat` endpoint to OpenAI-compatible responses.
+
+## Scripts
+
+- `pnpm run build` – Type-checks and emits ESM artifacts to `dist/`.
+- `pnpm run test` – Builds then executes AVA tests.
+- `pnpm run lint` – Runs ESLint on the package.
+
+## Usage
+
+```ts
+import {
+  createOpenAICompliantServer,
+  createOllamaChatCompletionHandler,
+} from '@promethean/openai-server';
+
+const handler = createOllamaChatCompletionHandler({
+  baseUrl: 'http://127.0.0.1:11434',
+});
+
+const { app } = createOpenAICompliantServer({
+  concurrency: 2,
+  handler,
+});
+
+await app.listen({ port: 3000, host: '0.0.0.0' });
+```
+
+## License
+
+GPL-3.0-only

--- a/packages/openai-server/ava.config.mjs
+++ b/packages/openai-server/ava.config.mjs
@@ -1,0 +1,1 @@
+export { default } from "../../config/ava.config.mjs";

--- a/packages/openai-server/package.json
+++ b/packages/openai-server/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@promethean/openai-server",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "license": "GPL-3.0-only",
+  "main": "dist/index.js",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    },
+    "./dist/*": "./dist/*",
+    "./static/*": "./static/*"
+  },
+  "files": [
+    "dist",
+    "static"
+  ],
+  "scripts": {
+    "build": "pnpm run clean && tsc -b",
+    "clean": "rimraf dist tsconfig.tsbuildinfo",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "test": "pnpm run build && ava",
+    "lint": "pnpm exec eslint ."
+  },
+  "dependencies": {
+    "@fastify/static": "8.2.0",
+    "@fastify/swagger": "9.5.1",
+    "@fastify/swagger-ui": "5.2.3",
+    "fastify": "5.0.0"
+  }
+}

--- a/packages/openai-server/project.json
+++ b/packages/openai-server/project.json
@@ -1,0 +1,37 @@
+{
+  "name": "openai-server",
+  "root": "packages/openai-server",
+  "sourceRoot": "packages/openai-server/src",
+  "targets": {
+    "build": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm run build",
+        "cwd": "packages/openai-server"
+      },
+      "outputs": ["{projectRoot}/dist"]
+    },
+    "typecheck": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm run typecheck",
+        "cwd": "packages/openai-server"
+      }
+    },
+    "test": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm run test",
+        "cwd": "packages/openai-server"
+      }
+    },
+    "lint": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm run lint",
+        "cwd": "packages/openai-server"
+      }
+    }
+  },
+  "tags": ["scope:packages"]
+}

--- a/packages/openai-server/src/frontend/queue-dashboard.ts
+++ b/packages/openai-server/src/frontend/queue-dashboard.ts
@@ -1,0 +1,258 @@
+import type { DeepReadonly } from "../types/deepReadonly.js";
+
+type QueueSummary = DeepReadonly<{
+  pending: Array<{ id: string; enqueuedAt: number }>;
+  processing: Array<{
+    id: string;
+    enqueuedAt: number;
+    startedAt: number;
+  }>;
+  metrics: {
+    enqueued: number;
+    completed: number;
+    failed: number;
+  };
+  recent: Array<{
+    id: string;
+    status: "completed" | "failed";
+    enqueuedAt: number;
+    startedAt: number;
+    finishedAt: number;
+    durationMs: number;
+  }>;
+  updatedAt: number;
+}>;
+
+const styles = `
+  <style>
+    :host {
+      display: block;
+      font-family: system-ui, sans-serif;
+      color: #1f2933;
+      background: #f5f7fa;
+      border-radius: 12px;
+      padding: 1.5rem;
+      box-shadow: 0 10px 30px rgba(15, 23, 42, 0.12);
+      max-width: 720px;
+      margin: 0 auto;
+    }
+
+    header {
+      display: flex;
+      justify-content: space-between;
+      align-items: baseline;
+      margin-bottom: 1.5rem;
+    }
+
+    h1 {
+      font-size: 1.5rem;
+      margin: 0;
+    }
+
+    time {
+      font-size: 0.85rem;
+      color: #52606d;
+    }
+
+    dl {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+      gap: 1rem;
+      margin: 0;
+    }
+
+    dt {
+      font-size: 0.85rem;
+      color: #52606d;
+    }
+
+    dd {
+      font-size: 1.5rem;
+      margin: 0;
+      font-weight: 600;
+    }
+
+    ul {
+      list-style: none;
+      padding: 0;
+      margin: 1.5rem 0 0;
+      display: grid;
+      gap: 0.75rem;
+    }
+
+    li {
+      background: white;
+      border-radius: 8px;
+      padding: 0.75rem 1rem;
+      border: 1px solid #d9e2ec;
+    }
+
+    .status {
+      font-weight: 600;
+      text-transform: uppercase;
+      font-size: 0.75rem;
+      letter-spacing: 0.05em;
+    }
+
+    .status[data-status="completed"] {
+      color: #0d9488;
+    }
+
+    .status[data-status="failed"] {
+      color: #dc2626;
+    }
+
+    .job-id {
+      font-family: 'Fira Mono', 'SFMono-Regular', ui-monospace;
+      font-size: 0.8rem;
+      color: #334155;
+    }
+
+    .muted {
+      color: #64748b;
+      font-size: 0.8rem;
+    }
+  </style>
+`;
+
+const formatRelativeTime = (timestamp: number): string => {
+  const delta = Date.now() - timestamp;
+  if (!Number.isFinite(delta)) {
+    return "";
+  }
+  if (delta < 1000) {
+    return "just now";
+  }
+  if (delta < 60000) {
+    return `${Math.round(delta / 1000)}s ago`;
+  }
+  if (delta < 3600000) {
+    return `${Math.round(delta / 60000)}m ago`;
+  }
+  return new Date(timestamp).toLocaleString();
+};
+
+const createRecentMarkup = (recent: QueueSummary["recent"]): string =>
+  recent
+    .map((entry) => {
+      const status = entry.status;
+      const duration = `${entry.durationMs} ms`;
+      const started = formatRelativeTime(entry.startedAt);
+      return `
+        <li>
+          <div class="status" data-status="${status}">${status}</div>
+          <div class="job-id">${entry.id}</div>
+          <div class="muted">Started ${started} · Duration ${duration}</div>
+        </li>
+      `;
+    })
+    .join("");
+
+const renderMarkup = (summary: QueueSummary): string => {
+  const updatedAtIso = new Date(summary.updatedAt).toISOString();
+  return `
+    ${styles}
+    <header>
+      <div>
+        <h1>Queue Dashboard</h1>
+        <p class="muted">Monitor pending, processing and recently completed requests.</p>
+      </div>
+      <time datetime="${updatedAtIso}">${formatRelativeTime(
+        summary.updatedAt,
+      )}</time>
+    </header>
+    <dl>
+      <div>
+        <dt>Pending</dt>
+        <dd>${summary.pending.length}</dd>
+      </div>
+      <div>
+        <dt>Processing</dt>
+        <dd>${summary.processing.length}</dd>
+      </div>
+      <div>
+        <dt>Completed</dt>
+        <dd>${summary.metrics.completed}</dd>
+      </div>
+      <div>
+        <dt>Failed</dt>
+        <dd>${summary.metrics.failed}</dd>
+      </div>
+    </dl>
+    <section>
+      <h2 class="muted">Recent jobs</h2>
+      <ul>${createRecentMarkup(summary.recent)}</ul>
+    </section>
+  `;
+};
+
+type DashboardRoot = { readonly [K in "replaceChildren"]: ShadowRoot[K] };
+
+type RenderParams = {
+  readonly root: DashboardRoot;
+  readonly summary: QueueSummary;
+};
+
+const renderDashboard = (params: RenderParams): void => {
+  const fragment = document
+    .createRange()
+    .createContextualFragment(renderMarkup(params.summary));
+  params.root.replaceChildren(fragment);
+};
+
+const fetchSnapshot = async (): Promise<QueueSummary> => {
+  const response = await fetch("/queue/snapshot", {
+    headers: { accept: "application/json" },
+  });
+  if (!response.ok) {
+    throw new Error(`Unable to fetch snapshot: ${response.status}`);
+  }
+  return (await response.json()) as QueueSummary;
+};
+
+const intervalRegistry = new WeakMap<OpenAIQueueDashboard, number>();
+
+const createInitialSummary = (): QueueSummary => ({
+  pending: [],
+  processing: [],
+  metrics: { enqueued: 0, completed: 0, failed: 0 },
+  recent: [],
+  updatedAt: Date.now(),
+});
+
+export class OpenAIQueueDashboard extends HTMLElement {
+  constructor() {
+    super();
+    const shadow = this.attachShadow({ mode: "open" });
+    renderDashboard({ root: shadow, summary: createInitialSummary() });
+  }
+
+  connectedCallback(): void {
+    void this.refresh();
+    const intervalId = window.setInterval(() => {
+      void this.refresh();
+    }, 2500);
+    intervalRegistry.set(this, intervalId);
+  }
+
+  disconnectedCallback(): void {
+    const intervalId = intervalRegistry.get(this);
+    if (typeof intervalId === "number") {
+      window.clearInterval(intervalId);
+      intervalRegistry.delete(this);
+    }
+  }
+
+  private readonly refresh = (): Promise<void> =>
+    fetchSnapshot()
+      .then((summary) => {
+        if (this.shadowRoot) {
+          renderDashboard({ root: this.shadowRoot, summary });
+        }
+      })
+      .catch((error) => {
+        console.error(error);
+      });
+}
+
+customElements.define("openai-queue-dashboard", OpenAIQueueDashboard);

--- a/packages/openai-server/src/index.ts
+++ b/packages/openai-server/src/index.ts
@@ -1,0 +1,24 @@
+export type {
+  ChatCompletionHandler,
+  ChatCompletionJob,
+  ChatCompletionMessage,
+  ChatCompletionRequest,
+  ChatCompletionResponse,
+  ChatCompletionRole,
+  ChatCompletionChoice,
+  ChatCompletionUsage,
+} from "./openai/types.js";
+export { createDefaultChatCompletionHandler } from "./openai/defaultHandler.js";
+export { createOllamaChatCompletionHandler } from "./openai/ollamaHandler.js";
+export type {
+  QueueOptions,
+  QueueSnapshot,
+  QueueTask,
+  TaskQueue,
+} from "./queue/taskQueue.js";
+export { createTaskQueue } from "./queue/taskQueue.js";
+export type {
+  OpenAIServer,
+  OpenAIServerOptions,
+} from "./server/createServer.js";
+export { createOpenAICompliantServer } from "./server/createServer.js";

--- a/packages/openai-server/src/openai/defaultHandler.ts
+++ b/packages/openai-server/src/openai/defaultHandler.ts
@@ -1,0 +1,72 @@
+import type {
+  ChatCompletionHandler,
+  ChatCompletionJob,
+  ChatCompletionMessage,
+  ChatCompletionResponse,
+} from "./types.js";
+
+const countTokens = (content: string): number => {
+  const trimmed = content.trim();
+  if (trimmed.length === 0) {
+    return 0;
+  }
+  return trimmed.split(/\s+/u).length;
+};
+
+const summariseUserMessages = (
+  messages: ReadonlyArray<ChatCompletionMessage>,
+): string => {
+  const userSegments = messages
+    .filter((message) => message.role === "user")
+    .map((message) => message.content.trim())
+    .filter((segment) => segment.length > 0);
+
+  if (userSegments.length === 0) {
+    return "The conversation did not include user-provided content.";
+  }
+
+  return userSegments
+    .map((segment, index) => `(${index + 1}) ${segment}`)
+    .join("\n");
+};
+
+const buildAssistantMessage = (job: ChatCompletionJob): string => {
+  const summary = summariseUserMessages(job.request.messages);
+  return `Echoed response for model ${job.request.model}:\n${summary}`;
+};
+
+export const createDefaultChatCompletionHandler = (): ChatCompletionHandler => {
+  return async (job) => {
+    const assistantMessage = buildAssistantMessage(job);
+    const promptTokens = job.request.messages.reduce(
+      (total, message) => total + countTokens(message.content),
+      0,
+    );
+    const completionTokens = countTokens(assistantMessage);
+    const created = Math.floor(Date.now() / 1000);
+
+    const response: ChatCompletionResponse = {
+      id: job.metadata.id,
+      object: "chat.completion",
+      created,
+      model: job.request.model,
+      choices: [
+        {
+          index: 0,
+          message: {
+            role: "assistant",
+            content: assistantMessage,
+          },
+          finish_reason: "stop",
+        },
+      ],
+      usage: {
+        prompt_tokens: promptTokens,
+        completion_tokens: completionTokens,
+        total_tokens: promptTokens + completionTokens,
+      },
+    };
+
+    return response;
+  };
+};

--- a/packages/openai-server/src/openai/ollamaHandler.ts
+++ b/packages/openai-server/src/openai/ollamaHandler.ts
@@ -1,0 +1,189 @@
+import { URL } from "node:url";
+
+import type {
+  ChatCompletionHandler,
+  ChatCompletionJob,
+  ChatCompletionMessage,
+  ChatCompletionRequest,
+  ChatCompletionResponse,
+} from "./types.js";
+
+type OllamaMessage = {
+  readonly role?: string;
+  readonly content?: string;
+};
+
+type OllamaChatResponse = {
+  readonly model?: string;
+  readonly created_at?: string;
+  readonly message?: OllamaMessage;
+  readonly done_reason?: string;
+  readonly prompt_eval_count?: number;
+  readonly eval_count?: number;
+};
+
+type OllamaHandlerOptions = Readonly<{
+  readonly baseUrl?: string;
+  readonly fetch?: typeof fetch;
+}>;
+
+const DEFAULT_BASE_URL = "http://127.0.0.1:11434";
+
+const normaliseFinishReason = (doneReason?: string): "stop" | "length" =>
+  doneReason === "length" ? "length" : "stop";
+
+const safeNumber = (value: unknown): number | undefined =>
+  typeof value === "number" && Number.isFinite(value) ? value : undefined;
+
+const parseCreatedAt = (
+  createdAt: string | undefined,
+  fallback: number,
+): number => {
+  if (!createdAt) {
+    return fallback;
+  }
+
+  const timestamp = Date.parse(createdAt);
+  if (Number.isFinite(timestamp)) {
+    return Math.floor(timestamp / 1000);
+  }
+  return fallback;
+};
+
+const resolveCreatedTimestamp = (
+  job: Readonly<ChatCompletionJob>,
+  response: Readonly<OllamaChatResponse>,
+): number =>
+  parseCreatedAt(
+    response.created_at,
+    Math.floor(job.metadata.enqueuedAt / 1000),
+  );
+
+const mapMessage = (
+  message: Readonly<ChatCompletionMessage>,
+): OllamaMessage => ({
+  role: message.role,
+  content: message.content,
+});
+
+type OllamaOptions = Readonly<Record<string, number>>;
+
+const buildOptions = (
+  request: Readonly<ChatCompletionRequest>,
+): OllamaOptions | undefined => {
+  const candidates: ReadonlyArray<readonly [string, number | undefined]> = [
+    ["temperature", request.temperature],
+    ["top_p", request.top_p],
+    ["num_predict", request.max_tokens],
+  ];
+
+  const defined = candidates.filter(([, value]) => typeof value === "number");
+  if (defined.length === 0) {
+    return undefined;
+  }
+
+  return Object.fromEntries(
+    defined as ReadonlyArray<readonly [string, number]>,
+  ) as OllamaOptions;
+};
+
+type OllamaChatPayload = Readonly<{
+  readonly model: string;
+  readonly messages: ReadonlyArray<OllamaMessage>;
+  readonly stream: false;
+  readonly options?: OllamaOptions;
+}>;
+
+const buildPayload = (
+  request: Readonly<ChatCompletionRequest>,
+): OllamaChatPayload => {
+  const basePayload: OllamaChatPayload = {
+    model: request.model,
+    messages: request.messages.map(mapMessage),
+    stream: false,
+  };
+
+  const options = buildOptions(request);
+  return options ? { ...basePayload, options } : basePayload;
+};
+
+type ChatUsage = Readonly<{
+  readonly prompt_tokens: number;
+  readonly completion_tokens: number;
+  readonly total_tokens: number;
+}>;
+
+const mapUsage = (response: Readonly<OllamaChatResponse>): ChatUsage => {
+  const promptTokens = safeNumber(response.prompt_eval_count) ?? 0;
+  const completionTokens = safeNumber(response.eval_count) ?? 0;
+  return {
+    prompt_tokens: promptTokens,
+    completion_tokens: completionTokens,
+    total_tokens: promptTokens + completionTokens,
+  };
+};
+
+const toChatCompletionResponse = (
+  job: Readonly<ChatCompletionJob>,
+  response: Readonly<OllamaChatResponse>,
+): ChatCompletionResponse => {
+  const assistantContent = response.message?.content ?? "";
+  return {
+    id: job.metadata.id,
+    object: "chat.completion",
+    created: resolveCreatedTimestamp(job, response),
+    model: response.model ?? job.request.model,
+    choices: [
+      {
+        index: 0,
+        message: {
+          role: "assistant",
+          content: assistantContent,
+        },
+        finish_reason: normaliseFinishReason(response.done_reason),
+      },
+    ],
+    usage: mapUsage(response),
+  };
+};
+
+type JsonResponse = Readonly<{
+  readonly ok: boolean;
+  readonly status: number;
+  readonly text: () => Promise<string>;
+  readonly json: Response["json"];
+}>;
+
+const ensureOkResponse = async <TResponse extends JsonResponse>(
+  response: TResponse,
+): Promise<TResponse> => {
+  if (response.ok) {
+    return response;
+  }
+  const detail = await response.text().catch(() => "");
+  const trimmedDetail = detail.trim();
+  const suffix = trimmedDetail.length > 0 ? `: ${trimmedDetail}` : "";
+  throw new Error(
+    `Ollama chat request failed with status ${response.status}${suffix}`,
+  );
+};
+
+export const createOllamaChatCompletionHandler = (
+  options: OllamaHandlerOptions = {},
+): ChatCompletionHandler => {
+  const baseUrl = options.baseUrl ?? DEFAULT_BASE_URL;
+  const fetchFn = options.fetch ?? fetch;
+  const endpoint = new URL("/api/chat", baseUrl).toString();
+
+  return async (job: Readonly<ChatCompletionJob>) => {
+    const payload = buildPayload(job.request);
+    const response = await fetchFn(endpoint, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(payload),
+    });
+    const checked = await ensureOkResponse(response);
+    const ollamaResponse = (await checked.json()) as OllamaChatResponse;
+    return toChatCompletionResponse(job, ollamaResponse);
+  };
+};

--- a/packages/openai-server/src/openai/types.ts
+++ b/packages/openai-server/src/openai/types.ts
@@ -1,0 +1,51 @@
+export type ChatCompletionRole = "system" | "user" | "assistant" | "tool";
+
+export type ChatCompletionMessage = {
+  readonly role: ChatCompletionRole;
+  readonly content: string;
+  readonly name?: string;
+};
+
+export type ChatCompletionRequest = {
+  readonly model: string;
+  readonly messages: ReadonlyArray<ChatCompletionMessage>;
+  readonly temperature?: number;
+  readonly max_tokens?: number;
+  readonly top_p?: number;
+  readonly user?: string;
+  readonly stream?: boolean;
+};
+
+export type ChatCompletionChoice = {
+  readonly index: number;
+  readonly message: ChatCompletionMessage;
+  readonly finish_reason: "stop" | "length";
+};
+
+export type ChatCompletionUsage = {
+  readonly prompt_tokens: number;
+  readonly completion_tokens: number;
+  readonly total_tokens: number;
+};
+
+export type ChatCompletionResponse = {
+  readonly id: string;
+  readonly object: "chat.completion";
+  readonly created: number;
+  readonly model: string;
+  readonly choices: ReadonlyArray<ChatCompletionChoice>;
+  readonly usage: ChatCompletionUsage;
+  readonly system_fingerprint?: string;
+};
+
+export type ChatCompletionJob = {
+  readonly metadata: {
+    readonly id: string;
+    readonly enqueuedAt: number;
+  };
+  readonly request: ChatCompletionRequest;
+};
+
+export type ChatCompletionHandler = (
+  job: ChatCompletionJob,
+) => Promise<ChatCompletionResponse>;

--- a/packages/openai-server/src/queue/state.ts
+++ b/packages/openai-server/src/queue/state.ts
@@ -1,0 +1,204 @@
+import type {
+  CompletionStatus,
+  QueueRecord,
+  QueueSnapshot,
+  QueueTask,
+} from "./types.js";
+
+type PendingEntry<TInput, TResult> = {
+  readonly task: QueueTask<TInput>;
+  readonly resolve: (value: TResult) => void;
+  readonly reject: (reason: unknown) => void;
+};
+
+type ProcessingEntry<TInput, TResult> = PendingEntry<TInput, TResult> & {
+  readonly startedAt: number;
+};
+
+type QueueState<TInput, TResult> = {
+  readonly pending: ReadonlyArray<PendingEntry<TInput, TResult>>;
+  readonly processing: ReadonlyArray<ProcessingEntry<TInput, TResult>>;
+  readonly metrics: {
+    readonly enqueued: number;
+    readonly completed: number;
+    readonly failed: number;
+  };
+  readonly recent: ReadonlyArray<QueueRecord>;
+};
+
+type ImmutableQueueState<TInput, TResult> = Readonly<
+  QueueState<TInput, TResult>
+>;
+
+type QueueStateController<TInput, TResult> = {
+  readonly get: () => QueueState<TInput, TResult>;
+  readonly set: (
+    state: ImmutableQueueState<TInput, TResult>,
+  ) => QueueState<TInput, TResult>;
+  readonly update: (
+    updater: (
+      state: ImmutableQueueState<TInput, TResult>,
+    ) => QueueState<TInput, TResult>,
+  ) => QueueState<TInput, TResult>;
+};
+
+type CompletionContext<TInput, TResult> = {
+  readonly entry: ProcessingEntry<TInput, TResult>;
+  readonly status: CompletionStatus;
+  readonly finishedAt: number;
+  readonly recentLimit: number;
+};
+
+const dropFirst = <T>(
+  items: ReadonlyArray<T>,
+): {
+  readonly head: T | undefined;
+  readonly tail: ReadonlyArray<T>;
+} => {
+  if (items.length === 0) {
+    return { head: undefined, tail: items };
+  }
+  const [head, ...tail] = items;
+  return { head, tail };
+};
+
+const removeById = <T extends { readonly task: QueueTask<unknown> }>(
+  items: ReadonlyArray<T>,
+  id: string,
+): ReadonlyArray<T> => items.filter((entry) => entry.task.id !== id);
+
+const buildRecord = <TInput, TResult>(
+  entry: Readonly<ProcessingEntry<TInput, TResult>>,
+  status: CompletionStatus,
+  finishedAt: number,
+): QueueRecord => ({
+  id: entry.task.id,
+  status,
+  enqueuedAt: entry.task.enqueuedAt,
+  startedAt: entry.startedAt,
+  finishedAt,
+  durationMs: finishedAt - entry.startedAt,
+});
+
+export const createQueueStateController = <TInput, TResult>(
+  initial: ImmutableQueueState<TInput, TResult>,
+): QueueStateController<TInput, TResult> => {
+  /* eslint-disable functional/no-let */
+  let current = initial;
+  const set = (
+    state: ImmutableQueueState<TInput, TResult>,
+  ): QueueState<TInput, TResult> => {
+    current = state;
+    return current;
+  };
+  /* eslint-enable functional/no-let */
+
+  const update = (
+    updater: (
+      state: QueueState<TInput, TResult>,
+    ) => QueueState<TInput, TResult>,
+  ): QueueState<TInput, TResult> => set(updater(current));
+
+  return {
+    get: () => current,
+    set,
+    update,
+  };
+};
+
+export const toSnapshot = <TInput, TResult>(
+  state: ImmutableQueueState<TInput, TResult>,
+  recentLimit: number,
+): QueueSnapshot => ({
+  pending: state.pending.map(({ task }) => ({
+    id: task.id,
+    enqueuedAt: task.enqueuedAt,
+  })),
+  processing: state.processing.map(({ task, startedAt }) => ({
+    id: task.id,
+    enqueuedAt: task.enqueuedAt,
+    startedAt,
+  })),
+  metrics: {
+    enqueued: state.metrics.enqueued,
+    completed: state.metrics.completed,
+    failed: state.metrics.failed,
+  },
+  recent: state.recent.slice(0, recentLimit),
+  updatedAt: Date.now(),
+});
+
+export const enqueueState = <TInput, TResult>(
+  state: ImmutableQueueState<TInput, TResult>,
+  entry: PendingEntry<TInput, TResult>,
+): QueueState<TInput, TResult> => ({
+  pending: [...state.pending, entry],
+  processing: state.processing,
+  metrics: {
+    ...state.metrics,
+    enqueued: state.metrics.enqueued + 1,
+  },
+  recent: state.recent,
+});
+
+export const completeState = <TInput, TResult>(
+  state: ImmutableQueueState<TInput, TResult>,
+  context: CompletionContext<TInput, TResult>,
+): QueueState<TInput, TResult> => {
+  const recentRecord = buildRecord(
+    context.entry,
+    context.status,
+    context.finishedAt,
+  );
+  const metrics =
+    context.status === "completed"
+      ? {
+          ...state.metrics,
+          completed: state.metrics.completed + 1,
+        }
+      : {
+          ...state.metrics,
+          failed: state.metrics.failed + 1,
+        };
+
+  return {
+    pending: state.pending,
+    processing: removeById(state.processing, context.entry.task.id),
+    metrics,
+    recent: [recentRecord, ...state.recent].slice(0, context.recentLimit),
+  };
+};
+
+export const startNextState = <TInput, TResult>(
+  state: ImmutableQueueState<TInput, TResult>,
+  concurrency: number,
+): {
+  readonly nextState: QueueState<TInput, TResult>;
+  readonly entry?: ProcessingEntry<TInput, TResult>;
+} => {
+  if (state.processing.length >= concurrency) {
+    return { nextState: state };
+  }
+
+  const { head, tail } = dropFirst(state.pending);
+  if (!head) {
+    return { nextState: state };
+  }
+
+  const processingEntry: ProcessingEntry<TInput, TResult> = {
+    ...head,
+    startedAt: Date.now(),
+  };
+
+  return {
+    nextState: {
+      pending: tail,
+      processing: [...state.processing, processingEntry],
+      metrics: state.metrics,
+      recent: state.recent,
+    },
+    entry: processingEntry,
+  };
+};
+
+export type { PendingEntry, ProcessingEntry, QueueState, QueueStateController };

--- a/packages/openai-server/src/queue/taskQueue.ts
+++ b/packages/openai-server/src/queue/taskQueue.ts
@@ -1,0 +1,177 @@
+import { randomUUID } from "node:crypto";
+
+import type {
+  CompletionStatus,
+  QueueOptions,
+  QueueSnapshot,
+  QueueTask,
+  TaskQueue,
+} from "./types.js";
+import type {
+  PendingEntry,
+  ProcessingEntry,
+  QueueStateController,
+} from "./state.js";
+import {
+  completeState,
+  createQueueStateController,
+  enqueueState,
+  startNextState,
+  toSnapshot,
+} from "./state.js";
+
+export type {
+  CompletionStatus,
+  QueueOptions,
+  QueueSnapshot,
+  QueueTask,
+  TaskQueue,
+} from "./types.js";
+
+const clampPositiveInteger = (value: number, fallback: number): number => {
+  if (!Number.isFinite(value) || value <= 0) {
+    return fallback;
+  }
+  return Math.floor(value);
+};
+
+const createSnapshotReader =
+  <TInput, TResult>(
+    state: QueueStateController<TInput, TResult>,
+    recentLimit: number,
+  ): (() => QueueSnapshot) =>
+  () =>
+    toSnapshot(state.get(), recentLimit);
+
+const createCompletionDispatcher = <TInput, TResult>(
+  state: QueueStateController<TInput, TResult>,
+  recentLimit: number,
+): ((
+  entry: Readonly<ProcessingEntry<TInput, TResult>>,
+  status: CompletionStatus,
+) => void) => {
+  return (entry, status) => {
+    state.update((current) =>
+      completeState(current, {
+        entry,
+        status,
+        finishedAt: Date.now(),
+        recentLimit,
+      }),
+    );
+  };
+};
+
+type SchedulerDependencies<TInput, TResult> = {
+  readonly state: QueueStateController<TInput, TResult>;
+  readonly concurrency: number;
+  readonly processor: (task: Readonly<QueueTask<TInput>>) => Promise<TResult>;
+  readonly onComplete: (
+    entry: Readonly<ProcessingEntry<TInput, TResult>>,
+    status: CompletionStatus,
+  ) => void;
+};
+
+const processEntry = <TInput, TResult>(
+  deps: SchedulerDependencies<TInput, TResult>,
+  entry: Readonly<ProcessingEntry<TInput, TResult>>,
+): Promise<void> =>
+  deps
+    .processor(entry.task)
+    .then((value) => {
+      entry.resolve(value);
+      deps.onComplete(entry, "completed");
+    })
+    .catch((error) => {
+      entry.reject(error);
+      deps.onComplete(entry, "failed");
+    });
+
+const createScheduler = <TInput, TResult>(
+  deps: SchedulerDependencies<TInput, TResult>,
+): (() => void) => {
+  const run = (): void => {
+    const { nextState, entry } = startNextState(
+      deps.state.get(),
+      deps.concurrency,
+    );
+    deps.state.set(nextState);
+
+    if (!entry) {
+      return;
+    }
+
+    void processEntry(deps, entry).finally(run);
+
+    if (nextState.processing.length < deps.concurrency) {
+      run();
+    }
+  };
+
+  return run;
+};
+
+type EnqueueDependencies<TInput, TResult> = {
+  readonly state: QueueStateController<TInput, TResult>;
+  readonly idFactory: () => string;
+  readonly schedule: () => void;
+};
+
+const createEnqueuer = <TInput, TResult>(
+  deps: EnqueueDependencies<TInput, TResult>,
+): ((input: Readonly<TInput>) => Promise<TResult>) => {
+  return (input) => {
+    const task: QueueTask<TInput> = {
+      id: deps.idFactory(),
+      input,
+      enqueuedAt: Date.now(),
+    };
+
+    return new Promise<TResult>((resolve, reject) => {
+      const entry: PendingEntry<TInput, TResult> = {
+        task,
+        resolve,
+        reject,
+      };
+
+      deps.state.update((current) => enqueueState(current, entry));
+      deps.schedule();
+    });
+  };
+};
+
+const createSizer =
+  <TInput, TResult>(
+    state: QueueStateController<TInput, TResult>,
+  ): (() => number) =>
+  () =>
+    state.get().pending.length;
+
+export const createTaskQueue = <TInput, TResult>(
+  processor: (task: Readonly<QueueTask<TInput>>) => Promise<TResult>,
+  options: Readonly<QueueOptions> = {},
+): TaskQueue<TInput, TResult> => {
+  const concurrency = clampPositiveInteger(options.concurrency ?? 1, 1);
+  const recentLimit = clampPositiveInteger(options.recentLimit ?? 10, 10);
+  const idFactory = options.idFactory ?? (() => randomUUID());
+
+  const state = createQueueStateController<TInput, TResult>({
+    pending: [],
+    processing: [],
+    metrics: { enqueued: 0, completed: 0, failed: 0 },
+    recent: [],
+  });
+
+  const snapshot = createSnapshotReader(state, recentLimit);
+  const complete = createCompletionDispatcher(state, recentLimit);
+  const scheduleNext = createScheduler({
+    state,
+    concurrency,
+    processor,
+    onComplete: complete,
+  });
+  const enqueue = createEnqueuer({ state, idFactory, schedule: scheduleNext });
+  const size = createSizer(state);
+
+  return { enqueue, size, snapshot };
+};

--- a/packages/openai-server/src/queue/types.ts
+++ b/packages/openai-server/src/queue/types.ts
@@ -1,0 +1,47 @@
+export type CompletionStatus = "completed" | "failed";
+
+export type QueueRecord = {
+  readonly id: string;
+  readonly status: CompletionStatus;
+  readonly enqueuedAt: number;
+  readonly startedAt: number;
+  readonly finishedAt: number;
+  readonly durationMs: number;
+};
+
+export type QueueSnapshot = {
+  readonly pending: ReadonlyArray<{
+    readonly id: string;
+    readonly enqueuedAt: number;
+  }>;
+  readonly processing: ReadonlyArray<{
+    readonly id: string;
+    readonly enqueuedAt: number;
+    readonly startedAt: number;
+  }>;
+  readonly metrics: {
+    readonly enqueued: number;
+    readonly completed: number;
+    readonly failed: number;
+  };
+  readonly recent: ReadonlyArray<QueueRecord>;
+  readonly updatedAt: number;
+};
+
+export type QueueTask<TInput> = {
+  readonly id: string;
+  readonly input: Readonly<TInput>;
+  readonly enqueuedAt: number;
+};
+
+export type QueueOptions = {
+  readonly concurrency?: number;
+  readonly recentLimit?: number;
+  readonly idFactory?: () => string;
+};
+
+export type TaskQueue<TInput, TResult> = {
+  readonly enqueue: (input: Readonly<TInput>) => Promise<TResult>;
+  readonly size: () => number;
+  readonly snapshot: () => QueueSnapshot;
+};

--- a/packages/openai-server/src/server/chatCompletionRoute.ts
+++ b/packages/openai-server/src/server/chatCompletionRoute.ts
@@ -1,0 +1,121 @@
+import type { FastifyReply, FastifyRequest } from "fastify";
+
+import type {
+  ChatCompletionRequest,
+  ChatCompletionResponse,
+} from "../openai/types.js";
+import type { TaskQueue } from "../queue/taskQueue.js";
+
+import type { FastifyApp } from "./fastifyTypes.js";
+
+const chatCompletionMessageSchema = {
+  type: "object",
+  required: ["role", "content"],
+  properties: {
+    role: {
+      type: "string",
+      enum: ["system", "user", "assistant", "tool"],
+    },
+    content: { type: "string" },
+    name: { type: "string" },
+  },
+  additionalProperties: false,
+};
+
+const chatCompletionRequestSchema = {
+  type: "object",
+  required: ["model", "messages"],
+  properties: {
+    model: { type: "string" },
+    messages: {
+      type: "array",
+      items: chatCompletionMessageSchema,
+      minItems: 1,
+    },
+    temperature: { type: "number", minimum: 0, maximum: 2 },
+    max_tokens: { type: "integer", minimum: 1 },
+    top_p: { type: "number", minimum: 0, maximum: 1 },
+    user: { type: "string" },
+    stream: { type: "boolean" },
+  },
+  additionalProperties: false,
+};
+
+const chatCompletionChoiceSchema = {
+  type: "object",
+  required: ["index", "message", "finish_reason"],
+  properties: {
+    index: { type: "integer", minimum: 0 },
+    message: chatCompletionMessageSchema,
+    finish_reason: { type: "string", enum: ["stop", "length"] },
+  },
+  additionalProperties: false,
+};
+
+const chatCompletionUsageSchema = {
+  type: "object",
+  required: ["prompt_tokens", "completion_tokens", "total_tokens"],
+  properties: {
+    prompt_tokens: { type: "integer", minimum: 0 },
+    completion_tokens: { type: "integer", minimum: 0 },
+    total_tokens: { type: "integer", minimum: 0 },
+  },
+  additionalProperties: false,
+};
+
+const chatCompletionResponseSchema = {
+  type: "object",
+  required: ["id", "object", "created", "model", "choices", "usage"],
+  properties: {
+    id: { type: "string" },
+    object: { type: "string", const: "chat.completion" },
+    created: { type: "integer", minimum: 0 },
+    model: { type: "string" },
+    choices: {
+      type: "array",
+      items: chatCompletionChoiceSchema,
+      minItems: 1,
+    },
+    usage: chatCompletionUsageSchema,
+    system_fingerprint: { type: "string" },
+  },
+  additionalProperties: false,
+};
+
+type ChatQueue = {
+  readonly enqueue: TaskQueue<
+    ChatCompletionRequest,
+    ChatCompletionResponse
+  >["enqueue"];
+};
+
+export const registerChatCompletionRoute = (
+  app: FastifyApp,
+  queue: ChatQueue,
+): void => {
+  type ImmutableChatRequest = Readonly<
+    Pick<FastifyRequest<{ Body: ChatCompletionRequest }>, "body">
+  >;
+  type ImmutableReply = Readonly<Pick<FastifyReply, "header">>;
+
+  app.post<{ Body: ChatCompletionRequest; Reply: ChatCompletionResponse }>(
+    "/v1/chat/completions",
+    {
+      schema: {
+        tags: ["Chat Completions"],
+        summary: "Queue-backed OpenAI compatible chat completion endpoint",
+        body: chatCompletionRequestSchema,
+        response: {
+          200: chatCompletionResponseSchema,
+        },
+      },
+    },
+    async (request: ImmutableChatRequest, reply: ImmutableReply) => {
+      const response: ChatCompletionResponse = await queue.enqueue(
+        request.body,
+      );
+      void reply.header("cache-control", "no-store");
+      return response;
+    },
+  );
+};

--- a/packages/openai-server/src/server/createServer.ts
+++ b/packages/openai-server/src/server/createServer.ts
@@ -1,0 +1,203 @@
+import { existsSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import fastifyStatic from "@fastify/static";
+import fastifySwagger from "@fastify/swagger";
+import fastifySwaggerUi from "@fastify/swagger-ui";
+import Fastify from "fastify";
+import type {
+  FastifyInstance,
+  FastifyReply,
+  FastifyServerOptions,
+} from "fastify";
+
+import { createDefaultChatCompletionHandler } from "../openai/defaultHandler.js";
+import type {
+  ChatCompletionHandler,
+  ChatCompletionRequest,
+  ChatCompletionResponse,
+} from "../openai/types.js";
+import { createTaskQueue } from "../queue/taskQueue.js";
+import type { TaskQueue } from "../queue/taskQueue.js";
+import type { DeepReadonly } from "../types/deepReadonly.js";
+
+import { registerChatCompletionRoute } from "./chatCompletionRoute.js";
+import { registerQueueRoutes } from "./queueRoutes.js";
+import type {
+  FastifyApp,
+  FastifyHealthApp,
+  FastifyStaticApp,
+} from "./fastifyTypes.js";
+
+export type OpenAIServerOptions = {
+  readonly concurrency?: number;
+  readonly recentLimit?: number;
+  readonly handler?: ChatCompletionHandler;
+  readonly fastify?: FastifyServerOptions;
+};
+
+export type OpenAIServer = DeepReadonly<{
+  app: FastifyInstance;
+  queue: TaskQueue<ChatCompletionRequest, ChatCompletionResponse>;
+}>;
+
+type PackageDirectories = {
+  readonly distDir: string;
+  readonly staticDir: string;
+  readonly frontendDir: string;
+};
+
+const resolvePackageDirectories = (): PackageDirectories => {
+  const currentDir = dirname(fileURLToPath(new URL(".", import.meta.url)));
+  const distDir = resolve(currentDir, "..");
+  const staticDir = resolve(distDir, "../static");
+  const frontendDir = resolve(distDir, "frontend");
+  return { distDir, staticDir, frontendDir };
+};
+
+const registerDocumentation = (app: FastifyApp): void => {
+  app.register(fastifySwagger, {
+    openapi: {
+      info: {
+        title: "Promethean OpenAI Compatible API",
+        description:
+          "Implements a queue-backed subset of the OpenAI chat completions API.",
+        version: "0.0.0",
+      },
+      servers: [{ url: "/" }],
+      components: {},
+    },
+  });
+
+  app.register(fastifySwaggerUi, {
+    routePrefix: "/docs",
+    staticCSP: true,
+    uiConfig: {
+      docExpansion: "list",
+      deepLinking: false,
+    },
+  });
+
+  app.after(() => {
+    app.get("/openapi.json", async () => app.swagger());
+  });
+};
+
+type StaticReply = Readonly<Pick<FastifyReply, "type" | "sendFile">>;
+type HealthQueue = {
+  readonly snapshot: TaskQueue<
+    ChatCompletionRequest,
+    ChatCompletionResponse
+  >["snapshot"];
+};
+
+const registerStaticAssets = (
+  app: FastifyStaticApp,
+  directories: PackageDirectories,
+): void => {
+  app.register(fastifyStatic, {
+    root: directories.staticDir,
+    prefix: "/static/",
+  });
+
+  const frontendRoot = existsSync(directories.frontendDir)
+    ? directories.frontendDir
+    : directories.staticDir;
+
+  app.register(fastifyStatic, {
+    root: frontendRoot,
+    prefix: "/frontend/",
+    decorateReply: false,
+  });
+
+  app.get("/", async (_request, reply: StaticReply) => {
+    void reply.type("text/html");
+    return reply.sendFile("index.html");
+  });
+};
+
+const registerHealthRoute = (
+  app: FastifyHealthApp,
+  queue: HealthQueue,
+): void => {
+  app.get(
+    "/health",
+    {
+      schema: {
+        tags: ["Health"],
+        summary: "Health check endpoint",
+        response: {
+          200: {
+            type: "object",
+            required: ["status", "queue"],
+            properties: {
+              status: { type: "string" },
+              queue: {
+                type: "object",
+                required: ["pending", "processing"],
+                properties: {
+                  pending: { type: "integer", minimum: 0 },
+                  processing: { type: "integer", minimum: 0 },
+                },
+              },
+            },
+            additionalProperties: false,
+          },
+        },
+      },
+    },
+    async () => {
+      const snapshot = queue.snapshot();
+      return {
+        status: "ok",
+        queue: {
+          pending: snapshot.pending.length,
+          processing: snapshot.processing.length,
+        },
+      };
+    },
+  );
+};
+
+const buildQueue = (
+  handler: ChatCompletionHandler,
+  options: Pick<OpenAIServerOptions, "concurrency" | "recentLimit">,
+): TaskQueue<ChatCompletionRequest, ChatCompletionResponse> =>
+  createTaskQueue<ChatCompletionRequest, ChatCompletionResponse>(
+    async (task) =>
+      handler({
+        metadata: { id: task.id, enqueuedAt: task.enqueuedAt },
+        request: task.input,
+      }),
+    {
+      ...(typeof options.concurrency === "number"
+        ? { concurrency: options.concurrency }
+        : {}),
+      ...(typeof options.recentLimit === "number"
+        ? { recentLimit: options.recentLimit }
+        : {}),
+    },
+  );
+
+export const createOpenAICompliantServer = (
+  options: OpenAIServerOptions = {},
+): OpenAIServer => {
+  const handler = options.handler ?? createDefaultChatCompletionHandler();
+  const queue = buildQueue(handler, options);
+  const app = Fastify({ logger: false, ...(options.fastify ?? {}) });
+  const directories = resolvePackageDirectories();
+
+  registerStaticAssets(app, directories);
+  registerDocumentation(app);
+  app.after(() => {
+    registerQueueRoutes(app, queue);
+    registerChatCompletionRoute(app, queue);
+    registerHealthRoute(app, queue);
+  });
+
+  return {
+    app,
+    queue,
+  } as OpenAIServer;
+};

--- a/packages/openai-server/src/server/fastifyTypes.ts
+++ b/packages/openai-server/src/server/fastifyTypes.ts
@@ -1,0 +1,36 @@
+import type {
+  FastifyBaseLogger,
+  FastifyInstance,
+  FastifyTypeProviderDefault,
+  RawReplyDefaultExpression,
+  RawRequestDefaultExpression,
+  RawServerDefault,
+} from "fastify";
+
+type DefaultFastifyInstance = FastifyInstance<
+  RawServerDefault,
+  RawRequestDefaultExpression,
+  RawReplyDefaultExpression,
+  FastifyBaseLogger,
+  FastifyTypeProviderDefault
+>;
+
+type FastifyMethod<TName extends keyof DefaultFastifyInstance> =
+  DefaultFastifyInstance[TName];
+
+export type FastifyApp = {
+  readonly register: FastifyMethod<"register">;
+  readonly after: FastifyMethod<"after">;
+  readonly get: FastifyMethod<"get">;
+  readonly post: FastifyMethod<"post">;
+  readonly swagger: FastifyMethod<"swagger">;
+};
+
+export type FastifyStaticApp = {
+  readonly register: FastifyMethod<"register">;
+  readonly get: FastifyMethod<"get">;
+};
+
+export type FastifyHealthApp = {
+  readonly get: FastifyMethod<"get">;
+};

--- a/packages/openai-server/src/server/queueRoutes.ts
+++ b/packages/openai-server/src/server/queueRoutes.ts
@@ -1,0 +1,100 @@
+import type {
+  ChatCompletionRequest,
+  ChatCompletionResponse,
+} from "../openai/types.js";
+import type { QueueSnapshot, TaskQueue } from "../queue/taskQueue.js";
+
+import type { FastifyApp } from "./fastifyTypes.js";
+
+type QueueSnapshotApi = {
+  readonly snapshot: TaskQueue<
+    ChatCompletionRequest,
+    ChatCompletionResponse
+  >["snapshot"];
+};
+
+const queueSnapshotSchema = {
+  type: "object",
+  required: ["pending", "processing", "metrics", "recent", "updatedAt"],
+  properties: {
+    pending: {
+      type: "array",
+      items: {
+        type: "object",
+        required: ["id", "enqueuedAt"],
+        properties: {
+          id: { type: "string" },
+          enqueuedAt: { type: "integer", minimum: 0 },
+        },
+        additionalProperties: false,
+      },
+    },
+    processing: {
+      type: "array",
+      items: {
+        type: "object",
+        required: ["id", "enqueuedAt", "startedAt"],
+        properties: {
+          id: { type: "string" },
+          enqueuedAt: { type: "integer", minimum: 0 },
+          startedAt: { type: "integer", minimum: 0 },
+        },
+        additionalProperties: false,
+      },
+    },
+    metrics: {
+      type: "object",
+      required: ["enqueued", "completed", "failed"],
+      properties: {
+        enqueued: { type: "integer", minimum: 0 },
+        completed: { type: "integer", minimum: 0 },
+        failed: { type: "integer", minimum: 0 },
+      },
+      additionalProperties: false,
+    },
+    recent: {
+      type: "array",
+      items: {
+        type: "object",
+        required: [
+          "id",
+          "status",
+          "enqueuedAt",
+          "startedAt",
+          "finishedAt",
+          "durationMs",
+        ],
+        properties: {
+          id: { type: "string" },
+          status: { type: "string", enum: ["completed", "failed"] },
+          enqueuedAt: { type: "integer", minimum: 0 },
+          startedAt: { type: "integer", minimum: 0 },
+          finishedAt: { type: "integer", minimum: 0 },
+          durationMs: { type: "integer" },
+        },
+        additionalProperties: false,
+      },
+    },
+    updatedAt: { type: "integer", minimum: 0 },
+  },
+  additionalProperties: false,
+};
+
+export const registerQueueRoutes = (
+  app: FastifyApp,
+  queue: QueueSnapshotApi,
+): void => {
+  app.get(
+    "/queue/snapshot",
+    {
+      schema: {
+        tags: ["Queue"],
+        summary: "Inspect queue metrics and state",
+        response: {
+          200: queueSnapshotSchema,
+        },
+      },
+    },
+    async (): Promise<QueueSnapshot> => queue.snapshot(),
+  );
+};

--- a/packages/openai-server/src/tests/ollamaHandler.test.ts
+++ b/packages/openai-server/src/tests/ollamaHandler.test.ts
@@ -1,0 +1,183 @@
+import test from "ava";
+import type { ExecutionContext, TestFn } from "ava";
+
+import { createOllamaChatCompletionHandler } from "../openai/ollamaHandler.js";
+import type {
+  ChatCompletionJob,
+  ChatCompletionRequest,
+} from "../openai/types.js";
+import type { DeepReadonly } from "../types/deepReadonly.js";
+
+type RecordedInit = DeepReadonly<{
+  readonly method?: string;
+  readonly body?: string;
+}>;
+
+type FetchInvocation = DeepReadonly<{
+  readonly input: string;
+  readonly init: RecordedInit | undefined;
+}>;
+
+type InvocationRecorder = Readonly<{
+  readonly record: (invocation: Readonly<FetchInvocation>) => void;
+  readonly read: () => ReadonlyArray<FetchInvocation>;
+}>;
+
+const createRecordedInit = (
+  method: string | undefined,
+  body: string | undefined,
+): RecordedInit | undefined =>
+  method || body
+    ? ({
+        ...(method ? { method } : {}),
+        ...(body ? { body } : {}),
+      } satisfies RecordedInit)
+    : undefined;
+
+/* eslint-disable functional/no-let */
+const createInvocationRecorder = (): InvocationRecorder => {
+  let invocations: ReadonlyArray<FetchInvocation> = [];
+  return {
+    record: (invocation) => {
+      invocations = [...invocations, invocation];
+    },
+    read: () => invocations,
+  };
+};
+/* eslint-enable functional/no-let */
+
+const buildChatRequest = (): DeepReadonly<ChatCompletionRequest> => ({
+  model: "llama3",
+  messages: [
+    { role: "system", content: "Keep it brief." },
+    { role: "user", content: "Hi" },
+  ],
+  temperature: 0.7,
+  top_p: 0.9,
+  max_tokens: 128,
+});
+
+type SuccessfulScenario = Readonly<{
+  readonly handler: ReturnType<typeof createOllamaChatCompletionHandler>;
+  readonly job: ChatCompletionJob;
+  readonly recorder: InvocationRecorder;
+  readonly expectedBody: DeepReadonly<{
+    readonly model: string;
+    readonly messages: ReadonlyArray<{
+      readonly role: string;
+      readonly content: string;
+    }>;
+    readonly stream: false;
+    readonly options: {
+      readonly temperature: number;
+      readonly top_p: number;
+      readonly num_predict: number;
+    };
+  }>;
+}>;
+
+const createSuccessfulScenario = (): SuccessfulScenario => {
+  const recorder = createInvocationRecorder();
+  const request = buildChatRequest();
+  const expectedBody = {
+    model: request.model,
+    messages: request.messages,
+    stream: false as const,
+    options: { temperature: 0.7, top_p: 0.9, num_predict: 128 } as const,
+  };
+
+  const handler = createOllamaChatCompletionHandler({
+    baseUrl: "http://localhost:11434",
+    fetch: async (...args) => {
+      const [input, init] = args;
+      const method = typeof init?.method === "string" ? init.method : undefined;
+      const body = typeof init?.body === "string" ? init.body : undefined;
+      const recordedInit = createRecordedInit(method, body);
+      const normalisedInput = typeof input === "string" ? input : String(input);
+      recorder.record({ input: normalisedInput, init: recordedInit });
+      return new Response(
+        JSON.stringify({
+          model: "llama3",
+          created_at: "2023-01-01T00:00:05Z",
+          message: { role: "assistant", content: "Hello there" },
+          done_reason: "stop",
+          prompt_eval_count: 12,
+          eval_count: 8,
+        }),
+        {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        },
+      );
+    },
+  });
+
+  const job: ChatCompletionJob = {
+    metadata: { id: "job-1", enqueuedAt: Date.UTC(2023, 0, 1, 0, 0, 0) },
+    request: request as ChatCompletionRequest,
+  };
+
+  return { handler, job, recorder, expectedBody };
+};
+
+const readonlyTest = test as TestFn<DeepReadonly<ExecutionContext>>;
+
+readonlyTest(
+  "sends chat requests to the Ollama API and maps the response",
+  async (context) => {
+    const scenario = createSuccessfulScenario();
+    const response = await scenario.handler(scenario.job);
+    const invocations = scenario.recorder.read();
+    context.is(invocations.length, 1);
+    const invocation = invocations.at(0);
+    context.truthy(invocation);
+    if (!invocation?.init) {
+      context.fail("fetch was not called with init parameters");
+      return;
+    }
+    context.is(invocation.init.method, "POST");
+    context.is(invocation.input, "http://localhost:11434/api/chat");
+    const body = invocation.init.body;
+    const serialised = typeof body === "string" ? body : "";
+    context.deepEqual(JSON.parse(serialised), scenario.expectedBody);
+    context.is(response.id, "job-1");
+    context.is(response.object, "chat.completion");
+    context.is(response.created, 1672531205);
+    context.is(response.model, "llama3");
+    context.deepEqual(response.choices, [
+      {
+        index: 0,
+        message: { role: "assistant", content: "Hello there" },
+        finish_reason: "stop",
+      },
+    ]);
+    context.deepEqual(response.usage, {
+      prompt_tokens: 12,
+      completion_tokens: 8,
+      total_tokens: 20,
+    });
+  },
+);
+
+readonlyTest(
+  "throws descriptive error when Ollama responds with failure",
+  async (context) => {
+    const handler = createOllamaChatCompletionHandler({
+      fetch: async () =>
+        new Response("kaput", {
+          status: 503,
+          headers: { "content-type": "text/plain" },
+        }),
+    });
+
+    const failingJob: ChatCompletionJob = {
+      metadata: { id: "job-err", enqueuedAt: Date.now() },
+      request: {
+        model: "llama3",
+        messages: [{ role: "user", content: "Ping" }],
+      },
+    };
+
+    await context.throwsAsync(handler(failingJob), { message: /status 503/ });
+  },
+);

--- a/packages/openai-server/src/tests/server.test.ts
+++ b/packages/openai-server/src/tests/server.test.ts
@@ -1,0 +1,135 @@
+import test from "ava";
+
+import type {
+  ChatCompletionHandler,
+  ChatCompletionResponse,
+} from "../openai/types.js";
+import type { QueueSnapshot } from "../queue/taskQueue.js";
+import { createOpenAICompliantServer } from "../server/createServer.js";
+
+type UnknownRecord = Record<string, unknown>;
+
+const createEchoHandler =
+  (): ChatCompletionHandler =>
+  async ({ metadata, request }) => ({
+    id: `test-${metadata.id}`,
+    object: "chat.completion",
+    created: 123,
+    model: request.model,
+    choices: [
+      {
+        index: 0,
+        message: {
+          role: "assistant",
+          content: request.messages.at(-1)?.content ?? "",
+        },
+        finish_reason: "stop",
+      },
+    ],
+    usage: {
+      prompt_tokens: request.messages.length,
+      completion_tokens: 1,
+      total_tokens: request.messages.length + 1,
+    },
+  });
+
+const chatPayload = {
+  model: "gpt-test",
+  messages: [
+    { role: "system", content: "You are a test." },
+    { role: "user", content: "Hello server" },
+  ],
+} as const;
+
+const isRecord = (value: unknown): value is UnknownRecord =>
+  typeof value === "object" && value !== null;
+
+const isChatCompletionResponse = (
+  value: unknown,
+): value is ChatCompletionResponse =>
+  isRecord(value) &&
+  typeof value.id === "string" &&
+  value.object === "chat.completion" &&
+  typeof value.model === "string";
+
+const isQueueSnapshot = (value: unknown): value is QueueSnapshot => {
+  if (!isRecord(value)) {
+    return false;
+  }
+  const { metrics } = value as { metrics?: unknown };
+  if (!isRecord(metrics)) {
+    return false;
+  }
+  return ["enqueued", "completed", "failed"].every(
+    (key) => typeof metrics[key] === "number",
+  );
+};
+
+const documentHasPath = (document: unknown, path: string): boolean => {
+  if (!isRecord(document)) {
+    return false;
+  }
+  const paths = document.paths;
+  if (!isRecord(paths)) {
+    return false;
+  }
+  return Object.prototype.hasOwnProperty.call(paths, path);
+};
+
+test("chat completions endpoint delegates to the provided handler", async (t) => {
+  const { app, queue } = createOpenAICompliantServer({
+    handler: createEchoHandler(),
+  });
+
+  t.teardown(async () => {
+    await app.close();
+  });
+
+  await app.ready();
+
+  const response = await app.inject({
+    method: "POST",
+    url: "/v1/chat/completions",
+    payload: chatPayload,
+  });
+
+  t.is(response.statusCode, 200);
+  const body: unknown = response.json();
+  t.true(isChatCompletionResponse(body));
+  if (isChatCompletionResponse(body)) {
+    t.true(body.id.startsWith("test-"));
+    t.is(body.model, "gpt-test");
+  }
+  t.is(queue.snapshot().metrics.completed, 1);
+});
+
+test("exposes queue snapshot and openapi documentation", async (t) => {
+  const { app } = createOpenAICompliantServer();
+  t.teardown(async () => {
+    await app.close();
+  });
+  await app.ready();
+
+  const snapshotResponse = await app.inject({
+    method: "GET",
+    url: "/queue/snapshot",
+  });
+  t.is(snapshotResponse.statusCode, 200);
+  const snapshotCandidate: unknown = snapshotResponse.json();
+  t.true(isQueueSnapshot(snapshotCandidate));
+  if (isQueueSnapshot(snapshotCandidate)) {
+    t.deepEqual(snapshotCandidate.metrics, {
+      enqueued: 0,
+      completed: 0,
+      failed: 0,
+    });
+  }
+
+  const openApiResponse = await app.inject({
+    method: "GET",
+    url: "/openapi.json",
+  });
+  t.is(openApiResponse.statusCode, 200);
+  const document: unknown = openApiResponse.json();
+  t.true(documentHasPath(document, "/v1/chat/completions"));
+});

--- a/packages/openai-server/src/tests/taskQueue.test.ts
+++ b/packages/openai-server/src/tests/taskQueue.test.ts
@@ -1,0 +1,77 @@
+import { sleep } from "@promethean/utils";
+import test from "ava";
+
+import { createTaskQueue } from "../queue/taskQueue.js";
+
+/* eslint-disable functional/no-let */
+const createRecorder = <T>() => {
+  let values: ReadonlyArray<T> = [];
+  return {
+    add: (value: T) => {
+      values = [...values, value];
+    },
+    all: (): ReadonlyArray<T> => values,
+  };
+};
+/* eslint-enable functional/no-let */
+
+test("processes tasks sequentially when concurrency is one", async (t) => {
+  const processed = createRecorder<string>();
+  const queue = createTaskQueue<string, string>(
+    async (task) => {
+      processed.add(`${task.id}:${task.input}`);
+      await sleep(5);
+      return task.input.toUpperCase();
+    },
+    {
+      concurrency: 1,
+    },
+  );
+
+  const results = await Promise.all([
+    queue.enqueue("alpha"),
+    queue.enqueue("beta"),
+    queue.enqueue("gamma"),
+  ]);
+
+  t.deepEqual(results, ["ALPHA", "BETA", "GAMMA"]);
+  const seenInputs = processed.all().map((entry) => entry.split(":")[1]);
+  t.deepEqual(seenInputs, ["alpha", "beta", "gamma"]);
+
+  const snapshot = queue.snapshot();
+  t.is(snapshot.pending.length, 0);
+  t.is(snapshot.metrics.completed, 3);
+  t.is(snapshot.metrics.failed, 0);
+  t.is(snapshot.recent.length, 3);
+});
+
+test("records failed tasks without blocking subsequent work", async (t) => {
+  const queue = createTaskQueue<number, number>(
+    async (task) => {
+      if (task.input === 2) {
+        throw new Error(`boom-${task.input}`);
+      }
+      await sleep(2);
+      return task.input * 2;
+    },
+    {
+      concurrency: 2,
+      recentLimit: 5,
+    },
+  );
+
+  const first = queue.enqueue(1);
+  const second = queue.enqueue(2);
+  const third = queue.enqueue(3);
+
+  await t.throwsAsync(second, { message: /boom-2/ });
+  const resolved = await Promise.all([first, third]);
+  t.deepEqual(resolved, [2, 6]);
+
+  const snapshot = queue.snapshot();
+  t.is(snapshot.metrics.completed, 2);
+  t.is(snapshot.metrics.failed, 1);
+  t.is(snapshot.pending.length, 0);
+  t.is(snapshot.processing.length, 0);
+  t.truthy(snapshot.recent.find((entry) => entry.status === "failed"));
+});

--- a/packages/openai-server/src/types/deepReadonly.ts
+++ b/packages/openai-server/src/types/deepReadonly.ts
@@ -1,0 +1,13 @@
+type Primitive = string | number | boolean | bigint | symbol | null | undefined;
+
+export type DeepReadonly<T> = T extends Primitive
+  ? T
+  : T extends (...args: readonly unknown[]) => unknown
+    ? T
+    : T extends Promise<infer U>
+      ? Promise<DeepReadonly<U>>
+      : T extends readonly (infer V)[]
+        ? ReadonlyArray<DeepReadonly<V>>
+        : T extends object
+          ? { readonly [K in keyof T]: DeepReadonly<T[K]> }
+          : T;

--- a/packages/openai-server/static/index.html
+++ b/packages/openai-server/static/index.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Promethean OpenAI Queue</title>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Fira+Mono&display=swap" />
+    <script type="module" src="/frontend/queue-dashboard.js"></script>
+    <style>
+      body {
+        margin: 0;
+        min-height: 100vh;
+        background: radial-gradient(circle at top, #e0f2fe, #f8fafc 60%);
+        display: grid;
+        place-items: center;
+        padding: 2rem 1rem;
+      }
+    </style>
+  </head>
+  <body>
+    <openai-queue-dashboard></openai-queue-dashboard>
+  </body>
+</html>

--- a/packages/openai-server/tsconfig.json
+++ b/packages/openai-server/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../config/tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "composite": true,
+    "declaration": true,
+    "strict": true,
+    "module": "Node16",
+    "moduleResolution": "node16",
+    "resolveJsonModule": true,
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["src/**/*"],
+  "references": []
+}


### PR DESCRIPTION
## Summary
- add an Ollama-backed chat completion handler that proxies OpenAI queue jobs to Ollama's /api/chat endpoint with usage accounting
- document the handler in the package README and capture a manual verification task for the ops team
- cover the handler with AVA tests to exercise success and failure paths and export it from the package index

## Testing
- pnpm --filter @promethean/openai-server lint
- pnpm --filter @promethean/openai-server build
- pnpm --filter @promethean/openai-server test

------
https://chatgpt.com/codex/tasks/task_e_68cc59252df88324af96c5bec91c5d23

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced an OpenAI-compatible chat completions server with queue-backed processing and configurable concurrency.
  - Added observability: live queue dashboard UI, queue snapshot endpoint, health check, and OpenAPI/Swagger docs.
  - Provided an Ollama-backed chat handler integration and a simple default handler.
- Documentation
  - New README detailing server usage, endpoints, and features.
  - Added tasks to verify Ollama handler integration and to validate staging deployments (including screenshots and acceptance criteria).
- Tests
  - Added tests covering the task queue, server endpoints, OpenAPI exposure, and Ollama handler success/error paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->