### PR TITLE
Fix docops relations cap state leakage

### DIFF
--- a/changelog.d/2025.09.27.00.05.23.md
+++ b/changelog.d/2025.09.27.00.05.23.md
@@ -1,0 +1,2 @@
+## Fixed
+- Reset @promethean/docops relations thresholds and caps between runs so CLI options no longer persist unexpectedly across invocations. Added regression coverage for cap reset behavior.


### PR DESCRIPTION
## Summary
- avoid leaking docops relations thresholds and caps across runs by computing per-invocation defaults instead of mutating module globals
- clamp user-provided cap values, keep CLI defaults in sync, and document the change in the changelog
- add a regression test ensuring the caps reset to defaults when subsequent runs omit overrides

## Testing
- `pnpm --filter @promethean/docops build`
- `pnpm --filter @promethean/docops test`
- `pnpm --filter @promethean/docops exec ava dist/tests/relations.caps.test.js --config ../../config/ava.config.mjs`


------
https://chatgpt.com/codex/tasks/task_e_68d7253aa49c8324bd91047a26e784c5