### PR TITLE
Fix generate-ecosystem CLI test invocation

### DIFF
--- a/changelog.d/2025.02.07.00.30.00.md
+++ b/changelog.d/2025.02.07.00.30.00.md
@@ -1,0 +1,2 @@
+## Fixed
+- Adjusted the generate-ecosystem integration test to invoke the `shadow-conf` CLI via its built binary path so the suite no longer depends on `pnpm exec` bin linking.

--- a/docs/agile/tasks/fix_failing_tests_suite.md
+++ b/docs/agile/tasks/fix_failing_tests_suite.md
@@ -1,0 +1,39 @@
+---
+uuid: 5e7d15b7-50dc-4bd8-9ab3-8c7737a8dbe7
+title: Fix failing tests suite
+status: accepted
+priority: P2
+labels:
+  - testing
+  - stabilization
+created_at: '2025-02-07T00:00:00.000Z'
+---
+## 🧭 Context
+- **What changed?**: Incoming bug report indicates some unit tests in the Promethean monorepo are currently failing on main.
+- **Where?**: Tests appear in the shared `tests/` workspace.
+- **Why now?**: Keeping regression suite green is required before other teams can merge changes.
+
+## 📥 Inputs / Artifacts
+- Local reproduction of failing test output
+- Recent CI report documenting failures (see `docs/reports/codex_cloud/describe/latest/summary.tsv`)
+
+## ✅ Definition of Done
+- [ ] Identify and document root cause for current failing tests
+- [ ] Implement fix with accompanying tests if necessary
+- [ ] Confirm the full affected test command passes locally
+- [ ] Update changelog entry describing the fix
+
+## 🗺 Plan
+1. Run the failing test command to confirm current status and capture error details.
+2. Investigate source modules referenced in the failure to understand regression.
+3. Implement minimal fix restoring expected behaviour, adding tests if coverage lacking.
+4. Re-run tests to ensure suite passes and no new failures introduced.
+5. Document changes and update changelog.
+
+## ⚠️ Risks / Open Questions
+- Failing tests may depend on external services or data fixtures requiring additional setup.
+- Potential mismatch between local environment and CI configuration.
+
+## 🔗 Related Resources
+- `docs/reports/codex_cloud/describe/latest/summary.tsv`
+- Repository AGENTS guidelines

--- a/tests/scripts/generate-ecosystem.test.js
+++ b/tests/scripts/generate-ecosystem.test.js
@@ -26,17 +26,18 @@ test("aggregates apps from edn definitions", async (t) => {
   );
 
   const outputDir = path.join(tmpRoot, "out");
+  const packageRoot = path.join(process.cwd(), "packages", "shadow-conf");
+  const manifestPath = path.join(packageRoot, "package.json");
+  const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
+  const relativeBinPath = manifest.bin?.["shadow-conf"];
+  if (typeof relativeBinPath !== "string") {
+    throw new Error("shadow-conf bin path missing from package manifest");
+  }
+  const binPath = path.join(packageRoot, relativeBinPath);
+
   execFileSync(
-    "pnpm",
-    [
-      "exec",
-      "shadow-conf",
-      "ecosystem",
-      "--input-dir",
-      inputDir,
-      "--out",
-      outputDir,
-    ],
+    "node",
+    [binPath, "ecosystem", "--input-dir", inputDir, "--out", outputDir],
     { stdio: "inherit" },
   );
 


### PR DESCRIPTION
## Summary
- update the generate-ecosystem integration test to invoke the shadow-conf CLI through its built binary so it no longer depends on pnpm bin linking
- add a changelog fragment recording the fix
- log the investigation and plan in a new agile task note

## Testing
- pnpm exec ava tests/**/*.test.js
- pnpm exec eslint tests/scripts/generate-ecosystem.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d5af0549a08324a2ed50b3c1003889