### PR TITLE
docs: document nx package workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ into small services that handle speech-to-text, text-to-speech, memory, and high
 📖 For a high-level overview, see [Vision Overview](docs/design/overview.md).
 📊 For architecture roadmaps and visualizations, see [[docs/architecture/index|docs/architecture/index.md]].
 📦 Data migration conventions and runbooks live under [[docs/data/contracts/readme|docs/data]].
+🧰 Need a new workspace package? Follow the [Nx package workflow](docs/packages/new-package.md) for presets, directory layout, and follow-up tasks.
 
 ### Development conventions
 

--- a/docs/packages/new-package.md
+++ b/docs/packages/new-package.md
@@ -4,10 +4,16 @@ Promethean packages are scaffolded with Nx so every service, library, and fronte
 
 ## Nx generator presets
 
+### Prerequisites
+
+- Ensure `tools/generators/package` exists in the workspace.
+- Confirm the generator path is registered under the `"plugins"` key in `nx.json`.
+- Verify a base TypeScript config is present at `config/tsconfig.base.json`.
+
 Run the shared generator from the repository root:
 
 ```bash
-nx g tools:package <name> --preset <type>
+pnpm exec nx g tools:package <name> --preset <type>
 ```
 
 Use one of the supported presets:

--- a/docs/packages/new-package.md
+++ b/docs/packages/new-package.md
@@ -1,0 +1,40 @@
+# New package workflow
+
+Promethean packages are scaffolded with Nx so every service, library, and frontend follows the same functional TypeScript, AVA-first foundation. This guide walks through the generator presets, directory expectations, and the follow-up tasks you must complete before shipping a new workspace package.
+
+## Nx generator presets
+
+Run the shared generator from the repository root:
+
+```bash
+nx g tools:package <name> --preset <type>
+```
+
+Use one of the supported presets:
+
+| Preset | When to use it | Key directories | Follow-up tasks |
+| --- | --- | --- | --- |
+| `library` | Shared functional TypeScript utilities, adapters, ports | `src/`, `src/tests/`, `dist/` | Flesh out AVA specs in `src/tests/`, ensure exports keep `.js` extensions, keep package license `GPL-3.0-only`. |
+| `service` | Fastify-based APIs or background services | `src/`, `src/tests/`, `static/openapi/`, `dist/` | Register `@fastify/swagger` + `@fastify/swagger-ui`, expose `/openapi.json`, keep schemas in `static/openapi/`, serve `static/` and `dist/frontend/` when present. |
+| `frontend` | Webcomponent frontends co-located with a service | `src/`, `src/frontend/`, `src/tests/`, `static/`, `dist/`, `dist/frontend/` | Build UI with webcomponents, wire static assets through `@fastify/static`, make sure Fastify host serves `dist/frontend` and `static`, cover UI logic with AVA-compatible tests. |
+
+All presets emit ESM-ready builds, keep `.js` extensions in TypeScript imports, and enforce the GPL-3.0-only license string in `package.json`.
+
+## Repository conventions to carry forward
+
+- **Functional TypeScript.** Compose small pure functions, favour immutable data, and isolate side effects behind ports/adapters.
+- **Ava tests in `src/tests`.** Generators provide stubs—expand them with deterministic specs and keep test-only helpers out of production paths.
+- **Flat package layout.** Place sources under `src/`, frontends under `src/frontend/`, and assets under `static/`. Generated builds live in `dist/` and `dist/frontend/`.
+- **Fastify integrations.** Service presets include scaffolding for `@fastify/swagger`, `@fastify/swagger-ui`, and `@fastify/static`. After generation, ensure `/openapi.json` returns the schema exported from `static/openapi/`.
+- **Native ESM everywhere.** Maintain `.js` extensions in imports even in TypeScript sources so the compiled output remains valid.
+- **License.** Do not change the default `"license": "GPL-3.0-only"` string in generated manifests.
+
+## Follow-up checklist
+
+1. Review the generated README and scripts; add `build`, `test`, `lint`, and `typecheck` entries if the generator stubbed placeholders.
+2. Update OpenAPI definitions in `static/openapi/` (service preset) and wire them to Fastify routes that expose `/openapi.json`.
+3. For frontend packages, confirm your bundler output lands in `dist/frontend/` and reference assets from `static/`.
+4. Add additional Nx targets (e.g., `lint`, `storybook`) if the package needs them, but avoid touching files inside `repo/config/`. If a configuration change there is unavoidable, raise a task for a human operator instead of editing it yourself.
+5. Run `pnpm lint:diff`, `pnpm test`, and `pnpm typecheck` for the new package before opening a pull request.
+
+Keeping to this workflow ensures new packages integrate smoothly with automation pipelines, Fastify infrastructure, and our functional TypeScript standards.

--- a/packages/AGENTS.md
+++ b/packages/AGENTS.md
@@ -16,9 +16,21 @@
 - Conventionally, store level cache data under `.cache/<package-name>`.
 
 
+## Package scaffolding
+
+- Use Nx to create new workspace packages:
+  - Libraries: `nx g tools:package <name> --preset library`
+  - Fastify services: `nx g tools:package <name> --preset service`
+  - Frontends: `nx g tools:package <name> --preset frontend`
+- The generator writes `src/` with functional TypeScript entry points, AVA stubs in `src/tests`, and `static/` for assets that should be served by `@fastify/static`.
+- Service presets include an OpenAPI template under `static/openapi`, and you must expose it through `/openapi.json` using `@fastify/swagger` and `@fastify/swagger-ui`.
+- Frontend presets emit `src/frontend/` alongside `dist/frontend/` targets; serve `dist/frontend` and `static` together from Fastify when deploying UI shells.
+- All packages compile to `dist/` with ESM outputs that keep `.js` extensions in import statements.
+- Every package stays GPL-3.0-only and follows our functional TypeScript conventions (pure functions, immutability, composition).
+
 ## Testing
 
-- Ava is always the test runner
+- Ava is always the test runner (tests live in `src/tests`).
 - Test logic does not belong in module logic
 - define **ports** (your own minimal interfaces),
 - provide **adapters** for external services like Mongo/Chroma/level/redis/sql/etc,


### PR DESCRIPTION
## Summary
- document the Nx `tools:package` generator in packages/AGENTS.md with presets and follow-up requirements for libraries, services, and frontends
- add a new docs/packages/new-package.md guide that includes a quick-reference table plus repository conventions and follow-up checklist
- link the repository README to the new Nx package workflow documentation for easy discovery

## Testing
- no automated tests were run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68cd7c7994c88324b232775672be264c

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Documentation
  - Added a new package-scaffolding guide documenting Nx workflows, presets (library/service/frontend), directory layouts, and follow-up tasks.
  - Updated README to reference the new package workflow.
  - Expanded AGENTS and testing docs with clearer test structure, placement, best practices (module-boundary mocking, DI boundaries, deterministic/parallel tests), and repository conventions (ESM, licensing, functional TypeScript).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->