### PR TITLE
Fix kanban attr escaping and add tests

### DIFF
--- a/changelog.d/2025.09.25.23.44.55.md
+++ b/changelog.d/2025.09.25.23.44.55.md
@@ -1,0 +1,1 @@
+- fix markdown kanban attribute serialization to escape backslashes alongside quotes.

--- a/packages/markdown/src/kanban.ts
+++ b/packages/markdown/src/kanban.ts
@@ -79,6 +79,16 @@ export type KanbanSettings = {
 
 const ID_COMMENT_PREFIX = 'id:';
 
+function unescapeAttrValue(value: string, quote: '"' | "'" | null): string {
+    let result = value.replace(/\\\\/g, '\\');
+    if (quote === '"') {
+        result = result.replace(/\\"/g, '"');
+    } else if (quote === "'") {
+        result = result.replace(/\\'/g, "'");
+    }
+    return result;
+}
+
 function parseAttrs(braced?: string): Attrs {
     if (!braced) return {};
     const out: Attrs = {};
@@ -90,12 +100,25 @@ function parseAttrs(braced?: string): Attrs {
     while ((m = tokenRe.exec(inner))) {
         const k = m[1];
         let v = m[2];
+        let quote: '"' | "'" | null = null;
         if ((v.startsWith('"') && v.endsWith('"')) || (v.startsWith("'") && v.endsWith("'"))) {
+            quote = v[0] as '"' | "'";
             v = v.slice(1, -1);
         }
-        out[k] = v;
+        out[k] = unescapeAttrValue(v, quote);
     }
     return out;
+}
+
+function formatAttrValue(value: string): string {
+    const withEscapedBackslashes = value.replace(/\\/g, '\\\\');
+    const needsQuotes = /\s/.test(value) || value.includes('"') || value.includes("'");
+    if (!needsQuotes) return withEscapedBackslashes;
+    if (value.includes('"') && !value.includes("'")) {
+        return `'${withEscapedBackslashes}'`;
+    }
+    const withEscapedDoubleQuotes = withEscapedBackslashes.replace(/"/g, '\\"');
+    return `"${withEscapedDoubleQuotes}"`;
 }
 
 function stringifyAttrs(attrs: Attrs): string | null {
@@ -103,7 +126,7 @@ function stringifyAttrs(attrs: Attrs): string | null {
     if (!keys.length) return null;
     const parts = keys.map((k) => {
         const v = attrs[k];
-        return /\s/.test(v) ? `${k}:"${v.replace(/"/g, '\\"')}"` : `${k}:${v}`;
+        return `${k}:${formatAttrValue(v)}`;
     });
     return `{${parts.join(' ')}}`;
 }

--- a/packages/markdown/src/tests/kanban.test.ts
+++ b/packages/markdown/src/tests/kanban.test.ts
@@ -1,0 +1,21 @@
+import test from 'ava';
+
+import { MarkdownBoard } from '../kanban.js';
+
+test('card attribute serialization escapes quotes and backslashes', async (t) => {
+    const board = await MarkdownBoard.load('');
+    board.addColumn('Todo');
+    const attrs = {
+        path: 'C:\\Temp\\File "name"',
+        note: 'needs space',
+    } as const;
+    board.addCard('Todo', {
+        text: 'Example task',
+        attrs: { ...attrs },
+    });
+
+    const md = await board.toMarkdown();
+    const reloaded = await MarkdownBoard.load(md);
+    const cards = reloaded.listCards('Todo');
+    t.deepEqual(cards[0].attrs, attrs);
+});


### PR DESCRIPTION
## Summary
- escape kanban attribute values by unescaping on parse and formatting with safe quoting
- add a regression test ensuring card attributes containing backslashes and quotes survive a round-trip
- record the fix in the changelog

## Testing
- pnpm --filter @promethean/markdown test *(fails: anchors › injectAnchors avoids fences and remains idempotent)*

------
https://chatgpt.com/codex/tasks/task_e_68d5d1afd5d88324b7104574f8af393d