### PR TITLE
feat(clj-hacks): drive workflows via babashka

### DIFF
--- a/bb.edn
+++ b/bb.edn
@@ -27,6 +27,12 @@
   simulate-ci      {:doc "Simulate CI locally" :task (mk.commands/simulate-ci)}
   snapshot         {:doc "Create tag snapshot-YYYY.MM.DD (PUSH=1 to push)" :task (mk.commands/snapshot)}
 
+  ;; Clojure packages
+  clj-hacks:prepare {:doc "Download deps for clj-hacks" :requires ([clj-hacks.tasks]) :task clj-hacks.tasks/prepare!}
+  clj-hacks:build   {:doc "Compile clj-hacks namespaces" :requires ([clj-hacks.tasks]) :task clj-hacks.tasks/build}
+  clj-hacks:lint    {:doc "Run clj-kondo on clj-hacks" :requires ([clj-hacks.tasks]) :task clj-hacks.tasks/lint}
+  clj-hacks:test    {:doc "Execute clj-hacks tests" :requires ([clj-hacks.tasks]) :task clj-hacks.tasks/test}
+
   ;; Language-specific tasks (mirroring Hy names)
   ;; Python
   setup-python-services     mk.python/setup-python-services

--- a/bb/src/clj_hacks/tasks.clj
+++ b/bb/src/clj_hacks/tasks.clj
@@ -1,0 +1,28 @@
+(ns clj-hacks.tasks
+  (:require [babashka.fs :as fs]
+            [babashka.process :as process]))
+
+(def project-dir "packages/clj-hacks")
+
+(defn- run! [cmd]
+  (-> (process/process cmd {:dir project-dir :out :inherit :err :inherit})
+      (process/check)))
+
+(defn- ensure-target! []
+  (fs/create-dirs (fs/path project-dir "target" "classes")))
+
+(defn prepare! []
+  (run! ["clojure" "-P"]))
+
+(defn build []
+  (ensure-target!)
+  (prepare!)
+  (run! ["clojure" "-M:compile"]))
+
+(defn lint []
+  (prepare!)
+  (run! ["clojure" "-M:lint"]))
+
+(defn test []
+  (prepare!)
+  (run! ["clojure" "-M:test"]))

--- a/packages/clj-hacks/README.md
+++ b/packages/clj-hacks/README.md
@@ -1,0 +1,52 @@
+# clj-hacks
+
+Utilities for experimenting with Emacs Lisp parsing using the Tree-sitter
+runtime from Clojure.
+
+## Tooling prerequisites
+
+* [Babashka](https://babashka.org/) – used for the local automation entry point.
+* [Clojure CLI tools](https://clojure.org/guides/install_clojure) – drives
+  compilation, linting, and tests via `deps.edn` aliases.
+
+Install both globally so the `bb` tasks can invoke them.
+
+## Babashka tasks
+
+The package exposes a set of Babashka entry points defined in
+`bb/src/clj_hacks/tasks.clj`. Run them from the repository root:
+
+```sh
+bb clj-hacks:prepare   # downloads maven dependencies
+bb clj-hacks:build     # AOT compiles elisp namespaces into target/classes
+bb clj-hacks:lint      # executes clj-kondo against src/ and test/
+bb clj-hacks:test      # runs clojure.test suites via cognitect test-runner
+```
+
+All tasks automatically resolve dependencies before executing. `build` will also
+create `packages/clj-hacks/target/classes` when needed.
+
+## Nx integration
+
+`packages/clj-hacks/project.json` is wired to the Babashka tasks, so the
+standard Nx workflows delegate to the Lisp toolchain:
+
+```sh
+pnpm nx run ts-clj-hacks:build
+pnpm nx run ts-clj-hacks:lint
+pnpm nx run ts-clj-hacks:test
+```
+
+These commands call the same Babashka tasks listed above, allowing Nx
+automation and local development to stay in sync.
+
+## Linting and tests
+
+Linting uses `clj-kondo` with configuration sourced from `deps.edn`. Tests rely
+on `cognitect-labs/test-runner`. Suites live in `packages/clj-hacks/test` using
+standard `clojure.test` namespaces.
+
+## Manual follow-up
+
+Verify that team machines have Babashka and the Clojure CLI installed globally
+so the delegated Nx tasks work outside CI.

--- a/packages/clj-hacks/deps.edn
+++ b/packages/clj-hacks/deps.edn
@@ -1,2 +1,14 @@
 {:deps {io.github.bonede/tree-sitter        {:mvn/version "0.25.3"}
-        io.github.bonede/tree-sitter-elisp  {:mvn/version "1.3.0a"}}}
+        io.github.bonede/tree-sitter-elisp  {:mvn/version "1.3.0a"}}
+ :aliases
+ {:lint    {:extra-deps {clj-kondo/clj-kondo {:mvn/version "2024.05.240"}}
+            :main-opts  ["-m" "clj-kondo.main" "--lint" "src" "test"]}
+  :test    {:extra-paths ["test"]
+            :extra-deps {io.github.cognitect-labs/test-runner
+                         {:git/url "https://github.com/cognitect-labs/test-runner"
+                          :git/tag "v0.5.1"
+                          :git/sha "dfb30dd"}}
+            :main-opts  ["-m" "cognitect.test-runner" "-d" "test"]}
+  :compile {:jvm-opts  ["-Dclojure.compile.path=target/classes"]
+            :main-opts ["-e"
+                        "(binding [*compile-path* (System/getProperty \"clojure.compile.path\" \"target/classes\")] (compile 'elisp.read))"]}}}

