### PR TITLE
Fix schema AVA config path and add SchemaRegistry tests

### DIFF
--- a/changelog.d/2025.09.26.00.50.27.md
+++ b/changelog.d/2025.09.26.00.50.27.md
@@ -1,0 +1,2 @@
+- Fix the schema package AVA config path so Nx can resolve the shared configuration.
+- Add basic SchemaRegistry tests to ensure version handling and validation continue to work.

--- a/changelog.d/2025.09.27.12.00.00.md
+++ b/changelog.d/2025.09.27.12.00.00.md
@@ -1,0 +1,2 @@
+- fix ava configs across packages to re-export the shared config path
+- update scaffolding script to point at the shared ava config

--- a/packages/agent-ecs/ava.config.mjs
+++ b/packages/agent-ecs/ava.config.mjs
@@ -1,1 +1,1 @@
-export { default } from '../../../config/ava.config.base.mjs';
+export { default } from '../../config/ava.config.mjs';

--- a/packages/buildfix/ava.config.mjs
+++ b/packages/buildfix/ava.config.mjs
@@ -2,7 +2,5 @@ import base from "../../config/ava.config.mjs";
 
 export default {
   ...base,
-  files: [
-    "dist/tests/**/*.js",
-  ],
+  files: ["dist/tests/**/*.js"],
 };

--- a/packages/changefeed/ava.config.mjs
+++ b/packages/changefeed/ava.config.mjs
@@ -1,1 +1,1 @@
-export { default } from '../../../config/ava.config.base.mjs';
+export { default } from '../../config/ava.config.mjs';

--- a/packages/cli/ava.config.mjs
+++ b/packages/cli/ava.config.mjs
@@ -1,1 +1,1 @@
-export { default } from '../../../config/ava.config.base.mjs';
+export { default } from '../../config/ava.config.mjs';

--- a/packages/compaction/ava.config.mjs
+++ b/packages/compaction/ava.config.mjs
@@ -1,1 +1,1 @@
-export { default } from '../../../config/ava.config.base.mjs';
+export { default } from '../../config/ava.config.mjs';

--- a/packages/compiler/ava.config.mjs
+++ b/packages/compiler/ava.config.mjs
@@ -1,1 +1,1 @@
-export { default } from '../../../config/ava.config.base.mjs';
+export { default } from '../../config/ava.config.mjs';

--- a/packages/contracts/ava.config.mjs
+++ b/packages/contracts/ava.config.mjs
@@ -1,1 +1,1 @@
-export { default } from '../../../config/ava.config.base.mjs';
+export { default } from '../../config/ava.config.mjs';

--- a/packages/dev/ava.config.mjs
+++ b/packages/dev/ava.config.mjs
@@ -1,1 +1,1 @@
-export { default } from '../../../config/ava.config.base.mjs';
+export { default } from '../../config/ava.config.mjs';

--- a/packages/dlq/ava.config.mjs
+++ b/packages/dlq/ava.config.mjs
@@ -1,1 +1,1 @@
-export { default } from '../../../config/ava.config.base.mjs';
+export { default } from '../../config/ava.config.mjs';

--- a/packages/ds/ava.config.mjs
+++ b/packages/ds/ava.config.mjs
@@ -1,1 +1,1 @@
-export { default } from '../../../config/ava.config.base.mjs';
+export { default } from '../../config/ava.config.mjs';

--- a/packages/effects/ava.config.mjs
+++ b/packages/effects/ava.config.mjs
@@ -1,1 +1,1 @@
-export { default } from '../../../config/ava.config.base.mjs';
+export { default } from '../../config/ava.config.mjs';

--- a/packages/event/ava.config.mjs
+++ b/packages/event/ava.config.mjs
@@ -1,1 +1,1 @@
-export { default } from '../../../config/ava.config.base.mjs';
+export { default } from '../../config/ava.config.mjs';

--- a/packages/examples/ava.config.mjs
+++ b/packages/examples/ava.config.mjs
@@ -1,1 +1,1 @@
-export { default } from '../../../config/ava.config.base.mjs';
+export { default } from '../../config/ava.config.mjs';

--- a/packages/fs/ava.config.mjs
+++ b/packages/fs/ava.config.mjs
@@ -1,1 +1,1 @@
-export { default } from '../../../config/ava.config.base.mjs';
+export { default } from '../../config/ava.config.mjs';

