### PR TITLE
Fix TypeScript build failures across packages

### DIFF
--- a/docs/agile/tasks/fix-build-errors-enso-docops-kanban-webcrawler.md
+++ b/docs/agile/tasks/fix-build-errors-enso-docops-kanban-webcrawler.md
@@ -1,0 +1,100 @@
+---
+task-id: TASK-20240921-buildfix
+title: Fix TypeScript build errors across key packages
+state: InProgress
+prev:
+txn: "2024-09-21T03:30:00Z-0001"
+owner: codex-cloud
+priority: p2
+size: m
+epic: EPC-000
+depends_on: []
+labels:
+  - board:auto
+  - lang:ts
+due:
+links: []
+artifacts: []
+rationale: |
+  The latest Codex Cloud build report shows TypeScript build failures in
+  `@promethean/enso-protocol`, `@promethean/docops`, `@promethean/kanban`, and
+  `@promethean/webcrawler-service`. These prevent `pnpm -r --no-bail build`
+  from succeeding and block downstream automation. We need to correct the
+  regressions so the workspace builds cleanly.
+proposed_transitions:
+  - New->Accepted
+  - Accepted->Breakdown
+  - Breakdown->Ready
+  - Ready->Todo
+  - Todo->InProgress
+  - InProgress->InReview
+  - InReview->Done
+  - InReview->Document
+  - Document->Done
+tags:
+  - task/TASK-20240921-buildfix
+  - board/kanban
+  - state/InProgress
+  - owner/codex-cloud
+  - priority/p2
+  - epic/EPC-000
+---
+<hr class="__chatgpt_plugin">
+
+<span style="font-size: small;"> (llama3.2:latest)</span>
+### role::assistant
+
+Here's a suggested revision of your context section:
+
+## Context
+### Changes and Updates
+- **What changed?**: Codex Cloud nightly build `pnpm -r --no-bail build` now fails in four workspace packages due to TypeScript errors involving unused variables, stricter nullability, and outdated API assumptions.
+- **Where?**: `packages/enso-protocol`, `packages/docops`, `packages/kanban`, `packages/webcrawler-service`.
+- **Why now?**: Build failures block integration work and violate the no-red-build gate for new tasks.
+
+## Inputs / Artifacts
+- docs/reports/codex_cloud/describe/latest/summary.tsv
+- docs/reports/codex_cloud/describe/latest/logs/pnpm-build.out.log
+
+## Definition of Done
+- [ ] `pnpm --filter @promethean/enso-protocol build` succeeds locally.
+- [ ] `pnpm --filter @promethean/docops build` succeeds locally.
+- [ ] `pnpm --filter @promethean/kanban-cli build` succeeds locally.
+- [ ] `pnpm --filter @promethean/webcrawler-service build` succeeds locally.
+- [ ] No new ESLint errors are introduced in touched files.
+- [ ] Codex Cloud build summary aligns with local fixes (documented in PR summary).
+
+## Plan
+1. Reproduce build failures locally for each package and capture the exact compiler diagnostics.
+2. Update code to satisfy TypeScript's strict null and optional property checks without weakening type safety.
+3. Remove or utilize unused variables and align test expectations with actual API responses.
+4. Run targeted builds and eslint on affected files before committing.
+
+## Relevant Resources
+
+You might find [this](link) useful while working on this task.
+
+### Smart Connections Configuration
+```smart-connections
+{
+  "render_markdown": true,
+  "show_full_path": false,
+  "exclude_blocks_from_source_connections": false,
+  "exclude_frontmatter_blocks": true,
+  "expanded_view": false,
+  "results_limit": "20",
+  "exclude_inlinks": false,
+  "exclude_outlinks": false
+}
+```
+
+### Smart ChatGPT Configuration
+```smart-chatgpt
+```
+<hr class="__chatgpt_plugin">
+
+### role::user
+
+fix-build-errors-enso-docops-kanban-webcrawler
+
+<% tp.app.commands.executeCommandById("chatgpt-md:call-chatgpt-api") %>

--- a/packages/docops/src/01-frontmatter.ts
+++ b/packages/docops/src/01-frontmatter.ts
@@ -38,15 +38,6 @@ const GenSchema = z.object({
   tags: z.array(z.string()).min(1),
 });
 
