### PR TITLE
feat: default privacy profile in handshakes

### DIFF
--- a/packages/enso-protocol/README.md
+++ b/packages/enso-protocol/README.md
@@ -75,7 +75,7 @@ const client = new EnsoClient(registry);
 await client.connect({
   proto: "ENSO-1",
   caps: ["can.send.text", "can.asset.put", "can.context.write", "can.context.apply"],
-  privacy: { profile: "pseudonymous" },
+  // Optional: privacy defaults to { profile: "pseudonymous" }
 });
 
 await client.post({ role: "human", parts: [{ kind: "text", text: "Hello" }] });
@@ -85,6 +85,8 @@ await client.contexts.apply(context.ctxId, [{ id: "human" }]);
 
 Missing capabilities raise informative errors (e.g. `missing capability: can.send.text`), mirroring the
 handshake rules in [`03-rooms-and-capabilities.md`](../../docs/design/enso-protocol/03-rooms-and-capabilities.md).
+Omitting the `privacy` block defaults the request to the documented `pseudonymous` profile while
+allowing the server to negotiate stricter settings if needed.
 
 ### Registering and invoking tools
 
@@ -146,7 +148,7 @@ const server = new EnsoServer();
 const hello = {
   proto: "ENSO-1" as const,
   caps: ["can.send.text"],
-  privacy: { profile: "pseudonymous" as const },
+  // privacy defaults to { profile: "pseudonymous" as const }
 };
 
 connectLocal(client, server, hello, {
@@ -171,7 +173,7 @@ const server = new EnsoServer();
 const { session } = connectLocal(client, server, {
   proto: "ENSO-1",
   caps: ["can.tool.call"],
-  privacy: { profile: "pseudonymous" },
+  // privacy defaults to { profile: "pseudonymous" }
 });
 
 server.enableEvaluationMode(session.id, true);

--- a/packages/enso-protocol/src/tests/transport.spec.ts
+++ b/packages/enso-protocol/src/tests/transport.spec.ts
@@ -3,6 +3,7 @@ import { EnsoClient } from "../client.js";
 import { EnsoServer } from "../server.js";
 import { ContextRegistry } from "../registry.js";
 import { connectLocal } from "../transport.js";
+import { DEFAULT_PRIVACY_PROFILE } from "../types/privacy.js";
 import type { HelloCaps } from "../types/privacy.js";
 import type { Envelope } from "../types/envelope.js";
 
@@ -10,6 +11,11 @@ const HELLO: HelloCaps = {
   proto: "ENSO-1",
   caps: ["can.send.text"],
   privacy: { profile: "pseudonymous" },
+};
+
+const HELLO_WITHOUT_PRIVACY: HelloCaps = {
+  proto: "ENSO-1",
+  caps: ["can.send.text"],
 };
 
 test("local transport negotiates capabilities and emits presence", async (t) => {
@@ -44,7 +50,10 @@ test("local transport negotiates capabilities and emits presence", async (t) => 
 
   const sessionInfo = server.getSessionInfo(session.id);
   t.truthy(sessionInfo);
-  t.deepEqual(sessionInfo?.capabilities, ["can.send.text", "can.context.apply"]);
+  t.deepEqual(sessionInfo?.capabilities, [
+    "can.send.text",
+    "can.context.apply",
+  ]);
   t.is(sessionInfo?.privacy, "persistent");
 
   const received: Envelope[] = [];
@@ -52,7 +61,10 @@ test("local transport negotiates capabilities and emits presence", async (t) => 
     received.push(env);
   });
 
-  await client.post({ role: "human", parts: [{ kind: "text", text: "hello" }] });
+  await client.post({
+    role: "human",
+    parts: [{ kind: "text", text: "hello" }],
+  });
   t.is(received.length, 1);
 
   connection.disconnect();
@@ -69,4 +81,52 @@ test("local transport preserves capability enforcement", async (t) => {
     message: /missing capability: can.asset.put/,
   });
   connection.disconnect();
+});
+
+test("local transport defaults privacy profile when omitted", (t) => {
+  const server = new EnsoServer();
+  const client = new EnsoClient(new ContextRegistry());
+  const acceptedEvents: Envelope[] = [];
+
+  client.on("event:privacy.accepted", (env) => acceptedEvents.push(env));
+
+  const connection = connectLocal(client, server, HELLO_WITHOUT_PRIVACY);
+
+  t.is(connection.accepted.payload.profile, DEFAULT_PRIVACY_PROFILE);
+  t.false(connection.accepted.payload.wantsE2E);
+  t.is(client.getPrivacyProfile(), DEFAULT_PRIVACY_PROFILE);
+  const sessionInfo = server.getSessionInfo(connection.session.id);
+  t.truthy(sessionInfo);
+  t.is(sessionInfo?.privacy, DEFAULT_PRIVACY_PROFILE);
+
+  const forwarded = acceptedEvents[0];
+  t.truthy(forwarded);
+  if (forwarded) {
+    const payload = forwarded.payload as { profile: string };
+    t.is(payload.profile, DEFAULT_PRIVACY_PROFILE);
+  }
+
+  connection.disconnect();
+});
+
+test("client connect emits default privacy when omitted", async (t) => {
+  const client = new EnsoClient(new ContextRegistry());
+  const acceptedEvents: Envelope[] = [];
+  client.on("event:privacy.accepted", (env) => acceptedEvents.push(env));
+
+  await client.connect(HELLO_WITHOUT_PRIVACY);
+
+  t.is(client.getPrivacyProfile(), DEFAULT_PRIVACY_PROFILE);
+  const accepted = acceptedEvents[0];
+  t.truthy(accepted);
+  if (accepted) {
+    const payload = accepted.payload as {
+      requested: HelloCaps;
+      profile: string;
+    };
+    t.is(payload.profile, DEFAULT_PRIVACY_PROFILE);
+    t.deepEqual(payload.requested.privacy, {
+      profile: DEFAULT_PRIVACY_PROFILE,
+    });
+  }
 });

--- a/packages/enso-protocol/src/types/privacy.ts
+++ b/packages/enso-protocol/src/types/privacy.ts
@@ -11,7 +11,7 @@ export interface HelloCaps {
     name: string;
     version: string;
   };
-  privacy: {
+  privacy?: {
     profile: PrivacyProfile;
     wantsE2E?: boolean;
     allowLogging?: boolean;
@@ -23,4 +23,19 @@ export interface HelloCaps {
     supportsPartial?: boolean;
     maxBytes?: number;
   };
+}
+
+export type HelloPrivacy = NonNullable<HelloCaps["privacy"]>;
+
+export const DEFAULT_PRIVACY_PROFILE: PrivacyProfile = "pseudonymous";
+
+export function resolveHelloPrivacy(
+  hello: HelloCaps,
+  fallbackProfile: PrivacyProfile = DEFAULT_PRIVACY_PROFILE,
+): HelloPrivacy {
+  const provided = hello.privacy;
+  if (!provided) {
+    return { profile: fallbackProfile };
+  }
+  return { ...provided, profile: provided.profile ?? fallbackProfile };
 }


### PR DESCRIPTION
## Summary
- make `HelloCaps.privacy` optional and add helpers for deriving privacy defaults
- update the client and server handshake flows to fall back to the pseudonymous profile when no privacy is provided
- expand transport handshake tests and README examples to cover the default privacy behaviour

## Testing
- pnpm --filter @promethean/enso-protocol test

------
https://chatgpt.com/codex/tasks/task_e_68cd793ebf288324a90428cc01e51c67