### PR TITLE
chore: remove python hy mk tasks

### DIFF
--- a/bb.edn
+++ b/bb.edn
@@ -1,23 +1,21 @@
 {:paths ["bb/src" "packages/clj-hacks/src" "packages/clj-hacks/test"]
  :tasks
  {;; Root tasks
-  build            {:doc "Build all languages" :task (mk.commands/build)}
-  clean            {:doc "Clean all artifacts" :task (mk.commands/clean)}
+  build            {:doc "Build Node services" :task (mk.commands/build)}
+  clean            {:doc "Clean Node artifacts" :task (mk.commands/clean)}
   distclean        {:doc "git clean -fdX for ignored files" :task (mk.commands/distclean)}
-  lint             {:doc "Lint py/js/ts" :task (mk.commands/lint)}
+  lint             {:doc "Lint js/ts" :task (mk.commands/lint)}
   lint-topics      {:doc "Lint bridge topics" :task (mk.commands/lint-topics)}
   validate-elisp   {:doc "Validate Emacs Lisp layers" :task (mk.commands/validate-elisp)}
-  test             {:doc "Run tests for all languages" :task (mk.commands/test)}
+  test             {:doc "Run tests for js/ts and validate elisp" :task (mk.commands/test)}
   test-integration {:doc "Run integration tests" :task (mk.commands/test-integration)}
   test-e2e         {:doc "Run e2e tests (best-effort)" :task (mk.commands/test-e2e)}
-  format           {:doc "Format py/js/ts" :task (mk.commands/format-code)}
-  coverage         {:doc "Coverage across languages" :task (mk.commands/coverage)}
-  setup            {:doc "Setup all services" :task (mk.commands/setup)}
-  setup-quick      {:doc "Quick setup (scoped recommended)" :task (mk.commands/setup-quick)}
+  format           {:doc "Format js/ts" :task (mk.commands/format-code)}
+  coverage         {:doc "Coverage for js/ts" :task (mk.commands/coverage)}
+  setup            {:doc "Setup Node services" :task (mk.commands/setup)}
+  setup-quick      {:doc "Quick setup for Node services" :task (mk.commands/setup-quick)}
   install          {:doc "Install deps with fallback" :task (mk.commands/install)}
   install-gha-artifacts {:doc "Install latest GHA artifacts" :task (mk.commands/install-gha-artifacts)}
-  probe-python-service {:doc "CUDA probe a python service (SERVICE env)" :task (mk.commands/probe-python-service)}
-  probe-python-services {:doc "CUDA probe all python services" :task (mk.commands/probe-python-services)}
   system-deps      {:doc "Install system deps (ffmpeg, uv, pnpm)" :task (mk.commands/system-deps)}
   install-mongodb  {:doc "Install MongoDB (Linux only)" :task (mk.commands/install-mongodb)}
   start            {:doc "pm2 start" :task (mk.commands/start)}
@@ -33,38 +31,6 @@
   clj-hacks:build   {:doc "Compile clj-hacks namespaces" :requires ([clj-hacks.tasks]) :task clj-hacks.tasks/build}
   clj-hacks:lint    {:doc "Run clj-kondo on clj-hacks" :requires ([clj-hacks.tasks]) :task clj-hacks.tasks/lint}
   clj-hacks:test    {:doc "Execute clj-hacks tests" :requires ([clj-hacks.tasks]) :task clj-hacks.tasks/test}
-
-  ;; Language-specific tasks (mirroring Hy names)
-  ;; Python
-  setup-python-services     mk.python/setup-python-services
-  setup-pipenv              mk.python/setup-pipenv
-  generate-python-shared-requirements mk.python/generate-python-shared-requirements
-  generate-python-services-requirements mk.python/generate-python-services-requirements
-  generate-requirements-service mk.python/generate-requirements-service
-  setup-shared-python       mk.python/setup-shared-python
-  lock-python-cpu           mk.python/lock-python-cpu
-  lock-python-gpu           mk.python/lock-python-gpu
-  setup-shared-python-quick mk.python/setup-shared-python-quick
-  setup-python-services-quick mk.python/setup-python-services-quick
-  setup-python              mk.python/setup-python
-  setup-python-quick        mk.python/setup-python-quick
-  build-python              mk.python/build-python
-  clean-python              mk.python/clean-python
-  setup-python-service      mk.python/setup-python-service
-  test-python-service       mk.python/test-python-service
-  test-python-services      mk.python/test-python-services
-  test-shared-python        mk.python/test-shared-python
-  test-python               mk.python/test-python
-  coverage-python-service   mk.python/coverage-python-service
-  coverage-python-services  mk.python/coverage-python-services
-  coverage-shared-python    mk.python/coverage-shared-python
-  coverage-python           mk.python/coverage-python
-  lint-python-service       mk.python/lint-python-service
-  lint-python               mk.python/lint-python
-  format-python             mk.python/format-python
-  typecheck-python          mk.python/typecheck-python
-  generate-python-requirements mk.python/generate-python-requirements
-  generate-requirements     mk.python/generate-requirements
 
   ;; JS/TS
   lint-js-service           mk.node/lint-js-service
@@ -95,14 +61,6 @@
   clean-ts                  mk.node/clean-ts
   build-ts                  mk.node/build-ts
   ts-type-check             mk.node/ts-type-check
-
-  ;; Hy
-  setup-hy                  mk.hy/setup-hy
-  setup-hy-service          mk.hy/setup-hy-service
-  compile-hy                mk.hy/compile-hy
-  test-hy-service           mk.hy/test-hy-service
-  test-hy-services          mk.hy/test-hy-services
-  test-hy                   mk.hy/test-hy
  }
 }
 

