### PR TITLE
Stabilize monitoring token bucket tests

### DIFF
--- a/changelog.d/2024.11.24.12.00.00.md
+++ b/changelog.d/2024.11.24.12.00.00.md
@@ -1,0 +1,1 @@
+Stabilize monitoring token bucket tests by using a synthetic clock for deterministic assertions.

--- a/packages/monitoring/tests/limiter.test.js
+++ b/packages/monitoring/tests/limiter.test.js
@@ -15,7 +15,12 @@ const createClock = () => {
 
 // ensure TokenBucket enforces capacity and returns deficit
 test("TokenBucket enforces capacity", (t) => {
-  const bucket = new TokenBucket({ capacity: 5, refillPerSec: 1 });
+  const clock = createClock();
+  const bucket = new TokenBucket({
+    capacity: 5,
+    refillPerSec: 1,
+    now: clock.now,
+  });
   t.true(bucket.tryConsume(3));
   t.false(bucket.tryConsume(3));
   t.true(Math.abs(bucket.deficit(3) - 1) < 1e-6);
@@ -52,7 +57,12 @@ test("TokenBucket limits and refills with capacity 2", (t) => {
 });
 
 test("TokenBucket drain empties remaining tokens", (t) => {
-  const bucket = new TokenBucket({ capacity: 5, refillPerSec: 1 });
+  const clock = createClock();
+  const bucket = new TokenBucket({
+    capacity: 5,
+    refillPerSec: 1,
+    now: clock.now,
+  });
   t.true(bucket.tryConsume(2));
   const drained = bucket.drain();
   t.is(drained, 3);


### PR DESCRIPTION
## Summary
- switch the monitoring token bucket unit tests to use an injected clock so they no longer depend on real time
- document the change with a changelog entry

## Testing
- pnpm --filter @promethean/monitoring test
- pnpm exec eslint packages/monitoring/tests/limiter.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d84421ff94832484e7785e2e5389d8