### PR TITLE
feat: share markdown frontmatter helpers

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@promethean/image-link-generator": "workspace:*",
     "@promethean/legacy": "workspace:*",
     "@promethean/level-cache": "workspace:*",
+    "@promethean/markdown": "workspace:*",
     "@promethean/llm-chat-frontend": "workspace:*",
     "@promethean/markdown-graph-frontend": "workspace:*",
     "@promethean/piper": "workspace:*",

--- a/packages/boardrev/package.json
+++ b/packages/boardrev/package.json
@@ -24,6 +24,7 @@
   },
   "dependencies": {
     "@promethean/utils": "workspace:*",
+    "@promethean/markdown": "workspace:*",
     "@promethean/level-cache": "workspace:*",
     "globby": "^14.0.2",
     "gray-matter": "^4.0.3",

--- a/packages/boardrev/tsconfig.json
+++ b/packages/boardrev/tsconfig.json
@@ -1,11 +1,15 @@
 {
-    "extends": "../../config/tsconfig.base.json",
-    "compilerOptions": {
-        "rootDir": "./src",
-        "outDir": "dist",
-        "composite": true,
-        "declaration": true
-    },
-    "include": ["src/**/*", "src/test/**/*.ts"],
-    "references": []
+  "extends": "../../config/tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "dist",
+    "composite": true,
+    "declaration": true
+  },
+  "include": ["src/**/*", "src/test/**/*.ts"],
+  "references": [
+    {
+      "path": "../markdown"
+    }
+  ]
 }

--- a/packages/docops/package.json
+++ b/packages/docops/package.json
@@ -34,6 +34,7 @@
     "yaml": "^2.8.1",
     "zod": "^4.1.5",
     "@promethean/fs": "workspace:*",
+    "@promethean/markdown": "workspace:*",
     "@promethean/utils": "workspace:*",
     "@promethean/docops-frontend": "workspace:*",
     "@promethean/file-indexer": "workspace:*"

--- a/packages/docops/src/01-frontmatter.ts
+++ b/packages/docops/src/01-frontmatter.ts
@@ -4,11 +4,18 @@ import { promises as fs } from "node:fs";
 import * as path from "node:path";
 import { pathToFileURL } from "node:url";
 
-import matter from "gray-matter";
 import { z } from "zod";
 import ollama from "ollama";
 import { scanFiles } from "@promethean/file-indexer";
 import type { IndexedFile, ScanProgress } from "@promethean/file-indexer";
+import {
+  ensureBaselineFrontmatter,
+  mergeFrontmatterWithGenerated,
+  normalizeStringList,
+  parseFrontmatter,
+  stringifyFrontmatter,
+  deriveFilenameFromPath,
+} from "@promethean/markdown/frontmatter";
 
 import { openDB } from "./db.js";
 import { parseArgs, randomUUID } from "./utils.js";
@@ -51,11 +58,6 @@ export async function runFrontmatter(
     valueEncoding: "json",
   });
   const docsKV = db.docs; // from db.ts — { path, title }
