### PR TITLE
Add alias for frontend-service testt script

### DIFF
--- a/changelog.d/2025.09.26.23.55.59.md
+++ b/changelog.d/2025.09.26.23.55.59.md
@@ -1,0 +1,1 @@
+- add a package script alias so `pnpm --filter @promethean/frontend-service testt` runs the existing test suite

--- a/packages/frontend-service/package.json
+++ b/packages/frontend-service/package.json
@@ -22,6 +22,7 @@
     "clean": "rimraf dist",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "test": "pnpm run build && ava",
+    "testt": "pnpm run test",
     "lint": "pnpm exec eslint .",
     "coverage": "pnpm run build && c8 ava",
     "format": "pnpm exec prettier --write .",


### PR DESCRIPTION
## Summary
- add a testt script alias to reuse the existing frontend-service test command
- document the change in the changelog

## Testing
- pnpm --filter @promethean/frontend-service testt

------
https://chatgpt.com/codex/tasks/task_e_68d7256026848324b835635e04b0e300