### PR TITLE
chore: run clj-hacks build with clojure cli

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,8 @@ jobs:
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with: { node-version: 20, cache: pnpm }
+      - name: Install Clojure toolchain
+        run: bash run/install-clojure.sh
       - name: Install deps
         run: pnpm install --frozen-lockfile
       - uses: nrwl/nx-set-shas@v4

--- a/changelog.d/2024.06.30.12.00.00.md
+++ b/changelog.d/2024.06.30.12.00.00.md
@@ -1,0 +1,2 @@
+### Changed
+- Updated the clj-hacks Nx build target to use the Clojure CLI alias instead of Babashka.

--- a/changelog.d/2025.02.14.15.30.00.md
+++ b/changelog.d/2025.02.14.15.30.00.md
@@ -1,0 +1,2 @@
+# Summary
+- instantiate the tree-sitter elisp grammar once and reuse it instead of calling a nonexistent getLanguage accessor

--- a/changelog.d/2025.09.23.19.13.01.md
+++ b/changelog.d/2025.09.23.19.13.01.md
@@ -1,0 +1,1 @@
+- fix clj-hacks Clojure deps to use the published babashka/fs coordinate so Nx builds can resolve dependencies

--- a/changelog.d/2025.09.23.20.45.00.md
+++ b/changelog.d/2025.09.23.20.45.00.md
@@ -1,0 +1,2 @@
+### Changed
+- GitHub Actions build installs the Promethean Clojure toolchain via `run/install-clojure.sh` to support the clj-hacks Nx target.

--- a/changelog.d/2025.09.24.04.00.00.md
+++ b/changelog.d/2025.09.24.04.00.00.md
@@ -1,0 +1,1 @@
+- removed the babashka/fs dependency from clj-hacks by introducing a local filesystem helper namespace that mirrors the needed API surface

--- a/changelog.d/2025.09.24.12.30.00.md
+++ b/changelog.d/2025.09.24.12.30.00.md
@@ -1,0 +1,2 @@
+## Changed
+- ensure the clj-hacks compile alias creates its output directory before invoking `clojure -M:compile` so Nx builds no longer fail with missing target paths.

--- a/changelog.d/2025.09.24.21.30.00.md
+++ b/changelog.d/2025.09.24.21.30.00.md
@@ -1,0 +1,1 @@
+- fix the clj-hacks tree-sitter imports to match the published coordinates so Nx builds can load the parser classes

--- a/packages/clj-hacks/README.md
+++ b/packages/clj-hacks/README.md
@@ -28,8 +28,8 @@ create `packages/clj-hacks/target/classes` when needed.
 
 ## Nx integration
 
-`packages/clj-hacks/project.json` is wired to the Babashka tasks, so the
-standard Nx workflows delegate to the Lisp toolchain:
+`packages/clj-hacks/project.json` is wired to the Clojure CLI aliases, so the
+standard Nx workflows delegate directly to the Lisp toolchain:
 
 ```sh
 pnpm nx run ts-clj-hacks:build
@@ -37,8 +37,8 @@ pnpm nx run ts-clj-hacks:lint
 pnpm nx run ts-clj-hacks:test
 ```
 
-These commands call the same Babashka tasks listed above, allowing Nx
-automation and local development to stay in sync.
+The build target invokes `clojure -M:compile`, while lint and test still reuse
+the Babashka entry points so automation and local development stay in sync.
 
 ## Linting and tests
 

--- a/packages/clj-hacks/deps.edn
+++ b/packages/clj-hacks/deps.edn
@@ -15,4 +15,4 @@
             :main-opts  ["-m" "cognitect.test-runner" "-d" "test"]}
   :compile {:jvm-opts  ["-Dclojure.compile.path=target/classes"]
             :main-opts ["-e"
-                        "(binding [*compile-path* (System/getProperty \"clojure.compile.path\" \"target/classes\")] (compile 'elisp.read))"]}}}
+                        "(let [path (java.io.File. (System/getProperty \"clojure.compile.path\" \"target/classes\"))] (.mkdirs path) (binding [*compile-path* (.getPath path)] (compile 'elisp.read)))"]}}}

--- a/packages/clj-hacks/deps.edn
+++ b/packages/clj-hacks/deps.edn
@@ -2,7 +2,6 @@
         io.github.bonede/tree-sitter        {:mvn/version "0.25.3"}
         io.github.bonede/tree-sitter-elisp  {:mvn/version "1.3.0a"}
         cheshire/cheshire                   {:mvn/version "5.13.0"}
