### PR TITLE
Fix web-utils crawler test Response dependency

### DIFF
--- a/changelog.d/2025.09.26.23.58.00.web-utils.md
+++ b/changelog.d/2025.09.26.23.58.00.web-utils.md
@@ -1,0 +1,3 @@
+## Summary
+- fix `@promethean/web-utils` crawler test to avoid relying on global `Response`
+- ensure package tests run on runtimes without fetch globals

--- a/docs/agile/tasks/fix-web-utils-test.md
+++ b/docs/agile/tasks/fix-web-utils-test.md
@@ -1,0 +1,57 @@
+---
+task-id: TASK-20250207-web-utils
+title: Fix failing web-utils test
+state: InProgress
+prev:
+txn: "2025-09-26T23:54:39+00:00-0001"
+owner: err
+priority: p2
+size: s
+epic: EPC-000
+depends_on: []
+labels:
+  - board:auto
+  - lang:ts
+due:
+links: []
+artifacts: []
+rationale: |
+  Address failing @promethean/web-utils unit test reported by CI. Ensures package passes test suite.
+proposed_transitions:
+  - New->Accepted
+  - Accepted->Breakdown
+  - Breakdown->Ready
+  - Ready->Todo
+  - Todo->InProgress
+tags:
+  - task/TASK-20250207-web-utils
+  - board/kanban
+  - state/InProgress
+  - owner/err
+  - priority/p2
+  - epic/EPC-000
+---
+
+## Context
+### Changes and Updates
+- **What changed?**: `@promethean/web-utils` has a failing test preventing CI success.
+- **Where?**: `packages/web-utils` tests.
+- **Why now?**: User requested fix for `@promethean/web-utils:test` failure.
+
+## Inputs / Artifacts
+- Pending test failure logs once reproduced locally.
+
+## Definition of Done
+- [ ] `pnpm --filter @promethean/web-utils test` passes locally.
+- [ ] No new lint errors in touched files.
+- [ ] PR prepared referencing this task.
+
+## Plan
+1. Reproduce failure by running package tests.
+2. Identify root cause and implement fix in source or tests.
+3. Update or add tests if necessary.
+4. Run lint and test commands to ensure success.
+5. Commit changes and prepare PR referencing task.
+
+## Relevant Resources
+- None yet.

--- a/packages/web-utils/src/tests/crawler.test.ts
+++ b/packages/web-utils/src/tests/crawler.test.ts
@@ -8,7 +8,14 @@ test("crawlPage fetches and extracts links", async (t) => {
   <a href="https://example.com/b">B</a>
   </body></html>`;
   const fakeFetch: typeof fetch = async () =>
-    new Response(html, { status: 200 });
+    ({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      async text() {
+        return html;
+      },
+    }) as Response;
   const result = await crawlPage("https://example.com", fakeFetch);
   t.is(result.url, "https://example.com/");
   t.is(result.title, "Example");


### PR DESCRIPTION
## Summary
- add task note for addressing the @promethean/web-utils test failure
- document the change in the changelog
- stub the crawler test response object so it no longer depends on the global Response implementation

## Testing
- pnpm --filter @promethean/web-utils test
- pnpm exec eslint packages/web-utils/src/tests/crawler.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d7253cdfcc8324a6a7c6c817817195