### PR TITLE
Ensure heartbeat service heartbeats retain pid

### DIFF
--- a/changelog.d/2025.02.26.00.00.00.md
+++ b/changelog.d/2025.02.26.00.00.00.md
@@ -1,0 +1,1 @@
+- Ensure heartbeat records persist the numeric PID and remain queryable when Mongo fallbacks lack `findOne`.


### PR DESCRIPTION
## Summary
- ensure the heartbeat handler falls back when findOne is unavailable and always persists the numeric pid field
- add a changelog entry describing the heartbeat persistence fix

## Testing
- pnpm --filter heartbeat-service test

------
https://chatgpt.com/codex/tasks/task_e_68d7266f82548324a3eac5d79968d27f