### PR TITLE
fix(nx): point github project to correct root

### DIFF
--- a/packages/github/project.json
+++ b/packages/github/project.json
@@ -1,13 +1,13 @@
 {
-  "name": "ts-agent",
-  "root": "packages/agent",
-  "sourceRoot": "packages/agent/src",
+  "name": "ts-github",
+  "root": "packages/github",
+  "sourceRoot": "packages/github/src",
   "targets": {
     "build": {
       "executor": "nx:run-commands",
       "options": {
         "command": "tsc -b",
-        "cwd": "packages/agent"
+        "cwd": "{projectRoot}"
       },
       "outputs": ["{projectRoot}/dist"]
     },
@@ -15,7 +15,7 @@
       "executor": "nx:run-commands",
       "options": {
         "command": "tsc -p tsconfig.json --noEmit",
-        "cwd": "packages/agent"
+        "cwd": "{projectRoot}"
       }
     },
     "test": {
@@ -30,7 +30,7 @@
       "executor": "nx:run-commands",
       "options": {
         "command": "eslint .",
-        "cwd": "packages/agent"
+        "cwd": "{projectRoot}"
       }
     }
   },


### PR DESCRIPTION
## Summary
- point the GitHub package Nx project at the package directory and src root
- run all Nx targets from the package root via {projectRoot}

## Testing
- pnpm exec nx affected -t build *(fails: Nx reports duplicate project name for @promethean/kanban-cli in packages/kanban and packages/kanban-cli)*

------
https://chatgpt.com/codex/tasks/task_e_68d0603f7ecc8324ad866cc46f932ea5