-const toStringArray = (value: unknown): readonly unknown[] | undefined => {
-  if (Array.isArray(value)) return value;
-  if (typeof value === "string") return [value];
-  return undefined;
-};
-
-const normalizeTags = (value: unknown): string[] =>
-  normalizeStringList(toStringArray(value));
-
 export async function runFrontmatter(
   opts: FrontmatterOptions,
   db: DBs,

--- a/packages/enso-protocol/src/client.ts
+++ b/packages/enso-protocol/src/client.ts
@@ -72,13 +72,18 @@ export class EnsoClient {
     hello: HelloCaps,
     adjustment: ServerAdjustment = {},
   ): Promise<void> {
-    this.capabilities = new Set(adjustment.capabilities ?? hello.caps ?? []);
-    this.privacyProfile = adjustment.privacyProfile ?? hello.privacy.profile;
+    const requestedPrivacy = resolveHelloPrivacy(
+      hello,
+      adjustment.privacyProfile,
+    );
+    const negotiatedCaps = adjustment.capabilities ?? hello.caps ?? [];
+    this.capabilities = new Set(negotiatedCaps);
+    this.privacyProfile = adjustment.privacyProfile ?? requestedPrivacy.profile;
     this.connected = true;
     if (adjustment.emitAccepted !== false) {
       const requested: HelloCaps = {
         ...hello,
-        privacy: requestedPrivacy,
+        privacy: { ...requestedPrivacy },
       };
       const envelope = createEnvelope({
         room: "local",

--- a/packages/enso-protocol/src/tests/cli.spec.ts
+++ b/packages/enso-protocol/src/tests/cli.spec.ts
@@ -5,6 +5,7 @@ import { runCliCommand } from "../cli.js";
 import { EnsoClient } from "../client.js";
 import { createStaticCapture } from "../audio.js";
 import type { HelloCaps } from "../types/privacy.js";
+import { resolveHelloPrivacy } from "../types/privacy.js";
 import type { Envelope } from "../types/envelope.js";
 
 function registerDemoSource(registry: ContextRegistry, location: string) {
@@ -136,14 +137,15 @@ test("voice-demo command streams audio and logs agent output", async (t) => {
             sent.push(env);
           },
         });
+        const privacy = resolveHelloPrivacy(options.hello);
         void instance.connect(options.hello, {
           capabilities: options.hello.caps,
-          privacyProfile: options.hello.privacy.profile,
+          privacyProfile: privacy.profile,
           emitAccepted: false,
         });
         instance.receive(
           makeEnvelope("privacy.accepted", "event", {
-            profile: options.hello.privacy.profile,
+            profile: privacy.profile,
             wantsE2E: false,
             negotiatedCaps: options.hello.caps,
           }),

--- a/packages/enso-protocol/src/tests/transport.spec.ts
+++ b/packages/enso-protocol/src/tests/transport.spec.ts
@@ -89,14 +89,14 @@ test("local transport preserves capability enforcement", async (t) => {
   connection.disconnect();
 });
 
-test("local transport defaults privacy profile when omitted", (t) => {
+test("local transport defaults privacy profile when omitted", async (t) => {
   const server = new EnsoServer();
   const client = new EnsoClient(new ContextRegistry());
   const acceptedEvents: Envelope[] = [];
 
   client.on("event:privacy.accepted", (env) => acceptedEvents.push(env));
 
-  const connection = connectLocal(client, server, HELLO_WITHOUT_PRIVACY);
+  const connection = await connectLocal(client, server, HELLO_WITHOUT_PRIVACY);
 
   t.is(connection.accepted.payload.profile, DEFAULT_PRIVACY_PROFILE);
   t.false(connection.accepted.payload.wantsE2E);

--- a/packages/enso-protocol/src/tests/voice-transport.spec.ts
+++ b/packages/enso-protocol/src/tests/voice-transport.spec.ts
@@ -8,6 +8,7 @@ import { EnsoClient } from "../client.js";
 import { EnsoServer } from "../server.js";
 import { connectLocal, connectWebSocket } from "../transport.js";
 import type { HelloCaps } from "../types/privacy.js";
+import { resolveHelloPrivacy } from "../types/privacy.js";
 import type { Envelope } from "../types/envelope.js";
 import type { ChatMessage } from "../types/content.js";
 
@@ -91,11 +92,12 @@ test("websocket transport performs handshake and maintains keepalive", async (t)
         const text = typeof raw === "string" ? raw : raw.toString();
         const frame = decodeFrame(text);
         if (frame.type === "hello") {
+          const requestedPrivacy = resolveHelloPrivacy(HELLO);
           const accepted = createEnvelope({
             kind: "event",
             type: "privacy.accepted",
             payload: {
-              profile: HELLO.privacy.profile,
+              profile: requestedPrivacy.profile,
               wantsE2E: false,
               negotiatedCaps: HELLO.caps,
             },
@@ -200,7 +202,7 @@ test("voice streaming issues flow control events", async (t) => {
     flowEvents.push(env);
   });
 
-  const connection = connectLocal(client, server, HELLO, {
+  const connection = await connectLocal(client, server, HELLO, {
     adjustCapabilities: (caps) =>
       Array.from(new Set([...caps, "can.voice.stream"])),
   });

--- a/packages/kanban/src/lib/kanban.ts
+++ b/packages/kanban/src/lib/kanban.ts
@@ -1,11 +1,6 @@
 import { promises as fs } from "node:fs";
+import { parseFrontmatter as parseMarkdownFrontmatter } from "@promethean/markdown/frontmatter";
 import type { Board, ColumnData, Task } from "./types.js";
-
-/**
- * Use the consolidated markdown lib only; no fallbacks.
- */
-// @ts-ignore
-const mdApi = await import("@promethean/markdown");
 
 const NOW_ISO = () => new Date().toISOString();
 
@@ -84,8 +79,8 @@ const cryptoRandomUUID = (): string =>
 type FM = Record<string, any>;
 
 const parseFrontmatter = (text: string): { fm: FM; body: string } => {
-  const res = mdApi.parseFrontmatter(text);
-  return { fm: res.frontmatter ?? {}, body: res.body || "" };
+  const res = parseMarkdownFrontmatter<FM>(text);
+  return { fm: (res.data ?? {}) as FM, body: res.content || "" };
 };
 
 const taskFromFM = (fm: FM, body: string): Task | null => {

--- a/packages/webcrawler-service/src/tests/webcrawler.integration.test.ts
+++ b/packages/webcrawler-service/src/tests/webcrawler.integration.test.ts
@@ -73,7 +73,10 @@ const createTestServer = async (): Promise<TestServer> => {
 
 const mkOutputDir = () => mkdtemp(join(tmpdir(), "webcrawler-integration-"));
 
-const applyRoutes = (target: TestServer, routes: ReadonlyArray<[string, RouteResponse]>) => {
+const applyRoutes = (
+  target: TestServer,
+  routes: ReadonlyArray<[string, RouteResponse]>,
+) => {
   routes.forEach(([path, response]) => target.setRoute(path, response));
 };
 
@@ -108,7 +111,8 @@ const configureLinkedServers = async () => {
 };
 
 const runLinkedServersScenario = async () => {
-  const { serverA, serverB, serverAHome, serverBPage } = await configureLinkedServers();
+  const { serverA, serverB, serverAHome, serverBPage } =
+    await configureLinkedServers();
 
   const outputDir = await mkOutputDir();
   const crawler = new WebCrawler({
@@ -139,7 +143,7 @@ const runLinkedServersScenario = async () => {
   } as const;
 };
 
-const buildRobotsRoutes = (homeUrl: string): ReadonlyArray<[string, RouteResponse]> => {
+const buildRobotsRoutes = (): ReadonlyArray<[string, RouteResponse]> => {
   return [
     [
       "/robots.txt",
@@ -173,14 +177,18 @@ const buildRobotsRoutes = (homeUrl: string): ReadonlyArray<[string, RouteRespons
 const configureRobotsServer = async () => {
   const server = await createTestServer();
   const homeUrl = `${server.baseUrl}/`;
-  applyRoutes(server, buildRobotsRoutes(homeUrl));
+  applyRoutes(server, buildRobotsRoutes());
   return { server, homeUrl } as const;
 };
 
 const runRobotsScenario = async () => {
   const { server, homeUrl } = await configureRobotsServer();
   const outputDir = await mkOutputDir();
-  await new WebCrawler({ seeds: [homeUrl], outputDir, requestDelayMs: 0 }).crawl();
+  await new WebCrawler({
+    seeds: [homeUrl],
+    outputDir,
+    requestDelayMs: 0,
+  }).crawl();
 
   const hostDir = join(outputDir, new URL(homeUrl).hostname.toLowerCase());
   const files = await readdir(hostDir);


### PR DESCRIPTION
## Summary
- record a Codex Cloud task for the cross-package TypeScript build regressions
- resolve privacy negotiation and handshake defaults in the Enso client/transport and update dependent tests
- remove unused frontmatter helpers, adopt the markdown frontmatter export in kanban, and tighten a webcrawler test helper

## Testing
- pnpm --filter @promethean/enso-protocol build
- pnpm --filter @promethean/docops build
- pnpm --filter @promethean/kanban-cli build
- pnpm --filter @promethean/webcrawler-service build
- pnpm exec eslint --max-warnings=0 packages/docops/src/01-frontmatter.ts packages/enso-protocol/src/client.ts packages/enso-protocol/src/tests/cli.spec.ts packages/enso-protocol/src/tests/transport.spec.ts packages/enso-protocol/src/tests/voice-transport.spec.ts packages/enso-protocol/src/transport.ts packages/kanban/src/lib/kanban.ts packages/webcrawler-service/src/tests/webcrawler.integration.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68cf67d25c2883249cfe736bd14a2f9a