### PR TITLE
Fix local transport handshake negotiation for enso protocol tests

### DIFF
--- a/changelog.d/2025.09.27.00.00.00.md
+++ b/changelog.d/2025.09.27.00.00.00.md
@@ -1,0 +1,1 @@
+- Fix local transport handshake to complete server negotiation before connecting the client, restoring @promethean/enso-protocol tests.


### PR DESCRIPTION
## Summary
- update the in-memory transport handshake to invoke the server negotiation directly
- reuse the negotiated capabilities and privacy when connecting the client to avoid double accepted events
- document the fix in the changelog

## Testing
- pnpm --filter @promethean/enso-protocol test

------
https://chatgpt.com/codex/tasks/task_e_68d7255a51948324aae593770d1e8e2d