### PR TITLE
Refactor kanban and heartbeat to ECS worlds

### DIFF
--- a/changelog.d/2025.09.21.04.05.07.md
+++ b/changelog.d/2025.09.21.04.05.07.md
@@ -1,0 +1,2 @@
+- Refactored the kanban processor and heartbeat services onto ECS worlds with persistence and broker systems.
+- Fixed heartbeat ECS scheduling, queue publishing, and monitoring so tests pass against in-memory persistence.

--- a/packages/heartbeat/ecs/components.js
+++ b/packages/heartbeat/ecs/components.js
@@ -1,0 +1,28 @@
+export function defineHeartbeatComponents(world) {
+  const MonitoredProcess = world.defineComponent({
+    name: "MonitoredProcess",
+    defaults: () => ({ pid: 0, name: "", sessionId: "", lastHeartbeat: 0 }),
+  });
+
+  const ProcessMetrics = world.defineComponent({
+    name: "ProcessMetrics",
+    defaults: () => ({ cpu: 0, memory: 0, netRx: 0, netTx: 0 }),
+  });
+
+  const KillRequest = world.defineComponent({
+    name: "KillRequest",
+    defaults: () => ({ pid: 0, requestedAt: 0, reason: "" }),
+  });
+
+  const BrokerQueue = world.defineComponent({
+    name: "HeartbeatBrokerQueue",
+    defaults: () => ({ pending: [], version: 0 }),
+  });
+
+  return {
+    MonitoredProcess,
+    ProcessMetrics,
+    KillRequest,
+    BrokerQueue,
+  };
+}

--- a/packages/heartbeat/ecs/helpers.js
+++ b/packages/heartbeat/ecs/helpers.js
@@ -1,0 +1,26 @@
+import fs from "fs";
+import pidusage from "pidusage";
+
+export async function getProcessMetrics(pid) {
+  const metrics = { cpu: 0, memory: 0, netRx: 0, netTx: 0 };
+  try {
+    const { cpu, memory } = await pidusage(pid);
+    metrics.cpu = cpu;
+    metrics.memory = memory;
+  } catch (err) {
+    console.warn(`failed to get cpu/memory for pid ${pid}`, err);
+  }
+  try {
+    const data = fs.readFileSync(`/proc/${pid}/net/dev`, "utf8");
+    for (const line of data.trim().split("\n").slice(2)) {
+      const parts = line.trim().split(/\s+/);
+      if (parts.length >= 17) {
+        metrics.netRx += parseInt(parts[1], 10) || 0;
+        metrics.netTx += parseInt(parts[9], 10) || 0;
+      }
+    }
+  } catch {
+    // ignore network stats errors
+  }
+  return metrics;
+}

--- a/packages/heartbeat/ecs/systems/ingest.js
+++ b/packages/heartbeat/ecs/systems/ingest.js
@@ -1,0 +1,131 @@
+import { getProcessMetrics } from "../helpers.js";
+
+export function createHeartbeatIngestSystem(world, components) {
+  return {
+    name: "heartbeat.ingest",
+    stage: "update",
+    reads: [
+      "incoming",
+      "persistence",
+      "processIndex",
+      "service",
+      "outgoingEvents",
+    ],
+    writes: ["incoming", "processIndex", "service", "outgoingEvents"],
+    writesComponents: [
+      components.MonitoredProcess,
+      components.ProcessMetrics,
+      components.KillRequest,
+    ],
+    async run({ resources, cmd }) {
+      const queue = resources.get("incoming");
+      if (!queue.events.length) return;
+
+      const persistence = resources.get("persistence");
+      if (!persistence.collection && persistence.initPromise) {
+        await persistence.initPromise;
+      }
+      if (!persistence.collection) {
+        return;
+      }
+
+      const processIndex = resources.get("processIndex");
+      const service = resources.get("service");
+      const outgoing = resources.get("outgoingEvents");
+
+      const now = Date.now();
+      const baseQueueLength = outgoing.events.length;
+      const processUpdates = new Map();
+      const metricUpdates = new Map();
+
+      while (queue.events.length) {
+        const event = queue.events.shift();
+        if (!event) break;
+        const pid = parseInt(event.pid, 10);
+        const name = event.name;
+        if (!pid || !name) continue;
+
+        let existing = null;
+        if (typeof persistence.collection.findOne === "function") {
+          existing = await persistence.collection.findOne({
+            pid,
+            sessionId: persistence.sessionId,
+          });
+        } else {
+          const docs = await persistence.collection
+            .find({ pid, sessionId: persistence.sessionId })
+            .toArray();
+          existing = docs[0] ?? null;
+        }
+
+        if (!existing) {
+          const allowed = persistence.allowedInstances[name] ?? Infinity;
+          const count = await persistence.collection.countDocuments({
+            name,
+            sessionId: persistence.sessionId,
+            last: { $gte: now - persistence.heartbeatTimeout },
+            killedAt: { $exists: false },
+          });
+          if (count >= allowed) continue;
+        }
+
+        const metrics = await getProcessMetrics(pid);
+        await persistence.collection.updateOne(
+          { pid },
+          {
+            $set: {
+              pid,
+              last: now,
+              name,
+              sessionId: persistence.sessionId,
+              ...metrics,
+            },
+            $unset: { killedAt: "" },
+          },
+          { upsert: true },
+        );
+
+        let entity = processIndex.byPid.get(pid);
+        if (!entity) {
+          entity = cmd.createEntity();
+          cmd.add(entity, components.MonitoredProcess, {
+            pid,
+            name,
+            sessionId: persistence.sessionId,
+            lastHeartbeat: now,
+          });
+          cmd.add(entity, components.ProcessMetrics, metrics);
+          processIndex.byPid.set(pid, entity);
+        } else {
+          processUpdates.set(entity, {
+            pid,
+            name,
+            sessionId: persistence.sessionId,
+            lastHeartbeat: now,
+          });
+          metricUpdates.set(entity, metrics);
+        }
+
+        if (world.has(entity, components.KillRequest)) {
+          cmd.remove(entity, components.KillRequest);
+        }
+
+        outgoing.events.push({
+          type: "heartbeat.received",
+          payload: { pid, name, metrics, sessionId: persistence.sessionId },
+        });
+      }
+
+      if (outgoing.events.length !== baseQueueLength) {
+        service.dirty = true;
+      }
+
+      for (const [entity, data] of processUpdates) {
+        cmd.set(entity, components.MonitoredProcess, data);
+      }
+      for (const [entity, data] of metricUpdates) {
+        cmd.set(entity, components.ProcessMetrics, data);
+      }
+    },
+  };
+}

--- a/packages/heartbeat/ecs/systems/kill.js
+++ b/packages/heartbeat/ecs/systems/kill.js
@@ -1,0 +1,62 @@
+export function createKillSystem(world, components) {
+  const query = world.makeQuery({
+    all: [components.KillRequest, components.MonitoredProcess],
+  });
+  return {
+    name: "heartbeat.kill",
+    stage: "render",
+    reads: ["persistence", "processIndex", "outgoingEvents"],
+    writes: ["processIndex", "outgoingEvents"],
+    writesComponents: [components.KillRequest],
+    async run({ world: w, resources, cmd }) {
+      const persistence = resources.get("persistence");
+      if (!persistence.collection) return;
+      const processIndex = resources.get("processIndex");
+      const outgoing = resources.get("outgoingEvents");
+
+      for (const [entity, get] of w.iter(query)) {
+        const proc = get(components.MonitoredProcess);
+        const req = get(components.KillRequest);
+        if (!proc || !req) continue;
+
+        const pid = proc.pid;
+        let killed = false;
+        try {
+          try {
+            process.kill(pid, 0);
+          } catch (err) {
+            if (err && err.code === "ESRCH") {
+              killed = true;
+            } else {
+              throw err;
+            }
+          }
+          if (!killed) {
+            process.kill(pid, "SIGKILL");
+            killed = true;
+          }
+        } catch (err) {
+          console.error(`failed to kill pid ${pid}`, err);
+        }
+
+        try {
+          await persistence.collection.updateOne(
+            { pid },
+            { $set: { killedAt: req.requestedAt } },
+          );
+        } catch (err) {
+          console.error("failed to mark kill in persistence", err);
+        }
+
+        outgoing.events.push({
+          type: "heartbeat.killed",
+          payload: { pid, name: proc.name, sessionId: proc.sessionId, killed },
+        });
+
+        cmd.remove(entity, components.KillRequest);
+        processIndex.byPid.delete(pid);
+        cmd.destroyEntity(entity);
+      }
+    },
+  };
+}

--- a/packages/heartbeat/ecs/systems/monitor.js
+++ b/packages/heartbeat/ecs/systems/monitor.js
@@ -1,0 +1,72 @@
+export function createMonitorSystem(world, components) {
+  return {
+    name: "heartbeat.monitor",
+    stage: "late",
+    reads: ["persistence", "timers", "processIndex", "outgoingEvents"],
+    writes: ["timers", "processIndex", "outgoingEvents"],
+    writesComponents: [components.MonitoredProcess, components.KillRequest],
+    async run({ resources, cmd, time = Date.now() }) {
+      const persistence = resources.get("persistence");
+      if (!persistence.collection) return;
+      const timers = resources.get("timers");
+      const processIndex = resources.get("processIndex");
+      const outgoing = resources.get("outgoingEvents");
+
+      const now = time;
+      if (now < timers.nextCheck) return;
+      timers.nextCheck = now + timers.checkInterval;
+
+      let stale = [];
+      try {
+        stale = await persistence.collection
+          .find({
+            last: { $lt: now - persistence.heartbeatTimeout },
+            killedAt: { $exists: false },
+          })
+          .toArray();
+      } catch (err) {
+        console.error("heartbeat monitor query failed", err);
+        return;
+      }
+
+      for (const doc of stale) {
+        const pid = doc.pid;
+        if (!pid) continue;
+        let entity = processIndex.byPid.get(pid);
+        if (!entity) {
+          entity = cmd.createEntity();
+          cmd.add(entity, components.MonitoredProcess, {
+            pid,
+            name: doc.name || "",
+            sessionId: doc.sessionId || persistence.sessionId,
+            lastHeartbeat: doc.last || 0,
+          });
+          processIndex.byPid.set(pid, entity);
+        } else {
+          cmd.set(entity, components.MonitoredProcess, {
+            pid,
+            name: doc.name || "",
+            sessionId: doc.sessionId || persistence.sessionId,
+            lastHeartbeat: doc.last || 0,
+          });
+        }
+
+        const killData = {
+          pid,
+          requestedAt: now,
+          reason: "stale",
+        };
+        if (world.has(entity, components.KillRequest)) {
+          cmd.set(entity, components.KillRequest, killData);
+        } else {
+          cmd.add(entity, components.KillRequest, killData);
+        }
+
+        outgoing.events.push({
+          type: "heartbeat.kill.requested",
+          payload: { pid, name: doc.name, sessionId: doc.sessionId },
+        });
+      }
+    },
+  };
+}

