### PR TITLE
Fix Nx CI failing suites by converting node:test cases to Ava

### DIFF
--- a/changelog.d/2025.09.26.23.36.30.md
+++ b/changelog.d/2025.09.26.23.36.30.md
@@ -1,0 +1,1 @@
+- Convert node:test suites to Ava so Nx stops failing when no tests are detected for auth-service and proxy frontend smoke tests.

--- a/tests/sites/llm_chat_frontend.test.mjs
+++ b/tests/sites/llm_chat_frontend.test.mjs
@@ -1,47 +1,62 @@
-import test from 'node:test';
-import assert from 'node:assert/strict';
-import http from 'node:http';
+import test from "ava";
+import http from "node:http";
 
-process.env.NODE_ENV = 'test';
-const { start: startProxy, stop: stopProxy } = await import('../../services/js/proxy/index.js');
+process.env.NODE_ENV = "test";
+const { start: startProxy, stop: stopProxy } = await import(
+  "../../services/js/proxy/index.js"
+);
 
-async function startMockLLM() {
-    const server = http.createServer((req, res) => {
-        if (req.url === '/generate' && req.method === 'POST') {
-            let body = '';
-            req.on('data', (c) => (body += c));
-            req.on('end', () => {
-                res.setHeader('Content-Type', 'application/json');
-                res.end(JSON.stringify({ reply: 'hi' }));
-            });
-            return;
-        }
-        res.statusCode = 404;
-        res.end();
+function closeServer(server) {
+  return new Promise((resolve, reject) => {
+    server.close((err) => {
+      if (err) reject(err);
+      else resolve();
     });
-    await new Promise((resolve) => server.listen(0, resolve));
-    return server;
+  });
 }
 
-test('LLM chat served and proxied via proxy service', async () => {
-    const llm = await startMockLLM();
-    const llmPort = llm.address().port;
-    const proxy = await startProxy(0, { '/llm': `http://127.0.0.1:${llmPort}` });
-    await new Promise((resolve) => proxy.on('listening', resolve));
-    const proxyPort = proxy.address().port;
+async function startMockLLM() {
+  const server = http.createServer((req, res) => {
+    if (req.url === "/generate" && req.method === "POST") {
+      let body = "";
+      req.on("data", (chunk) => {
+        body += chunk;
+      });
+      req.on("end", () => {
+        res.setHeader("Content-Type", "application/json");
+        res.end(JSON.stringify({ reply: "hi" }));
+      });
+      return;
+    }
+    res.statusCode = 404;
+    res.end();
+  });
+  await new Promise((resolve) => server.listen(0, resolve));
+  return server;
+}
 
-    const page = await fetch(`http://127.0.0.1:${proxyPort}/llm-chat/`);
-    const text = await page.text();
-    assert.ok(text.includes('LLM Chat'));
+test("LLM chat served and proxied via proxy service", async (t) => {
+  const llm = await startMockLLM();
+  t.teardown(() => closeServer(llm));
 
-    const res = await fetch(`http://127.0.0.1:${proxyPort}/llm/generate`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ prompt: 'hi', context: [] }),
-    });
-    const data = await res.json();
-    assert.equal(data.reply, 'hi');
-
+  const llmPort = llm.address().port;
+  const proxy = await startProxy(0, { "/llm": `http://127.0.0.1:${llmPort}` });
+  await new Promise((resolve) => proxy.on("listening", resolve));
+  t.teardown(async () => {
     await stopProxy();
-    await new Promise((resolve) => llm.close(resolve));
+  });
+
+  const proxyPort = proxy.address().port;
+
+  const page = await fetch(`http://127.0.0.1:${proxyPort}/llm-chat/`);
+  const text = await page.text();
+  t.true(text.includes("LLM Chat"));
+
+  const res = await fetch(`http://127.0.0.1:${proxyPort}/llm/generate`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ prompt: "hi", context: [] }),
+  });
+  const data = await res.json();
+  t.is(data.reply, "hi");
 });

--- a/tests/sites/markdown_graph_frontend.test.mjs
+++ b/tests/sites/markdown_graph_frontend.test.mjs
@@ -1,9 +1,17 @@
-import test from "node:test";
-import assert from "node:assert/strict";
+import test from "ava";
 import http from "node:http";
 import { fetchGraph } from "@promethean/markdown-graph-frontend/dist/frontend/graph.mjs";
 
