### PR TITLE
Fix startProcess cleanup for exited processes

### DIFF
--- a/changelog.d/2025.09.26.21.02.10.md
+++ b/changelog.d/2025.09.26.21.02.10.md
@@ -1,0 +1,2 @@
+## Fixed
+- Prevented `startProcess` from hanging when spawned child processes exit before cleanup by treating already-terminated processes as stopped during teardown.


### PR DESCRIPTION
## Summary
- ensure `startProcess` treats already-terminated child processes as stopped so cleanup hooks resolve
- wrap the public signature with immutable facades and document the Node-specific mutable types
- record the regression fix in a changelog fragment

## Testing
- pnpm nx run ts-test-utils:test

------
https://chatgpt.com/codex/tasks/task_e_68d6fb0ea8f483248790dc1de5ef8486