-
-  const uniq = (xs: readonly string[] | undefined) =>
-    Array.from(new Set((xs ?? []).map((s) => s.trim()).filter(Boolean)));
-
-  const deriveFilename = (fpath: string) => path.parse(fpath).name;
 
   const buildPrompt = (fpath: string, fm: Front, preview: string) =>
     [
@@ -112,33 +114,6 @@ export async function runFrontmatter(
     return m ? `${m[1]}-${m[2]}-${m[3]}T${m[4]}:${m[5]}:${m[6]}Z` : name;
   };
 
-  const ensureBaseFront = (fpath: string, fm: Front): Front => {
-    const baseName = path.basename(fpath);
-    return Object.freeze<Front>({
-      ...fm,
-      uuid: fm.uuid ?? randomUUID(),
-      created_at: fm.created_at ?? isoFromBasename(baseName),
-    });
-  };
-
-  const mergeFront = (
-    base: Front,
-    gen: Partial<z.infer<typeof GenSchema>>,
-    fpath: string,
-  ): Front => {
-    const filename = base.filename ?? gen.filename ?? deriveFilename(fpath);
-    const description = base.description ?? gen.description ?? "";
-    const tags = base.tags && base.tags.length ? base.tags : uniq(gen.tags);
-    const title = base.title ?? filename;
-    return Object.freeze<Front>({
-      ...base,
-      filename,
-      title,
-      description,
-      tags,
-    });
-  };
-
   const validateGen = (obj: unknown) => {
     const p = GenSchema.safeParse(obj);
     return p.success ? p.data : null;
@@ -147,28 +122,33 @@ export async function runFrontmatter(
   const writeFrontmatter = (fpath: string, content: string, fm: Front) =>
     DRY
       ? Promise.resolve()
-      : fs.writeFile(
-          fpath,
-          matter.stringify(content, fm, { language: "yaml" }),
-          "utf8",
-        );
+      : fs.writeFile(fpath, stringifyFrontmatter(content, fm), "utf8");
 
   const persistKV = (uuid: string, fpath: string, fm: Front) =>
     Promise.all([
       frontKV.put(uuid, fm),
       docsKV.put(uuid, {
         path: fpath,
-        title: fm.title ?? fm.filename ?? deriveFilename(fpath),
+        title: fm.title ?? fm.filename ?? deriveFilenameFromPath(fpath),
       }),
     ]).then(() => undefined);
 
   const processFile = (fpath: string, raw: string) => {
-    const gm = matter(raw);
-    const base = ensureBaseFront(fpath, (gm.data || {}) as Front);
+    const gm = parseFrontmatter<Front>(raw);
+    const base = ensureBaselineFrontmatter(gm.data ?? ({} as Front), {
+      filePath: fpath,
+      uuidFactory: randomUUID,
+      createdAtFactory: ({ filePath }: { filePath?: string }) =>
+        filePath ? isoFromBasename(path.basename(filePath)) : undefined,
+      titleFactory: ({ frontmatter }: { frontmatter: Front }) =>
+        typeof frontmatter.filename === "string"
+          ? frontmatter.filename
+          : undefined,
+    });
     const hasAll =
       Boolean(base.filename) &&
       Boolean(base.description) &&
-      Boolean(base.tags && base.tags.length);
+      Boolean(normalizeStringList(base.tags).length);
 
     const preview = gm.content.slice(0, 4000);
 
@@ -180,15 +160,18 @@ export async function runFrontmatter(
         });
 
     return genP.then((gen) => {
-      const next = mergeFront(base, gen, fpath);
+      const next = mergeFrontmatterWithGenerated(base, gen, {
+        filePath: fpath,
+        descriptionFallback: "",
+      }) as Front;
 
       const changed =
         next.uuid !== (gm.data as Front)?.uuid ||
         next.created_at !== (gm.data as Front)?.created_at ||
         next.filename !== (gm.data as Front)?.filename ||
         next.description !== (gm.data as Front)?.description ||
-        JSON.stringify(uniq(next.tags)) !==
-          JSON.stringify(uniq((gm.data as Front)?.tags));
+        JSON.stringify(normalizeStringList(next.tags)) !==
+          JSON.stringify(normalizeStringList((gm.data as Front)?.tags));
 
       return (
         changed ? writeFrontmatter(fpath, gm.content, next) : Promise.resolve()

--- a/packages/docops/tsconfig.json
+++ b/packages/docops/tsconfig.json
@@ -14,6 +14,12 @@
     },
     {
       "path": "../docops-frontend"
+    },
+    {
+      "path": "../file-indexer"
+    },
+    {
+      "path": "../markdown"
     }
   ]
 }

--- a/packages/markdown/package.json
+++ b/packages/markdown/package.json
@@ -11,6 +11,10 @@
             "import": "./dist/index.js",
             "require": "./dist/index.cjs"
         },
+        "./frontmatter": {
+            "types": "./dist/frontmatter.d.ts",
+            "import": "./dist/frontmatter.js"
+        },
         "./dist/*": "./dist/*",
         "./*": "./dist/*"
     },

--- a/packages/markdown/src/frontmatter.ts
+++ b/packages/markdown/src/frontmatter.ts
@@ -1,0 +1,181 @@
+import { randomUUID as nodeRandomUUID } from 'node:crypto';
+import * as path from 'node:path';
+import matter, { type GrayMatterFile } from 'gray-matter';
+
+export type ParsedMarkdown<T extends Record<string, unknown>> = GrayMatterFile<string> & {
+    readonly data: Readonly<T>;
+};
+
+export type EnsureBaselineOptions<T extends Record<string, unknown>> = {
+    readonly filePath?: string;
+    readonly content?: string;
+    readonly uuidFactory?: () => string;
+    readonly createdAtFactory?: (args: {
+        readonly frontmatter: Readonly<T>;
+        readonly filePath?: string;
+    }) => string | undefined;
+    readonly fallbackCreatedAt?: string;
+    readonly now?: () => string;
+    readonly titleFactory?: (args: {
+        readonly frontmatter: Readonly<T>;
+        readonly filePath?: string;
+        readonly content?: string;
+    }) => string | undefined;
+    readonly fallbackTitle?: string;
+};
+
+export type BaselineFrontmatter = {
+    readonly uuid: string;
+    readonly created_at: string;
+    readonly title: string;
+};
+
+export type MergeGenerated = {
+    readonly filename?: string;
+    readonly description?: string;
+    readonly tags?: readonly string[];
+    readonly title?: string;
+};
+
+export type MergeOptions = {
+    readonly filePath?: string;
+    readonly descriptionFallback?: string;
+    readonly deriveFilename?: (args: { readonly filePath?: string }) => string;
+};
+
+const isNonEmptyString = (value: unknown): value is string => typeof value === 'string' && value.trim().length > 0;
+
+const defaultNow = () => new Date().toISOString();
+
+const defaultUuidFactory = () => nodeRandomUUID();
+
+const defaultTitleFromPath = (filePath?: string) => (filePath ? path.parse(filePath).name : undefined);
+
+const toTrimmed = (value: string) => value.trim();
+
+export const parseFrontmatter = <T extends Record<string, unknown> = Record<string, unknown>>(
+    raw: string,
+): ParsedMarkdown<T> => matter(raw) as ParsedMarkdown<T>;
+
+export const stringifyFrontmatter = <T extends Record<string, unknown>>(
+    content: string,
+    frontmatter: Readonly<T>,
+): string => matter.stringify(content, frontmatter, { language: 'yaml' });
+
+export const normalizeStringList = (values: readonly unknown[] | undefined): string[] =>
+    Array.from(
+        new Set(
+            (values ?? [])
+                .filter((value): value is string => typeof value === 'string')
+                .map(toTrimmed)
+                .filter((value) => value.length > 0),
+        ),
+    );
+
+export const deriveFilenameFromPath = (filePath: string): string => path.parse(filePath).name;
+
+export const ensureBaselineFrontmatter = <T extends Record<string, unknown>>(
+    frontmatter: Readonly<T>,
+    options: EnsureBaselineOptions<T> = {},
+): Readonly<T & BaselineFrontmatter> => {
+    const {
+        filePath,
+        content,
+        uuidFactory = defaultUuidFactory,
+        createdAtFactory,
+        fallbackCreatedAt,
+        now = defaultNow,
+        titleFactory,
+        fallbackTitle,
+    } = options;
+
+    const uuid = isNonEmptyString((frontmatter as Record<string, unknown>).uuid)
+        ? toTrimmed((frontmatter as Record<string, unknown>).uuid as string)
+        : uuidFactory();
+
+    const createdAtFromFront = (frontmatter as Record<string, unknown>).created_at;
+    const createdAt = isNonEmptyString(createdAtFromFront)
+        ? toTrimmed(createdAtFromFront)
+        : (() => {
+              const fromFactory = createdAtFactory?.({ frontmatter, filePath });
+              if (isNonEmptyString(fromFactory)) return toTrimmed(fromFactory);
+              if (isNonEmptyString(fallbackCreatedAt)) return toTrimmed(fallbackCreatedAt);
+              return now();
+          })();
+
+    const title = (() => {
+        const existing = (frontmatter as Record<string, unknown>).title;
+        if (isNonEmptyString(existing)) return toTrimmed(existing);
+        const fromFilename = (frontmatter as Record<string, unknown>).filename;
+        if (isNonEmptyString(fromFilename)) return toTrimmed(fromFilename);
+        const generated = titleFactory?.({ frontmatter, filePath, content });
+        if (isNonEmptyString(generated)) return toTrimmed(generated);
+        if (isNonEmptyString(fallbackTitle)) return toTrimmed(fallbackTitle);
+        const fromPath = defaultTitleFromPath(filePath);
+        return fromPath && fromPath.length > 0 ? fromPath : 'Untitled';
+    })();
+
+    return Object.freeze({
+        ...frontmatter,
+        uuid,
+        created_at: createdAt,
+        title,
+    }) as Readonly<T & BaselineFrontmatter>;
+};
+
+export const mergeFrontmatterWithGenerated = <T extends Record<string, unknown>, G extends MergeGenerated>(
+    base: Readonly<T>,
+    generated: Readonly<G>,
+    options: MergeOptions = {},
+): Readonly<
+    T & {
+        filename: string;
+        title: string;
+        description: string;
+        tags: string[];
+    }
+> => {
+    const { filePath, descriptionFallback = '', deriveFilename } = options;
+
+    const derive =
+        deriveFilename ??
+        ((args: { readonly filePath?: string }) => {
+            if (args.filePath) return deriveFilenameFromPath(args.filePath);
+            return 'untitled';
+        });
+
+    const filenameCandidate = (() => {
+        const fromBase = (base as Record<string, unknown>).filename;
+        if (isNonEmptyString(fromBase)) return toTrimmed(fromBase);
+        if (isNonEmptyString(generated.filename)) return toTrimmed(generated.filename);
+        return derive({ filePath });
+    })();
+
+    const description = (() => {
+        const fromBase = (base as Record<string, unknown>).description;
+        if (isNonEmptyString(fromBase)) return toTrimmed(fromBase);
+        if (isNonEmptyString(generated.description)) return toTrimmed(generated.description);
+        return descriptionFallback;
+    })();
+
+    const baseTags = (base as Record<string, unknown>).tags;
+    const tags =
+        Array.isArray(baseTags) && baseTags.length > 0
+            ? normalizeStringList(baseTags)
+            : normalizeStringList(generated.tags);
+
+    const title = (() => {
+        const fromBase = (base as Record<string, unknown>).title;
+        if (isNonEmptyString(fromBase)) return toTrimmed(fromBase);
+        if (isNonEmptyString(generated.title)) return toTrimmed(generated.title);
+        return filenameCandidate;
+    })();
+
+    return Object.freeze({
+        ...base,
+        filename: filenameCandidate,
+        description,
+        tags,
+        title,
+    });
+};

--- a/packages/markdown/src/tests/frontmatter.test.ts
+++ b/packages/markdown/src/tests/frontmatter.test.ts
@@ -1,0 +1,121 @@
+import test from 'ava';
+import * as path from 'node:path';
+
+import {
+    ensureBaselineFrontmatter,
+    mergeFrontmatterWithGenerated,
+    normalizeStringList,
+    parseFrontmatter,
+    stringifyFrontmatter,
+} from '../frontmatter.js';
+
+test('ensureBaselineFrontmatter uses docops-style created_at fallback', (t) => {
+    type Front = { uuid?: string; created_at?: string; title?: string; filename?: string };
+    const isoFromBasename = (name: string) => {
+        const match = name.match(/(\d{4})\.(\d{2})\.(\d{2})\.(\d{2})\.(\d{2})\.(\d{2})/);
+        if (!match) return undefined;
+        const [, y, m, d, hh, mm, ss] = match;
+        return `${y}-${m}-${d}T${hh}:${mm}:${ss}Z`;
+    };
+
+    const filePath = '/docs/2024.05.10.12.34.56-note.md';
+    const front: Front = { filename: 'Docops Note' };
+    const baseline = ensureBaselineFrontmatter(front, {
+        filePath,
+        uuidFactory: () => 'uuid-123',
+        createdAtFactory: ({ filePath: fp }) => (fp ? isoFromBasename(path.basename(fp)) : undefined),
+    });
+
+    t.deepEqual(baseline, {
+        filename: 'Docops Note',
+        uuid: 'uuid-123',
+        created_at: '2024-05-10T12:34:56Z',
+        title: 'Docops Note',
+    });
+    t.true(Object.isFrozen(baseline));
+});
+
+test('mergeFrontmatterWithGenerated mirrors docops merge behaviour', (t) => {
+    const base = Object.freeze({
+        uuid: 'u-1',
+        created_at: 'ts',
+    });
+
+    const merged = mergeFrontmatterWithGenerated(
+        base,
+        {
+            filename: 'generated-name',
+            description: 'generated description ',
+            tags: ['alpha', 'beta', 'alpha'],
+        },
+        {
+            filePath: '/docs/fallback.md',
+        },
+    );
+
+    t.deepEqual(merged, {
+        uuid: 'u-1',
+        created_at: 'ts',
+        filename: 'generated-name',
+        description: 'generated description',
+        tags: ['alpha', 'beta'],
+        title: 'generated-name',
+    });
+});
+
+test('normalizeStringList trims and dedupes', (t) => {
+    t.deepEqual(normalizeStringList([' a ', 'b', 'a', 1, null as unknown as string]), ['a', 'b']);
+});
+
+test('ensureBaselineFrontmatter reproduces process-unique defaults', (t) => {
+    const baseline = ensureBaselineFrontmatter(
+        {},
+        {
+            filePath: '/docs/example.md',
+            uuidFactory: () => 'unique-uuid',
+            createdAtFactory: ({ filePath: fp }) => (fp ? path.basename(fp) : undefined),
+            fallbackTitle: 'example',
+        },
+    );
+
+    t.deepEqual(baseline, {
+        uuid: 'unique-uuid',
+        created_at: 'example.md',
+        title: 'example',
+    });
+});
+
+test('ensureBaselineFrontmatter layers boardrev-style defaults', (t) => {
+    const baseline = ensureBaselineFrontmatter(
+        {},
+        {
+            filePath: '/tasks/foo-bar.md',
+            uuidFactory: () => 'board-uuid',
+            now: () => '2024-05-11T01:02:03Z',
+            titleFactory: ({ content }) => (content ? content.match(/^#\s+(.+)$/m)?.[1] : undefined),
+            fallbackTitle: 'foo bar',
+            content: '# Task heading\nMore',
+        },
+    );
+
+    t.deepEqual(baseline, {
+        uuid: 'board-uuid',
+        created_at: '2024-05-11T01:02:03Z',
+        title: 'Task heading',
+    });
+});
+
+test('parseFrontmatter and stringifyFrontmatter roundtrip', (t) => {
+    const source = `---\nuuid: u1\ntitle: Sample\n---\nBody`;
+    const parsed = parseFrontmatter(source);
+    t.is(parsed.content.trim(), 'Body');
+    t.deepEqual(parsed.data, { uuid: 'u1', title: 'Sample' });
+
+    const next = stringifyFrontmatter(parsed.content, {
+        ...parsed.data,
+        title: 'Updated',
+    });
+
+    const reparsed = parseFrontmatter(next);
+    t.deepEqual(reparsed.data, { uuid: 'u1', title: 'Updated' });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,6 +31,9 @@ importers:
       '@promethean/llm-chat-frontend':
         specifier: workspace:*
         version: link:packages/llm-chat-frontend
+      '@promethean/markdown':
+        specifier: workspace:*
+        version: link:packages/markdown
       '@promethean/markdown-graph-frontend':
         specifier: workspace:*
         version: link:packages/markdown-graph-frontend
@@ -441,6 +444,9 @@ importers:
       '@promethean/level-cache':
         specifier: workspace:*
         version: link:../level-cache
+      '@promethean/markdown':
+        specifier: workspace:*
+        version: link:../markdown
       '@promethean/utils':
         specifier: workspace:*
         version: link:../utils
@@ -1460,6 +1466,9 @@ importers:
       '@promethean/fs':
         specifier: workspace:*
         version: link:../fs
+      '@promethean/markdown':
+        specifier: workspace:*
+        version: link:../markdown
       '@promethean/utils':
         specifier: workspace:*
         version: link:../utils
@@ -2048,6 +2057,8 @@ importers:
       '@types/ws':
         specifier: ^8.5.9
         version: 8.18.1
+
+  packages/fsm: {}
 
   packages/health:
     dependencies:

--- a/scripts/process-unique.ts
+++ b/scripts/process-unique.ts
@@ -357,8 +357,12 @@ async function main() {
     const baseline = ensureBaselineFrontmatter(originalFront, {
       filePath: f,
       uuidFactory: randomUUID,
-      createdAtFactory: ({ filePath: filePathFromOpts }) =>
-        filePathFromOpts ? path.basename(filePathFromOpts) : undefined,
+      createdAtFactory: ({ filePath: p }) => {
+        if (!p) return undefined;
+        const b = path.basename(p);
+        const m = b.match(/(\d{4})\.(\d{2})\.(\d{2})\.(\d{2})\.(\d{2})\.(\d{2})/);
+        return m ? `${m[1]}-${m[2]}-${m[3]}T${m[4]}:${m[5]}:${m[6]}Z` : undefined;
+      },
       fallbackTitle:
         (typeof originalFront.title === "string" && originalFront.title) ||
         (typeof originalFront.filename === "string" &&


### PR DESCRIPTION
## Summary
- add shared frontmatter utilities in @promethean/markdown with coverage for docops, process-unique, and boardrev baselines
- refactor docops frontmatter CLI, boardrev ensure-fm, and process-unique pipeline to reuse the shared helpers
- register @promethean/markdown as a dependency where needed so scripts and packages compile against the shared utilities

## Testing
- pnpm --filter @promethean/docops test
- pnpm --filter @promethean/boardrev test
- pnpm --filter @promethean/markdown test
- pnpm tsx scripts/process-unique.ts --dir docs/unique --dry-run true --doc-threshold 1 --ref-threshold 1 --gen-model skip --embed-model skip *(fails: Ollama fetch refused)*

------
https://chatgpt.com/codex/tasks/task_e_68cd895d7e048324909d36b9c437649a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Consistent frontmatter handling across projects with automatic title derivation and planned filename updates for cleaner, predictable document names.
  - New exported frontmatter utilities made available for other packages.

- Improvements
  - Immutable, more reliable metadata updates with better change detection, normalized tags, descriptions, and related-document fields.

- Chores
  - Added shared markdown utilities to workspace dependencies and updated project build references.

- Tests
  - Added tests validating parsing, stringifying, normalization, merging, and baseline behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->