-test("fetchGraph collects nodes and links", async () => {
+function closeServer(server) {
+  return new Promise((resolve, reject) => {
+    server.close((err) => {
+      if (err) reject(err);
+      else resolve();
+    });
+  });
+}
+
+test("fetchGraph collects nodes and links", async (t) => {
   const routes = {
     "/links/readme.md": { links: ["docs/a.md"] },
     "/links/docs/a.md": { links: [] },
@@ -21,12 +29,13 @@ test("fetchGraph collects nodes and links", async () => {
   });
 
   await new Promise((resolve) => server.listen(0, resolve));
+  t.teardown(() => closeServer(server));
+
   const { port } = server.address();
   const baseUrl = `http://127.0.0.1:${port}`;
   const graph = await fetchGraph(baseUrl);
-  server.close();
 
-  assert.deepEqual(graph, {
+  t.deepEqual(graph, {
     nodes: [{ id: "readme.md" }, { id: "docs/a.md" }],
     links: [{ source: "readme.md", target: "docs/a.md" }],
   });

--- a/tests/sites/smartgpt_dashboard_frontend.test.mjs
+++ b/tests/sites/smartgpt_dashboard_frontend.test.mjs
@@ -1,39 +1,54 @@
-import test from 'node:test';
-import assert from 'node:assert/strict';
-import http from 'node:http';
+import test from "ava";
+import http from "node:http";
 
-process.env.NODE_ENV = 'test';
-const { start: startProxy, stop: stopProxy } = await import('../../services/js/proxy/index.js');
+process.env.NODE_ENV = "test";
+const { start: startProxy, stop: stopProxy } = await import(
+  "../../services/js/proxy/index.js"
+);
 
-async function startMockBridge() {
-    const server = http.createServer((req, res) => {
-        if (req.url === '/auth/me') {
-            res.setHeader('Content-Type', 'application/json');
-            res.end(JSON.stringify({ auth: true }));
-            return;
-        }
-        res.statusCode = 404;
-        res.end();
+function closeServer(server) {
+  return new Promise((resolve, reject) => {
+    server.close((err) => {
+      if (err) reject(err);
+      else resolve();
     });
-    await new Promise((resolve) => server.listen(0, resolve));
-    return server;
+  });
 }
 
-test('SmartGPT dashboard served and proxied via proxy service', async () => {
-    const bridge = await startMockBridge();
-    const bridgePort = bridge.address().port;
-    const proxy = await startProxy(0, { '/bridge': `http://127.0.0.1:${bridgePort}` });
-    await new Promise((resolve) => proxy.on('listening', resolve));
-    const proxyPort = proxy.address().port;
+async function startMockBridge() {
+  const server = http.createServer((req, res) => {
+    if (req.url === "/auth/me") {
+      res.setHeader("Content-Type", "application/json");
+      res.end(JSON.stringify({ auth: true }));
+      return;
+    }
+    res.statusCode = 404;
+    res.end();
+  });
+  await new Promise((resolve) => server.listen(0, resolve));
+  return server;
+}
 
-    const page = await fetch(`http://127.0.0.1:${proxyPort}/smartgpt-dashboard/`);
-    const text = await page.text();
-    assert.ok(text.includes('SmartGPT Bridge'));
+test("SmartGPT dashboard served and proxied via proxy service", async (t) => {
+  const bridge = await startMockBridge();
+  t.teardown(() => closeServer(bridge));
 
-    const res = await fetch(`http://127.0.0.1:${proxyPort}/bridge/auth/me`);
-    const data = await res.json();
-    assert.equal(data.auth, true);
-
+  const bridgePort = bridge.address().port;
+  const proxy = await startProxy(0, {
+    "/bridge": `http://127.0.0.1:${bridgePort}`,
+  });
+  await new Promise((resolve) => proxy.on("listening", resolve));
+  t.teardown(async () => {
     await stopProxy();
-    await new Promise((resolve) => bridge.close(resolve));
+  });
+
+  const proxyPort = proxy.address().port;
+
+  const page = await fetch(`http://127.0.0.1:${proxyPort}/smartgpt-dashboard/`);
+  const text = await page.text();
+  t.true(text.includes("SmartGPT Bridge"));
+
+  const res = await fetch(`http://127.0.0.1:${proxyPort}/bridge/auth/me`);
+  const data = await res.json();
+  t.is(data.auth, true);
 });


### PR DESCRIPTION
## Summary
- convert the auth-service OAuth flow test from node:test to Ava so the Nx test target finds the suite
- switch the proxy frontend smoke tests to Ava with teardown hooks to prevent "no tests found" failures
- document the CI stability fix in the changelog

## Testing
- pnpm nx run @promethean/auth-service:test
- pnpm ava tests/sites/llm_chat_frontend.test.mjs tests/sites/markdown_graph_frontend.test.mjs tests/sites/smartgpt_dashboard_frontend.test.mjs
- pnpm exec eslint packages/auth-service/test/oauth-flow.test.mjs tests/sites/llm_chat_frontend.test.mjs tests/sites/markdown_graph_frontend.test.mjs tests/sites/smartgpt_dashboard_frontend.test.mjs

------
https://chatgpt.com/codex/tasks/task_e_68d71f9a17348324a1b2cf62d4378bc8