### PR TITLE
Fix docops frontmatter tag normalization test

### DIFF
--- a/changelog.d/2025.09.20.23.11.55.md
+++ b/changelog.d/2025.09.20.23.11.55.md
@@ -1,0 +1,1 @@
+- fix docops frontmatter tag normalization helper usage to satisfy TypeScript


### PR DESCRIPTION
## Summary
- reuse the normalizeTags helper when determining whether generated frontmatter differs
- ensure tag comparisons share the helper so the TypeScript build passes for docops

## Testing
- pnpm --filter @promethean/docops test

------
https://chatgpt.com/codex/tasks/task_e_68cf309f34888324b904c7862f21fba5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected frontmatter tag normalization to ensure consistent handling and avoid type issues, improving reliability in doc processing.

* **Refactor**
  * Simplified tag normalization within frontmatter processing for better consistency and maintainability.

* **Documentation**
  * Added a changelog entry describing the fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->