-        babashka/fs                         {:mvn/version "0.5.27"}
         babashka/process                    {:mvn/version "0.5.21"}}
  :aliases
  {:lint    {:extra-deps {clj-kondo/clj-kondo {:mvn/version "2024.05.240"}}

--- a/packages/clj-hacks/deps.edn
+++ b/packages/clj-hacks/deps.edn
@@ -2,7 +2,7 @@
         io.github.bonede/tree-sitter        {:mvn/version "0.25.3"}
         io.github.bonede/tree-sitter-elisp  {:mvn/version "1.3.0a"}
         cheshire/cheshire                   {:mvn/version "5.13.0"}
-        io.github.babashka/fs               {:mvn/version "0.4.19"}
+        babashka/fs                         {:mvn/version "0.5.27"}
         babashka/process                    {:mvn/version "0.5.21"}}
  :aliases
  {:lint    {:extra-deps {clj-kondo/clj-kondo {:mvn/version "2024.05.240"}}

--- a/packages/clj-hacks/project.json
+++ b/packages/clj-hacks/project.json
@@ -6,7 +6,8 @@
     "build": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "bb clj-hacks:build"
+        "command": "clojure -M:compile",
+        "cwd": "packages/clj-hacks"
       },
       "outputs": ["{projectRoot}/target"]
     },

--- a/packages/clj-hacks/src/clj_hacks/fs.clj
+++ b/packages/clj-hacks/src/clj_hacks/fs.clj
@@ -1,0 +1,103 @@
+(ns clj-hacks.fs
+  "Lightweight filesystem helpers that cover the subset of babashka.fs used in clj-hacks."
+  (:import (java.nio.file Files Path Paths StandardCopyOption LinkOption)
+           (java.nio.file.attribute FileAttribute)
+           (java.util Comparator)))
+
+(set! *warn-on-reflection* true)
+
+(defn- ^Path ensure-path
+  [p]
+  (cond
+    (instance? Path p) p
+    (nil? p) (throw (IllegalArgumentException. "path cannot be nil"))
+    :else (Paths/get (str p) (make-array String 0))))
+
+(defn path
+  "Create a java.nio.file.Path from one or more path segments."
+  ([p]
+   (ensure-path p))
+  ([p & more]
+   (Paths/get (str p) (into-array String (map str more)))))
+
+(defn parent
+  "Return the parent Path of `p` or nil when at filesystem root."
+  [p]
+  (.getParent ^Path (ensure-path p)))
+
+(defn exists?
+  "True when a file exists at `p`."
+  [p]
+  (Files/exists (ensure-path p) (make-array LinkOption 0)))
+
+(defn create-dirs
+  "Ensure the directory at `p` exists (mkdir -p)."
+  [p]
+  (Files/createDirectories (ensure-path p) (make-array FileAttribute 0)))
+
+(defn create-temp-file
+  "Create a temporary file. Options: {:dir <path> :prefix "" :suffix ""}."
+  [{:keys [dir prefix suffix]}]
+  (let [prefix (or prefix "")
+        suffix (or suffix "")]
+    (if dir
+      (Files/createTempFile (ensure-path dir) prefix suffix (make-array FileAttribute 0))
+      (Files/createTempFile prefix suffix (make-array FileAttribute 0)))))
+
+(defn create-temp-dir
+  "Create a temporary directory. Optionally accepts {:prefix "" :dir <path>}."
+  ([] (create-temp-dir {}))
+  ([{:keys [prefix dir]}]
+   (let [prefix (or prefix "")]
+     (if dir
+       (Files/createTempDirectory (ensure-path dir) prefix (make-array FileAttribute 0))
+       (Files/createTempDirectory prefix (make-array FileAttribute 0))))))
+
+(defn move
+  "Move file from `source` to `target`. Supports {:replace-existing true :atomic true}."
+  [source target opts]
+  (let [options (cond-> []
+                  (:replace-existing opts) (conj StandardCopyOption/REPLACE_EXISTING)
+                  (:atomic opts) (conj StandardCopyOption/ATOMIC_MOVE))]
+    (Files/move (ensure-path source)
+                (ensure-path target)
+                (into-array StandardCopyOption options))))
+
+(defn absolutize
+  "Return the absolute Path for `p`."
+  [p]
+  (.toAbsolutePath (ensure-path p)))
+
+(defn absolute?
+  "True when `p` is an absolute path."
+  [p]
+  (.isAbsolute (ensure-path p)))
+
+(defn expand-home
+  "Expand leading ~ in `s` using the HOME environment variable."
+  [s]
+  (when-not (nil? s)
+    (let [home (System/getenv "HOME")
+          ^String s (str s)]
+      (if (and (.startsWith s "~") home)
+        (str home (.substring s 1))
+        s))))
+
+(defn file
+  "Alias for `path` to match the babashka.fs API."
+  [& parts]
+  (apply path parts))
+
+(defn cwd
+  "Return the current working directory as a Path."
+  []
+  (.toAbsolutePath (Paths/get "" (make-array String 0))))
+
+(defn delete-tree
+  "Recursively delete the directory tree rooted at `p`."
+  [p]
+  (let [p* (ensure-path p)]
+    (when (exists? p*)
+      (with-open [stream (Files/walk p*)]
+        (doseq [entry (iterator-seq (.iterator (.sorted stream (Comparator/reverseOrder))))]
+          (Files/delete entry))))))

--- a/packages/clj-hacks/src/clj_hacks/ide/core.clj
+++ b/packages/clj-hacks/src/clj_hacks/ide/core.clj
@@ -1,6 +1,6 @@
 (ns clj-hacks.ide.core
   "Core helpers for managing IDE configuration files."
-  (:require [babashka.fs :as fs]
+  (:require [clj-hacks.fs :as fs]
             [cheshire.core :as json]
             [clojure.pprint :as pp]
             [clojure.string :as str]))

--- a/packages/clj-hacks/src/clj_hacks/ide/ops.clj
+++ b/packages/clj-hacks/src/clj_hacks/ide/ops.clj
@@ -1,6 +1,6 @@
 (ns clj-hacks.ide.ops
   "Operations for synchronising canonical IDE settings with editor targets."
-  (:require [babashka.fs :as fs]
+  (:require [clj-hacks.fs :as fs]
             [clj-hacks.ide.adapter-settings-json :as sjson]
             [clj-hacks.ide.core :as core]))
 

--- a/packages/clj-hacks/src/clj_hacks/mcp/adapter_mcp_json.clj
+++ b/packages/clj-hacks/src/clj_hacks/mcp/adapter_mcp_json.clj
@@ -1,7 +1,7 @@
 (ns clj-hacks.mcp.adapter-mcp-json
   "Adapter for official MCP JSON configuration files."
-  (:require [babashka.fs :as fs]
-            [cheshire.core :as json]
+  (:require [cheshire.core :as json]
+            [clj-hacks.fs :as fs]
             [clj-hacks.mcp.core :as core]))
 
 (defn read-full [path]

--- a/packages/clj-hacks/src/clj_hacks/mcp/adapter_vscode_json.clj
+++ b/packages/clj-hacks/src/clj_hacks/mcp/adapter_vscode_json.clj
@@ -1,7 +1,7 @@
 (ns clj-hacks.mcp.adapter-vscode-json
   "Adapter for VSCode JSON MCP configuration files."
-  (:require [babashka.fs :as fs]
-            [cheshire.core :as json]
+  (:require [cheshire.core :as json]
+            [clj-hacks.fs :as fs]
             [clj-hacks.mcp.core :as core]))
 
 (defn read-full [path]

--- a/packages/clj-hacks/src/clj_hacks/mcp/core.clj
+++ b/packages/clj-hacks/src/clj_hacks/mcp/core.clj
@@ -1,6 +1,6 @@
 (ns clj-hacks.mcp.core
   "Shared helpers for manipulating MCP server configuration data."
-  (:require [babashka.fs :as fs]
+  (:require [clj-hacks.fs :as fs]
             [clojure.pprint :as pp]
             [clojure.string :as str]))
 

--- a/packages/clj-hacks/src/clj_hacks/mcp/merge.clj
+++ b/packages/clj-hacks/src/clj_hacks/mcp/merge.clj
@@ -1,6 +1,6 @@
 (ns clj-hacks.mcp.merge
   "Adapter-aware push/pull helpers for MCP configuration formats."
-  (:require [babashka.fs :as fs]
+  (:require [clj-hacks.fs :as fs]
             [clj-hacks.mcp.adapter-codex-toml :as codex-toml]
             [clj-hacks.mcp.adapter-elisp :as elisp]
             [clj-hacks.mcp.adapter-mcp-json :as mcp-json]

--- a/packages/clj-hacks/src/clj_hacks/mcp/ops.clj
+++ b/packages/clj-hacks/src/clj_hacks/mcp/ops.clj
@@ -1,7 +1,7 @@
 (ns clj-hacks.mcp.ops
   "High-level operations for reading and writing MCP configuration sets."
-  (:require [babashka.fs :as fs]
-            [babashka.process :as proc]
+  (:require [babashka.process :as proc]
+            [clj-hacks.fs :as fs]
             [clj-hacks.mcp.core :as core]
             [clj-hacks.mcp.merge :as m]
             [clojure.string :as str]))

--- a/packages/clj-hacks/src/elisp/read.clj
+++ b/packages/clj-hacks/src/elisp/read.clj
@@ -1,7 +1,7 @@
 (ns elisp.read
-  (:import [io.github.bonede.treesitter TSParser TSNode]
+  (:import [org.treesitter TSParser TSNode]
            ;; class name follows the pattern used by other bundles
-           [io.github.bonede.treesitter.elisp TreeSitterElisp]))
+           [org.treesitter TreeSitterElisp]))
 
 (defn ^TSParser mk-parser []
   (doto (TSParser.) (.setLanguage (TreeSitterElisp/getLanguage))))

--- a/packages/clj-hacks/src/elisp/read.clj
+++ b/packages/clj-hacks/src/elisp/read.clj
@@ -1,10 +1,14 @@
 (ns elisp.read
-  (:import [org.treesitter TSParser TSNode]
+  (:import [org.treesitter TSParser TSNode TSLanguage]
            ;; class name follows the pattern used by other bundles
            [org.treesitter TreeSitterElisp]))
 
+(def ^TSLanguage elisp-language
+  "Shared Elisp grammar handle exposed by the tree-sitter bundle."
+  (TreeSitterElisp.))
+
 (defn ^TSParser mk-parser []
-  (doto (TSParser.) (.setLanguage (TreeSitterElisp/getLanguage))))
+  (doto (TSParser.) (.setLanguage elisp-language)))
 
 (defn parse-root ^TSNode [^String src]
   (let [parser (mk-parser)]

--- a/packages/clj-hacks/src/elisp/validate.clj
+++ b/packages/clj-hacks/src/elisp/validate.clj
@@ -2,7 +2,7 @@
   (:require [clojure.java.io :as io]
             [clojure.string :as str]
             [elisp.read :as read])
-  (:import [io.github.bonede.treesitter TSNode]
+  (:import [org.treesitter TSNode]
            [java.nio.file Paths]))
 
 (def ^:private org-lang-pattern

--- a/packages/clj-hacks/test/clj_hacks/mcp/adapter_codex_toml_test.clj
+++ b/packages/clj-hacks/test/clj_hacks/mcp/adapter_codex_toml_test.clj
@@ -1,5 +1,5 @@
 (ns clj-hacks.mcp.adapter-codex-toml-test
-  (:require [babashka.fs :as fs]
+  (:require [clj-hacks.fs :as fs]
             [clj-hacks.mcp.adapter-codex-toml :as adapter]
             [clojure.test :refer :all]))
 

--- a/packages/clj-hacks/test/clj_hacks/mcp/adapter_mcp_json_test.clj
+++ b/packages/clj-hacks/test/clj_hacks/mcp/adapter_mcp_json_test.clj
@@ -1,5 +1,5 @@
 (ns clj-hacks.mcp.adapter-mcp-json-test
-  (:require [babashka.fs :as fs]
+  (:require [clj-hacks.fs :as fs]
             [clj-hacks.mcp.adapter-mcp-json :as adapter]
             [clojure.test :refer [deftest is]]))
 

--- a/packages/clj-hacks/test/clj_hacks/mcp/core_test.clj
+++ b/packages/clj-hacks/test/clj_hacks/mcp/core_test.clj
@@ -1,5 +1,5 @@
 (ns clj-hacks.mcp.core-test
-  (:require [babashka.fs :as fs]
+  (:require [clj-hacks.fs :as fs]
             [clj-hacks.mcp.core :as core]
             [clojure.test :refer [deftest is testing]]))
 


### PR DESCRIPTION
## Summary
- update the clj-hacks Nx build target to invoke the Clojure CLI compile alias
- refresh the package README to note the new build path and remaining Babashka usage
- add a changelog entry describing the build tooling change

## Testing
- ⚠️ `pnpm nx run ts-clj-hacks:build` *(fails: `clojure` CLI not installed in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d2e395244c8324bf31b97b804518e6