### PR TITLE
Add unit tests for sonarflow utilities

### DIFF
--- a/changelog.d/2025.09.27.00.01.58.md
+++ b/changelog.d/2025.09.27.00.01.58.md
@@ -1,0 +1,2 @@
+- Added unit tests for sonarflow utilities and enabled CLI argument parsing and auth header helpers to support deterministic testing.
+- Hardened sonarflow utility functions with immutable return types and safer JSON reading semantics.

--- a/packages/sonarflow/src/tests/utils.test.ts
+++ b/packages/sonarflow/src/tests/utils.test.ts
@@ -1,0 +1,61 @@
+import test from "ava";
+import type { ReadonlyDeep } from "type-fest";
+
+type UtilsModule = typeof import("../utils.js");
+
+const utilsHref = new URL("../utils.js", import.meta.url).href;
+const importUtils = async (): Promise<ReadonlyDeep<UtilsModule>> =>
+  import(
+    `${utilsHref}?v=${Date.now()}-${Math.random().toString(36).slice(2)}`
+  ).then((mod) => mod as ReadonlyDeep<UtilsModule>);
+
+test.serial("parseArgs merges CLI flags with defaults", async (t) => {
+  const { parseArgs } = await importUtils();
+  const result = parseArgs(
+    {
+      "--project": "",
+      "--toggle": "false",
+      "--unchanged": "default",
+    },
+    ["node", "script", "--project", "demo", "--toggle", "--unchanged", "value"],
+  );
+
+  t.deepEqual(result, {
+    "--project": "demo",
+    "--toggle": "true",
+    "--unchanged": "value",
+  });
+});
+
+test.serial(
+  "severityToPriority maps severities to priority levels",
+  async (t) => {
+    const { severityToPriority } = await importUtils();
+
+    t.is(severityToPriority("BLOCKER"), "P0");
+    t.is(severityToPriority("CRITICAL"), "P1");
+    t.is(severityToPriority("MAJOR"), "P2");
+    t.is(severityToPriority("MINOR"), "P3");
+    t.is(severityToPriority("INFO"), "P4");
+    t.is(severityToPriority("UNKNOWN"), "P4");
+  },
+);
+
+test.serial("pathPrefix trims to the requested depth", async (t) => {
+  const { pathPrefix } = await importUtils();
+
+  t.is(pathPrefix("a/b/c/d.ts"), "a/b");
+  t.is(pathPrefix("a/b/c/d.ts", 3), "a/b/c");
+  t.is(pathPrefix("single", 5), "single");
+});
+
+test.serial("authHeader requires SONAR_TOKEN", async (t) => {
+  const { authHeader } = await importUtils();
+  const error = t.throws(() => authHeader(""));
+  t.is(error?.message, "SONAR_TOKEN env is required");
+});
+
+test.serial("authHeader encodes SONAR_TOKEN using basic auth", async (t) => {
+  const { authHeader } = await importUtils();
+  t.deepEqual(authHeader("secret"), { Authorization: "Basic c2VjcmV0Og==" });
+});

--- a/packages/sonarflow/src/utils.ts
+++ b/packages/sonarflow/src/utils.ts
@@ -1,11 +1,15 @@
 import { promises as fs } from "fs";
 import * as path from "path";
+
+import type { ReadonlyDeep } from "type-fest";
+
 export { sha1 } from "@promethean/utils";
 
 export function parseArgs(
   defaults: Readonly<Record<string, string>>,
-): Record<string, string> {
-  return process.argv.slice(2).reduce<Record<string, string>>(
+  argv: ReadonlyArray<string> = process.argv,
+): ReadonlyDeep<Record<string, string>> {
+  const parsed = argv.slice(2).reduce<Record<string, string>>(
     (out, cur, idx, arr) => {
       if (!cur.startsWith("--")) return out;
       const next = arr[idx + 1];
@@ -14,28 +18,38 @@ export function parseArgs(
     },
     { ...defaults },
   );
+  return Object.freeze(parsed) as ReadonlyDeep<Record<string, string>>;
 }
 
-export async function writeJSON(p: string, data: unknown): Promise<void> {
+export async function writeJSON(
+  p: string,
+  data: ReadonlyDeep<unknown>,
+): Promise<void> {
   await fs.mkdir(path.dirname(p), { recursive: true });
   await fs.writeFile(p, JSON.stringify(data, null, 2), "utf-8");
 }
 
-export async function readJSON<T>(p: string): Promise<T | undefined> {
-  try {
-    return JSON.parse(await fs.readFile(p, "utf-8")) as T;
-  } catch {
-    return undefined;
-  }
+export async function readJSON<T>(
+  p: string,
+): Promise<ReadonlyDeep<T> | undefined> {
+  return fs
+    .readFile(p, "utf-8")
+    .then((contents) => JSON.parse(contents) as T)
+    .then((parsed) => Object.freeze(parsed) as ReadonlyDeep<T>)
+    .catch(() => undefined);
 }
 
 export const SONAR_URL = process.env.SONAR_HOST_URL ?? "http://localhost:9000";
 export const SONAR_TOKEN = process.env.SONAR_TOKEN ?? "";
 
-export function authHeader(): Record<string, string> {
-  if (!SONAR_TOKEN) throw new Error("SONAR_TOKEN env is required");
-  const b = Buffer.from(`${SONAR_TOKEN}:`).toString("base64");
-  return { Authorization: `Basic ${b}` };
+export function authHeader(
+  token = SONAR_TOKEN,
+): ReadonlyDeep<Record<string, string>> {
+  if (!token) throw new Error("SONAR_TOKEN env is required");
+  const b = Buffer.from(`${token}:`).toString("base64");
+  return Object.freeze({ Authorization: `Basic ${b}` }) as ReadonlyDeep<
+    Record<string, string>
+  >;
 }
 
 export function severityToPriority(


### PR DESCRIPTION
## Summary
- add AVA coverage for sonarflow's argument parsing, severity mapping, path prefix, and auth header helpers
- adjust sonarflow utilities to return immutable data and allow token/argv injection for deterministic tests
- log the update in a changelog fragment

## Testing
- pnpm exec nx test @promethean/sonarflow
- pnpm exec eslint packages/sonarflow/src/tests/utils.test.ts packages/sonarflow/src/utils.ts

------
https://chatgpt.com/codex/tasks/task_e_68d72551515c8324bb4af063e9255905