### PR TITLE
Fix clj-hacks deps resolution

### DIFF
--- a/changelog.d/2025.09.26.00.30.13.md
+++ b/changelog.d/2025.09.26.00.30.13.md
@@ -1,0 +1,1 @@
+- Fix clj-hacks build by sourcing babashka/fs directly from Git instead of Maven Central.

--- a/packages/clj-hacks/deps.edn
+++ b/packages/clj-hacks/deps.edn
@@ -2,7 +2,9 @@
         io.github.bonede/tree-sitter        {:mvn/version "0.25.3"}
         io.github.bonede/tree-sitter-elisp  {:mvn/version "1.3.0a"}
         cheshire/cheshire                   {:mvn/version "5.13.0"}
-        io.github.babashka/fs               {:mvn/version "0.4.19"}
+        io.github.babashka/fs               {:git/url "https://github.com/babashka/fs"
+                                            :git/tag "v0.5.27"
+                                            :git/sha "49421aef29a6998a332e8f6814073b96cc311106"}
         babashka/process                    {:mvn/version "0.5.21"}}
  :aliases
  {:lint    {:extra-deps {clj-kondo/clj-kondo {:mvn/version "2024.05.240"}}


### PR DESCRIPTION
## Summary
- fetch babashka/fs via git tag so clj-hacks can resolve its fs dependency
- document the change in the changelog

## Testing
- `pnpm nx run ts-clj-hacks:build` *(fails: bb not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d5dc8688f483248dd2593ca7c168d8