--- a/packages/clj-hacks/project.json
+++ b/packages/clj-hacks/project.json
@@ -6,30 +6,26 @@
     "build": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "tsc -b",
-        "cwd": "packages/clj-hacks"
+        "command": "bb clj-hacks:build"
       },
-      "outputs": ["{projectRoot}/dist"]
+      "outputs": ["{projectRoot}/target"]
     },
     "typecheck": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "tsc -p tsconfig.json --noEmit",
-        "cwd": "packages/clj-hacks"
+        "command": "bb clj-hacks:lint"
       }
     },
     "test": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "ava",
-        "cwd": "packages/clj-hacks"
+        "command": "bb clj-hacks:test"
       }
     },
     "lint": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "eslint .",
-        "cwd": "packages/clj-hacks"
+        "command": "bb clj-hacks:lint"
       }
     }
   },

--- a/packages/clj-hacks/test/elisp/read_test.clj
+++ b/packages/clj-hacks/test/elisp/read_test.clj
@@ -1,0 +1,25 @@
+(ns elisp.read-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [elisp.read :as sut]))
+
+(deftest parses-simple-list
+  (testing "function application"
+    (is (= [:el/list
+            {:el/type :symbol :name "foo"}
+            42
+            5.5
+            "\"bar\""]
+           (sut/elisp->data "(foo 42 5.5 \"bar\")")))))
+
+(deftest parses-quoted-symbol
+  (testing "quote normalisation"
+    (is (= {:el/type :quote
+            :form {:el/type :symbol :name "baz"}}
+           (sut/elisp->data "'baz")))))
+
+(deftest parses-dotted-pair
+  (testing "cons cells"
+    (is (= {:el/type :cons
+            :car {:el/type :symbol :name "a"}
+            :cdr {:el/type :symbol :name "b"}}
+           (sut/elisp->data "(a . b)")))))


### PR DESCRIPTION
## Summary
- add dedicated Babashka tasks that build, lint, and test the clj-hacks package
- wire the Nx project to those tasks and extend deps.edn with the needed aliases
- document the workflow and add clojure.test coverage for the elisp reader

## Testing
- `bb clj-hacks:lint` *(fails: babashka not installed in execution environment)*
- `clojure -M:lint` *(fails: clojure CLI not installed in execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cd90da8ba48324ab0766d1c8203654