--- a/packages/heartbeat/ecs/systems/persistence.js
+++ b/packages/heartbeat/ecs/systems/persistence.js
@@ -1,0 +1,39 @@
+export function createPersistenceSystem() {
+  return {
+    name: "heartbeat.persistenceInit",
+    stage: "startup",
+    writes: ["persistence"],
+    async run({ resources }) {
+      const persistence = resources.get("persistence");
+      if (persistence.collection) return;
+      if (!persistence.initPromise) {
+        persistence.initPromise = (async () => {
+          try {
+            persistence.client = await persistence.getMongoClient();
+            persistence.collection = persistence.client
+              .db(persistence.dbName)
+              .collection(persistence.collectionName);
+          } catch (err) {
+            console.error("heartbeat persistence init failed", err);
+            persistence.client = null;
+            persistence.collection = null;
+          }
+        })();
+      }
+      try {
+        await persistence.initPromise;
+      } catch (err) {
+        console.error("heartbeat persistence init promise failed", err);
+        persistence.initPromise = null;
+      }
+    },
+  };
+}
+
+export async function closePersistence(persistence) {
+  try {
+    await persistence.client?.close();
+  } catch (err) {
+    console.error("heartbeat mongo close failed", err);
+  }
+}

--- a/packages/heartbeat/ecs/systems/publish.js
+++ b/packages/heartbeat/ecs/systems/publish.js
@@ -1,0 +1,64 @@
+export function createQueueSystem(components) {
+  return {
+    name: "heartbeat.brokerQueue",
+    stage: "cleanup",
+    reads: ["outgoingEvents", "service", "broker"],
+    writes: ["outgoingEvents", "service"],
+    writesComponents: [components.BrokerQueue],
+    run({ resources, world, cmd }) {
+      const outgoing = resources.get("outgoingEvents");
+      if (!outgoing.events.length) return;
+      const service = resources.get("service");
+      const broker = resources.get("broker");
+      const queue = world.get(service.entity, components.BrokerQueue);
+      const hasQueue = Boolean(queue);
+      const basePending =
+        queue && broker.lastPublishedVersion === queue.version
+          ? []
+          : queue?.pending || [];
+      const pending = basePending.concat(outgoing.events);
+      outgoing.events.length = 0;
+      if (!pending.length && !hasQueue) return;
+      const nextVersion = queue ? queue.version + (pending.length ? 1 : 0) : 1;
+      const nextState = {
+        pending,
+        version: nextVersion,
+      };
+      if (hasQueue) {
+        cmd.set(service.entity, components.BrokerQueue, nextState);
+      } else {
+        cmd.add(service.entity, components.BrokerQueue, nextState);
+      }
+    },
+  };
+}
+
+export function createPublishSystem(components) {
+  return {
+    name: "heartbeat.publish",
+    stage: "cleanup",
+    reads: ["broker", "service"],
+    writes: ["broker"],
+    writesComponents: [components.BrokerQueue],
+    after: ["heartbeat.brokerQueue"],
+    async run({ resources, world, cmd }) {
+      const service = resources.get("service");
+      const queue = world.get(service.entity, components.BrokerQueue);
+      if (!queue || !queue.pending.length) return;
+      const broker = resources.get("broker");
+      if (!broker.client) return;
+      let failed = false;
+      for (const event of queue.pending) {
+        try {
+          broker.client.publish(event.type, event.payload);
+        } catch (err) {
+          console.error("heartbeat publish failed", err);
+          failed = true;
+        }
+      }
+      if (failed) return;
+      broker.lastPublishedVersion = queue.version;
+      cmd.remove(service.entity, components.BrokerQueue);
+    },
+  };
+}

--- a/packages/heartbeat/ecs/world.js
+++ b/packages/heartbeat/ecs/world.js
@@ -1,0 +1,101 @@
+import { World } from "@promethean/ds/ecs.js";
+import { Scheduler } from "@promethean/ds/ecs.scheduler.js";
+
+import { defineHeartbeatComponents } from "./components.js";
+import {
+  createPersistenceSystem,
+  closePersistence,
+} from "./systems/persistence.js";
+import { createHeartbeatIngestSystem } from "./systems/ingest.js";
+import { createMonitorSystem } from "./systems/monitor.js";
+import { createKillSystem } from "./systems/kill.js";
+import { createQueueSystem, createPublishSystem } from "./systems/publish.js";
+
+export function createHeartbeatWorld(options) {
+  const world = new World();
+  const scheduler = new Scheduler(world);
+  const components = defineHeartbeatComponents(world);
+
+  const cmd = world.beginTick();
+  const serviceEntity = cmd.createEntity();
+  cmd.add(serviceEntity, components.BrokerQueue);
+  cmd.flush();
+  world.endTick();
+
+  const resources = scheduler.resourcesBag();
+  resources
+    .define("incoming", { events: [] })
+    .define("persistence", {
+      sessionId: options.sessionId,
+      allowedInstances: options.allowedInstances,
+      heartbeatTimeout: options.heartbeatTimeout,
+      dbName: options.dbName,
+      collectionName: options.collectionName,
+      getMongoClient: options.getMongoClient,
+      client: null,
+      collection: null,
+      initPromise: null,
+    })
+    .define("processIndex", { byPid: new Map() })
+    .define("service", { entity: serviceEntity, dirty: false })
+    .define("timers", {
+      nextCheck: Date.now(),
+      checkInterval: options.checkInterval,
+    })
+    .define("outgoingEvents", { events: [] })
+    .define("broker", { client: options.broker, lastPublishedVersion: 0 });
+
+  scheduler
+    .register(createPersistenceSystem())
+    .register(createHeartbeatIngestSystem(world, components))
+    .register(createMonitorSystem(world, components))
+    .register(createKillSystem(world, components))
+    .register(createQueueSystem(components))
+    .register(createPublishSystem(components));
+
+  let lastTime = Date.now();
+  async function run(time = Date.now()) {
+    const dt = time - lastTime;
+    lastTime = time;
+    await scheduler.runFrame(dt, time, { parallel: false });
+  }
+
+  function enqueueHeartbeat(event) {
+    resources.get("incoming").events.push(event);
+  }
+
+  async function forceMonitor(time = Date.now()) {
+    const timers = resources.get("timers");
+    timers.nextCheck = Math.min(timers.nextCheck, time);
+    await run(time);
+    await run(time + 1);
+  }
+
+  async function close() {
+    await closePersistence(resources.get("persistence"));
+  }
+
+  async function cleanup() {
+    const persistence = resources.get("persistence");
+    if (!persistence.collection) return;
+    try {
+      await persistence.collection.updateMany(
+        { sessionId: persistence.sessionId, killedAt: { $exists: false } },
+        { $set: { killedAt: Date.now() } },
+      );
+    } catch (err) {
+      console.error("heartbeat cleanup failed", err);
+    }
+  }
+
+  return {
+    world,
+    scheduler,
+    resources,
+    run,
+    enqueueHeartbeat,
+    forceMonitor,
+    close,
+    cleanup,
+  };
+}

--- a/packages/heartbeat/index.js
+++ b/packages/heartbeat/index.js
@@ -1,10 +1,11 @@
 import { getMongoClient } from "@promethean/persistence/clients.js";
 import { createRequire } from "module";
 import path from "path";
-import fs from "fs";
-import pidusage from "pidusage";
 import { randomUUID } from "crypto";
+import { pathToFileURL } from "url";
 import { BrokerClient } from "@promethean/legacy/brokerClient.js";
+
+import { createHeartbeatWorld } from "./ecs/world.js";
 
 let HEARTBEAT_TIMEOUT = 10000;
 let CHECK_INTERVAL = 5000;
@@ -12,121 +13,58 @@ let DB_NAME = "heartbeat_db";
 let COLLECTION = "heartbeats";
 let BROKER_URL = "ws://127.0.0.1:7000";
 
-let client;
-let collection;
-let interval;
-let broker;
-let allowedInstances = {};
-let SESSION_ID;
-let shuttingDown = false;
-
-async function getProcessMetrics(pid) {
-  const metrics = { cpu: 0, memory: 0, netRx: 0, netTx: 0 };
-  try {
-    const { cpu, memory } = await pidusage(pid);
-    metrics.cpu = cpu;
-    metrics.memory = memory;
-  } catch (err) {
-    console.warn(`failed to get cpu/memory for pid ${pid}`, err);
-  }
-  try {
-    const data = fs.readFileSync(`/proc/${pid}/net/dev`, "utf8");
-    for (const line of data.trim().split("\n").slice(2)) {
-      const parts = line.trim().split(/\s+/);
-      if (parts.length >= 17) {
-        metrics.netRx += parseInt(parts[1], 10) || 0;
-        metrics.netTx += parseInt(parts[9], 10) || 0;
-      }
-    }
-  } catch (err) {
-    // ignore network stats errors
-  }
-  return metrics;
-}
+const state = {
+  world: null,
+  broker: null,
+  interval: null,
+  runChain: Promise.resolve(),
+  sessionId: null,
+  shuttingDown: false,
+};
 
 function loadConfig() {
+  const require = createRequire(import.meta.url);
+  const configPath = process.env.ECOSYSTEM_CONFIG;
+  if (!configPath) return {};
   try {
-    const require = createRequire(import.meta.url);
-    const configPath =
-      process.env.ECOSYSTEM_CONFIG ||
-      path.resolve(process.cwd(), "../../../ecosystem.config.js");
     const ecosystem = require(configPath);
-    allowedInstances = {};
+    const allowed = {};
     for (const app of ecosystem.apps || []) {
       if (app?.name) {
-        allowedInstances[app.name] = app.instances || 1;
+        allowed[app.name] = app.instances || 1;
       }
     }
+    return allowed;
   } catch (err) {
     console.warn("failed to load ecosystem config", err);
-    allowedInstances = {};
+    return {};
   }
 }
 
