### PR TITLE
Add rate limiting to exec command endpoint

### DIFF
--- a/changelog.d/2025.09.27.20.03.36.md
+++ b/changelog.d/2025.09.27.20.03.36.md
@@ -1,0 +1,1 @@
+- Add rate limiting to the SmartGPT bridge exec endpoint to guard remote command execution.

--- a/packages/smartgpt-bridge/src/routes/v1/exec.ts
+++ b/packages/smartgpt-bridge/src/routes/v1/exec.ts
@@ -12,6 +12,12 @@ export function registerExecRoutes(v1: any, deps: ExecDeps = {}) {
   const ROOT_PATH = v1.ROOT_PATH;
   const run = deps.runCommand ?? runCommand;
   v1.post("/exec/run", {
+    config: {
+      rateLimit: {
+        max: 5,
+        timeWindow: "1 minute",
+      },
+    },
     schema: {
       summary: "Run a shell command",
       operationId: "runCommand",


### PR DESCRIPTION
## Summary
- add a per-route rate limit to the `/exec/run` command execution endpoint
- document the change in the package changelog

## Testing
- pnpm exec eslint packages/smartgpt-bridge/src/routes/v1/exec.ts *(fails: pre-existing lint violations in the file)*

------
https://chatgpt.com/codex/tasks/task_e_68d840ef86748324b9fc580b40dc8c01