--- a/packages/http/ava.config.mjs
+++ b/packages/http/ava.config.mjs
@@ -1,1 +1,1 @@
-export { default } from '../../../config/ava.config.base.mjs';
+export { default } from '../../config/ava.config.mjs';

--- a/packages/intention/ava.config.mjs
+++ b/packages/intention/ava.config.mjs
@@ -1,1 +1,1 @@
-export { default } from '../../../config/ava.config.base.mjs';
+export { default } from '../../config/ava.config.mjs';

--- a/packages/llm/ava.config.mjs
+++ b/packages/llm/ava.config.mjs
@@ -1,1 +1,1 @@
-export { default } from '../../../config/ava.config.base.mjs';
+export { default } from '../../config/ava.config.mjs';

--- a/packages/markdown/ava.config.mjs
+++ b/packages/markdown/ava.config.mjs
@@ -1,1 +1,1 @@
-export { default } from '../../../config/ava.config.base.mjs';
+export { default } from '../../config/ava.config.mjs';

--- a/packages/migrations/ava.config.mjs
+++ b/packages/migrations/ava.config.mjs
@@ -1,1 +1,1 @@
-export { default } from '../../../config/ava.config.base.mjs';
+export { default } from '../../config/ava.config.mjs';

--- a/packages/monitoring/ava.config.mjs
+++ b/packages/monitoring/ava.config.mjs
@@ -1,2 +1,2 @@
-import base from '../../config/ava.config.mjs';
-export default { ...base, files: ['tests/**/*.test.js'] };
+import base from "../../config/ava.config.mjs";
+export default { ...base, files: ["tests/**/*.test.js"] };

--- a/packages/naming/ava.config.mjs
+++ b/packages/naming/ava.config.mjs
@@ -1,1 +1,1 @@
-export { default } from '../../../config/ava.config.base.mjs';
+export { default } from '../../config/ava.config.mjs';

--- a/packages/parity/ava.config.mjs
+++ b/packages/parity/ava.config.mjs
@@ -1,1 +1,1 @@
-export { default } from '../../../config/ava.config.base.mjs';
+export { default } from '../../config/ava.config.mjs';

--- a/packages/persistence/ava.config.mjs
+++ b/packages/persistence/ava.config.mjs
@@ -1,1 +1,1 @@
-export { default } from '../../../config/ava.config.base.mjs';
+export { default } from '../../config/ava.config.mjs';

--- a/packages/platform/ava.config.mjs
+++ b/packages/platform/ava.config.mjs
@@ -1,1 +1,1 @@
-export { default } from '../../../config/ava.config.base.mjs';
+export { default } from '../../config/ava.config.mjs';

--- a/packages/projectors/ava.config.mjs
+++ b/packages/projectors/ava.config.mjs
@@ -1,1 +1,1 @@
-export { default } from '../../../config/ava.config.base.mjs';
+export { default } from '../../config/ava.config.mjs';

--- a/packages/providers/ava.config.mjs
+++ b/packages/providers/ava.config.mjs
@@ -1,1 +1,1 @@
-export { default } from '../../../config/ava.config.base.mjs';
+export { default } from '../../config/ava.config.mjs';

--- a/packages/schema/ava.config.mjs
+++ b/packages/schema/ava.config.mjs
@@ -1,1 +1,1 @@
-export { default } from '../../../config/ava.config.base.mjs';
+export { default } from '../../config/ava.config.mjs';