--- a/bb/src/mk/commands.clj
+++ b/bb/src/mk/commands.clj
@@ -1,10 +1,7 @@
 (ns mk.commands
-  (:require [mk.python :as py]
-            [mk.node :as js]
-            [mk.hy :as hy]
+  (:require [mk.node :as js]
             [mk.util :as u]
             [mk.configs :as cfg]
-            [babashka.process :as p]
             [babashka.fs :as fs]))
 
 ;; Root tasks ---------------------------------------------------------------
@@ -14,8 +11,7 @@
 
 (defn clean []
   (js/clean-js)
-  (js/clean-ts)
-  (py/clean-python))
+  (js/clean-ts))
 
 (defn distclean []
   (println "[distclean] Removing ignored files repo-wide via git clean -fdX")
@@ -23,7 +19,6 @@
   (println "[distclean] Done. Tracked files untouched."))
 
 (defn lint []
-  (py/lint-python)
   (js/lint-js)
   (js/lint-ts))
 
@@ -51,8 +46,6 @@
           (println "[validate-elisp] No Lisp sources found under .emacs/layers"))))))
 
 (defn test []
-  (py/test-python)
-  (hy/test-hy)
   (js/test-js)
   (js/test-ts)
   (validate-elisp))
@@ -66,28 +59,23 @@
     (u/sh! "pytest tests/e2e || true" {:shell true})))
 
 (defn format-code []
-  (py/format-python)
   (js/format-js)
   (js/format-ts))
 
 (defn coverage []
-  (py/coverage-python)
   (js/coverage-js)
   (js/coverage-ts))
 
 (defn setup []
   (println "Setting up all services...")
-  (py/setup-python)
   (js/setup-js)
   (js/setup-ts)
-  (hy/setup-hy)
   (println "[note] sibilant setup not ported; skipping")
   (when-not (u/has-cmd? "pm2")
     (u/sh! ["npm" "install" "-g" "pm2"])) )
 
 (defn setup-quick []
-  (println "Quick setup using requirements.txt files...")
-  (py/setup-python-quick)
+  (println "Quick setup using workspace dependencies...")
   ;; Use pnpm workspace for efficient install
   (println "Installing all workspace dependencies...")
   (if (u/has-pnpm?)
@@ -97,7 +85,6 @@
       ;; Build shared TS to create bin files
       (u/sh! "pnpm -r --filter @shared/ts run build" {:shell true}))
     (u/require-pnpm))
-  (hy/setup-hy)
   (println "[note] sibilant setup not ported; skipping")
   (when-not (u/has-cmd? "pm2")
     (u/sh! ["npm" "install" "-g" "pm2"])) )

--- a/changelog.d/2025.09.21.05.36.18.changed.md
+++ b/changelog.d/2025.09.21.05.36.18.changed.md
@@ -1,0 +1,1 @@
+Removed mk tasks and command hooks for Python/Hy so Babashka workflows rely solely on existing Node/Clojure tooling.


### PR DESCRIPTION
## Summary
- drop the mk.python and mk.hy references from the top-level commands so shared tasks only call existing Node workflows
- prune the Python and Hy task entries from `bb.edn` and refresh the root task descriptions to match the remaining functionality
- record the tooling change in the changelog for visibility

## Testing
- bb --list *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cf8c50fa4483248573141dafa8724a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Consolidated build, test, lint, format, and coverage to Node/JS tooling; removed Python/Hy workflows and probes.
  - Streamlined setup to workspace-based (pnpm) installation and build.
  - Tests now cover JS/TS and include Elisp validation.

- Documentation
  - Updated task descriptions to reflect Node-only scope across build, clean, lint, test, format, coverage, and setup.

- Chores
  - Removed obsolete Python/Hy tasks and related hooks from the public task set.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->