### PR TITLE
Improve JS worker error reporting

### DIFF
--- a/changelog.d/2025.09.27.17.55.47.md
+++ b/changelog.d/2025.09.27.17.55.47.md
@@ -1,0 +1,1 @@
+- Improve js worker error message to include module URL when exports are missing.

--- a/packages/piper/src/js-worker.ts
+++ b/packages/piper/src/js-worker.ts
@@ -77,14 +77,10 @@ const { modUrl, exportName, args, env, cwd } = workerData as {
       (exportName && mod && mod[exportName]) || (mod && mod.default) || mod;
 
     if (typeof fn !== "function") {
-      throw new Error(`export '${exportName ?? "default"}' is not a function`);
-      // const name = exportName ?? "default";
-      // const fn = (mod as any)[name];
-      // if (typeof fn !== "function") {
-      //   throw new Error(
-      //     `JS worker: export '${name}' is not a function in ${modUrl}`,
-      //   );
-      // }
+      const name = exportName ?? "default";
+      throw new Error(
+        `JS worker: export '${name}' is not a function in ${modUrl}`,
+      );
     }
 
     const res = await fn(args);


### PR DESCRIPTION
## Summary
- include the module URL in the JS worker error when an expected export is missing
- remove the outdated commented error handling snippet
- document the change in the changelog

## Testing
- pnpm --filter @promethean/piper build

------
https://chatgpt.com/codex/tasks/task_e_68d823bc68608324939af318236bbdb0