### PR TITLE
chore: install babashka in build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,8 @@ jobs:
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with: { node-version: 20, cache: pnpm }
+      - name: Install Clojure toolchain
+        run: bash run/install-clojure.sh
       - name: Install deps
         run: pnpm install --frozen-lockfile
       - uses: nrwl/nx-set-shas@v4

--- a/changelog.d/2025.09.25.20.35.43.md
+++ b/changelog.d/2025.09.25.20.35.43.md
@@ -1,0 +1,2 @@
+- ensure the GitHub build workflow installs the clojure toolchain (including Babashka)
+- make the Babashka install step idempotent within the clojure installer script

--- a/run/install-clojure.sh
+++ b/run/install-clojure.sh
@@ -53,7 +53,12 @@ clojure -Sdescribe | sed -n '1,12p' || true
 # Babashka (bb)
 ############################################
 echo "==> Installing Babashka..."
-$SUDO bash < <(curl -s https://raw.githubusercontent.com/babashka/babashka/master/install)
+if command -v bb >/dev/null 2>&1; then
+  echo "bb already installed: $(bb --version | head -n 1)"
+else
+  echo "Downloading latest Babashka install script..."
+  $SUDO bash < <(curl -fsSL https://raw.githubusercontent.com/babashka/babashka/master/install)
+fi
 bb --version || true
 
 ############################################


### PR DESCRIPTION
## Summary
- ensure the build workflow installs the Clojure toolchain before Nx builds
- make the Babashka installation in the Clojure installer idempotent so repeated runs do not reinstall unnecessarily

## Testing
- bash -n run/install-clojure.sh

------
https://chatgpt.com/codex/tasks/task_e_68d5a34f9fdc8324a4d7faee0d734b97