-async function handleHeartbeat({ pid, name }) {
-  pid = parseInt(pid, 10);
-  if (!pid || !name || !collection) return;
-  const now = Date.now();
-  try {
-    const existing = await collection.findOne({ pid, sessionId: SESSION_ID });
-    if (!existing) {
-      const allowed = allowedInstances[name] ?? Infinity;
-      const count = await collection.countDocuments({
-        name,
-        sessionId: SESSION_ID,
-        last: { $gte: now - HEARTBEAT_TIMEOUT },
-        killedAt: { $exists: false },
-      });
-      if (count >= allowed) return;
-    }
-    const metrics = await getProcessMetrics(pid);
-    await collection.updateOne(
-      { pid },
-      {
-        $set: { last: now, name, sessionId: SESSION_ID, ...metrics },
-        $unset: { killedAt: "" },
-      },
-      { upsert: true },
-    );
-  } catch {
-    /* swallow processing errors */
-  }
-}
-
-export async function monitor(now = Date.now()) {
-  if (!collection) return;
-  let stale = [];
-  try {
-    stale = await collection
-      .find({
-        last: { $lt: now - HEARTBEAT_TIMEOUT },
-        killedAt: { $exists: false },
-      })
-      .toArray();
-  } catch {
-    return;
-  }
-  for (const doc of stale) {
+function queueRun(time = Date.now()) {
+  if (!state.world) return Promise.resolve();
+  const scheduled = time;
+  state.runChain = state.runChain.then(async () => {
     try {
-      // Preflight: if process does not exist, mark killed without logging noise
-      try {
-        process.kill(doc.pid, 0);
-      } catch (e) {
-        if (e && e.code === "ESRCH") {
-          await collection.updateOne(
-            { pid: doc.pid },
-            { $set: { killedAt: now } },
-          );
-          continue;
-        }
-      }
-      process.kill(doc.pid, "SIGKILL");
+      await state.world.run(scheduled);
     } catch (err) {
-      console.error(`failed to kill pid ${doc.pid}`, err);
-    } finally {
-      await collection.updateOne({ pid: doc.pid }, { $set: { killedAt: now } });
+      console.error("heartbeat frame failed", err);
     }
-  }
+  });
+  return state.runChain;
+}
+
+function queueForceMonitor(time = Date.now()) {
+  if (!state.world) return Promise.resolve();
+  const scheduled = time;
+  state.runChain = state.runChain.then(async () => {
+    try {
+      await state.world.forceMonitor(scheduled);
+    } catch (err) {
+      console.error("heartbeat monitor failed", err);
+    }
+  });
+  return state.runChain;
 }
 
 export async function start() {
@@ -136,69 +74,70 @@ export async function start() {
   COLLECTION = process.env.COLLECTION || COLLECTION;
   BROKER_URL = process.env.BROKER_URL || BROKER_URL;
 
-  loadConfig();
+  const allowedInstances = loadConfig();
+  state.sessionId = randomUUID();
 
-  SESSION_ID = randomUUID();
+  const broker = new BrokerClient({ url: BROKER_URL });
+  const world = createHeartbeatWorld({
+    sessionId: state.sessionId,
+    allowedInstances,
+    heartbeatTimeout: HEARTBEAT_TIMEOUT,
+    checkInterval: CHECK_INTERVAL,
+    dbName: DB_NAME,
+    collectionName: COLLECTION,
+    getMongoClient,
+    broker,
+  });
 
-  client = await getMongoClient();
-  collection = client.db(DB_NAME).collection(COLLECTION);
-  broker = new BrokerClient({ url: BROKER_URL });
+  state.world = world;
+  state.broker = broker;
+  await queueRun();
+
   await broker.connect();
   broker.subscribe("heartbeat", (event) => {
-    handleHeartbeat(event.payload || {}).catch(() => {});
+    if (!state.world) return;
+    state.world.enqueueHeartbeat(event.payload || {});
+    queueRun();
   });
-  interval = setInterval(() => {
-    monitor().catch(() => {});
+
+  state.interval = setInterval(() => {
+    queueRun();
   }, CHECK_INTERVAL);
 }
 
+export async function monitor(now = Date.now()) {
+  await queueForceMonitor(now);
+}
+
 export async function cleanup() {
-  if (collection) {
-    const now = Date.now();
-    try {
-      await collection.updateMany(
-        { sessionId: SESSION_ID, killedAt: { $exists: false } },
-        { $set: { killedAt: now } },
-      );
-    } catch {
-      /* ignore cleanup errors */
-    }
+  await state.runChain;
+  if (state.world) {
+    await state.world.cleanup();
   }
 }
 
 export async function stop() {
   await cleanup();
-  if (interval) {
-    clearInterval(interval);
-    interval = null;
+  if (state.interval) {
+    clearInterval(state.interval);
+    state.interval = null;
   }
-  if (broker) {
+  if (state.broker) {
     try {
-      broker.disconnect();
+      state.broker.disconnect();
     } catch {}
-    broker = null;
+    state.broker = null;
   }
-  if (client) {
-    try {
-      await client.close();
-    } catch {
-      /* ignore errors from closing */
-    }
-    client = null;
-    collection = null;
+  if (state.world) {
+    await state.world.close();
+    state.world = null;
   }
-}
-
-if (process.env.NODE_ENV !== "test") {
-  start().catch((err) => {
-    console.error("Failed to start service", err);
-    process.exit(1);
-  });
+  state.runChain = Promise.resolve();
 }
 
 async function handleSignal() {
-  if (shuttingDown) return;
-  shuttingDown = true;
+  if (state.shuttingDown) return;
+  state.shuttingDown = true;
   await stop();
   process.exit(0);
 }
@@ -210,3 +149,21 @@ for (const sig of ["SIGINT", "SIGTERM"]) {
 process.on("beforeExit", () => {
   cleanup().catch(() => {});
 });
+
+if (process.env.NODE_ENV !== "test") {
+  const entry = process.argv[1];
+  const isMain = () => {
+    if (!entry) return false;
+    try {
+      return pathToFileURL(path.resolve(entry)).href === import.meta.url;
+    } catch {
+      return false;
+    }
+  };
+  if (isMain()) {
+    start().catch((err) => {
+      console.error("Failed to start service", err);
+      process.exit(1);
+    });
+  }
+}

--- a/packages/heartbeat/package.json
+++ b/packages/heartbeat/package.json
@@ -10,6 +10,7 @@
     "lint": "eslint -c ../eslint.config.js ."
   },
   "dependencies": {
+    "@promethean/ds": "workspace:*",
     "@promethean/legacy": "workspace:*",
     "@promethean/persistence": "workspace:*",
     "@types/node": "^24.3.0",

--- a/packages/kanban-processor/package.json
+++ b/packages/kanban-processor/package.json
@@ -15,6 +15,7 @@
     "format": "prettier --cache --write . && eslint . --fix --cache || true"
   },
   "dependencies": {
+    "@promethean/ds": "workspace:*",
     "@promethean/legacy": "workspace:*",
     "@promethean/markdown": "file:../markdown",
     "@promethean/persistence": "file:../persistence",

--- a/packages/kanban-processor/src/ecs/components.ts
+++ b/packages/kanban-processor/src/ecs/components.ts
@@ -1,0 +1,73 @@
+import type { World } from "@promethean/ds/ecs.js";
+
+export type KanbanCard = {
+  id: string;
+  title: string;
+  column: string;
+  link: string;
+};
+
+export type BoardSnapshotState = {
+  version: number;
+  source: "none" | "board" | "tasks";
+  updatedAt: number;
+  cards: KanbanCard[];
+};
+
+export type TaskDiffState = {
+  version: number;
+  events: { type: string; payload: any }[];
+  upserts: KanbanCard[];
+};
+
+export type BrokerQueueState = {
+  lastVersion: number;
+  pending: { type: string; payload: any }[];
+};
+
+export type PreviousState = {
+  map: Record<string, KanbanCard>;
+};
+
+export const defineKanbanComponents = (w: World) => {
+  const BoardSnapshot = w.defineComponent<BoardSnapshotState>({
+    name: "BoardSnapshot",
+    defaults: () => ({
+      version: 0,
+      source: "none" as const,
+      updatedAt: 0,
+      cards: [],
+    }),
+  });
+
+  const TaskDiff = w.defineComponent<TaskDiffState>({
+    name: "TaskDiff",
+    defaults: () => ({
+      version: 0,
+      events: [],
+      upserts: [],
+    }),
+  });
+
+  const BrokerQueue = w.defineComponent<BrokerQueueState>({
+    name: "BrokerQueue",
+    defaults: () => ({
+      lastVersion: 0,
+      pending: [],
+    }),
+  });
+
+  const PreviousCards = w.defineComponent<PreviousState>({
+    name: "PreviousCards",
+    defaults: () => ({
+      map: {},
+    }),
+  });
+
+  return {
+    BoardSnapshot,
+    TaskDiff,
+    BrokerQueue,
+    PreviousCards,
+  };
+};

--- a/packages/kanban-processor/src/ecs/systems/diff.ts
+++ b/packages/kanban-processor/src/ecs/systems/diff.ts
@@ -1,0 +1,82 @@
+import type {
+  SystemSpec,
+  SystemContext,
+} from "@promethean/ds/ecs.scheduler.js";
+
+import type {
+  KanbanCard,
+  BoardSnapshotState,
+  TaskDiffState,
+  PreviousState,
+} from "../components.js";
+import { EVENTS } from "./filesystem.js";
+
+export function createDiffSystem(
+  components: {
+    BoardSnapshot: any;
+    TaskDiff: any;
+    PreviousCards: any;
+  },
+  entity: number,
+): SystemSpec {
+  return {
+    name: "kanban.diff",
+    stage: "late",
+    readsComponents: [components.BoardSnapshot, components.PreviousCards],
+    writesComponents: [components.TaskDiff, components.PreviousCards],
+    run({ world, cmd }: SystemContext) {
+      const snapshot = world.get(entity, components.BoardSnapshot) as
+        | BoardSnapshotState
+        | undefined;
+      if (!snapshot || snapshot.version === 0) return;
+
+      const currentDiff = world.get(entity, components.TaskDiff) as
+        | TaskDiffState
+        | undefined;
+      if (currentDiff && currentDiff.version === snapshot.version) return;
+
+      const previous =
+        (world.get(entity, components.PreviousCards) as
+          | PreviousState
+          | undefined) ||
+        ({ map: {} as Record<string, KanbanCard> } as PreviousState);
+
+      const nextMap: Record<string, KanbanCard> = {};
+      const events: { type: string; payload: any }[] = [];
+
+      for (const card of snapshot.cards) {
+        nextMap[card.id] = card;
+        const prev = previous.map[card.id];
+        if (!prev) {
+          events.push({ type: EVENTS.cardCreated, payload: card });
+          continue;
+        }
+        if (prev.column !== card.column) {
+          events.push({
+            type: EVENTS.cardMoved,
+            payload: { id: card.id, from: prev.column, to: card.column },
+          });
+        }
+        if (prev.title !== card.title) {
+          events.push({
+            type: EVENTS.cardRenamed,
+            payload: { id: card.id, from: prev.title, to: card.title },
+          });
+        }
+        if (prev.link !== card.link) {
+          events.push({
+            type: EVENTS.cardTaskChanged,
+            payload: { id: card.id, from: prev.link, to: card.link },
+          });
+        }
+      }
+
+      cmd.set(entity, components.TaskDiff, {
+        version: snapshot.version,
+        events,
+        upserts: snapshot.cards,
+      });
+      cmd.set(entity, components.PreviousCards, { map: nextMap });
+    },
+  };
+}

--- a/packages/kanban-processor/src/ecs/systems/filesystem.ts
+++ b/packages/kanban-processor/src/ecs/systems/filesystem.ts
@@ -1,0 +1,224 @@
+import { join } from "path";
+import { readFile, readdir, stat, writeFile } from "fs/promises";
+import crypto from "crypto";
+
+import type {
+  SystemSpec,
+  SystemContext,
+} from "@promethean/ds/ecs.scheduler.js";
+import { MarkdownBoard } from "@promethean/markdown/kanban.js";
+import { syncBoardStatuses } from "@promethean/markdown/sync.js";
+import { MarkdownTask } from "@promethean/markdown/task.js";
+import { STATUS_ORDER, STATUS_SET } from "@promethean/markdown/statuses.js";
+
+import type { KanbanCard } from "../components.js";
+
+export type FileEvent = { kind: "board" | "tasks" };
+
+export type FileResources = {
+  queue: FileEvent[];
+  ignoreBoard: boolean;
+  ignoreTasks: boolean;
+  timers: NodeJS.Timeout[];
+};
+
+type PathResources = {
+  boardPath: string;
+  tasksPath: string;
+};
+
+type FlagResources = {
+  disable: boolean;
+};
+
+export const EVENTS = {
+  boardChange: "file-watcher-board-change",
+  taskAdd: "file-watcher-task-add",
+  taskChange: "file-watcher-task-change",
+  cardCreated: "kanban-card-created",
+  cardMoved: "kanban-card-moved",
+  cardRenamed: "kanban-card-renamed",
+  cardTaskChanged: "kanban-card-task-changed",
+} as const;
+
+function firstWiki(cardLinks: string[] | undefined): string | null {
+  if (!cardLinks || cardLinks.length === 0) return null;
+  const raw = cardLinks[0]!;
+  return raw.split("|")[0]!.split("#")[0]!.trim();
+}
+
+async function boardToCards(
+  board: any,
+  tasksDir: string,
+): Promise<KanbanCard[]> {
+  const out: KanbanCard[] = [];
+  for (const col of board.listColumns()) {
+    for (const c of board.listCards(col.name)) {
+      const title = c.text || firstWiki(c.links) || c.id;
+      const file = firstWiki(c.links) || "";
+      const link = file
+        ? join("..", "tasks", encodeURI(file)).replace(/\\/g, "/")
+        : "";
+      if (file) {
+        try {
+          const content = await readFile(join(tasksDir, file), "utf8");
+          const task = await MarkdownTask.load(content);
+          const id = task.getId() || "";
+          out.push({ id: id || c.id, title, column: col.name, link });
+          continue;
+        } catch {
+          // ignore missing task files
+        }
+      }
+      out.push({ id: c.id, title, column: col.name, link });
+    }
+  }
+  return out;
+}
+
+async function buildBoardFromTasks(board: any, tasksDir: string) {
+  const entries = await readdir(tasksDir);
+  const tasks: { file: string; id: string; title: string; status: string }[] =
+    [];
+  for (const name of entries) {
+    const p = join(tasksDir, name);
+    const st = await stat(p).catch(() => null as any);
+    if (!st || !st.isFile()) continue;
+    if (!name.toLowerCase().endsWith(".md")) continue;
+    const text = await readFile(p, "utf8");
+    const t = await MarkdownTask.load(text);
+    const id = t.getId() || crypto.randomUUID();
+    const title = t.getTitle() || name;
+    const tags = t.getHashtags();
+    const status = tags.find((x: string) => STATUS_SET.has(x)) || "#todo";
+    tasks.push({ file: name, id, title, status });
+  }
+
+  const statusToCards = new Map<
+    string,
+    { id: string; text: string; link: string }[]
+  >();
+  for (const s of STATUS_ORDER) statusToCards.set(s, []);
+  for (const t of tasks) {
+    const link = `${t.file}|${t.title}`;
+    const arr = statusToCards.get(t.status) || statusToCards.get("#todo")!;
+    arr.push({ id: t.id, text: t.title, link });
+  }
+
+  for (const col of board.listColumns()) {
+    if (!STATUS_SET.has(`#${col.name.toLowerCase().replace(/\s+/g, "-")}`))
+      continue;
+    const current = board.listCards(col.name);
+    for (const c of current) board.removeCard(col.name, c.id);
+  }
+
+  for (const col of board.listColumns()) {
+    const status = `#${col.name.toLowerCase().replace(/\s+/g, "-")}`;
+    const items = statusToCards.get(status);
+    if (!items) continue;
+    for (const it of items) {
+      board.addCard(col.name, {
+        id: it.id,
+        text: it.text,
+        links: [it.link],
+        done: false,
+        tags: [status],
+      });
+    }
+  }
+}
+
+async function writeBoardFile(
+  path: string,
+  lines: string[],
+  modified: boolean,
+) {
+  if (!modified) return;
+  await writeFile(path, lines.join("\n"));
+}
+
+export function createFilesystemSystem(
+  components: { BoardSnapshot: any },
+  entity: number,
+): SystemSpec {
+  return {
+    name: "kanban.filesystem",
+    stage: "update",
+    reads: ["fs", "paths", "flags"],
+    writesComponents: [components.BoardSnapshot],
+    async run({ resources, cmd, world }: SystemContext) {
+      const flags = resources.get("flags") as FlagResources;
+      if (flags.disable) return;
+
+      const fsRes = resources.get("fs") as FileResources;
+      if (!fsRes.queue.length) return;
+
+      const paths = resources.get("paths") as PathResources;
+
+      const event = fsRes.queue.shift()!;
+      if (event.kind === "board" && fsRes.ignoreBoard) {
+        fsRes.ignoreBoard = false;
+        return;
+      }
+      if (event.kind === "tasks" && fsRes.ignoreTasks) {
+        fsRes.ignoreTasks = false;
+        return;
+      }
+
+      const now = Date.now();
+      const snapshot =
+        world.get(entity, components.BoardSnapshot) ||
+        components.BoardSnapshot.defaults?.();
+
+      try {
+        const text = await readFile(paths.boardPath, "utf8");
+        const board = await MarkdownBoard.load(text);
+
+        if (event.kind === "board") {
+          fsRes.ignoreTasks = true;
+          const changed = await syncBoardStatuses(board, {
+            tasksDir: paths.tasksPath,
+            createMissingTasks: true,
+          });
+          const nextMd = await board.toMarkdown();
+          await writeBoardFile(paths.boardPath, nextMd.split(/\r?\n/), changed);
+          const cards = await boardToCards(board, paths.tasksPath);
+          cmd.set(entity, components.BoardSnapshot, {
+            version: (snapshot?.version ?? 0) + 1,
+            source: "board",
+            updatedAt: now,
+            cards,
+          });
+          const taskTimer = setTimeout(() => {
+            fsRes.ignoreTasks = false;
+            fsRes.timers = fsRes.timers.filter((t) => t !== taskTimer);
+          }, 500);
+          fsRes.timers.push(taskTimer);
+        } else {
+          fsRes.ignoreBoard = true;
+          await buildBoardFromTasks(board, paths.tasksPath);
+          await syncBoardStatuses(board, {
+            tasksDir: paths.tasksPath,
+            createMissingTasks: false,
+          });
+          const nextMd = await board.toMarkdown();
+          await writeBoardFile(paths.boardPath, nextMd.split(/\r?\n/), true);
+          const cards = await boardToCards(board, paths.tasksPath);
+          cmd.set(entity, components.BoardSnapshot, {
+            version: (snapshot?.version ?? 0) + 1,
+            source: "tasks",
+            updatedAt: now,
+            cards,
+          });
+          const boardTimer = setTimeout(() => {
+            fsRes.ignoreBoard = false;
+            fsRes.timers = fsRes.timers.filter((t) => t !== boardTimer);
+          }, 500);
+          fsRes.timers.push(boardTimer);
+        }
+      } catch (err) {
+        console.error("kanban filesystem system failed", err);
+      }
+    },
+  };
+}

--- a/packages/kanban-processor/src/ecs/systems/persistence.ts
+++ b/packages/kanban-processor/src/ecs/systems/persistence.ts
@@ -1,0 +1,86 @@
+import type { MongoClient } from "mongodb";
+import type {
+  SystemSpec,
+  SystemContext,
+} from "@promethean/ds/ecs.scheduler.js";
+
+import type { KanbanCard } from "../components.js";
+
+export type PersistenceResource = {
+  context: any;
+  getMongoClient: () => Promise<MongoClient>;
+  store: any | null;
+  mongoClient: MongoClient | null;
+  initPromise: Promise<void> | null;
+  lastVersion: number;
+};
+
+export function createPersistenceSystem(
+  components: { TaskDiff: any },
+  entity: number,
+): SystemSpec {
+  return {
+    name: "kanban.persistence",
+    stage: "render",
+    reads: ["persistence"],
+    writes: ["persistence"],
+    readsComponents: [components.TaskDiff],
+    async run({ resources, world }: SystemContext) {
+      const persistence = resources.get("persistence") as PersistenceResource;
+      if (!persistence.store) {
+        if (!persistence.initPromise) {
+          persistence.initPromise = (async () => {
+            try {
+              persistence.mongoClient = await persistence.getMongoClient();
+              persistence.store = await persistence.context.createCollection(
+                "kanban",
+                "title",
+                "updatedAt",
+              );
+            } catch (err) {
+              console.error("kanban persistence init failed", err);
+              persistence.mongoClient = null;
+              persistence.store = null;
+            }
+          })();
+        }
+        try {
+          await persistence.initPromise;
+        } catch (err) {
+          console.error("kanban persistence init promise failed", err);
+          persistence.initPromise = null;
+          return;
+        }
+      }
+      if (!persistence.store) return;
+
+      const diff = world.get(entity, components.TaskDiff) as
+        | { version: number; upserts: KanbanCard[] }
+        | undefined;
+      if (!diff || diff.version === 0) return;
+      if (persistence.lastVersion === diff.version) return;
+
+      for (const card of diff.upserts) {
+        try {
+          await persistence.store.mongoCollection.updateOne(
+            { id: card.id },
+            { $set: card },
+            { upsert: true },
+          );
+        } catch (err) {
+          console.error("kanban persistence update failed", err);
+        }
+      }
+
+      persistence.lastVersion = diff.version;
+    },
+  };
+}
+
+export async function closePersistence(persistence: PersistenceResource) {
+  try {
+    await persistence.mongoClient?.close();
+  } catch (err) {
+    console.error("kanban mongo close failed", err);
+  }
+}

--- a/packages/kanban-processor/src/ecs/systems/publish.ts
+++ b/packages/kanban-processor/src/ecs/systems/publish.ts
@@ -1,0 +1,77 @@
+import type {
+  SystemSpec,
+  SystemContext,
+} from "@promethean/ds/ecs.scheduler.js";
+
+export type BrokerResource = {
+  client: { publish(type: string, payload: any): void } | null;
+};
+
+type BrokerQueueComponent = {
+  lastVersion: number;
+  pending: { type: string; payload: any }[];
+};
+
+export function createQueueSystem(
+  components: { TaskDiff: any; BrokerQueue: any },
+  entity: number,
+): SystemSpec {
+  return {
+    name: "kanban.queue",
+    stage: "render",
+    readsComponents: [components.TaskDiff, components.BrokerQueue],
+    writesComponents: [components.BrokerQueue],
+    run({ world, cmd }: SystemContext) {
+      const diff = world.get(entity, components.TaskDiff) as
+        | { version: number; events: { type: string; payload: any }[] }
+        | undefined;
+      if (!diff || diff.version === 0) return;
+
+      const queue =
+        (world.get(entity, components.BrokerQueue) as
+          | BrokerQueueComponent
+          | undefined) || components.BrokerQueue.defaults?.();
+      if (!queue) return;
+      if (queue.lastVersion === diff.version) return;
+
+      cmd.set(entity, components.BrokerQueue, {
+        lastVersion: diff.version,
+        pending: diff.events.slice(),
+      });
+    },
+  };
+}
+
+export function createPublishSystem(
+  components: { BrokerQueue: any },
+  entity: number,
+): SystemSpec {
+  return {
+    name: "kanban.publish",
+    stage: "cleanup",
+    reads: ["broker"],
+    writesComponents: [components.BrokerQueue],
+    async run({ resources, world, cmd }: SystemContext) {
+      const queue = world.get(entity, components.BrokerQueue) as
+        | BrokerQueueComponent
+        | undefined;
+      if (!queue || queue.pending.length === 0) return;
+
+      const broker = resources.get("broker") as BrokerResource;
+      if (!broker.client) return;
+
+      for (const event of queue.pending) {
+        try {
+          broker.client.publish(event.type, event.payload);
+        } catch (err) {
+          console.error("kanban publish failed", err);
+        }
+      }
+
+      cmd.set(entity, components.BrokerQueue, {
+        lastVersion: queue.lastVersion,
+        pending: [],
+      });
+    },
+  };
+}

--- a/packages/kanban-processor/src/ecs/world.ts
+++ b/packages/kanban-processor/src/ecs/world.ts
@@ -1,0 +1,119 @@
+import { World } from "@promethean/ds/ecs.js";
+import { Scheduler, ResourceBag } from "@promethean/ds/ecs.scheduler.js";
+
+import { defineKanbanComponents } from "./components.js";
+import {
+  createFilesystemSystem,
+  type FileEvent,
+  type FileResources,
+} from "./systems/filesystem.js";
+import { createDiffSystem } from "./systems/diff.js";
+import {
+  createPersistenceSystem,
+  type PersistenceResource,
+  closePersistence,
+} from "./systems/persistence.js";
+import { createPublishSystem, createQueueSystem } from "./systems/publish.js";
+
+export type KanbanWorldOptions = {
+  boardPath: string;
+  tasksPath: string;
+  contextStore: any;
+  getMongoClient: () => Promise<any>;
+  broker: { publish(type: string, payload: any): void } | null;
+  disabled?: boolean;
+};
+
+export type KanbanWorld = {
+  enqueue(event: FileEvent): void;
+  run(): Promise<void>;
+  close(): Promise<void>;
+  resources: ResourceBag;
+  scheduler: Scheduler;
+};
+
+export function createKanbanWorld(options: KanbanWorldOptions): KanbanWorld {
+  const world = new World();
+  const scheduler = new Scheduler(world);
+  const C = defineKanbanComponents(world);
+
+  const cmd = world.beginTick();
+  const entity = cmd.createEntity();
+  cmd.add(entity, C.BoardSnapshot);
+  cmd.add(entity, C.TaskDiff);
+  cmd.add(entity, C.BrokerQueue);
+  cmd.add(entity, C.PreviousCards);
+  cmd.flush();
+  world.endTick();
+
+  const resources = scheduler.resourcesBag();
+  const fsRes: FileResources = {
+    queue: [],
+    ignoreBoard: false,
+    ignoreTasks: false,
+    timers: [],
+  };
+  resources.define("fs", fsRes);
+  resources.define("paths", {
+    boardPath: options.boardPath,
+    tasksPath: options.tasksPath,
+  });
+  resources.define("flags", { disable: options.disabled ?? false });
+  const persistence: PersistenceResource = {
+    context: options.contextStore,
+    getMongoClient: options.getMongoClient,
+    store: null,
+    mongoClient: null,
+    initPromise: null,
+    lastVersion: 0,
+  };
+  resources.define("persistence", persistence);
+  resources.define("broker", { client: options.broker });
+
+  scheduler
+    .register(
+      createFilesystemSystem({ BoardSnapshot: C.BoardSnapshot }, entity),
+    )
+    .register(
+      createDiffSystem(
+        {
+          BoardSnapshot: C.BoardSnapshot,
+          TaskDiff: C.TaskDiff,
+          PreviousCards: C.PreviousCards,
+        },
+        entity,
+      ),
+    )
+    .register(createPersistenceSystem({ TaskDiff: C.TaskDiff }, entity))
+    .register(
+      createQueueSystem(
+        { TaskDiff: C.TaskDiff, BrokerQueue: C.BrokerQueue },
+        entity,
+      ),
+    )
+    .register(createPublishSystem({ BrokerQueue: C.BrokerQueue }, entity));
+
+  let lastTime = Date.now();
+  async function run(time = Date.now()) {
+    const dt = time - lastTime;
+    lastTime = time;
+    await scheduler.runFrame(dt, time, { parallel: false });
+  }
+
+  function enqueue(event: FileEvent) {
+    fsRes.queue.push(event);
+  }
+
+  async function close() {
+    for (const timer of fsRes.timers.splice(0)) clearTimeout(timer);
+    await closePersistence(persistence);
+  }
+
+  return {
+    enqueue,
+    run,
+    close,
+    resources,
+    scheduler,
+  };
+}

--- a/packages/kanban-processor/src/index.ts
+++ b/packages/kanban-processor/src/index.ts
@@ -1,300 +1,53 @@
-import {
-  // dirname,
-  join,
-} from "path";
-import { readdir, readFile, stat, writeFile } from "fs/promises";
-import crypto from "crypto";
+import { join } from "path";
 
 import { ContextStore } from "@promethean/persistence/contextStore.js";
-// DualStoreManager types resolved at runtime; avoid compile-time coupling
 import { getMongoClient } from "@promethean/persistence/clients.js";
 import type { MongoClient } from "mongodb";
-// @ts-ignore
+// @ts-ignore legacy broker typing
 import { BrokerClient } from "@promethean/legacy/brokerClient.js";
-import { MarkdownBoard } from "@promethean/markdown/kanban.js";
-import { syncBoardStatuses } from "@promethean/markdown/sync.js";
-import { MarkdownTask } from "@promethean/markdown/task.js";
-import { STATUS_SET, STATUS_ORDER } from "@promethean/markdown/statuses.js";
 
-const EVENTS = {
-  boardChange: "file-watcher-board-change",
-  taskAdd: "file-watcher-task-add",
-  taskChange: "file-watcher-task-change",
-  cardCreated: "kanban-card-created",
-  cardMoved: "kanban-card-moved",
-  cardRenamed: "kanban-card-renamed",
-  cardTaskChanged: "kanban-card-task-changed",
-};
-
-type KanbanCard = {
-  id: string;
-  title: string;
-  column: string;
-  link: string;
-};
+import { createKanbanWorld } from "./ecs/world.js";
+import { EVENTS, type FileResources } from "./ecs/systems/filesystem.js";
 
 const defaultRepoRoot = process.env.REPO_ROOT || "";
 
-// async function loadBoard(path: string): Promise<string[]> {
-//   const text = await readFile(path, "utf8");
-//   return text.split(/\r?\n/);
-// }
+export type KanbanProcessorHandle = {
+  close(): Promise<void>;
+  world: ReturnType<typeof createKanbanWorld>;
+  broker: any;
+};
 
-// async function ensureTaskFile(
-//   tasksPath: string,
-//   title: string,
-// ): Promise<{ id: string; link: string }> {
-//   const id = crypto.randomUUID();
-//   const filename = `${title.replace(/[<>:\"/\\|?*]/g, "-")}.md`;
-//   const filePath = join(tasksPath, filename);
-//   await writeFile(filePath, `id: ${id}\n`);
-//   const rel = join("..", "tasks", encodeURI(filename)).replace(/\\/g, "/");
-//   return { id, link: rel };
-// }
-
-function firstWiki(cardLinks: string[] | undefined): string | null {
-  if (!cardLinks || cardLinks.length === 0) return null;
-  const raw = cardLinks[0]!;
-  return raw.split("|")[0]!.split("#")[0]!.trim();
-}
-
-async function boardToCards(
-  board: any,
-  tasksDir: string,
-): Promise<KanbanCard[]> {
-  const out: KanbanCard[] = [];
-  for (const col of board.listColumns()) {
-    for (const c of board.listCards(col.name)) {
-      // title from card.text
-      const title = c.text || firstWiki(c.links) || c.id;
-      const file = firstWiki(c.links) || "";
-      const link = file
-        ? join("..", "tasks", encodeURI(file)).replace(/\\/g, "/")
-        : "";
-      // ensure id in target task file
-      if (file) {
-        try {
-          const content = await readFile(join(tasksDir, file), "utf8");
-          const task = await MarkdownTask.load(content);
-          const id = task.getId() || "";
-          out.push({ id: id || c.id, title, column: col.name, link });
-          continue;
-        } catch {
-          // fallthrough
-        }
-      }
-      out.push({ id: c.id, title, column: col.name, link });
-    }
-  }
-  return out;
-}
-
-async function buildBoardFromTasks(board: any, tasksDir: string) {
-  // Build status -> items map
-  const entries = await readdir(tasksDir);
-  const tasks: { file: string; id: string; title: string; status: string }[] =
-    [];
-  for (const name of entries) {
-    const p = join(tasksDir, name);
-    const st = await stat(p).catch(() => null as any);
-    if (!st || !st.isFile()) continue;
-    if (!name.toLowerCase().endsWith(".md")) continue;
-    const text = await readFile(p, "utf8");
-    const t = await MarkdownTask.load(text);
-    const id = t.getId() || crypto.randomUUID();
-    const title = t.getTitle() || name;
-    const tags = t.getHashtags();
-    const status = tags.find((x: string) => STATUS_SET.has(x)) || "#todo";
-    tasks.push({ file: name, id, title, status });
-  }
-
-  // Ensure status columns exist and replace their cards
-  const statusToCards = new Map<
-    string,
-    { id: string; text: string; link: string }[]
-  >();
-  for (const s of STATUS_ORDER) statusToCards.set(s, []);
-  for (const t of tasks) {
-    const link = `${t.file}|${t.title}`;
-    const arr = statusToCards.get(t.status) || statusToCards.get("#todo")!;
-    arr.push({ id: t.id, text: t.title, link });
-  }
-
-  // remove existing status cards from the board
-  for (const col of board.listColumns()) {
-    if (!STATUS_SET.has(`#${col.name.toLowerCase().replace(/\s+/g, "-")}`))
-      continue;
-    const current = board.listCards(col.name);
-    for (const c of current) board.removeCard(col.name, c.id);
-  }
-
-  // add back cards according to grouping
-  for (const col of board.listColumns()) {
-    const status = `#${col.name.toLowerCase().replace(/\s+/g, "-")}`;
-    const items = statusToCards.get(status);
-    if (!items) continue;
-    for (const it of items) {
-      board.addCard(col.name, {
-        id: it.id,
-        text: it.text,
-        links: [it.link],
-        done: false,
-        tags: [status],
-      });
-    }
-  }
-}
-
-async function writeBoardFile(
-  path: string,
-  lines: string[],
-  modified: boolean,
-) {
-  if (modified) {
-    await writeFile(path, lines.join("\n"));
-  }
-}
-
-async function projectState(
-  cards: KanbanCard[],
-  previous: Record<string, KanbanCard>,
-  publish: (type: string, payload: any) => void,
-  store: any | null,
-): Promise<Record<string, KanbanCard>> {
-  const current: Record<string, KanbanCard> = {};
-  for (const card of cards) {
-    current[card.id] = card;
-    if (store) {
-      await store.mongoCollection.updateOne(
-        { id: card.id } as any,
-        { $set: card as any },
-        { upsert: true },
-      );
-    }
-    const prev = previous[card.id];
-    if (!prev) {
-      publish(EVENTS.cardCreated, card);
-    } else {
-      if (prev.column !== card.column) {
-        publish(EVENTS.cardMoved, {
-          id: card.id,
-          from: prev.column,
-          to: card.column,
-        });
-      }
-      if (prev.title !== card.title) {
-        publish(EVENTS.cardRenamed, {
-          id: card.id,
-          from: prev.title,
-          to: card.title,
-        });
-      }
-      if (prev.link !== card.link) {
-        publish(EVENTS.cardTaskChanged, {
-          id: card.id,
-          from: prev.link,
-          to: card.link,
-        });
-      }
-    }
-  }
-  return current;
-}
-
-export function startKanbanProcessor(repoRoot = defaultRepoRoot) {
+export function startKanbanProcessor(
+  repoRoot = defaultRepoRoot,
+): KanbanProcessorHandle {
   const boardPath = join(repoRoot, "docs", "agile", "boards", "kanban.md");
   const tasksPath = join(repoRoot, "docs", "agile", "tasks");
-  // const boardDir = dirname(boardPath);
 
   const ctx = new ContextStore();
-  let kanbanStore: any | null = null;
-  let mongoClient: MongoClient | null = null;
-  if (process.env.NODE_ENV !== "test") {
-    getMongoClient()
-      .then((client: any) => {
-        mongoClient = client;
-        return ctx.createCollection("kanban", "title", "updatedAt");
-      })
-      .then((store: any) => {
-        kanbanStore = store;
-      })
-      .catch((err: unknown) => console.error("dual store init failed", err));
-  }
-
   const brokerUrl = process.env.BROKER_URL || "ws://localhost:7000";
   const broker = new BrokerClient({ url: brokerUrl, id: "kanban-processor" });
+
+  const world = createKanbanWorld({
+    boardPath,
+    tasksPath,
+    contextStore: ctx,
+    getMongoClient: () => getMongoClient() as Promise<MongoClient>,
+    broker,
+    disabled: process.env.KANBAN_DISABLE_PROCESS === "1",
+  });
+
   const QUEUE = "kanban-processor";
+  let running = Promise.resolve();
 
-  let previousState: Record<string, KanbanCard> = {};
-  let ignoreBoard = false;
-  let ignoreTasks = false;
-
-  function publish(type: string, payload: any) {
-    broker.publish(type, payload);
-  }
-
-  async function handleBoardChange() {
-    if (process.env.KANBAN_DISABLE_PROCESS === "1") {
-      return;
-    }
-    if (ignoreBoard) {
-      ignoreBoard = false;
-      return;
-    }
-    ignoreTasks = true;
-    try {
-      const text = await readFile(boardPath, "utf8");
-      const board = await MarkdownBoard.load(text);
-      const changed = await syncBoardStatuses(board, {
-        tasksDir: tasksPath,
-        createMissingTasks: true,
-      });
-      const nextMd = await board.toMarkdown();
-      await writeBoardFile(boardPath, nextMd.split(/\r?\n/), changed);
-      const cards = await boardToCards(board, tasksPath);
-      previousState = await projectState(
-        cards,
-        previousState,
-        publish,
-        kanbanStore,
-      );
-    } catch (err) {
-      console.error("processKanban failed", err);
-    } finally {
-      setTimeout(() => {
-        ignoreTasks = false;
-      }, 500);
-    }
-  }
-
-  async function handleTasksChange() {
-    if (process.env.KANBAN_DISABLE_PROCESS === "1") {
-      return;
-    }
-    if (ignoreTasks) return;
-    ignoreBoard = true;
-    try {
-      // Rebuild board sections from tasks while preserving settings/frontmatter
-      const text = await readFile(boardPath, "utf8");
-      const board = await MarkdownBoard.load(text);
-      await buildBoardFromTasks(board, tasksPath);
-      const changed = await syncBoardStatuses(board, {
-        tasksDir: tasksPath,
-        createMissingTasks: false,
-      });
-      const nextMd = await board.toMarkdown();
-      await writeBoardFile(boardPath, nextMd.split(/\r?\n/), true || changed);
-      const cards = await boardToCards(board, tasksPath);
-      previousState = await projectState(
-        cards,
-        previousState,
-        publish,
-        kanbanStore,
-      );
-    } catch (err) {
-      console.error("updateBoard failed", err);
-    }
-  }
+  const drain = () => {
+    running = running.then(async () => {
+      const fsRes = world.resources.get("fs") as FileResources;
+      while (fsRes.queue.length) {
+        await world.run();
+      }
+    });
+    return running;
+  };
 
   broker
     .connect()
@@ -314,23 +67,23 @@ export function startKanbanProcessor(repoRoot = defaultRepoRoot) {
     .catch((err: unknown) => console.error("broker connect failed", err));
 
   broker.onTaskReceived((task: any) => {
-    const kind = task.payload?.kind;
-    const fn = kind === "tasks" ? handleTasksChange : handleBoardChange;
-    fn().finally(() => {
-      broker.ack(task.id);
-      broker.ready(QUEUE);
-    });
+    const kind = task.payload?.kind === "tasks" ? "tasks" : "board";
+    world.enqueue({ kind });
+    drain()
+      .catch((err) => console.error("kanban frame failed", err))
+      .finally(() => {
+        broker.ack(task.id);
+        broker.ready(QUEUE);
+      });
   });
 
   return {
     async close() {
       broker.socket?.close();
-      try {
-        await mongoClient?.close();
-      } catch (err) {
-        console.error("mongo close failed", err);
-      }
+      await world.close();
     },
+    world,
+    broker,
   };
 }
 

--- a/packages/kanban-processor/tsconfig.json
+++ b/packages/kanban-processor/tsconfig.json
@@ -24,6 +24,8 @@
     "baseUrl": ".",
     "paths": {
       "@shared/js/*": ["../../js/*"],
+      "@promethean/ds": ["../ds/dist/index"],
+      "@promethean/ds/*": ["../ds/dist/*"],
       "@promethean/persistence": ["../persistence/dist/index"],
       "@promethean/persistence/*": ["../persistence/dist/*"],
       "@promethean/markdown": ["../markdown/dist/index"],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2205,6 +2205,9 @@ importers:
 
   packages/heartbeat:
     dependencies:
+      '@promethean/ds':
+        specifier: workspace:*
+        version: link:../ds
       '@promethean/legacy':
         specifier: workspace:*
         version: link:../legacy
@@ -2454,8 +2457,17 @@ importers:
         specifier: ^5.4.0
         version: 5.9.2
 
+  packages/kanban-cli:
+    dependencies:
+      '@promethean/markdown':
+        specifier: workspace:*
+        version: link:../markdown
+
   packages/kanban-processor:
     dependencies:
+      '@promethean/ds':
+        specifier: workspace:*
+        version: link:../ds
       '@promethean/legacy':
         specifier: workspace:*
         version: link:../legacy
@@ -15286,7 +15298,7 @@ snapshots:
 
   axios@1.11.0:
     dependencies:
-      follow-redirects: 1.15.11(debug@4.4.3)
+      follow-redirects: 1.15.11(debug@4.3.7)
       form-data: 4.0.4
       proxy-from-env: 1.1.0
     transitivePeerDependencies:
@@ -17796,7 +17808,7 @@ snapshots:
   http-proxy@1.18.1:
     dependencies:
       eventemitter3: 4.0.7
-      follow-redirects: 1.15.11(debug@4.4.3)
+      follow-redirects: 1.15.11(debug@4.3.7)
       requires-port: 1.0.0
     transitivePeerDependencies:
       - debug

--- a/services/js/heartbeat/ecs/components.js
+++ b/services/js/heartbeat/ecs/components.js
@@ -1,0 +1,28 @@
+export function defineHeartbeatComponents(world) {
+  const MonitoredProcess = world.defineComponent({
+    name: "MonitoredProcess",
+    defaults: () => ({ pid: 0, name: "", sessionId: "", lastHeartbeat: 0 }),
+  });
+
+  const ProcessMetrics = world.defineComponent({
+    name: "ProcessMetrics",
+    defaults: () => ({ cpu: 0, memory: 0, netRx: 0, netTx: 0 }),
+  });
+
+  const KillRequest = world.defineComponent({
+    name: "KillRequest",
+    defaults: () => ({ pid: 0, requestedAt: 0, reason: "" }),
+  });
+
+  const BrokerQueue = world.defineComponent({
+    name: "HeartbeatBrokerQueue",
+    defaults: () => ({ pending: [], version: 0 }),
+  });
+
+  return {
+    MonitoredProcess,
+    ProcessMetrics,
+    KillRequest,
+    BrokerQueue,
+  };
+}

--- a/services/js/heartbeat/ecs/helpers.js
+++ b/services/js/heartbeat/ecs/helpers.js
@@ -1,0 +1,26 @@
+import fs from "fs";
+import pidusage from "pidusage";
+
+export async function getProcessMetrics(pid) {
+  const metrics = { cpu: 0, memory: 0, netRx: 0, netTx: 0 };
+  try {
+    const { cpu, memory } = await pidusage(pid);
+    metrics.cpu = cpu;
+    metrics.memory = memory;
+  } catch (err) {
+    console.warn(`failed to get cpu/memory for pid ${pid}`, err);
+  }
+  try {
+    const data = fs.readFileSync(`/proc/${pid}/net/dev`, "utf8");
+    for (const line of data.trim().split("\n").slice(2)) {
+      const parts = line.trim().split(/\s+/);
+      if (parts.length >= 17) {
+        metrics.netRx += parseInt(parts[1], 10) || 0;
+        metrics.netTx += parseInt(parts[9], 10) || 0;
+      }
+    }
+  } catch {
+    // ignore network stats errors
+  }
+  return metrics;
+}

--- a/services/js/heartbeat/ecs/systems/ingest.js
+++ b/services/js/heartbeat/ecs/systems/ingest.js
@@ -1,0 +1,131 @@
+import { getProcessMetrics } from "../helpers.js";
+
+export function createHeartbeatIngestSystem(world, components) {
+  return {
+    name: "heartbeat.ingest",
+    stage: "update",
+    reads: [
+      "incoming",
+      "persistence",
+      "processIndex",
+      "service",
+      "outgoingEvents",
+    ],
+    writes: ["incoming", "processIndex", "service", "outgoingEvents"],
+    writesComponents: [
+      components.MonitoredProcess,
+      components.ProcessMetrics,
+      components.KillRequest,
+    ],
+    async run({ resources, cmd }) {
+      const queue = resources.get("incoming");
+      if (!queue.events.length) return;
+
+      const persistence = resources.get("persistence");
+      if (!persistence.collection && persistence.initPromise) {
+        await persistence.initPromise;
+      }
+      if (!persistence.collection) {
+        return;
+      }
+
+      const processIndex = resources.get("processIndex");
+      const service = resources.get("service");
+      const outgoing = resources.get("outgoingEvents");
+
+      const now = Date.now();
+      const baseQueueLength = outgoing.events.length;
+      const processUpdates = new Map();
+      const metricUpdates = new Map();
+
+      while (queue.events.length) {
+        const event = queue.events.shift();
+        if (!event) break;
+        const pid = parseInt(event.pid, 10);
+        const name = event.name;
+        if (!pid || !name) continue;
+
+        let existing = null;
+        if (typeof persistence.collection.findOne === "function") {
+          existing = await persistence.collection.findOne({
+            pid,
+            sessionId: persistence.sessionId,
+          });
+        } else {
+          const docs = await persistence.collection
+            .find({ pid, sessionId: persistence.sessionId })
+            .toArray();
+          existing = docs[0] ?? null;
+        }
+
+        if (!existing) {
+          const allowed = persistence.allowedInstances[name] ?? Infinity;
+          const count = await persistence.collection.countDocuments({
+            name,
+            sessionId: persistence.sessionId,
+            last: { $gte: now - persistence.heartbeatTimeout },
+            killedAt: { $exists: false },
+          });
+          if (count >= allowed) continue;
+        }
+
+        const metrics = await getProcessMetrics(pid);
+        await persistence.collection.updateOne(
+          { pid },
+          {
+            $set: {
+              pid,
+              last: now,
+              name,
+              sessionId: persistence.sessionId,
+              ...metrics,
+            },
+            $unset: { killedAt: "" },
+          },
+          { upsert: true },
+        );
+
+        let entity = processIndex.byPid.get(pid);
+        if (!entity) {
+          entity = cmd.createEntity();
+          cmd.add(entity, components.MonitoredProcess, {
+            pid,
+            name,
+            sessionId: persistence.sessionId,
+            lastHeartbeat: now,
+          });
+          cmd.add(entity, components.ProcessMetrics, metrics);
+          processIndex.byPid.set(pid, entity);
+        } else {
+          processUpdates.set(entity, {
+            pid,
+            name,
+            sessionId: persistence.sessionId,
+            lastHeartbeat: now,
+          });
+          metricUpdates.set(entity, metrics);
+        }
+
+        if (world.has(entity, components.KillRequest)) {
+          cmd.remove(entity, components.KillRequest);
+        }
+
+        outgoing.events.push({
+          type: "heartbeat.received",
+          payload: { pid, name, metrics, sessionId: persistence.sessionId },
+        });
+      }
+
+      if (outgoing.events.length !== baseQueueLength) {
+        service.dirty = true;
+      }
+
+      for (const [entity, data] of processUpdates) {
+        cmd.set(entity, components.MonitoredProcess, data);
+      }
+      for (const [entity, data] of metricUpdates) {
+        cmd.set(entity, components.ProcessMetrics, data);
+      }
+    },
+  };
+}

--- a/services/js/heartbeat/ecs/systems/kill.js
+++ b/services/js/heartbeat/ecs/systems/kill.js
@@ -1,0 +1,62 @@
+export function createKillSystem(world, components) {
+  const query = world.makeQuery({
+    all: [components.KillRequest, components.MonitoredProcess],
+  });
+  return {
+    name: "heartbeat.kill",
+    stage: "render",
+    reads: ["persistence", "processIndex", "outgoingEvents"],
+    writes: ["processIndex", "outgoingEvents"],
+    writesComponents: [components.KillRequest],
+    async run({ world: w, resources, cmd }) {
+      const persistence = resources.get("persistence");
+      if (!persistence.collection) return;
+      const processIndex = resources.get("processIndex");
+      const outgoing = resources.get("outgoingEvents");
+
+      for (const [entity, get] of w.iter(query)) {
+        const proc = get(components.MonitoredProcess);
+        const req = get(components.KillRequest);
+        if (!proc || !req) continue;
+
+        const pid = proc.pid;
+        let killed = false;
+        try {
+          try {
+            process.kill(pid, 0);
+          } catch (err) {
+            if (err && err.code === "ESRCH") {
+              killed = true;
+            } else {
+              throw err;
+            }
+          }
+          if (!killed) {
+            process.kill(pid, "SIGKILL");
+            killed = true;
+          }
+        } catch (err) {
+          console.error(`failed to kill pid ${pid}`, err);
+        }
+
+        try {
+          await persistence.collection.updateOne(
+            { pid },
+            { $set: { killedAt: req.requestedAt } },
+          );
+        } catch (err) {
+          console.error("failed to mark kill in persistence", err);
+        }
+
+        outgoing.events.push({
+          type: "heartbeat.killed",
+          payload: { pid, name: proc.name, sessionId: proc.sessionId, killed },
+        });
+
+        cmd.remove(entity, components.KillRequest);
+        processIndex.byPid.delete(pid);
+        cmd.destroyEntity(entity);
+      }
+    },
+  };
+}

--- a/services/js/heartbeat/ecs/systems/monitor.js
+++ b/services/js/heartbeat/ecs/systems/monitor.js
@@ -1,0 +1,72 @@
+export function createMonitorSystem(world, components) {
+  return {
+    name: "heartbeat.monitor",
+    stage: "late",
+    reads: ["persistence", "timers", "processIndex", "outgoingEvents"],
+    writes: ["timers", "processIndex", "outgoingEvents"],
+    writesComponents: [components.MonitoredProcess, components.KillRequest],
+    async run({ resources, cmd, time = Date.now() }) {
+      const persistence = resources.get("persistence");
+      if (!persistence.collection) return;
+      const timers = resources.get("timers");
+      const processIndex = resources.get("processIndex");
+      const outgoing = resources.get("outgoingEvents");
+
+      const now = time;
+      if (now < timers.nextCheck) return;
+      timers.nextCheck = now + timers.checkInterval;
+
+      let stale = [];
+      try {
+        stale = await persistence.collection
+          .find({
+            last: { $lt: now - persistence.heartbeatTimeout },
+            killedAt: { $exists: false },
+          })
+          .toArray();
+      } catch (err) {
+        console.error("heartbeat monitor query failed", err);
+        return;
+      }
+
+      for (const doc of stale) {
+        const pid = doc.pid;
+        if (!pid) continue;
+        let entity = processIndex.byPid.get(pid);
+        if (!entity) {
+          entity = cmd.createEntity();
+          cmd.add(entity, components.MonitoredProcess, {
+            pid,
+            name: doc.name || "",
+            sessionId: doc.sessionId || persistence.sessionId,
+            lastHeartbeat: doc.last || 0,
+          });
+          processIndex.byPid.set(pid, entity);
+        } else {
+          cmd.set(entity, components.MonitoredProcess, {
+            pid,
+            name: doc.name || "",
+            sessionId: doc.sessionId || persistence.sessionId,
+            lastHeartbeat: doc.last || 0,
+          });
+        }
+
+        const killData = {
+          pid,
+          requestedAt: now,
+          reason: "stale",
+        };
+        if (world.has(entity, components.KillRequest)) {
+          cmd.set(entity, components.KillRequest, killData);
+        } else {
+          cmd.add(entity, components.KillRequest, killData);
+        }
+
+        outgoing.events.push({
+          type: "heartbeat.kill.requested",
+          payload: { pid, name: doc.name, sessionId: doc.sessionId },
+        });
+      }
+    },
+  };
+}

--- a/services/js/heartbeat/ecs/systems/persistence.js
+++ b/services/js/heartbeat/ecs/systems/persistence.js
@@ -1,0 +1,39 @@
+export function createPersistenceSystem() {
+  return {
+    name: "heartbeat.persistenceInit",
+    stage: "startup",
+    writes: ["persistence"],
+    async run({ resources }) {
+      const persistence = resources.get("persistence");
+      if (persistence.collection) return;
+      if (!persistence.initPromise) {
+        persistence.initPromise = (async () => {
+          try {
+            persistence.client = await persistence.getMongoClient();
+            persistence.collection = persistence.client
+              .db(persistence.dbName)
+              .collection(persistence.collectionName);
+          } catch (err) {
+            console.error("heartbeat persistence init failed", err);
+            persistence.client = null;
+            persistence.collection = null;
+          }
+        })();
+      }
+      try {
+        await persistence.initPromise;
+      } catch (err) {
+        console.error("heartbeat persistence init promise failed", err);
+        persistence.initPromise = null;
+      }
+    },
+  };
+}
+
+export async function closePersistence(persistence) {
+  try {
+    await persistence.client?.close();
+  } catch (err) {
+    console.error("heartbeat mongo close failed", err);
+  }
+}

--- a/services/js/heartbeat/ecs/systems/publish.js
+++ b/services/js/heartbeat/ecs/systems/publish.js
@@ -1,0 +1,64 @@
+export function createQueueSystem(components) {
+  return {
+    name: "heartbeat.brokerQueue",
+    stage: "cleanup",
+    reads: ["outgoingEvents", "service", "broker"],
+    writes: ["outgoingEvents", "service"],
+    writesComponents: [components.BrokerQueue],
+    run({ resources, world, cmd }) {
+      const outgoing = resources.get("outgoingEvents");
+      if (!outgoing.events.length) return;
+      const service = resources.get("service");
+      const broker = resources.get("broker");
+      const queue = world.get(service.entity, components.BrokerQueue);
+      const hasQueue = Boolean(queue);
+      const basePending =
+        queue && broker.lastPublishedVersion === queue.version
+          ? []
+          : queue?.pending || [];
+      const pending = basePending.concat(outgoing.events);
+      outgoing.events.length = 0;
+      if (!pending.length && !hasQueue) return;
+      const nextVersion = queue ? queue.version + (pending.length ? 1 : 0) : 1;
+      const nextState = {
+        pending,
+        version: nextVersion,
+      };
+      if (hasQueue) {
+        cmd.set(service.entity, components.BrokerQueue, nextState);
+      } else {
+        cmd.add(service.entity, components.BrokerQueue, nextState);
+      }
+    },
+  };
+}
+
+export function createPublishSystem(components) {
+  return {
+    name: "heartbeat.publish",
+    stage: "cleanup",
+    reads: ["broker", "service"],
+    writes: ["broker"],
+    writesComponents: [components.BrokerQueue],
+    after: ["heartbeat.brokerQueue"],
+    async run({ resources, world, cmd }) {
+      const service = resources.get("service");
+      const queue = world.get(service.entity, components.BrokerQueue);
+      if (!queue || !queue.pending.length) return;
+      const broker = resources.get("broker");
+      if (!broker.client) return;
+      let failed = false;
+      for (const event of queue.pending) {
+        try {
+          broker.client.publish(event.type, event.payload);
+        } catch (err) {
+          console.error("heartbeat publish failed", err);
+          failed = true;
+        }
+      }
+      if (failed) return;
+      broker.lastPublishedVersion = queue.version;
+      cmd.remove(service.entity, components.BrokerQueue);
+    },
+  };
+}

--- a/services/js/heartbeat/ecs/world.js
+++ b/services/js/heartbeat/ecs/world.js
@@ -1,0 +1,101 @@
+import { World } from "@promethean/ds/ecs.js";
+import { Scheduler } from "@promethean/ds/ecs.scheduler.js";
+
+import { defineHeartbeatComponents } from "./components.js";
+import {
+  createPersistenceSystem,
+  closePersistence,
+} from "./systems/persistence.js";
+import { createHeartbeatIngestSystem } from "./systems/ingest.js";
+import { createMonitorSystem } from "./systems/monitor.js";
+import { createKillSystem } from "./systems/kill.js";
+import { createQueueSystem, createPublishSystem } from "./systems/publish.js";
+
+export function createHeartbeatWorld(options) {
+  const world = new World();
+  const scheduler = new Scheduler(world);
+  const components = defineHeartbeatComponents(world);
+
+  const cmd = world.beginTick();
+  const serviceEntity = cmd.createEntity();
+  cmd.add(serviceEntity, components.BrokerQueue);
+  cmd.flush();
+  world.endTick();
+
+  const resources = scheduler.resourcesBag();
+  resources
+    .define("incoming", { events: [] })
+    .define("persistence", {
+      sessionId: options.sessionId,
+      allowedInstances: options.allowedInstances,
+      heartbeatTimeout: options.heartbeatTimeout,
+      dbName: options.dbName,
+      collectionName: options.collectionName,
+      getMongoClient: options.getMongoClient,
+      client: null,
+      collection: null,
+      initPromise: null,
+    })
+    .define("processIndex", { byPid: new Map() })
+    .define("service", { entity: serviceEntity, dirty: false })
+    .define("timers", {
+      nextCheck: Date.now(),
+      checkInterval: options.checkInterval,
+    })
+    .define("outgoingEvents", { events: [] })
+    .define("broker", { client: options.broker, lastPublishedVersion: 0 });
+
+  scheduler
+    .register(createPersistenceSystem())
+    .register(createHeartbeatIngestSystem(world, components))
+    .register(createMonitorSystem(world, components))
+    .register(createKillSystem(world, components))
+    .register(createQueueSystem(components))
+    .register(createPublishSystem(components));
+
+  let lastTime = Date.now();
+  async function run(time = Date.now()) {
+    const dt = time - lastTime;
+    lastTime = time;
+    await scheduler.runFrame(dt, time, { parallel: false });
+  }
+
+  function enqueueHeartbeat(event) {
+    resources.get("incoming").events.push(event);
+  }
+
+  async function forceMonitor(time = Date.now()) {
+    const timers = resources.get("timers");
+    timers.nextCheck = Math.min(timers.nextCheck, time);
+    await run(time);
+    await run(time + 1);
+  }
+
+  async function close() {
+    await closePersistence(resources.get("persistence"));
+  }
+
+  async function cleanup() {
+    const persistence = resources.get("persistence");
+    if (!persistence.collection) return;
+    try {
+      await persistence.collection.updateMany(
+        { sessionId: persistence.sessionId, killedAt: { $exists: false } },
+        { $set: { killedAt: Date.now() } },
+      );
+    } catch (err) {
+      console.error("heartbeat cleanup failed", err);
+    }
+  }
+
+  return {
+    world,
+    scheduler,
+    resources,
+    run,
+    enqueueHeartbeat,
+    forceMonitor,
+    close,
+    cleanup,
+  };
+}


### PR DESCRIPTION
## Summary
- Extracted the kanban processor orchestration into ECS components/systems and bootstrapped the processor through a world scheduler.
- Migrated the heartbeat package to ECS with persistence/queue fixes and a safer bootstrap entry guard.
- Mirrored the ECS scaffolding for the services/js heartbeat shim and added a changelog entry.

## Testing
- pnpm --filter @promethean/kanban-processor build
- pnpm --filter heartbeat-service test

------
https://chatgpt.com/codex/tasks/task_e_68cf703dae808324b3c2459c646a40ce