### PR TITLE
Clarify estimation guidance in agile process doc

### DIFF
--- a/docs/agile/process.md
+++ b/docs/agile/process.md
@@ -6,7 +6,7 @@
    
 
 3. **Breakdown & Estimate**
-   Break into small, testable slices; estimate **complexity, scale, time (in cloud sessions)** and assign a Fibonacci score. If **13+ ⇒ must split**; **≤5 ⇒ eligible to implement**.&#x20;
+   Break into small, testable slices; estimate **complexity, scale, time (in cloud sessions)** and assign a Fibonacci score from **1, 2, 3, 5, 8, 13** on the task card. Scores of **13+ ⇒ must split**; **8 ⇒ continue refinement before implementation**; **≤5 ⇒ eligible to implement**. Any score **>5** must cycle back through clarification/breakdown until the slice is small enough to implement, capturing the updated score on the task card.&#x20;
 
 4. **Ready Gate** *(hard stop before code)*
    Only proceed if:


### PR DESCRIPTION
## Summary
- detail the Fibonacci scoring options directly in step 3 of the process
- specify that scores of 8 require refinement before implementation and that any score above 5 loops back through clarification/breakdown
- note that task cards should capture the estimate during each refinement cycle

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68cf65c9247c83248dd624c33e720a35

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the Breakdown & Estimate step with explicit Fibonacci scoring options (1, 2, 3, 5, 8, 13) on task cards.
  * Defined handling rules: 13+ must be split; 8 requires additional refinement; ≤5 is eligible for implementation.
  * Any score >5 cycles back through clarification/breakdown until small enough, with the updated score recorded on the task card.
  * Enhances consistency and transparency in estimation and workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->