### PR TITLE
Add semverguard utility tests

### DIFF
--- a/changelog.d/2025.09.26.23.57.00.md
+++ b/changelog.d/2025.09.26.23.57.00.md
@@ -1,0 +1,1 @@
+- add unit tests for semverguard utilities and expose a list-based arg parser to make tests deterministic

--- a/packages/semverguard/src/tests/utils.test.ts
+++ b/packages/semverguard/src/tests/utils.test.ts
@@ -1,0 +1,30 @@
+import path from "path";
+
+import test from "ava";
+
+import { hashSignature, parseArgsFromList, rel } from "../utils.js";
+
+test("parseArgs merges CLI flags without mutating defaults", (t) => {
+  const defaults = {
+    "--foo": "one",
+    "--flag": "false",
+  } as const satisfies Record<string, string>;
+  const result = parseArgsFromList(defaults, ["--foo", "two", "--flag"]);
+
+  t.is(result["--foo"], "two");
+  t.is(result["--flag"], "true");
+  t.deepEqual(defaults, {
+    "--foo": "one",
+    "--flag": "false",
+  });
+});
+
+test("hashSignature produces stable hashes", (t) => {
+  t.is(hashSignature("alpha"), hashSignature("alpha"));
+  t.not(hashSignature("alpha"), hashSignature("beta"));
+});
+
+test("rel normalizes path separators relative to cwd", (t) => {
+  const nested = path.join(process.cwd(), "foo", "bar", "baz.txt");
+  t.is(rel(nested), "foo/bar/baz.txt");
+});

--- a/packages/semverguard/src/utils.ts
+++ b/packages/semverguard/src/utils.ts
@@ -1,42 +1,59 @@
 import { promises as fs } from "fs";
 import * as path from "path";
 
-export function parseArgs(def: Record<string, string>) {
-  const out = { ...def };
-  const a = process.argv.slice(2);
-  for (let i = 0; i < a.length; i++) {
-    const k = a[i]!;
-    if (!k.startsWith("--")) continue;
-    const next = a[i + 1];
-    const useNext = !!next && !next.startsWith("--");
-    const v = useNext ? next : "true";
-    if (useNext) i++;
-    out[k] = v;
-  }
-  return out as Record<string, string>;
+export function parseArgs(
+  def: Readonly<Record<string, string>>,
+): Readonly<Record<string, string>> {
+  return parseArgsFromList(def, process.argv.slice(2));
+}
+
+export function parseArgsFromList(
+  def: Readonly<Record<string, string>>,
+  argv: ReadonlyArray<string>,
+): Readonly<Record<string, string>> {
+  const initial = {
+    index: 0,
+    result: Object.freeze({ ...def }) as Readonly<Record<string, string>>,
+  } as const;
+  const state = argv.reduce<{
+    readonly index: number;
+    readonly result: Readonly<Record<string, string>>;
+  }>((prev, token, index, list) => {
+    if (index < prev.index || !token.startsWith("--")) {
+      return prev;
+    }
+    const next = list[index + 1];
+    const useNext = typeof next === "string" && !next.startsWith("--");
+    const value = useNext ? next : "true";
+    return {
+      index: useNext ? index + 2 : index + 1,
+      result: Object.freeze({
+        ...prev.result,
+        [token]: value,
+      }) as Readonly<Record<string, string>>,
+    };
+  }, initial);
+  return state.result;
 }
 export async function readJSON<T>(p: string): Promise<T | undefined> {
-  try {
-    return JSON.parse(await fs.readFile(p, "utf-8")) as T;
-  } catch {
-    return undefined;
-  }
+  return fs
+    .readFile(p, "utf-8")
+    .then((content) => JSON.parse(content) as T)
+    .catch(() => undefined);
 }
-export async function writeJSON(p: string, data: any) {
+export async function writeJSON(p: string, data: unknown): Promise<void> {
   await fs.mkdir(path.dirname(p), { recursive: true });
   await fs.writeFile(p, JSON.stringify(data, null, 2), "utf-8");
 }
 
-export function rel(abs: string) {
+export function rel(abs: string): string {
   return path.relative(process.cwd(), abs).replace(/\\/g, "/");
 }
 
-export function hashSignature(s: string) {
-  // very simple hash to keep snapshots light (avoid crypto dep)
-  let h = 2166136261 >>> 0;
-  for (let i = 0; i < s.length; i++) {
-    h ^= s.charCodeAt(i);
-    h = Math.imul(h, 16777619);
-  }
-  return `h${h.toString(16)}`;
+export function hashSignature(s: string): string {
+  const hash = s.split("").reduce((acc, char) => {
+    const next = acc ^ char.charCodeAt(0);
+    return Math.imul(next, 16777619);
+  }, 2166136261 >>> 0);
+  return `h${hash.toString(16)}`;
 }


### PR DESCRIPTION
## Summary
- add unit tests for the semverguard utility helpers to ensure CLI parsing, hashing, and path normalization remain stable
- refactor the shared utilities to expose a list-based argument parser and align helper implementations with functional lint rules

## Testing
- pnpm nx test @promethean/semverguard

------
https://chatgpt.com/codex/tasks/task_e_68d7251bec0483249c8e8eaf8b91eba8