### PR TITLE
feat(markdown): share anchor helpers

### DIFF
--- a/packages/docops/package.json
+++ b/packages/docops/package.json
@@ -36,6 +36,7 @@
     "@promethean/fs": "workspace:*",
     "@promethean/utils": "workspace:*",
     "@promethean/docops-frontend": "workspace:*",
-    "@promethean/file-indexer": "workspace:*"
+    "@promethean/file-indexer": "workspace:*",
+    "@promethean/markdown": "workspace:*"
   }
 }

--- a/packages/docops/src/05-footers.ts
+++ b/packages/docops/src/05-footers.ts
@@ -6,12 +6,8 @@ import { pathToFileURL } from "node:url";
 import matter from "gray-matter";
 
 // DB is injected by caller
-import {
-  parseArgs,
-  stripGeneratedSections,
-  anchorId,
-  injectAnchors,
-} from "./utils.js";
+import { anchorId, injectAnchors } from "@promethean/markdown/anchors.js";
+import { parseArgs, stripGeneratedSections } from "./utils.js";
 import type { Front } from "./types.js";
 
 // CLI entry

--- a/packages/markdown/src/anchors.ts
+++ b/packages/markdown/src/anchors.ts
@@ -1,0 +1,105 @@
+import * as path from 'node:path';
+
+export type AnchorTarget = {
+    readonly line: number;
+    readonly id: string;
+};
+
+const FENCE_RE = /^(\s*)(`{3,}|~{3,})(.*)$/;
+
+type FenceState = {
+    readonly inside: boolean[];
+    readonly inFence: boolean;
+    readonly fenceChar: '`' | '~' | null;
+    readonly fenceLen: number;
+};
+
+const initialFenceState: FenceState = {
+    inside: [],
+    inFence: false,
+    fenceChar: null,
+    fenceLen: 0,
+};
+
+const fenceStateReducer = (state: FenceState, line: string): FenceState => {
+    const rawLine = line ?? '';
+    const match = rawLine.match(FENCE_RE);
+    if (!state.inFence) {
+        if (!match) {
+            return {
+                ...state,
+                inside: state.inside.concat(false),
+            };
+        }
+        const marker = match[2] ?? '';
+        const char = (marker[0] as '`' | '~') ?? '`';
+        return {
+            inside: state.inside.concat(true),
+            inFence: true,
+            fenceChar: char,
+            fenceLen: marker.length,
+        };
+    }
+
+    const marker = match?.[2] ?? '';
+    const closing =
+        !!match &&
+        !!state.fenceChar &&
+        (marker[0] as '`' | '~' | undefined) === state.fenceChar &&
+        marker.length >= state.fenceLen;
+
+    return {
+        inside: state.inside.concat(true),
+        inFence: closing ? false : state.inFence,
+        fenceChar: closing ? null : state.fenceChar,
+        fenceLen: closing ? 0 : state.fenceLen,
+    };
+};
+
+export const anchorId = (docUuid: string, line: number, col: number): string =>
+    `ref-${(docUuid ?? 'nouuid').slice(0, 8)}-${line}-${col}`;
+
+export const relMdLink = (fromFileAbs: string, toFileAbs: string, anchor?: string): string => {
+    const relative = path.relative(path.dirname(fromFileAbs), toFileAbs).replace(/\\/g, '/');
+    return anchor ? `${relative}#${anchor}` : relative;
+};
+
+export const computeFenceMap = (lines: readonly string[]): boolean[] =>
+    lines.reduce(fenceStateReducer, initialFenceState).inside;
+
+export const injectAnchors = (content: string, want: ReadonlyArray<AnchorTarget>): string => {
+    if (!want.length) return content;
+    const lines = [...content.split('\n')];
+    const inside = computeFenceMap(lines);
+    const uniq = want.reduce((acc, anchor) => {
+        acc.set(`${anchor.line}:${anchor.id}`, anchor);
+        return acc;
+    }, new Map<string, AnchorTarget>());
+    const anchors = Array.from(uniq.values()).sort((a, b) => a.line - b.line);
+
+    const hasIdOnOrNext = (idx: number, id: string) =>
+        (lines[idx] ?? '').includes(`^${id}`) || (lines[idx + 1] ?? '').trim() === `^${id}`;
+
+    const nextOutsideIdx = (idx: number) => {
+        let i = Math.min(idx, Math.max(lines.length - 1, 0));
+        while (i < lines.length && inside[i]) i++;
+        return i;
+    };
+
+    for (const { line, id } of anchors) {
+        const idx = Math.max(1, Math.min(line, lines.length)) - 1;
+        if (hasIdOnOrNext(idx, id)) continue;
+        if (inside[idx]) {
+            const j = nextOutsideIdx(idx + 1);
+            if (j >= lines.length) {
+                lines.push(`^${id}`);
+            } else if (!hasIdOnOrNext(j, id)) {
+                lines.splice(j, 0, `^${id}`);
+            }
+        } else {
+            lines[idx] = (lines[idx] ?? '').replace(/\s*$/, ` ^${id}`);
+        }
+    }
+
+    return lines.join('\n');
+};

