### PR TITLE
fix: ensure markdown anchor injection is idempotent

### DIFF
--- a/changelog.d/2025.09.26.20.22.05.md
+++ b/changelog.d/2025.09.26.20.22.05.md
@@ -1,0 +1,1 @@
+- Fix markdown anchor injection to skip existing anchors outside fences, restoring idempotence.

--- a/packages/markdown/src/anchors.ts
+++ b/packages/markdown/src/anchors.ts
@@ -91,7 +91,16 @@ export const injectAnchors = (content: string, want: ReadonlyArray<AnchorTarget>
         return i;
     };
 
+    const anchorExistsOutside = (id: string): boolean =>
+        lines.some((line, idx) => {
+            if (inside[idx]) return false;
+            const trimmed = line.trim();
+            if (trimmed === `^${id}`) return true;
+            return trimmed.endsWith(` ^${id}`);
+        });
+
     for (const { line, id } of anchors) {
+        if (anchorExistsOutside(id)) continue;
         const idx = Math.max(1, Math.min(line, lines.length)) - 1;
         if (hasIdOnOrNext(idx, id)) continue;
         if (inside[idx]) {


### PR DESCRIPTION
## Summary
- skip reinserting anchors that already exist outside fenced sections when injecting markdown anchors
- document the change in the changelog

## Testing
- pnpm nx run ts-markdown:test

------
https://chatgpt.com/codex/tasks/task_e_68d6f3ba0d648324b57ac7e03425ec24