### PR TITLE
fix: allow stubbing the v1 exec runner in tests

### DIFF
--- a/changelog.d/2025.09.27.00.30.00.md
+++ b/changelog.d/2025.09.27.00.30.00.md
@@ -1,0 +1,1 @@
+- fix: allow v1 exec routes to use injected runner so tests can stub command execution and avoid touching the real shell

--- a/packages/smartgpt-bridge/src/fastifyApp.ts
+++ b/packages/smartgpt-bridge/src/fastifyApp.ts
@@ -261,7 +261,7 @@ export async function buildFastifyApp(
     async (v1Scope) => {
       // Register rate limiting for v1 routes (best-effort; ignore version mismatches)
       if (!isTestEnv) {
-        await registerV1Routes(v1Scope);
+        await registerV1Routes(v1Scope, { runCommand: deps.runCommand });
       }
 
       const v1Auth = authFactory();
@@ -270,7 +270,7 @@ export async function buildFastifyApp(
     { prefix: "/v1" },
   );
 
-  await registerV1Routes(app);
+  await registerV1Routes(app, { runCommand: deps.runCommand });
 
   // Initialize indexer bootstrap/incremental state unless in test
   if (!isTestEnv) {

--- a/packages/smartgpt-bridge/src/routes/v1/exec.ts
+++ b/packages/smartgpt-bridge/src/routes/v1/exec.ts
@@ -1,7 +1,16 @@
 import { runCommand } from "../../exec.js";
 
-export function registerExecRoutes(v1: any) {
+export type ExecDeps = {
+  runCommand?:
+    | ((
+        opts: Parameters<typeof runCommand>[0],
+      ) => ReturnType<typeof runCommand>)
+    | undefined;
+};
+
+export function registerExecRoutes(v1: any, deps: ExecDeps = {}) {
   const ROOT_PATH = v1.ROOT_PATH;
+  const run = deps.runCommand ?? runCommand;
   v1.post("/exec/run", {
     schema: {
       summary: "Run a shell command",
@@ -43,12 +52,11 @@ export function registerExecRoutes(v1: any) {
         if (!execEnabled)
           return reply.code(403).send({ ok: false, error: "exec disabled" });
         const { command, cwd, env, timeoutMs, tty } = req.body || {};
-        console.log({ command, cwd, env, timeoutMs, tty });
         if (!command)
           return reply
             .code(400)
             .send({ ok: false, error: "Missing 'command'" });
-        const out = await runCommand({
+        const out = await run({
           command: String(command),
           cwd: cwd ? String(cwd) : ROOT_PATH,
           repoRoot: ROOT_PATH,

--- a/packages/smartgpt-bridge/src/routes/v1/index.ts
+++ b/packages/smartgpt-bridge/src/routes/v1/index.ts
@@ -6,11 +6,16 @@ import { registerSearchRoutes } from "./search.js";
 import { registerSinkRoutes } from "./sinks.js";
 import { registerIndexerRoutes } from "./indexer.js";
 import { registerAgentRoutes } from "./agents.js";
-import { registerExecRoutes } from "./exec.js";
+import { registerExecRoutes, type ExecDeps } from "./exec.js";
 import { FastifyInstance } from "fastify";
 import rateLimit from "@fastify/rate-limit";
 
-export async function registerV1Routes(app: FastifyInstance): Promise<void> {
+type V1Deps = Pick<ExecDeps, "runCommand">;
+
+export async function registerV1Routes(
+  app: FastifyInstance,
+  deps: V1Deps = {},
+): Promise<void> {
   // Everything defined here will be reachable under /v1 because of the prefix in fastifyApp.js
   await app.register(
     async function v1(v1: FastifyInstance) {
@@ -75,7 +80,7 @@ export async function registerV1Routes(app: FastifyInstance): Promise<void> {
       registerSinkRoutes(v1);
       registerIndexerRoutes(v1);
       registerAgentRoutes(v1);
-      registerExecRoutes(v1);
+      registerExecRoutes(v1, deps);
     },
     { prefix: "/v1" },
   );

--- a/packages/smartgpt-bridge/src/tests/integration/server.v1.routes.test.ts
+++ b/packages/smartgpt-bridge/src/tests/integration/server.v1.routes.test.ts
@@ -37,3 +37,29 @@ test("GET /v1/files/readme.md returns file snippet", async (t) => {
     t.true(typeof res.body.snippet === "string");
   });
 });
+
+test.serial("POST /v1/exec/run uses stubbed runner", async (t) => {
+  const prev = { EXEC_ENABLED: process.env.EXEC_ENABLED };
+  try {
+    t.timeout(180000);
+    process.env.EXEC_ENABLED = "true";
+    await withServer(ROOT, async (req) => {
+      const ok = await req
+        .post("/v1/exec/run")
+        .send({ command: "echo hello" })
+        .expect(200);
+      t.true(ok.body.ok);
+      t.is(ok.body.stdout, "hello");
+
+      const blocked = await req
+        .post("/v1/exec/run")
+        .send({ command: "rm -rf /tmp" })
+        .expect(200);
+      t.false(blocked.body.ok);
+      t.regex(blocked.body.error || "", /blocked by guard/i);
+    });
+  } finally {
+    if (prev.EXEC_ENABLED === undefined) delete process.env.EXEC_ENABLED;
+    else process.env.EXEC_ENABLED = prev.EXEC_ENABLED;
+  }
+});


### PR DESCRIPTION
## Summary
- pass the optional runCommand dependency through fastifyApp so /v1 routes can reuse the injected runner
- update the v1 exec route to respect the injected runner and add a regression test that exercises the stubbed execution path
- record the change in the changelog

## Testing
- pnpm --filter @promethean/smartgpt-bridge test


------
https://chatgpt.com/codex/tasks/task_e_68d725571ee083248b76d1a628e1576d