### PR TITLE
Add rate limiting to SmartGPT bridge OpenAPI endpoint

### DIFF
--- a/changelog.d/2025.09.27.19.39.50.md
+++ b/changelog.d/2025.09.27.19.39.50.md
@@ -1,0 +1,1 @@
+- add rate limiting to the OpenAPI discovery endpoint in smartgpt bridge


### PR DESCRIPTION
## Summary
- register the @fastify/rate-limit plugin in the SmartGPT bridge Fastify app
- apply a per-minute limit to the public /openapi.json discovery route
- document the change in the changelog entry

## Testing
- pnpm exec eslint packages/smartgpt-bridge/src/fastifyApp.ts *(fails: existing lint violations in legacy code)*

------
https://chatgpt.com/codex/tasks/task_e_68d839e621dc83249c2e5adb191669df