### PR TITLE
Fix Nx test command for webcrawler service

### DIFF
--- a/changelog.d/2025.09.27.00.03.02.md
+++ b/changelog.d/2025.09.27.00.03.02.md
@@ -1,0 +1,1 @@
+- Fix `@promethean/webcrawler-service:test` by updating the Nx target to execute Ava from the package directory with the shared config so only the crawler's compiled tests run.

--- a/packages/webcrawler-service/project.json
+++ b/packages/webcrawler-service/project.json
@@ -20,7 +20,8 @@
       "executor": "nx:run-commands",
       "dependsOn": ["build"],
       "options": {
-        "command": "ava"
+        "command": "ava --config ../../config/ava.config.mjs \"dist/**/*.test.js\"",
+        "cwd": "packages/webcrawler-service"
       }
     },
     "lint": {


### PR DESCRIPTION
## Summary
- scope the @promethean/webcrawler-service Nx test target to run Ava from the package directory with the shared config so only its compiled specs execute
- record the test fix in a dated changelog fragment

## Testing
- pnpm nx test @promethean/webcrawler-service --verbose

Refs TASK-20240921-buildfix.

------
https://chatgpt.com/codex/tasks/task_e_68d7254a84bc8324b4dfe8120cf53fc3