### PR TITLE
Fix kanban markdown subpath imports

### DIFF
--- a/packages/kanban/src/board/indexer.ts
+++ b/packages/kanban/src/board/indexer.ts
@@ -2,7 +2,7 @@ import { readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
 
 import { listFilesRec } from "@promethean/utils/list-files-rec.js";
-import { parseFrontmatter } from "@promethean/markdown/frontmatter.js";
+import { parseFrontmatter } from "@promethean/markdown/frontmatter";
 
 import type { IndexedTask, TaskFM } from "./types.js";
 import type { ReadonlySetLike } from "./config/shared.js";

--- a/packages/kanban/src/board/lints.ts
+++ b/packages/kanban/src/board/lints.ts
@@ -2,7 +2,7 @@ import { readFile } from "node:fs/promises";
 import path from "node:path";
 
 import { listFilesRec } from "@promethean/utils/list-files-rec.js";
-import { parseFrontmatter } from "@promethean/markdown/frontmatter.js";
+import { parseFrontmatter } from "@promethean/markdown/frontmatter";
 
 import type { TaskFM } from "./types.js";
 import type { ReadonlySetLike } from "./config/shared.js";

--- a/packages/kanban/src/board/projector.ts
+++ b/packages/kanban/src/board/projector.ts
@@ -1,7 +1,7 @@
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
 
-import { STATUS_ORDER, headerToStatus } from "@promethean/markdown/statuses.js";
+import { STATUS_ORDER, headerToStatus } from "@promethean/markdown/statuses";
 
 import { loadKanbanConfig } from "./config.js";
 import type { IndexedTask } from "./types.js";

--- a/packages/markdown/package.json
+++ b/packages/markdown/package.json
@@ -19,6 +19,10 @@
             "types": "./dist/frontmatter.d.ts",
             "import": "./dist/frontmatter.js"
         },
+        "./statuses": {
+            "types": "./dist/statuses.d.ts",
+            "import": "./dist/statuses.js"
+        },
         "./dist/*": "./dist/*",
         "./*": "./dist/*"
     },


### PR DESCRIPTION
## Summary
- update the kanban board tooling to import the markdown frontmatter utilities via the package export
- expose the markdown statuses helper through the package export map so consuming packages can resolve types

## Testing
- pnpm --filter ./packages/kanban build
- pnpm exec eslint packages/kanban/src/board/indexer.ts packages/kanban/src/board/lints.ts packages/kanban/src/board/projector.ts

------
https://chatgpt.com/codex/tasks/task_e_68d6e980dcf08324930efdc1feae9095