### PR TITLE
fix: remove invalid TypeScript option from report-forge

### DIFF
--- a/changelog.d/2025.09.21.23.06.07.md
+++ b/changelog.d/2025.09.21.23.06.07.md
@@ -1,0 +1,1 @@
+- fix report-forge TypeScript build configuration by removing unsupported allowImportingTsExtensions option

--- a/packages/report-forge/tsconfig.json
+++ b/packages/report-forge/tsconfig.json
@@ -9,7 +9,6 @@
     "sourceMap": true,
     "resolveJsonModule": true,
     "verbatimModuleSyntax": true,
-    "allowImportingTsExtensions": true,
     "exactOptionalPropertyTypes": true,
     "noUncheckedIndexedAccess": true,
     "strict": true


### PR DESCRIPTION
## Summary
- remove the unsupported `allowImportingTsExtensions` compiler option from the report-forge tsconfig
- document the build fix in the changelog

## Testing
- pnpm --filter @promethean/report-forge build *(fails: shadow-cljs dependency download blocked by network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68d0830d1ef88324b882526e240af27b