--- a/packages/markdown/src/tests/anchors.test.ts
+++ b/packages/markdown/src/tests/anchors.test.ts
@@ -1,0 +1,40 @@
+import test from 'ava';
+
+import { anchorId, relMdLink, computeFenceMap, injectAnchors, type AnchorTarget } from '../anchors.js';
+
+test('anchorId uses stable prefix and coordinates', (t) => {
+    const id = anchorId('abc123456789', 10, 2);
+    t.is(id, 'ref-abc12345-10-2');
+    t.is(anchorId('', 1, 1), 'ref--1-1');
+});
+
+test('relMdLink resolves relative paths and optional anchors', (t) => {
+    const from = '/root/docs/a/b/file.md';
+    const to = '/root/docs/a/other.md';
+    t.is(relMdLink(from, to), '../other.md');
+    t.is(relMdLink(from, to, 'ref'), '../other.md#ref');
+});
+
+test('computeFenceMap marks every line inside fenced blocks', (t) => {
+    const lines = ['before', '```js', 'code', '```', 'after'] as const;
+    t.deepEqual(computeFenceMap(lines), [false, true, true, true, false]);
+});
+
+test('injectAnchors avoids fences and remains idempotent', (t) => {
+    const md = ['# H', 'text line', '```', 'code line', '```', 'after'].join('\n');
+    const anchors: readonly AnchorTarget[] = [
+        { line: 4, id: 'ref-block-4-1' },
+        { line: 6, id: 'ref-block-6-1' },
+    ];
+    const once = injectAnchors(md, anchors);
+    const lines = once.split('\n');
+    const openIdx = lines.indexOf('```');
+    const closeIdx = lines.lastIndexOf('```');
+    t.true(openIdx >= 0 && closeIdx >= 0);
+    const anchorIdx = lines.findIndex((ln) => ln.includes('^ref-block-4-1'));
+    t.true(anchorIdx > closeIdx);
+    const fenceSection = lines.slice(openIdx, closeIdx + 1).join('\n');
+    t.false(fenceSection.includes('^ref-block-6-1'));
+    t.true(lines.some((ln) => ln.includes('^ref-block-6-1')));
+    t.is(injectAnchors(once, anchors), once);
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1460,6 +1460,9 @@ importers:
       '@promethean/fs':
         specifier: workspace:*
         version: link:../fs
+      '@promethean/markdown':
+        specifier: workspace:*
+        version: link:../markdown
       '@promethean/utils':
         specifier: workspace:*
         version: link:../utils
@@ -2048,6 +2051,8 @@ importers:
       '@types/ws':
         specifier: ^8.5.9
         version: 8.18.1
+
+  packages/fsm: {}
 
   packages/health:
     dependencies:
@@ -14706,7 +14711,7 @@ snapshots:
 
   axios@1.11.0:
     dependencies:
-      follow-redirects: 1.15.11(debug@4.3.7)
+      follow-redirects: 1.15.11(debug@4.4.3)
       form-data: 4.0.4
       proxy-from-env: 1.1.0
     transitivePeerDependencies:
@@ -17154,7 +17159,7 @@ snapshots:
   http-proxy@1.18.1:
     dependencies:
       eventemitter3: 4.0.7
-      follow-redirects: 1.15.11(debug@4.3.7)
+      follow-redirects: 1.15.11(debug@4.4.3)
       requires-port: 1.0.0
     transitivePeerDependencies:
       - debug


### PR DESCRIPTION
## Summary
- extract shared anchor helpers into @promethean/markdown with AVA coverage
- update docops utilities, footers flow, and regen-footers script to import the shared helpers
- add @promethean/markdown as a docops dependency and reuse the new exports

## Testing
- pnpm --filter @promethean/markdown test
- pnpm --filter @promethean/docops test

------
https://chatgpt.com/codex/tasks/task_e_68cd895cc09083248cbbc521caceba21