### PR TITLE
Stabilize frontend-service tests with synthetic mounts

### DIFF
--- a/changelog.d/2025.09.27.19.40.21.md
+++ b/changelog.d/2025.09.27.19.40.21.md
@@ -1,0 +1,2 @@
+## Fixed
+- Stabilized `@promethean/frontend-service` tests by allowing injected package fixtures and cleaning up Fastify instances.

--- a/docs/agile/tasks/fix-frontend-service-test.md
+++ b/docs/agile/tasks/fix-frontend-service-test.md
@@ -1,0 +1,55 @@
+---
+task-id: TASK-20250927
+title: Fix frontend-service test failure
+state: New
+prev:
+txn: "2025-09-27T19:36:34Z-1234"
+owner: err
+priority: p3
+size: s
+epic: EPC-000
+depends_on: []
+labels:
+  - board:auto
+  - lang:ts
+due:
+links: []
+artifacts: []
+rationale: Fix failing @promethean/frontend-service:test to restore confidence in CI for frontend-service package.
+proposed_transitions:
+  - New->Accepted
+  - Accepted->Breakdown
+tags:
+  - task/TASK-20250927-frontend-service-test
+  - board/kanban
+  - state/New
+  - owner/err
+  - priority/p3
+  - epic/EPC-000
+---
+<hr class="__chatgpt_plugin">
+
+## Context
+### Changes and Updates
+- **What changed?**: Test suite for @promethean/frontend-service currently fails, blocking confident deployments.
+- **Where?**: packages/frontend-service/src/tests.
+- **Why now?**: User requested to fix the failing test.
+
+## Inputs / Artifacts
+- `pnpm --filter @promethean/frontend-service test` output.
+
+## Definition of Done
+- [ ] @promethean/frontend-service:test passes locally.
+- [ ] Root cause documented in changelog entry.
+- [ ] Pull request merged with reference to this task.
+
+## Plan
+1. Reproduce the failing test via pnpm command.
+2. Diagnose and implement minimal fix under packages/frontend-service.
+3. Update or add tests ensuring coverage for regression.
+4. Run package tests to confirm pass.
+5. Document change via changelog entry and prepare PR.
+
+## Relevant Resources
+- `packages/frontend-service` package code and tests.
+<hr class="__chatgpt_plugin">

--- a/packages/frontend-service/src/tests/server.test.ts
+++ b/packages/frontend-service/src/tests/server.test.ts
@@ -1,33 +1,119 @@
-import test from "ava";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import avaTest, { type TestFn } from "ava";
 
 import { createServer } from "../index.js";
 
-async function build() {
-  const app = await createServer();
-  return app;
-}
+const test = avaTest as unknown as TestFn<unknown>;
+
+type PackageFixture = Readonly<{
+  dir: string;
+  name: string;
+  distFiles?: Readonly<Record<string, string>>;
+  staticFiles?: Readonly<Record<string, string>>;
+}>;
+
+type WriteFileInput = Readonly<{ filePath: string; contents: string }>;
+
+const writeFile = ({ filePath, contents }: WriteFileInput): void => {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, contents, "utf8");
+};
+
+const createPackageFixture = (root: string, pkg: PackageFixture): void => {
+  const pkgDir = path.join(root, pkg.dir);
+  fs.mkdirSync(pkgDir, { recursive: true });
+  writeFile({
+    filePath: path.join(pkgDir, "package.json"),
+    contents: JSON.stringify({ name: pkg.name }, null, 2),
+  });
+
+  (
+    Object.entries(pkg.distFiles ?? {}) as ReadonlyArray<
+      readonly [string, string]
+    >
+  ).forEach(([rel, contents]) => {
+    writeFile({
+      filePath: path.join(pkgDir, "dist", rel),
+      contents,
+    });
+  });
+
+  (
+    Object.entries(pkg.staticFiles ?? {}) as ReadonlyArray<
+      readonly [string, string]
+    >
+  ).forEach(([rel, contents]) => {
+    writeFile({
+      filePath: path.join(pkgDir, "static", rel),
+      contents,
+    });
+  });
+};
+
+const setupPackagesFixture = (): string => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "frontend-service-test-"));
+
+  const fixtures: ReadonlyArray<PackageFixture> = [
+    {
+      dir: "piper",
+      name: "@promethean/piper",
+      distFiles: { "frontend/main.js": "export default 'ok';" },
+    },
+    {
+      dir: "llm-chat-frontend",
+      name: "@promethean/llm-chat-frontend",
+      staticFiles: { "index.html": "<html></html>" },
+    },
+    {
+      dir: "smart-chat-frontend",
+      name: "@promethean/smart-chat-frontend",
+      staticFiles: { "index.html": "<html></html>" },
+    },
+  ];
+
+  fixtures.forEach((pkg) => createPackageFixture(root, pkg));
+
+  return root;
+};
+
+const startApp = async () => {
+  const packagesDir = setupPackagesFixture();
+  const app = await createServer({ packagesDir });
+  return { packagesDir, app };
+};
 
 test("health route responds", async (t) => {
-  const app = await build();
+  const { packagesDir, app } = await startApp();
+  t.teardown(() => fs.rmSync(packagesDir, { recursive: true, force: true }));
+  t.teardown(() => app.close());
   const res = await app.inject("/health");
   t.is(res.statusCode, 200);
 });
 
 test("diagnostics route responds", async (t) => {
-  const app = await build();
+  const { packagesDir, app } = await startApp();
+  t.teardown(() => fs.rmSync(packagesDir, { recursive: true, force: true }));
+  t.teardown(() => app.close());
   const res = await app.inject("/diagnostics");
   t.is(res.statusCode, 200);
 });
 
 test("serves piper frontend asset", async (t) => {
-  const app = await build();
+  const { packagesDir, app } = await startApp();
+  t.teardown(() => fs.rmSync(packagesDir, { recursive: true, force: true }));
+  t.teardown(() => app.close());
   const res = await app.inject("/piper/main.js");
   t.is(res.statusCode, 200);
 });
 
 ["llm-chat-frontend", "smart-chat-frontend"].forEach((pkg) => {
   test(`serves static asset for ${pkg}`, async (t) => {
-    const app = await build();
+    const { packagesDir, app } = await startApp();
+    t.teardown(() => fs.rmSync(packagesDir, { recursive: true, force: true }));
+    t.teardown(() => app.close());
     const res = await app.inject(`/${pkg}/static/index.html`);
     t.is(res.statusCode, 200);
   });


### PR DESCRIPTION
## Summary
- add a discoverPackageMounts helper so createServer can mount frontends from either the repo packages directory or injected fixtures
- rewrite the frontend-service tests to generate synthetic package structures per test and clean up resources
- document the test stabilization in the changelog and capture the scoped task note

## Testing
- pnpm --filter @promethean/frontend-service test
- pnpm exec eslint packages/frontend-service/src/index.ts packages/frontend-service/src/tests/server.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d839feefc48324902c9bbe99c1ace1