### PR TITLE
Fix Hy test task symbol in bb config

### DIFF
--- a/bb.edn
+++ b/bb.edn
@@ -95,6 +95,7 @@
   compile-hy                mk.hy/compile-hy
   test-hy-service           mk.hy/test-hy-service
   test-hy-services          mk.hy/test-hy-services
-  test-hy                   mk.hy/test-hy}
+  test-hy                   mk.hy/test-hy
+ }
 }
 


### PR DESCRIPTION
## Summary
- remove the stray brace from the Hy test task in `bb.edn`
- re-indent the closing braces for the `:tasks` map to make the structure clear

## Testing
- `bb tasks` *(fails: `bb` command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cd97c76cec83248c94925a2f1f3cc5