### PR TITLE
Fix Markdown kanban column handling

### DIFF
--- a/changelog.d/2025.09.20.19.51.06.md
+++ b/changelog.d/2025.09.20.19.51.06.md
@@ -1,0 +1,1 @@
+- Fix kanban column insertion to preserve heading text and keep wiki links unescaped in markdown serialization.

--- a/packages/markdown/src/kanban.ts
+++ b/packages/markdown/src/kanban.ts
@@ -33,7 +33,19 @@ import matter from 'gray-matter';
 import { v4 as uuidv4 } from 'uuid';
 import type { Node, Parent } from 'unist';
 function toString(node: Node): string {
-    return toStringWithNodes(node).text;
+    const result = toStringWithNodes(node).text;
+    if (result && result.trim().length > 0) return result;
+
+    if (typeof (node as any)?.value === 'string') {
+        return (node as any).value as string;
+    }
+
+    const children = (node as any)?.children;
+    if (Array.isArray(children)) {
+        return children.map((child: Node) => toString(child)).join('');
+    }
+
+    return '';
 }
 
 // ---------- Types ----------
@@ -290,7 +302,7 @@ export class MarkdownBoard {
             )}\n\`\`\`\n%%`;
             full = settingsBlock + '\n\n' + full;
         }
-        return full;
+        return full.replace(/\\\[\\\[/g, '[[').replace(/\\\]\]/g, ']]');
     }
 
     // ---------- Internal utilities ----------


### PR DESCRIPTION
## Summary
- ensure MarkdownBoard falls back to nested node text when extracting headings so added columns retain their names
- stop escaping wiki links when serializing kanban boards back to markdown
- log the fix in a new changelog entry

## Testing
- pnpm test (from packages/tests)
- pnpm --filter @promethean/markdown build

------
https://chatgpt.com/codex/tasks/task_e_68cf00ce698483248d25bb433dec0dd2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Inserting a Kanban column no longer alters the heading; original text is preserved.
  * Wiki links remain properly formatted (e.g., [[Page]]) instead of showing escaped brackets in Markdown output.
  * Improved text rendering for nested content, reducing cases where empty or partial text appeared.
* **Documentation**
  * Added changelog entry detailing the Kanban column insertion fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->