### PR TITLE
fix(web-utils): handle invalid URLs in crawler

### DIFF
--- a/changelog.d/2024.06.08.00.00.00.md
+++ b/changelog.d/2024.06.08.00.00.00.md
@@ -1,0 +1,3 @@
+# Summary
+- handle invalid URLs gracefully in `crawlPage`
+- add regression test covering invalid URL rejection

--- a/packages/web-utils/src/crawler.ts
+++ b/packages/web-utils/src/crawler.ts
@@ -3,19 +3,64 @@ import { load } from "cheerio";
 import { canonicalUrl, isUrlAllowed } from "./url.js";
 
 export type CrawlResult = {
-  url: string;
-  title: string | null;
-  links: string[];
+  readonly url: string;
+  readonly title: string | null;
+  readonly links: readonly string[];
 };
+
+type AttemptResult<T> =
+  | { readonly ok: true; readonly value: T }
+  | { readonly ok: false; readonly error?: unknown };
+
+function attempt<T>(fn: () => T): Promise<AttemptResult<T>> {
+  return Promise.resolve()
+    .then(fn)
+    .then((value) => ({ ok: true as const, value }))
+    .catch((error: unknown) => ({ ok: false as const, error }));
+}
+
+async function toAbsoluteLink(
+  href: string,
+  base: string,
+): Promise<string | null> {
+  const result = await attempt(() => new URL(href, base).toString());
+  return result.ok ? result.value : null;
+}
+
+async function canonicalizeLink(href: string): Promise<string | null> {
+  const result = await attempt(() => canonicalUrl(href));
+  return result.ok ? result.value : null;
+}
+
+async function normalizeLink(
+  href: string,
+  base: string,
+): Promise<string | null> {
+  const absolute = await toAbsoluteLink(href, base);
+  if (!absolute) {
+    return null;
+  }
+  const canonical = await canonicalizeLink(absolute);
+  return canonical && isUrlAllowed(canonical) ? canonical : null;
+}
 
 export async function crawlPage(
   url: string,
   fetchFn: typeof fetch = fetch,
 ): Promise<CrawlResult> {
-  const normalized = canonicalUrl(url);
-  if (!normalized) {
-    throw new Error("invalid url");
+  const normalizedResult = await attempt(() => canonicalUrl(url));
+
+  if (!normalizedResult.ok) {
+    const cause =
+      normalizedResult.error instanceof Error
+        ? normalizedResult.error
+        : undefined;
+    throw cause
+      ? new Error("invalid url", { cause })
+      : new Error("invalid url");
   }
+
+  const normalized = normalizedResult.value;
   if (!isUrlAllowed(normalized)) {
     throw new Error("url not allowed");
   }
@@ -26,19 +71,15 @@ export async function crawlPage(
   const html = await res.text();
   const $ = load(html);
   const title = $("title").text() || null;
-  const links = $("a[href]")
-    .map((_, el) => {
-      const href = $(el).attr("href");
-      if (!href) return null;
-      try {
-        const abs = new URL(href, normalized).toString();
-        const canon = canonicalUrl(abs);
-        return canon && isUrlAllowed(canon) ? canon : null;
-      } catch {
-        return null;
-      }
-    })
+  const anchors = $("a[href]")
+    .map((_, el) => $(el).attr("href") ?? null)
     .get()
-    .filter((l): l is string => Boolean(l));
+    .filter(
+      (href): href is string => typeof href === "string" && href.length > 0,
+    );
+
+  const links = (
+    await Promise.all(anchors.map((href) => normalizeLink(href, normalized)))
+  ).filter((link): link is string => link !== null);
   return { url: normalized, title, links };
 }

--- a/packages/web-utils/src/tests/crawler.test.ts
+++ b/packages/web-utils/src/tests/crawler.test.ts
@@ -21,3 +21,7 @@ test("crawlPage fetches and extracts links", async (t) => {
   t.is(result.title, "Example");
   t.deepEqual(result.links, ["https://example.com/a", "https://example.com/b"]);
 });
+
+test("crawlPage rejects invalid URLs with a friendly error", async (t) => {
+  await t.throwsAsync(() => crawlPage("not-a-url"), { message: "invalid url" });
+});


### PR DESCRIPTION
## Summary
- guard `crawlPage` against invalid URLs with functional helpers and immutable result typing
- reuse the helpers when normalizing discovered links to avoid runtime throws and satisfy lint rules
- add regression coverage for invalid URLs and note the change in the changelog

## Testing
- pnpm --filter @promethean/web-utils test

------
https://chatgpt.com/codex/tasks/task_e_68d839fa6ddc8324b9e5a245d86035e5