### PR TITLE
fix(auth-service): run unit tests with ava

### DIFF
--- a/changelog.d/2025.09.27.00.02.34.md
+++ b/changelog.d/2025.09.27.00.02.34.md
@@ -1,0 +1,1 @@
+- Fix @promethean/auth-service unit test script to execute AVA runner instead of Node's built-in test runner.

--- a/packages/auth-service/package.json
+++ b/packages/auth-service/package.json
@@ -13,7 +13,7 @@
     "lint": "prettier --cache --check . && eslint . --cache || true",
     "format": "prettier --cache --write . && eslint . --fix --cache || true",
     "test": "pnpm run test:unit",
-    "test:unit": "pnpm run build && node --test \"test/**/*.test.mjs\"",
+    "test:unit": "pnpm run build && pnpm exec ava \"test/**/*.test.mjs\"",
     "test:integration": "node -e \"console.log('no integration tests for auth-service')\"",
     "test:e2e": "node -e \"console.log('no e2e tests for auth-service')\""
   },


### PR DESCRIPTION
## Summary
- update the auth-service unit test script to execute Ava so package tests run successfully
- record the change in the changelog logbook

## Testing
- pnpm --filter @promethean/auth-service test

------
https://chatgpt.com/codex/tasks/task_e_68d72550f9f88324b1f773fb95ab20e5