### PR TITLE
Add utility tests for cookbookflow

### DIFF
--- a/changelog.d/2024.07.22.000000.md
+++ b/changelog.d/2024.07.22.000000.md
@@ -1,0 +1,1 @@
+- add ava test coverage for `@promethean/cookbookflow` utilities so the package test target passes

--- a/packages/cookbookflow/ava.config.mjs
+++ b/packages/cookbookflow/ava.config.mjs
@@ -1,0 +1,1 @@
+export { default } from "../../config/ava.config.mjs";

--- a/packages/cookbookflow/src/tests/utils.test.ts
+++ b/packages/cookbookflow/src/tests/utils.test.ts
@@ -1,0 +1,80 @@
+import { promises as fs } from "fs";
+import os from "os";
+import path from "path";
+
+import test from "ava";
+
+import { readMaybe, writeJSON, writeText, execShell } from "../utils.js";
+
+const tempRoot = path.join(os.tmpdir(), "cookbookflow-tests");
+
+async function makeTempDir() {
+  await fs.mkdir(tempRoot, { recursive: true });
+  return fs.mkdtemp(path.join(tempRoot, "run-"));
+}
+
+test("readMaybe returns undefined for missing files", async (t) => {
+  const dir = await makeTempDir();
+  const missingFile = path.join(dir, "missing.txt");
+
+  const result = await readMaybe(missingFile);
+
+  t.is(result, undefined);
+});
+
+test("writeText writes file content", async (t) => {
+  const dir = await makeTempDir();
+  const file = path.join(dir, "notes.txt");
+  const expected = "hello world";
+
+  await writeText(file, expected);
+  const actual = await fs.readFile(file, "utf-8");
+
+  t.is(actual, expected);
+});
+
+test("writeJSON writes structured data", async (t) => {
+  const dir = await makeTempDir();
+  const file = path.join(dir, "data.json");
+  const payload = { foo: "bar" };
+
+  await writeJSON(file, payload);
+  const raw = await fs.readFile(file, "utf-8");
+
+  t.deepEqual(JSON.parse(raw), payload);
+});
+
+test("readMaybe reads file content when present", async (t) => {
+  const dir = await makeTempDir();
+  const file = path.join(dir, "note.txt");
+  await fs.writeFile(file, "hello", "utf-8");
+
+  const result = await readMaybe(file);
+
+  t.is(result, "hello");
+});
+
+test("execShell captures stdout and exit code", async (t) => {
+  const dir = await makeTempDir();
+  const { code, stdout, stderr } = await execShell(
+    process.execPath,
+    ["-e", "process.stdout.write('ok')"],
+    dir,
+  );
+
+  t.is(code, 0);
+  t.is(stdout, "ok");
+  t.is(stderr, "");
+});
+
+test("execShell reports failures", async (t) => {
+  const dir = await makeTempDir();
+  const { code, stdout } = await execShell(
+    process.execPath,
+    ["-e", "process.exit(5)"],
+    dir,
+  );
+
+  t.is(code, 5);
+  t.is(stdout, "");
+});


### PR DESCRIPTION
## Summary
- add an AVA config for @promethean/cookbookflow to align with the repo defaults
- implement filesystem and execShell utility tests so the package test target has coverage
- document the addition in the changelog

## Testing
- pnpm exec nx test @promethean/cookbookflow

------
https://chatgpt.com/codex/tasks/task_e_68d72553b278832489fbff9e9337d069