--- a/packages/schema/src/tests/registry.test.ts
+++ b/packages/schema/src/tests/registry.test.ts
@@ -1,0 +1,43 @@
+import test from 'ava';
+import { z } from 'zod';
+
+import { SchemaRegistry } from '../registry.js';
+
+test('latest returns the highest registered version', (t) => {
+    const registry = new SchemaRegistry();
+    const schemaV1 = z.object({ foo: z.string().optional() });
+    const schemaV2 = schemaV1.extend({ bar: z.number().optional() });
+
+    registry.register({ topic: 'demo.topic', version: 1, schema: schemaV1, compat: 'none' });
+    registry.register({ topic: 'demo.topic', version: 2, schema: schemaV2, compat: 'backward' });
+
+    const latest = registry.latest('demo.topic');
+
+    t.truthy(latest);
+    t.is(latest?.version, 2);
+    t.notThrows(() => registry.validate('demo.topic', { foo: 'value', bar: 1 }));
+});
+
+test('register rejects non-increasing versions', (t) => {
+    const registry = new SchemaRegistry();
+    const schema = z.object({ foo: z.string().optional() });
+
+    registry.register({ topic: 'demo.topic', version: 1, schema, compat: 'none' });
+
+    const error = t.throws(() => registry.register({ topic: 'demo.topic', version: 1, schema, compat: 'none' }));
+
+    t.truthy(error);
+    t.regex(error?.message ?? '', /version must increase/);
+});
+
+test('validate uses the requested schema version when provided', (t) => {
+    const registry = new SchemaRegistry();
+    const schemaV1 = z.object({ foo: z.string() });
+    const schemaV2 = z.object({ foo: z.string(), bar: z.number() });
+
+    registry.register({ topic: 'demo.topic', version: 1, schema: schemaV1, compat: 'none' });
+    registry.register({ topic: 'demo.topic', version: 2, schema: schemaV2, compat: 'none' });
+
+    t.notThrows(() => registry.validate('demo.topic', { foo: 'value' }, 1));
+    t.throws(() => registry.validate('demo.topic', { foo: 'value' }));
+});

--- a/packages/stream/ava.config.mjs
+++ b/packages/stream/ava.config.mjs
@@ -1,1 +1,1 @@
-export { default } from '../../../config/ava.config.base.mjs';
+export { default } from '../../config/ava.config.mjs';

--- a/packages/tests/ava.config.mjs
+++ b/packages/tests/ava.config.mjs
@@ -1,1 +1,1 @@
-export { default } from '../../../config/ava.config.base.mjs';
+export { default } from '../../config/ava.config.mjs';

--- a/packages/timetravel/ava.config.mjs
+++ b/packages/timetravel/ava.config.mjs
@@ -1,1 +1,1 @@
-export { default } from '../../../config/ava.config.base.mjs';
+export { default } from '../../config/ava.config.mjs';

--- a/packages/utils/ava.config.mjs
+++ b/packages/utils/ava.config.mjs
@@ -1,1 +1,1 @@
-export { default } from '../../../config/ava.config.base.mjs';
+export { default } from "../../config/ava.config.mjs";

--- a/packages/worker/ava.config.mjs
+++ b/packages/worker/ava.config.mjs
@@ -1,1 +1,1 @@
-export { default } from '../../../config/ava.config.base.mjs';
+export { default } from '../../config/ava.config.mjs';

--- a/packages/ws/ava.config.mjs
+++ b/packages/ws/ava.config.mjs
@@ -1,1 +1,1 @@
-export { default } from '../../../config/ava.config.base.mjs';
+export { default } from '../../config/ava.config.mjs';

--- a/scripts/scaffold-nx.mjs
+++ b/scripts/scaffold-nx.mjs
@@ -132,7 +132,7 @@ async function scaffoldPackage(dirent) {
   const avaPath = path.join(pkgRoot, "ava.config.mjs");
   await writeIfMissing(
     avaPath,
-    `export { default } from "../../config/ava.config.base.mjs";\n`,
+    `export { default } from "../../config/ava.config.mjs";\n`,
   );
 
   // .eslintrc.cjs (extends)


### PR DESCRIPTION
## Summary
- fix the schema package AVA config import so it resolves the shared base configuration
- add SchemaRegistry unit tests covering version ordering and explicit version validation
- document the change in the changelog
- update remaining package AVA configs and the package scaffold to use the shared root config while preserving each package's overrides

## Testing
- pnpm nx run ts-schema:test
- pnpm exec eslint scripts/scaffold-nx.mjs packages/*/ava.config.mjs
- pnpm exec eslint packages/buildfix/ava.config.mjs packages/docops/ava.config.mjs packages/file-watcher/ava.config.mjs packages/kanban-processor/ava.config.mjs packages/monitoring/ava.config.mjs packages/nitpack/ava.config.mjs packages/piper/ava.config.mjs packages/report-forge/ava.config.mjs packages/smartgpt-bridge/ava.config.mjs

------
https://chatgpt.com/codex/tasks/task_e_68d5e0ad56e88324b35ae9a4982b4ac4