### PR TITLE
Fix webcrawler-service tests on Node 18

### DIFF
--- a/changelog.d/2025.09.27.19.40.37.fixed.md
+++ b/changelog.d/2025.09.27.19.40.37.fixed.md
@@ -1,0 +1,1 @@
+- fix(webcrawler-service): tolerate Node 18 lack of URL.canParse by safely parsing URLs and add regression coverage

--- a/packages/webcrawler-service/src/helpers.ts
+++ b/packages/webcrawler-service/src/helpers.ts
@@ -6,37 +6,61 @@ type QueueState = {
   readonly maxPages: number;
 };
 
-const shouldStop = ({ queueLength, processed, maxPages }: QueueState): boolean =>
-  queueLength === 0 || processed >= maxPages;
+// eslint-disable-next-line functional/prefer-immutable-types
+const tryParseUrl = (value: string, base?: string): URL | null => {
+  // eslint-disable-next-line functional/no-try-statements
+  try {
+    return base === undefined ? new URL(value) : new URL(value, base);
+  } catch {
+    return null;
+  }
+};
+
+const shouldStop = ({
+  queueLength,
+  processed,
+  maxPages,
+}: QueueState): boolean => queueLength === 0 || processed >= maxPages;
 
 const dedupeStrings = (input: readonly string[]): readonly string[] =>
-  input.reduce<readonly string[]>((acc, value) => (acc.includes(value) ? acc : [...acc, value]), []);
+  input.reduce<readonly string[]>(
+    (acc, value) => (acc.includes(value) ? acc : [...acc, value]),
+    [],
+  );
 
-const appendUnique = (input: readonly string[], value: string): readonly string[] =>
-  input.includes(value) ? input : [...input, value];
+const appendUnique = (
+  input: readonly string[],
+  value: string,
+): readonly string[] => (input.includes(value) ? input : [...input, value]);
 
 const appendManyUnique = (
   input: readonly string[],
   values: readonly string[],
 ): readonly string[] =>
-  values.reduce<readonly string[]>((acc, value) => appendUnique(acc, value), input);
+  values.reduce<readonly string[]>(
+    (acc, value) => appendUnique(acc, value),
+    input,
+  );
 
-const hostIsAllowed = (allowedHosts: readonly string[], url: string): boolean => {
+const hostIsAllowed = (
+  allowedHosts: readonly string[],
+  url: string,
+): boolean => {
   if (allowedHosts.length === 0) {
     return true;
   }
-  if (!URL.canParse(url)) {
+  const parsed = tryParseUrl(url);
+  if (!parsed) {
     return false;
   }
-  const host = new URL(url).host;
-  return allowedHosts.includes(host);
+  return allowedHosts.includes(parsed.host);
 };
 
 const canonicalHttpUrl = (input: string): string | null => {
-  if (!URL.canParse(input)) {
+  const parsed = tryParseUrl(input);
+  if (!parsed) {
     return null;
   }
-  const parsed = new URL(input);
   if (!isHttpProtocol(parsed.protocol)) {
     return null;
   }
@@ -44,10 +68,10 @@ const canonicalHttpUrl = (input: string): string | null => {
 };
 
 const resolveHttpHref = (baseUrl: string, href: string): string | null => {
-  if (!URL.canParse(href, baseUrl)) {
+  const resolved = tryParseUrl(href, baseUrl);
+  if (!resolved) {
     return null;
   }
-  const resolved = new URL(href, baseUrl);
   if (!isHttpProtocol(resolved.protocol)) {
     return null;
   }
@@ -64,12 +88,18 @@ const sanitizeSegment = (segment: string): string =>
     .replace(/^-+/, "")
     .replace(/-+$/, "") || "index";
 
-const determineFileSegment = (pathname: string, segments: readonly string[]): string => {
+const determineFileSegment = (
+  pathname: string,
+  segments: readonly string[],
+): string => {
   const last = segments[segments.length - 1] ?? "";
-  return last === "" || pathname.endsWith("/") ? "index" : sanitizeSegment(last);
+  return last === "" || pathname.endsWith("/")
+    ? "index"
+    : sanitizeSegment(last);
 };
 
-const isHttpProtocol = (protocol: string): boolean => protocol === "http:" || protocol === "https:";
+const isHttpProtocol = (protocol: string): boolean =>
+  protocol === "http:" || protocol === "https:";
 
 export {
   appendManyUnique,

--- a/packages/webcrawler-service/src/tests/helpers.test.ts
+++ b/packages/webcrawler-service/src/tests/helpers.test.ts
@@ -1,0 +1,29 @@
+/* eslint-disable functional/immutable-data */
+import test from "ava";
+
+import {
+  canonicalHttpUrl,
+  hostIsAllowed,
+  resolveHttpHref,
+} from "../helpers.js";
+
+test.serial("helpers tolerate environments without URL.canParse", (t) => {
+  const descriptor = Object.getOwnPropertyDescriptor(
+    globalThis.URL,
+    "canParse",
+  );
+
+  if (descriptor !== undefined) {
+    Object.defineProperty(globalThis.URL, "canParse", {
+      ...descriptor,
+      value: undefined,
+    });
+    t.teardown(() => {
+      Object.defineProperty(globalThis.URL, "canParse", descriptor);
+    });
+  }
+
+  t.false(hostIsAllowed(["example.com"], "nota url"));
+  t.is(canonicalHttpUrl("nota url"), null);
+  t.is(resolveHttpHref("https://example.com", "javascript:alert(1)"), null);
+});


### PR DESCRIPTION
Resolves TASK-20240921-buildfix.

## Summary
- add a safe URL parser fallback so the crawler helpers work when `URL.canParse` is missing
- cover the regression by simulating environments without `URL.canParse`
- document the fix in the changelog

## Testing
- pnpm --filter @promethean/webcrawler-service test
- pnpm exec eslint packages/webcrawler-service/src/helpers.ts packages/webcrawler-service/src/tests/helpers.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d839f624808324961a96d23d412fdc