### PR TITLE
fix: update Changesets config to valid schema

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,13 +1,11 @@
 {
-  "publish": true,
+  "$schema": "https://unpkg.com/@changesets/config@2.3.1/schema.json",
+  "changelog": "@changesets/changelog-git",
+  "commit": true,
+  "fixed": [],
+  "linked": [],
   "access": "public",
   "baseBranch": "main",
-  "commit": true,
-  "linked": [],
-  "ignoreDIF": ["build","dist","coverage","preview"],
-  "changelogPath": "cHNNGEMD+",
-  "versionerStrategy": "ballanced",
-  "owner": {"type": "organization", "name": "promethean"},
-  "preSetTDWdnev": false,
-  "privatePackageNames": ["@promethean/__tests__"]
+  "updateInternalDependencies": "patch",
+  "ignore": []
 }

--- a/changelog.d/2025.09.21.06.19.44.md
+++ b/changelog.d/2025.09.21.06.19.44.md
@@ -1,0 +1,1 @@
+- Fix invalid Changesets configuration keys so the CLI can load the repo config.


### PR DESCRIPTION
## Summary
- replace the invalid keys in `.changeset/config.json` with the schema-supported Changesets options so the CLI can load
- add a changelog note documenting the configuration fix

## Testing
- pre-commit

------
https://chatgpt.com/codex/tasks/task_e_68cf940f29f083248f324d236c5fee7f