### PR TITLE
Add websocket gateway auth regression test

### DIFF
--- a/changelog.d/2025.09.26.23.54.15.md
+++ b/changelog.d/2025.09.26.23.54.15.md
@@ -1,0 +1,1 @@
+- add an integration test for the websocket gateway to require authentication before publish calls

--- a/packages/ws/src/tests/server.test.ts
+++ b/packages/ws/src/tests/server.test.ts
@@ -1,0 +1,103 @@
+import { once } from 'node:events';
+import type { AddressInfo } from 'node:net';
+
+import test from 'ava';
+import type { ReadonlyDeep } from 'type-fest';
+import WebSocket from 'ws';
+
+import { startWSGateway } from '../server.js';
+
+type GatewayError = {
+    readonly op: 'ERR';
+    readonly code: string;
+    readonly msg: string;
+    readonly corr: string;
+};
+
+type BusStub = {
+    readonly publish: () => Promise<{ readonly id: string }>;
+    readonly subscribe: () => Promise<() => Promise<void>>;
+    readonly ack: () => Promise<void>;
+    readonly nack: () => Promise<void>;
+};
+
+const bus: BusStub = {
+    publish: async () => ({ id: 'noop' }),
+    subscribe: async () => async () => {},
+    ack: async () => {},
+    nack: async () => {},
+};
+
+type GatewayHandles = {
+    readonly ws: WebSocket;
+    readonly close: () => Promise<void>;
+};
+
+async function startGateway(): Promise<GatewayHandles> {
+    const wss = startWSGateway(bus, 0, { ackTimeoutMs: 50 });
+    await once(wss, 'listening');
+    const address = wss.address();
+    if (!address || typeof address === 'string') {
+        throw new Error('failed to acquire server address');
+    }
+
+    const ws = new WebSocket(`ws://127.0.0.1:${(address as AddressInfo).port}`);
+    await once(ws, 'open');
+
+    const close = async () => {
+        if (ws.readyState === WebSocket.OPEN || ws.readyState === WebSocket.CONNECTING) {
+            ws.close();
+        }
+        if (ws.readyState !== WebSocket.CLOSED) {
+            await once(ws, 'close').catch(() => {});
+        }
+        await new Promise<void>((resolve, reject) => {
+            wss.close((err) => {
+                if (err) reject(err);
+                else resolve();
+            });
+        });
+    };
+
+    return { ws, close } as const;
+}
+
+function isGatewayError(value: unknown): value is GatewayError {
+    if (typeof value !== 'object' || value === null) return false;
+    const candidate = value as Partial<GatewayError>;
+    return (
+        candidate.op === 'ERR' &&
+        typeof candidate.code === 'string' &&
+        typeof candidate.msg === 'string' &&
+        typeof candidate.corr === 'string'
+    );
+}
+
+async function receiveError(ws: ReadonlyDeep<WebSocket>): Promise<GatewayError> {
+    const [raw] = (await once(ws, 'message')) as [WebSocket.RawData];
+    const parsed: unknown = JSON.parse(raw.toString());
+    if (!isGatewayError(parsed)) {
+        throw new TypeError('unexpected gateway response');
+    }
+    return parsed;
+}
+
+test('gateway rejects operations before auth', async (t) => {
+    const { ws, close } = await startGateway();
+    t.teardown(close);
+    ws.send(
+        JSON.stringify({
+            op: 'PUBLISH',
+            topic: 'demo',
+            payload: { hello: 'world' },
+            corr: 'corr-1',
+        }),
+    );
+    const err = await receiveError(ws);
+    t.deepEqual(err, {
+        op: 'ERR',
+        code: 'unauthorized',
+        msg: 'Call AUTH first.',
+        corr: 'corr-1',
+    });
+});


### PR DESCRIPTION
## Summary
- add an integration test that exercises the websocket gateway before authentication
- ensure cleanup helpers close the websocket and gateway to avoid resource leaks
- record the change in the changelog log

## Testing
- pnpm --filter @promethean/ws test
- pnpm exec eslint packages/ws/src/tests/server.test.ts


------
https://chatgpt.com/codex/tasks/task_e_68d725093ee083249e6a59feb4384858