### PR TITLE
Add repo-wide test coverage command

### DIFF
--- a/changelog.d/2025.03.09.12.45.00.md
+++ b/changelog.d/2025.03.09.12.45.00.md
@@ -1,0 +1,2 @@
+# Summary
+- Added a root pnpm script to run the consolidated test coverage suite and emit the combined report to `./coverage`.

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "generate_mcp_configs": "bb ./mk/mcp-compile.clj ./config/mcp_servers.edn ~/.codex/config.toml ~/.config/mcp/config.json ~/.config/Code/User/mcp.json",
     "coverage": "c8 --all --reporter=text --reporter=lcov ava --config ./config/ava.config.mjs \"services/**/dist/**/*.test.js\" \"packages/**/dist/**/*.test.js\" \"shared/**/dist/**/*.test.js\" \"tests/**/*.js\"",
+    "test:all": "C8_OUT_DIR=coverage pnpm --filter @promethean/tests run coverage",
     "build:docs": "node scripts/generate-service-docs.js",
     "health:node-abi": "node -p \"process.versions.node + ' ABI ' + process.versions.modules\"",
     "prepare": "node ./scripts/ensure-cli-perms.mjs",


### PR DESCRIPTION
## Summary
- add a root `pnpm test:all` script that invokes the consolidated `@promethean/tests` coverage runner and writes results to `./coverage`
- record the new command in the changelog for visibility

## Testing
- pnpm test:all

------
https://chatgpt.com/codex/tasks/task_e_68d0861e24488324ad74e76f2c89674b