### PR TITLE
fix: dedupe web crawler links

### DIFF
--- a/changelog.d/2025.09.27.20.18.33.md
+++ b/changelog.d/2025.09.27.20.18.33.md
@@ -1,0 +1,1 @@
+- fix(web-utils): drop self-referential links from crawler results and dedupe normalized URLs

--- a/packages/web-utils/src/crawler.ts
+++ b/packages/web-utils/src/crawler.ts
@@ -41,7 +41,15 @@ async function normalizeLink(
     return null;
   }
   const canonical = await canonicalizeLink(absolute);
-  return canonical && isUrlAllowed(canonical) ? canonical : null;
+  if (!canonical) {
+    return null;
+  }
+
+  if (canonical === base) {
+    return null;
+  }
+
+  return isUrlAllowed(canonical) ? canonical : null;
 }
 
 export async function crawlPage(
@@ -80,6 +88,8 @@ export async function crawlPage(
 
   const links = (
     await Promise.all(anchors.map((href) => normalizeLink(href, normalized)))
-  ).filter((link): link is string => link !== null);
+  )
+    .filter((link): link is string => link !== null)
+    .filter((link, index, all) => all.indexOf(link) === index);
   return { url: normalized, title, links };
 }


### PR DESCRIPTION
## Summary
- skip normalized crawler links that point back to the crawled page itself
- deduplicate normalized links collected from anchors to avoid repeats
- record the change in the changelog

## Testing
- pnpm --filter @promethean/web-utils test


------
https://chatgpt.com/codex/tasks/task_e_68d8442a843c832482e0f6892c72998c