### PR TITLE
Clarify solo developer actions in process step 2

### DIFF
--- a/docs/agile/process.md
+++ b/docs/agile/process.md
@@ -3,8 +3,11 @@
    Find or create the task; never work off-board; do not edit the board file directly—tasks drive the board. &#x20;
 
 2. **Clarify & Scope**
-   
-
+   Anchor on the kanban card as the single source of truth and, before advancing, do the solo pass:
+   * Confirm the desired outcomes so the card reflects the slice you intend to deliver.
+   * Capture acceptance criteria or explicit exit signals on the task so "done" is unambiguous.
+   * Note any uncertainties, risks, or open questions directly on the task to surface follow-ups early.
+   * Record the scoped plan and supporting notes on the linked task before moving to step 3.
 3. **Breakdown & Estimate**
    Break into small, testable slices; estimate **complexity, scale, time (in cloud sessions)** and assign a Fibonacci score. If **13+ ⇒ must split**; **≤5 ⇒ eligible to implement**.&#x20;
 


### PR DESCRIPTION
## Summary
- expand the "Clarify & Scope" step with solo-developer actions that stay anchored to the kanban card
- emphasize confirming outcomes, documenting acceptance criteria, uncertainties, and scoped notes before proceeding

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68cf65c822b0832490383786f267c9a9