### PR TITLE
fix(dev): add harness smoke test

### DIFF
--- a/changelog.d/2025.09.26.23.52.46.md
+++ b/changelog.d/2025.09.26.23.52.46.md
@@ -1,0 +1,2 @@
+- fix(@promethean/dev): add harness smoke test so pnpm test passes
+- chore(@promethean/dev): tighten harness typing and graceful shutdown helpers

--- a/packages/dev/src/harness.ts
+++ b/packages/dev/src/harness.ts
@@ -1,15 +1,35 @@
 import { InMemoryEventBus } from '@promethean/event/memory.js';
-import { startWSGateway } from '@promethean/ws/server.js';
-import { startHttpPublisher } from '@promethean/http/publish.js';
+import type { EventBus } from '@promethean/event/types.js';
 import { startProcessProjector } from '@promethean/examples/process/projector.js';
+import { startHttpPublisher } from '@promethean/http/publish.js';
+import { startWSGateway } from '@promethean/ws/server.js';
 
 export type Harness = {
-    bus: any;
+    bus: EventBus;
     stop(): Promise<void>;
 };
 
-export async function startHarness({ wsPort = 9090, httpPort = 9091 } = {}): Promise<Harness> {
-    const bus = new InMemoryEventBus();
+export type HarnessOptions = {
+    readonly wsPort?: number;
+    readonly httpPort?: number;
+};
+
+type CloseHandler = (err?: Readonly<Error>) => void;
+
+const closeGracefully = (closer: (handler: CloseHandler) => void): Promise<void> =>
+    new Promise<void>((resolve, reject) => {
+        const onClose: CloseHandler = (err) => {
+            if (err) {
+                reject(err);
+                return;
+            }
+            resolve();
+        };
+        closer(onClose);
+    });
+
+export async function startHarness({ wsPort = 9090, httpPort = 9091 }: HarnessOptions = {}): Promise<Harness> {
+    const bus: EventBus = new InMemoryEventBus();
 
     const wss = startWSGateway(bus, wsPort, { auth: async () => ({ ok: true }) });
     const http = startHttpPublisher(bus, httpPort);
@@ -18,8 +38,12 @@ export async function startHarness({ wsPort = 9090, httpPort = 9091 } = {}): Pro
     return {
         bus,
         async stop() {
-            await new Promise((r) => (http as any).close(r));
-            wss.close();
+            await closeGracefully((handler) => {
+                http.close(handler);
+            });
+            await closeGracefully((handler) => {
+                wss.close(handler);
+            });
             stopProj();
         },
     };

--- a/packages/dev/src/shims.d.ts
+++ b/packages/dev/src/shims.d.ts
@@ -1,2 +1,15 @@
-declare module '@promethean/event/memory.js';
-declare module '@promethean/ws/server.js';
+declare module '@promethean/event/memory.js' {
+    export * from '@promethean/event/dist/memory.js';
+}
+
+declare module '@promethean/ws/server.js' {
+    export * from '@promethean/ws/dist/server.js';
+}
+
+declare module '@promethean/http/publish.js' {
+    export * from '@promethean/http/dist/publish.js';
+}
+
+declare module '@promethean/examples/process/projector.js' {
+    export * from '@promethean/examples/dist/process/projector.js';
+}

--- a/packages/dev/src/tests/harness.test.ts
+++ b/packages/dev/src/tests/harness.test.ts
@@ -1,0 +1,11 @@
+import test from 'ava';
+
+import { startHarness } from '../harness.js';
+
+test('startHarness exposes a bus and stops cleanly', async (t) => {
+    const harness = await startHarness({ wsPort: 0, httpPort: 0 });
+    t.teardown(() => harness.stop());
+
+    t.truthy(harness.bus);
+    t.is(typeof harness.bus.publish, 'function');
+});


### PR DESCRIPTION
## Summary
- add an Ava smoke test that starts and stops the dev harness on ephemeral ports so the package test suite no longer fails empty
- tighten the harness typing and add a graceful shutdown helper to remove `any` usage around close calls
- expose module shims that forward to generated declaration files so TypeScript sees the real shapes of imported helpers

## Testing
- pnpm --filter @promethean/dev test
- pnpm exec eslint packages/dev/src/harness.ts packages/dev/src/tests/harness.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d7250c944c8324b59910a1bf102a4f