### PR TITLE
Fix markdown graph link parsing to avoid ReDoS

### DIFF
--- a/changelog.d/2025.09.27.01.17.33.md
+++ b/changelog.d/2025.09.27.01.17.33.md
@@ -1,0 +1,1 @@
+- Hardened markdown graph link parsing to avoid catastrophic backtracking and covered degenerate input with tests.


### PR DESCRIPTION
## Summary
- replace the markdown link regex with a linear-time parser to avoid ReDoS
- add a regression test that exercises degenerate bracket-heavy input
- record the change in the changelog

## Testing
- pnpm --filter @promethean/markdown-graph test


------
https://chatgpt.com/codex/tasks/task_e_68d738dba0148324a0f7efc667bd5828