### PR TITLE
Fix agent-ecs coverage script to run ava tests

### DIFF
--- a/changelog.d/2025.09.26.20.15.40.md
+++ b/changelog.d/2025.09.26.20.15.40.md
@@ -1,0 +1,1 @@
+- fix agent-ecs coverage script typo to run ava tests

--- a/packages/agent-ecs/package.json
+++ b/packages/agent-ecs/package.json
@@ -23,7 +23,7 @@
         "typecheck": "tsc -p tsconfig.json --noEmit",
         "test": "pnpm run build && ava",
         "lint": "pnpm exec eslint .",
-        "coverage": "pnpm run build && c8 avas",
+        "coverage": "pnpm run build && c8 ava",
         "test:markdown": "pnpm run build && ava",
         "format": "pnpm exec prettier --write ."
     },


### PR DESCRIPTION
## Summary
- correct the @promethean/agent-ecs coverage script to invoke ava instead of the misspelled binary
- document the coverage fix in the changelog

## Testing
- pnpm --filter @promethean/agent-ecs coverage
- pnpm exec eslint packages/agent-ecs --ext .ts

------
https://chatgpt.com/codex/tasks/task_e_68d6f1f7fb0483249b19ab65ca96d1ea