### PR TITLE
Fix kanban CLI markdown dependencies

### DIFF
--- a/changelog.d/2025.03.09.12.00.00.md
+++ b/changelog.d/2025.03.09.12.00.00.md
@@ -1,0 +1,2 @@
+- Fix `@promethean/kanban-cli` build by referencing the shared markdown package via the workspace base config and adding argument validation.
+- Harden kanban parsing helpers against `undefined` matches and unsafe values so TypeScript strict mode succeeds.

--- a/packages/kanban/tsconfig.json
+++ b/packages/kanban/tsconfig.json
@@ -1,12 +1,15 @@
 {
+  "$schema": "https://json.schemastore.org/tsconfig.json",
+  "extends": "../../config/tsconfig.base.json",
   "compilerOptions": {
-    "target": "ES2022",
-    "module": "ESNext",
-    "moduleResolution": "Bundler",
-    "outDir": "dist",
     "rootDir": "src",
-    "declaration": false,
-    "skipLibCheck": true
+    "outDir": "dist",
+    "composite": true,
+    "paths": {
+      "@promethean/markdown": ["../markdown/dist/index"],
+      "@promethean/markdown/*": ["../markdown/dist/*"]
+    }
   },
-  "include": ["src"]
+  "include": ["src/**/*"],
+  "references": [{ "path": "../markdown" }]
 }


### PR DESCRIPTION
## Summary
- extend the kanban CLI TypeScript config with the workspace base settings and reference the shared markdown package
- harden CLI argument handling and markdown parsing helpers to avoid undefined values under strict compilation
- add a changelog entry documenting the build fix

## Testing
- pnpm --filter ./packages/kanban build
- pnpm exec eslint packages/kanban/src/index.ts packages/kanban/src/lib/kanban.ts


------
https://chatgpt.com/codex/tasks/task_e_68d6fe7fc4848324be009dbb60188303

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Hardened Kanban markdown parsing to prevent crashes, ignore unsafe/empty fields, and improve task/label handling and move behavior.
  - Validates required CLI arguments with clearer messages and consistent exit codes.
  - Improved error reporting: shows stack only when available, otherwise a concise message.

- Documentation
  - Added changelog entries covering build fix and parsing hardening.

- Chores
  - Updated build configuration to use shared workspace settings and project references for improved package reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->