### PR TITLE
feat(mcp): support multiple HTTP endpoints

### DIFF
--- a/changelog.d/2025.02.09.12.00.00.md
+++ b/changelog.d/2025.02.09.12.00.00.md
@@ -1,0 +1,2 @@
+## Fixed
+- Restored the legacy `/mcp` HTTP endpoint when additional MCP routes are configured so existing deployments retain their primary path without duplicating configuration.

--- a/docs/agile/tasks/refactor-mcp-endpoints.md
+++ b/docs/agile/tasks/refactor-mcp-endpoints.md
@@ -1,0 +1,60 @@
+---
+task-id: TASK-20240705-mcp-http
+title: Refactor MCP package for multi-endpoint HTTP transport
+state: InProgress
+prev:
+txn: "2024-07-05T00:00:00Z-0000"
+owner: err
+priority: p3
+size: s
+epic: EPC-000
+depends_on: []
+labels:
+  - board:auto
+  - lang:ts
+  - package:@promethean/mcp
+due:
+links: []
+artifacts: []
+rationale: Allow a single MCP package to expose multiple HTTP endpoints configured via promethean.mcp.json.
+proposed_transitions:
+  - New->Accepted
+  - Accepted->Breakdown
+  - Breakdown->Ready
+  - Ready->Todo
+  - Todo->InProgress
+  - InProgress->InReview
+  - InReview->Done
+  - Done->Archive
+  - InProgress->Todo
+  - Todo->Breakdown
+  - Breakdown->Archive
+tags:
+  - task/TASK-20240705-mcp-http
+  - board/kanban
+  - state/InProgress
+  - owner/err
+  - priority/p3
+  - epic/EPC-000
+---
+
+## Context
+- **What changed?**: Need to extend MCP transport loader to support multiple HTTP endpoints from config.
+- **Where?**: `packages/mcp`
+- **Why now?**: Enables testing different MCP tool sets while sharing one package build.
+
+## Inputs / Artifacts
+- `promethean.mcp.json`
+
+## Definition of Done
+- [ ] Config schema accepts endpoint map for HTTP transports.
+- [ ] MCP HTTP server registers each configured endpoint with its toolset.
+- [ ] Tests cover multi-endpoint configuration.
+- [ ] Documentation updated if needed.
+
+## Plan
+1. Inspect current MCP package configuration parsing.
+2. Update configuration types and loader to accept `endpoints` map.
+3. Adjust HTTP server composition to register multiple routers.
+4. Add tests verifying configuration and runtime wiring.
+

--- a/packages/mcp/src/config/load-config.ts
+++ b/packages/mcp/src/config/load-config.ts
@@ -3,9 +3,13 @@ import path from "node:path";
 import { z } from "zod";
 
 const ToolId = z.string();
+const EndpointConfig = z.object({
+  tools: z.array(ToolId).default([]),
+});
 const Config = z.object({
   transport: z.enum(["stdio", "http"]).default("http"),
   tools: z.array(ToolId).default([]),
+  endpoints: z.record(EndpointConfig).default({}),
 });
 
 export type AppConfig = z.infer<typeof Config>;

--- a/packages/mcp/src/core/resolve-config.ts
+++ b/packages/mcp/src/core/resolve-config.ts
@@ -21,10 +21,23 @@ export const resolveHttpEndpoints = (
     ];
   }
 
