### PR TITLE
Add rate limiting guards for WebSocket gateway

### DIFF
--- a/changelog.d/2024.05.29.12.00.00.md
+++ b/changelog.d/2024.05.29.12.00.00.md
@@ -1,0 +1,1 @@
+- Hardened the WebSocket gateway with per-connection inbound limits on publish, subscribe, and acknowledgement operations, and tightened client handler validation.


### PR DESCRIPTION
## Summary
- add dedicated inbound and outbound token buckets to rate limit publish, subscribe, and acknowledgement flows on the WebSocket gateway
- harden the WebSocket client by validating pending callbacks and handlers before invocation
- record the change in the changelog

## Testing
- pnpm --filter @promethean/ws build
- pnpm exec eslint packages/ws/src/client.ts packages/ws/src/server.ts *(fails: existing lint violations in legacy code)*

------
https://chatgpt.com/codex/tasks/task_e_68d82ebfa7408324a1289b88c59d0cf1