### PR TITLE
Add README and smoke test for Promethean CLI

### DIFF
--- a/changelog.d/2025.09.26.20.00.15.md
+++ b/changelog.d/2025.09.26.20.00.15.md
@@ -1,0 +1,2 @@
+- docs: add package README for `@promethean/promethean-cli`
+- test: cover CLI help output with an automated script test

--- a/packages/promethean-cli/README.md
+++ b/packages/promethean-cli/README.md
@@ -1,0 +1,40 @@
+# Promethean CLI
+
+The Promethean CLI provides a thin wrapper around the workspace's `pnpm` scripts.
+It discovers every package in the repository, lists their runnable scripts, and
+then proxies invocations so that contributors can run project tasks with short,
+memorable aliases.
+
+## Usage
+
+After installing dependencies run the build once so the distributable script is
+available:
+
+```sh
+pnpm --filter @promethean/promethean-cli run build
+```
+
+Once built you can execute the CLI via the repo-level binaries:
+
+```sh
+pnpm exec promethean --help
+# or, using the short alias
+pnpm exec prom packages lint
+```
+
+The `--help` flag lists every discovered package and their registered scripts.
+If you request an unknown package or action the CLI will display the available
+options to help you recover quickly.
+
+## Development
+
+- Source lives in [`src/promethean/cli`](./src/promethean/cli/).
+- Builds are produced with `shadow-cljs` and written to `dist/promethean_cli.js`.
+- Tests live under [`tests/scripts`](../../tests/scripts/) and can be run with:
+
+  ```sh
+  pnpm exec ava tests/scripts/promethean-cli.test.js
+  ```
+
+Rebuild the distributable after making code changes so the binaries stay in sync
+with the source.

--- a/tests/scripts/promethean-cli.test.js
+++ b/tests/scripts/promethean-cli.test.js
@@ -1,0 +1,68 @@
+import test from "ava";
+import fs from "node:fs";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+
+const CLI_PATH = path.resolve(
+  "packages",
+  "promethean-cli",
+  "dist",
+  "promethean_cli.js",
+);
+
+const SOURCE_PATH = path.resolve(
+  "packages",
+  "promethean-cli",
+  "src",
+  "promethean",
+  "cli",
+  "core.cljs",
+);
+
+const run = (command, args, options = {}) => {
+  const result = spawnSync(command, args, {
+    cwd: path.resolve("."),
+    encoding: "utf8",
+    ...options,
+  });
+
+  if (result.error) {
+    throw result.error;
+  }
+
+  return result;
+};
+
+test("promethean cli exposes usage text for contributors", (t) => {
+  if (fs.existsSync(CLI_PATH)) {
+    const result = run("node", [CLI_PATH, "--help"]);
+
+    t.is(result.status, 0);
+    t.true(
+      result.stdout.includes("Promethean CLI"),
+      "expected help output to mention the CLI title",
+    );
+    t.true(
+      result.stdout.includes(
+        "Usage: promethean <package> <action> [-- <script-args>]",
+      ),
+      "expected help output to include usage instructions",
+    );
+    return;
+  }
+
+  t.true(
+    fs.existsSync(SOURCE_PATH),
+    "expected the CLI source file to be available when dist assets are missing",
+  );
+  const source = fs.readFileSync(SOURCE_PATH, "utf8");
+  t.true(
+    source.includes("Promethean CLI"),
+    "expected CLI source to contain the help heading",
+  );
+  t.regex(
+    source,
+    /Usage: promethean <package> <action> \[-- <script-args>]/,
+    "expected CLI source to include usage instructions",
+  );
+});


### PR DESCRIPTION
## Summary
- add a package-level README that explains what the Promethean CLI does and how to use it
- create a scripts test that asserts the CLI help text is available even when the dist build is absent
- record the documentation and testing updates in the changelog

## Testing
- pnpm exec ava tests/scripts/promethean-cli.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d6ecbfcf4883249c92eadf0d546aac