-  return entries.map(([path, cfg]) => ({
+  const resolved = entries.map(([path, cfg]) => ({
     path: ensureLeadingSlash(path),
     tools: cfg.tools,
   }));
+
+  const shouldIncludeLegacyEndpoint =
+    config.tools.length > 0 &&
+    resolved.every((endpoint) => endpoint.path !== "/mcp");
+
+  if (shouldIncludeLegacyEndpoint) {
+    resolved.unshift({
+      path: "/mcp",
+      tools: config.tools,
+    });
+  }
+
+  return resolved;
 };
 
 export const resolveStdioTools = (config: AppConfig): readonly string[] => {

--- a/packages/mcp/src/core/resolve-config.ts
+++ b/packages/mcp/src/core/resolve-config.ts
@@ -1,0 +1,41 @@
+import type { AppConfig } from "../config/load-config.js";
+
+const ensureLeadingSlash = (path: string): string =>
+  path.startsWith("/") ? path : `/${path}`;
+
+export type EndpointDefinition = Readonly<{
+  path: string;
+  tools: readonly string[];
+}>;
+
+export const resolveHttpEndpoints = (
+  config: AppConfig,
+): readonly EndpointDefinition[] => {
+  const entries = Object.entries(config.endpoints ?? {});
+  if (entries.length === 0) {
+    return [
+      {
+        path: "/mcp",
+        tools: config.tools,
+      },
+    ];
+  }
+
+  return entries.map(([path, cfg]) => ({
+    path: ensureLeadingSlash(path),
+    tools: cfg.tools,
+  }));
+};
+
+export const resolveStdioTools = (config: AppConfig): readonly string[] => {
+  if (config.tools.length > 0) return config.tools;
+
+  const collected = new Set<string>();
+  for (const endpoint of Object.values(config.endpoints ?? {})) {
+    for (const tool of endpoint.tools) {
+      collected.add(tool);
+    }
+  }
+
+  return [...collected];
+};

--- a/packages/mcp/src/core/transports/fastify.ts
+++ b/packages/mcp/src/core/transports/fastify.ts
@@ -5,34 +5,33 @@ import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/
 import { isInitializeRequest } from "@modelcontextprotocol/sdk/types.js";
 import crypto from "node:crypto";
 
-export const fastifyTransport = (opts?: {
-  port?: number;
-  host?: string;
-}): Transport => {
-  const port = opts?.port ?? Number(process.env.PORT ?? 3210);
-  const host = opts?.host ?? process.env.HOST ?? "0.0.0.0";
-  const app = Fastify({ logger: false });
+type ServerEntries = ReadonlyArray<readonly [string, McpServer]>;
 
-  // Minimal parsers: keep request body as Buffer or object exactly as sent
-  app.removeAllContentTypeParsers();
-  app.addContentTypeParser(
-    ["application/json", "application/*+json"],
-    { parseAs: "buffer" },
-    (_req, payload, done) => done(null, payload),
-  );
-  app.addContentTypeParser("*", { parseAs: "buffer" }, (_req, payload, done) =>
-    done(null, payload),
-  );
+const toEntries = (input: unknown): ServerEntries => {
+  if (!input) return [];
+  if (input instanceof Map) {
+    return Array.from(input.entries());
+  }
+  if (
+    typeof input === "object" &&
+    input !== null &&
+    "connect" in (input as Record<string, unknown>) &&
+    typeof (input as Record<string, unknown>)["connect"] === "function"
+  ) {
+    return [["/mcp", input as McpServer]];
+  }
+  if (typeof input === "object" && input !== null) {
+    return Object.entries(input as Record<string, McpServer>);
+  }
+  return [["/mcp", input as McpServer]];
+};
 
-  app.get("/healthz", (_req, rep) => rep.send({ ok: true }));
-  // If you previously had GET /mcp, remove it: Fastify will throw FST_ERR_DUPLICATED_ROUTE on restarts
+const normalizePath = (p: string): string => (p.startsWith("/") ? p : `/${p}`);
 
-  let srv: McpServer | undefined;
-
-  // Active session transports
-  const transports = new Map<string, StreamableHTTPServerTransport>();
-
-  // Helper: parse a Buffer/JSON body into unknown
+const createRouteHandler = (
+  server: McpServer,
+  sessions: Map<string, StreamableHTTPServerTransport>,
+) => {
   const parseBody = (b: unknown): unknown => {
     if (Buffer.isBuffer(b)) {
       try {
@@ -44,13 +43,11 @@ export const fastifyTransport = (opts?: {
     return b;
   };
 
-  app.post("/mcp", async (req: any, reply: any) => {
-    // We hand raw sockets to the SDK transport
+  return async function handler(req: any, reply: any) {
     reply.hijack();
     const rawReq = req.raw;
     const rawRes = reply.raw;
 
-    // Spec: client must accept both JSON and event-stream
     const accept = String(rawReq.headers["accept"] || "");
     if (
       !(
@@ -62,16 +59,13 @@ export const fastifyTransport = (opts?: {
     }
 
     try {
-      if (!srv) throw new Error("MCP server not bound");
-
       const body = parseBody(req.body);
       const sidHeader = rawReq.headers["mcp-session-id"] as string | undefined;
 
       let transport: StreamableHTTPServerTransport | undefined;
 
       if (sidHeader) {
-        // Reuse existing transport for this session
-        transport = transports.get(sidHeader);
+        transport = sessions.get(sidHeader);
         if (!transport) {
           rawRes.writeHead(400).end(
             JSON.stringify({
@@ -86,26 +80,23 @@ export const fastifyTransport = (opts?: {
           return;
         }
       } else if (body && isInitializeRequest(body)) {
-        // *** New session: predeclare a variable to break self-reference ***
         let self: StreamableHTTPServerTransport;
 
         const t: StreamableHTTPServerTransport =
           new StreamableHTTPServerTransport({
             sessionIdGenerator: crypto.randomUUID?.bind(crypto),
             onsessioninitialized: (sid: string): void => {
-              transports.set(sid, self);
+              sessions.set(sid, self);
             },
           });
 
         t.onclose = () => {
-          if (t.sessionId) transports.delete(t.sessionId);
+          if (t.sessionId) sessions.delete(t.sessionId);
         };
 
-        self = t; // set after create to satisfy TS
+        self = t;
         transport = t;
-
-        // Connect server to this transport exactly once (on first initialize)
-        await srv.connect(transport);
+        await server.connect(transport);
       } else {
         rawRes.writeHead(400).end(
           JSON.stringify({
@@ -120,7 +111,6 @@ export const fastifyTransport = (opts?: {
         return;
       }
 
-      // Hand off to SDK (it will set Mcp-Session-Id on initialize responses)
       await transport.handleRequest(rawReq, rawRes, body);
     } catch (e: any) {
       if (!rawRes.headersSent) {
@@ -137,14 +127,53 @@ export const fastifyTransport = (opts?: {
         );
       }
     }
-  });
+  };
+};
+
+export const fastifyTransport = (opts?: {
+  port?: number;
+  host?: string;
+}): Transport => {
+  const port = opts?.port ?? Number(process.env.PORT ?? 3210);
+  const host = opts?.host ?? process.env.HOST ?? "0.0.0.0";
+  const app = Fastify({ logger: false });
+
+  app.removeAllContentTypeParsers();
+  app.addContentTypeParser(
+    ["application/json", "application/*+json"],
+    { parseAs: "buffer" },
+    (_req, payload, done) => done(null, payload),
+  );
+  app.addContentTypeParser("*", { parseAs: "buffer" }, (_req, payload, done) =>
+    done(null, payload),
+  );
+
+  app.get("/healthz", (_req, rep) => rep.send({ ok: true }));
+
+  const sessionStores = new Map<
+    string,
+    Map<string, StreamableHTTPServerTransport>
+  >();
 
   return {
     start: async (server?: unknown) => {
-      if (server) {
-        srv = server as McpServer;
-        console.log("[mcp:http] server bound");
+      const entries = toEntries(server);
+      if (entries.length === 0) {
+        throw new Error("fastifyTransport requires at least one MCP server");
       }
+
+      for (const [route, srv] of entries) {
+        const normalized = normalizePath(route);
+        if (sessionStores.has(normalized)) {
+          throw new Error(`Duplicate MCP endpoint path: ${normalized}`);
+        }
+
+        const sessions = new Map<string, StreamableHTTPServerTransport>();
+        sessionStores.set(normalized, sessions);
+        app.post(normalized, createRouteHandler(srv, sessions));
+        console.log(`[mcp:http] bound endpoint ${normalized}`);
+      }
+
       await app.listen({ port, host } as any);
       console.log(`[mcp:http] listening on http://${host}:${port}`);
     },

--- a/packages/mcp/src/tests/config.test.ts
+++ b/packages/mcp/src/tests/config.test.ts
@@ -33,6 +33,22 @@ test("resolveHttpEndpoints normalizes endpoint paths", (t) => {
   ]);
 });
 
+test("resolveHttpEndpoints retains legacy /mcp when endpoints present", (t) => {
+  const cfg: AppConfig = {
+    transport: "http",
+    tools: ["files.view-file"],
+    endpoints: {
+      "github/mcp": { tools: ["github.request"] },
+    },
+  };
+
+  const result = resolveHttpEndpoints(cfg);
+  t.deepEqual(result, [
+    { path: "/mcp", tools: ["files.view-file"] },
+    { path: "/github/mcp", tools: ["github.request"] },
+  ]);
+});
+
 test("resolveStdioTools prefers top-level tools", (t) => {
   const cfg: AppConfig = {
     transport: "stdio",

--- a/packages/mcp/src/tests/config.test.ts
+++ b/packages/mcp/src/tests/config.test.ts
@@ -1,0 +1,64 @@
+import test from "ava";
+import {
+  resolveHttpEndpoints,
+  resolveStdioTools,
+} from "../core/resolve-config.js";
+import type { AppConfig } from "../config/load-config.js";
+
+test("resolveHttpEndpoints falls back to /mcp with top-level tools", (t) => {
+  const cfg: AppConfig = {
+    transport: "http",
+    tools: ["files.view-file"],
+    endpoints: {},
+  };
+
+  const result = resolveHttpEndpoints(cfg);
+  t.deepEqual(result, [{ path: "/mcp", tools: ["files.view-file"] }]);
+});
+
+test("resolveHttpEndpoints normalizes endpoint paths", (t) => {
+  const cfg: AppConfig = {
+    transport: "http",
+    tools: [],
+    endpoints: {
+      "github/mcp": { tools: ["github.request"] },
+      "/fs/mcp": { tools: ["files.list-directory"] },
+    },
+  };
+
+  const result = resolveHttpEndpoints(cfg);
+  t.deepEqual(result, [
+    { path: "/github/mcp", tools: ["github.request"] },
+    { path: "/fs/mcp", tools: ["files.list-directory"] },
+  ]);
+});
+
+test("resolveStdioTools prefers top-level tools", (t) => {
+  const cfg: AppConfig = {
+    transport: "stdio",
+    tools: ["files.view-file"],
+    endpoints: {
+      "github/mcp": { tools: ["github.request"] },
+    },
+  };
+
+  const result = resolveStdioTools(cfg);
+  t.deepEqual(result, ["files.view-file"]);
+});
+
+test("resolveStdioTools unions endpoint tools when top-level empty", (t) => {
+  const cfg: AppConfig = {
+    transport: "stdio",
+    tools: [],
+    endpoints: {
+      "github/mcp": { tools: ["github.request"] },
+      "fs/mcp": { tools: ["files.list-directory", "files.view-file"] },
+    },
+  };
+
+  const result = resolveStdioTools(cfg);
+  t.deepEqual(
+    new Set(result),
+    new Set(["github.request", "files.list-directory", "files.view-file"]),
+  );
+});

--- a/packages/mcp/src/tests/files.test.ts
+++ b/packages/mcp/src/tests/files.test.ts
@@ -1,8 +1,15 @@
 import test from "ava";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { loadConfig } from "../config/load-config.js";
 
 test("loadConfig defaults when nothing set", (t) => {
-  const cfg = loadConfig({});
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "mcp-test-"));
+  t.teardown(() => fs.rmSync(tempDir, { recursive: true, force: true }));
+
+  const cfg = loadConfig({}, [], tempDir);
   t.is(cfg.transport, "http");
   t.deepEqual(cfg.tools, []);
+  t.deepEqual(cfg.endpoints, {});
 });


### PR DESCRIPTION
## Summary
- extend the MCP config schema to accept per-endpoint tool selections alongside the legacy tools list
- register multiple HTTP routes when configured and reuse a resolver for stdio vs HTTP tool wiring
- add unit coverage for config resolution and record the new agile task for tracking

## Testing
- pnpm --filter @promethean/mcp test

------
https://chatgpt.com/codex/tasks/task_e_68d6ec678fa08324806fa5313d69e49f