### PR TITLE
chore: add lockfile healer workflow

### DIFF
--- a/.github/workflows/lockfile-heal.yml
+++ b/.github/workflows/lockfile-heal.yml
@@ -1,0 +1,41 @@
+name: lockfile-heal
+
+on:
+  push:
+    branches:
+      - main
+  schedule:
+    - cron: "0 5 * * *"
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  heal-lockfile:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+      - name: Run lockfile healer
+        id: heal
+        run: node scripts/ensure-lockfile.mjs
+        continue-on-error: true
+      - name: Create lockfile refresh pull request
+        if: steps.heal.outcome == 'failure'
+        uses: peter-evans/create-pull-request@v6
+        with:
+          commit-message: "chore: refresh pnpm-lock.yaml"
+          title: "chore: refresh pnpm-lock.yaml"
+          body: |
+            Automated lockfile healer detected drift in `pnpm-lock.yaml` and refreshed it.
+          branch: chore/lockfile-heal
+          delete-branch: true
+          add-paths: |
+            pnpm-lock.yaml

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -21,6 +21,19 @@ step.
 Both `make test` and `make simulate-ci` should succeed before sending a pull
 request.
 
+## Lockfile healer
+
+The `lockfile-heal` workflow runs on every push to `main` and once per day via
+cron. It executes `scripts/ensure-lockfile.mjs`, which regenerates
+`pnpm-lock.yaml` and checks the repository status. If a fresh generation changes
+the lockfile, the workflow opens a pull request that commits the updated lock so
+`main` stays authoritative.
+
+Contributors should still run `pnpm install` locally whenever they add, remove,
+or upgrade dependencies. Local installs ensure the working tree is consistent
+before opening a pull request, while the healer workflow acts as a safety net in
+case drift slips through.
+
 ## Dependency caching
 
 The CI workflows cache package downloads to speed up installs:

--- a/scripts/ensure-lockfile.mjs
+++ b/scripts/ensure-lockfile.mjs
@@ -1,0 +1,35 @@
+#!/usr/bin/env node
+import { spawnSync } from "node:child_process";
+
+function run(command, args, options = {}) {
+  const result = spawnSync(command, args, { stdio: "inherit", ...options });
+  if (result.status !== 0) {
+    const code = typeof result.status === "number" ? result.status : 1;
+    process.exit(code);
+  }
+  return result;
+}
+
+run("pnpm", ["install", "--lockfile-only"]);
+
+const statusResult = spawnSync("git", ["status", "--short", "pnpm-lock.yaml"], {
+  encoding: "utf8",
+});
+
+if (statusResult.status !== 0) {
+  process.stderr.write(statusResult.stderr ?? "");
+  const code =
+    typeof statusResult.status === "number" ? statusResult.status : 1;
+  process.exit(code);
+}
+
+const output = (statusResult.stdout ?? "").trim();
+
+if (output.length > 0) {
+  console.error(
+    "pnpm-lock.yaml is out of date. Run pnpm install to regenerate the lockfile.",
+  );
+  process.exit(1);
+}
+
+console.log("pnpm-lock.yaml is up to date.");


### PR DESCRIPTION
## Summary
- add a lockfile check script that runs pnpm install --lockfile-only and exits when pnpm-lock.yaml needs regeneration
- introduce a scheduled workflow that runs the healer script and opens a PR with refreshed lockfiles when drift occurs
- document the healer in docs/ci.md and remind contributors to run pnpm install when changing dependencies

## Testing
- node scripts/ensure-lockfile.mjs

------
https://chatgpt.com/codex/tasks/task_e_68cf7de0c82c83248703e54b8454a06e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Added an automated workflow to detect and heal outdated dependency lockfiles on every push to main and on a daily schedule.
  - Automatically opens a pull request to refresh the lockfile when changes are needed and cleans up the temporary branch after creation.
- Documentation
  - Added CI documentation describing the lockfile healing process and guidance for contributors to keep dependencies consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->