### PR TITLE
Fix kanban-processor persistence dependency resolution

### DIFF
--- a/changelog.d/2025.09.27.00.01.47.md
+++ b/changelog.d/2025.09.27.00.01.47.md
@@ -1,0 +1,1 @@
+- fix: align @promethean/kanban-processor internal dependency declarations with workspace links to restore persistence module resolution during tests

--- a/packages/kanban-processor/package.json
+++ b/packages/kanban-processor/package.json
@@ -18,8 +18,8 @@
     "@promethean/ds": "workspace:*",
     "@promethean/fs": "workspace:*",
     "@promethean/legacy": "workspace:*",
-    "@promethean/markdown": "file:../markdown",
-    "@promethean/persistence": "file:../persistence",
+    "@promethean/markdown": "workspace:*",
+    "@promethean/persistence": "workspace:*",
     "mongodb": "^6.17.0",
     "ws": "^8.18.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2280,11 +2280,11 @@ importers:
         specifier: workspace:*
         version: link:../legacy
       '@promethean/markdown':
-        specifier: file:../markdown
-        version: file:packages/markdown(socks@2.8.7)
+        specifier: workspace:*
+        version: link:../markdown
       '@promethean/persistence':
-        specifier: file:../persistence
-        version: file:packages/persistence(socks@2.8.7)
+        specifier: workspace:*
+        version: link:../persistence
       mongodb:
         specifier: ^6.17.0
         version: 6.18.0(socks@2.8.7)


### PR DESCRIPTION
## Summary
- switch @promethean/kanban-processor to use workspace links for its markdown and persistence dependencies
- update the lockfile and changelog to document the dependency alignment

## Testing
- pnpm --filter @promethean/kanban-processor build
- pnpm --filter @promethean/kanban-processor test

------
https://chatgpt.com/codex/tasks/task_e_68d72535a5c4832497bc0b7364f3ecca