### PR TITLE
Stabilize monitoring token bucket tests

### DIFF
--- a/changelog.d/2025.09.27.19.45.04.md
+++ b/changelog.d/2025.09.27.19.45.04.md
@@ -1,0 +1,1 @@
+- Stabilized the monitoring token bucket by injecting a configurable clock and removing time-based sleeps from the test suite.

--- a/docs/agile/tasks/TASK-2025-09-27-monitoring-test.md
+++ b/docs/agile/tasks/TASK-2025-09-27-monitoring-test.md
@@ -1,0 +1,84 @@
+---
+task-id: TASK-2025-09-27-monitoring-test
+title: Stabilize monitoring token bucket tests
+state: InProgress
+prev:
+txn: "2025-09-27T19:45:30Z-0000"
+owner: err
+priority: p3
+size: s
+epic: EPC-000
+depends_on: []
+labels:
+  - board:auto
+  - lang:ts
+due:
+links: []
+artifacts: []
+rationale: Fix flaky time-based monitoring token bucket tests.
+proposed_transitions:
+  - New->Accepted
+  - Accepted->Breakdown
+tags:
+  - task/TASK-20250927-194530-0000
+  - board/kanban
+  - state/InProgress
+  - owner/err
+  - priority/p3
+  - epic/EPC-000
+---
+<hr class="__chatgpt_plugin">
+
+<span style="font-size: small;"> (llama3.2:latest)</span>
+### role::assistant
+
+Here's a suggested revision of your context section:
+
+## Context
+### Changes and Updates
+- **What changed?**: Received a request to fix `@promethean/monitoring:test` by eliminating flakiness from wall-clock sleeps.
+- **Where?**: `packages/monitoring`.
+- **Why now?**: Package tests can intermittently fail when real time drifts.
+
+## Inputs / Artifacts
+- (changelog.d/2025.09.27.19.45.04.md)
+
+## Definition of Done
+- [x] `pnpm --filter @promethean/monitoring test` passes deterministically.
+- [x] ESLint clean on touched files.
+- [x] Clock injection wired through the package exports.
+
+## Plan
+1. Inject a configurable clock into `TokenBucket` and store state immutably.
+2. Update token bucket tests to advance a synthetic clock instead of waiting.
+3. Run package tests and lint the touched files.
+
+## Relevant Resources
+- `packages/monitoring/src/limiter.ts`
+- `packages/monitoring/tests/limiter.test.js`
+- `packages/monitoring/src/index.ts`
+
+### Smart Connections Configuration
+```smart-connections
+{
+  "render_markdown": true,
+  "show_full_path": false,
+  "exclude_blocks_from_source_connections": false,
+  "exclude_frontmatter_blocks": true,
+  "expanded_view": false,
+  "results_limit": "20",
+  "exclude_inlinks": false,
+  "exclude_outlinks": false
+}
+```
+
+### Smart ChatGPT Configuration
+```smart-chatgpt
+```
+<hr class="__chatgpt_plugin">
+
+### role::user
+
+TASK-2025-09-27-monitoring-test
+
+<% tp.app.commands.executeCommandById("chatgpt-md:call-chatgpt-api") %>

--- a/packages/monitoring/src/index.ts
+++ b/packages/monitoring/src/index.ts
@@ -1,2 +1,3 @@
-export { metrics } from './prom.js';
-export { TokenBucket } from './limiter.js';
+export { metrics } from "./prom.js";
+export { TokenBucket } from "./limiter.js";
+export type { TokenBucketOptions } from "./limiter.js";


### PR DESCRIPTION
## Summary
- inject a configurable clock and immutable state handling into the monitoring token bucket
- rewrite the limiter tests to advance a synthetic clock and export the new options type
- document the work in the changelog and agile task tracker

## Testing
- pnpm --filter @promethean/monitoring test
- pnpm exec eslint packages/monitoring/src/limiter.ts packages/monitoring/src/index.ts packages/monitoring/tests/limiter.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d839f14d948324aad0756669fd0576