### PR TITLE
Harden command execution paths

### DIFF
--- a/changelog.d/2025.09.27.20.22.38.md
+++ b/changelog.d/2025.09.27.20.22.38.md
@@ -1,0 +1,4 @@
+## Summary
+- Hardened buildfix process execution helpers and tests to avoid shell command injection.
+- Updated semverguard git automation to spawn safe commands when preparing release branches.
+- Added per-route rate limiting to the SmartGPT exec endpoint to satisfy CodeQL security checks.

--- a/packages/buildfix/src/iter/git.ts
+++ b/packages/buildfix/src/iter/git.ts
@@ -1,21 +1,21 @@
 import { git, isGitRepo, sanitizeBranch } from "../utils.js";
 
 export async function ensureBranch(branch: string) {
-  const chk = await git(`rev-parse --verify ${branch}`);
-  if (chk.code !== 0) await git(`checkout -b ${branch}`);
-  else await git(`checkout ${branch}`);
+  const chk = await git(["rev-parse", "--verify", branch]);
+  if (chk.code !== 0) await git(["checkout", "-b", branch]);
+  else await git(["checkout", branch]);
 }
 export async function commitIfChanges(message: string) {
-  const st = await git("status --porcelain");
+  const st = await git(["status", "--porcelain"]);
   if (!st.out) return undefined;
-  await git("add -A");
-  const c = await git(`commit -m "${message.replace(/"/g, '\\"')}"`);
+  await git(["add", "-A"]);
+  const c = await git(["commit", "-m", message]);
   if (c.code !== 0) return undefined;
-  const sha = await git("rev-parse HEAD");
+  const sha = await git(["rev-parse", "HEAD"]);
   return sha.out || undefined;
 }
 export async function pushBranch(branch: string, remote: string) {
-  return (await git(`push ${remote} ${branch}`)).code === 0;
+  return (await git(["push", remote, branch])).code === 0;
 }
 export async function createPR(
   branch: string,
@@ -36,8 +36,8 @@ export async function createPR(
 }
 export async function rollbackWorktree() {
   // hard reset unstaged/staged changes; also drop untracked new files (e.g., snippets accidentally written in src/)
-  await git("reset --hard");
-  await git("clean -fd");
+  await git(["reset", "--hard"]);
+  await git(["clean", "-fd"]);
 }
 
 export { isGitRepo, sanitizeBranch };

--- a/packages/buildfix/src/tests/errors.step.test.ts
+++ b/packages/buildfix/src/tests/errors.step.test.ts
@@ -39,11 +39,17 @@ test("bf:01-errors writes error list", async (t) => {
   const outPath = path.join(dir, "errors.json");
   const tsconfig = path.join(dir, "tsconfig.json");
   const { code } = await run(
-    `node ${path.join(
-      PKG_ROOT,
-      "dist/01-errors.js",
-    )} --root false --tsconfig ${tsconfig} --out ${outPath}`,
-    PKG_ROOT,
+    "node",
+    [
+      path.join(PKG_ROOT, "dist/01-errors.js"),
+      "--root",
+      "false",
+      "--tsconfig",
+      tsconfig,
+      "--out",
+      outPath,
+    ],
+    { cwd: PKG_ROOT },
   );
   t.is(code, 0);
   const data = JSON.parse(await fs.readFile(outPath, "utf-8"));

--- a/packages/buildfix/src/tests/integration/pipeline.run.test.ts
+++ b/packages/buildfix/src/tests/integration/pipeline.run.test.ts
@@ -42,11 +42,17 @@ test.serial("buildfix pipeline runs end-to-end", async (t) => {
   t.is(
     (
       await run(
-        `node ${path.join(
-          PKG_ROOT,
-          "dist/01-errors.js",
-        )} --root false --tsconfig ${tsconfig} --out ${errorsPath}`,
-        PKG_ROOT,
+        "node",
+        [
+          path.join(PKG_ROOT, "dist/01-errors.js"),
+          "--root",
+          "false",
+          "--tsconfig",
+          tsconfig,
+          "--out",
+          errorsPath,
+        ],
+        { cwd: PKG_ROOT },
       )
     ).code,
     0,
@@ -56,11 +62,19 @@ test.serial("buildfix pipeline runs end-to-end", async (t) => {
   t.is(
     (
       await run(
-        `node ${path.join(
-          PKG_ROOT,
-          "dist/02-iterate.js",
-        )} --errors ${errorsPath} --out ${dir} --max-cycles 0 --git off`,
-        PKG_ROOT,
+        "node",
+        [
+          path.join(PKG_ROOT, "dist/02-iterate.js"),
+          "--errors",
+          errorsPath,
+          "--out",
+          dir,
+          "--max-cycles",
+          "0",
+          "--git",
+          "off",
+        ],
+        { cwd: PKG_ROOT },
       )
     ).code,
     0,
@@ -73,11 +87,17 @@ test.serial("buildfix pipeline runs end-to-end", async (t) => {
   t.is(
     (
       await run(
-        `node ${path.join(
-          PKG_ROOT,
-          "dist/03-report.js",
-        )} --summary ${summaryPath} --history-root ${historyRoot} --out ${reportDir}`,
-        PKG_ROOT,
+        "node",
+        [
+          path.join(PKG_ROOT, "dist/03-report.js"),
+          "--summary",
+          summaryPath,
+          "--history-root",
+          historyRoot,
+          "--out",
+          reportDir,
+        ],
+        { cwd: PKG_ROOT },
       )
     ).code,
     0,

--- a/packages/buildfix/src/tests/iterate.step.test.ts
+++ b/packages/buildfix/src/tests/iterate.step.test.ts
@@ -34,11 +34,19 @@ test("bf:02-iterate generates summary without attempts when max-cycles=0", async
   await fs.writeFile(errorsPath, JSON.stringify(errors, null, 2));
 
   const { code } = await run(
-    `node ${path.join(
-      PKG_ROOT,
-      "dist/02-iterate.js",
-    )} --errors ${errorsPath} --out ${tmp} --max-cycles 0 --git off`,
-    PKG_ROOT,
+    "node",
+    [
+      path.join(PKG_ROOT, "dist/02-iterate.js"),
+      "--errors",
+      errorsPath,
+      "--out",
+      tmp,
+      "--max-cycles",
+      "0",
+      "--git",
+      "off",
+    ],
+    { cwd: PKG_ROOT },
   );
   t.is(code, 0);
   const summary = JSON.parse(

--- a/packages/buildfix/src/tests/path-resolution.test.ts
+++ b/packages/buildfix/src/tests/path-resolution.test.ts
@@ -51,11 +51,15 @@ test.serial("uses INIT_CWD for relative paths", async (t) => {
     t.is(
       (
         await run(
-          `node ${path.join(
-            PKG_ROOT,
-            "dist/01-errors.js",
-          )} --tsconfig tsconfig.json --out .cache/buildfix/errors.json`,
-          PKG_ROOT,
+          "node",
+          [
+            path.join(PKG_ROOT, "dist/01-errors.js"),
+            "--tsconfig",
+            "tsconfig.json",
+            "--out",
+            ".cache/buildfix/errors.json",
+          ],
+          { cwd: PKG_ROOT },
         )
       ).code,
       0,
@@ -65,11 +69,19 @@ test.serial("uses INIT_CWD for relative paths", async (t) => {
     t.is(
       (
         await run(
-          `node ${path.join(
-            PKG_ROOT,
-            "dist/02-iterate.js",
-          )} --errors .cache/buildfix/errors.json --out .cache/buildfix --max-cycles 0 --git off`,
-          PKG_ROOT,
+          "node",
+          [
+            path.join(PKG_ROOT, "dist/02-iterate.js"),
+            "--errors",
+            ".cache/buildfix/errors.json",
+            "--out",
+            ".cache/buildfix",
+            "--max-cycles",
+            "0",
+            "--git",
+            "off",
+          ],
+          { cwd: PKG_ROOT },
         )
       ).code,
       0,
@@ -79,11 +91,17 @@ test.serial("uses INIT_CWD for relative paths", async (t) => {
     t.is(
       (
         await run(
-          `node ${path.join(
-            PKG_ROOT,
-            "dist/03-report.js",
-          )} --summary .cache/buildfix/summary.json --history-root .cache/buildfix/history --out reports`,
-          PKG_ROOT,
+          "node",
+          [
+            path.join(PKG_ROOT, "dist/03-report.js"),
+            "--summary",
+            ".cache/buildfix/summary.json",
+            "--history-root",
+            ".cache/buildfix/history",
+            "--out",
+            "reports",
+          ],
+          { cwd: PKG_ROOT },
         )
       ).code,
       0,

--- a/packages/buildfix/src/tests/report.step.test.ts
+++ b/packages/buildfix/src/tests/report.step.test.ts
@@ -37,11 +37,17 @@ test("bf:03-report renders markdown report", async (t) => {
   );
   const outDir = path.join(tmp, "reports");
   const { code } = await run(
-    `node ${path.join(
-      PKG_ROOT,
-      "dist/03-report.js",
-    )} --summary ${summaryPath} --history-root ${histRoot} --out ${outDir}`,
-    PKG_ROOT,
+    "node",
+    [
+      path.join(PKG_ROOT, "dist/03-report.js"),
+      "--summary",
+      summaryPath,
+      "--history-root",
+      histRoot,
+      "--out",
+      outDir,
+    ],
+    { cwd: PKG_ROOT },
   );
   t.is(code, 0);
   const files = await fs.readdir(outDir);

--- a/packages/smartgpt-bridge/src/routes/v1/exec.ts
+++ b/packages/smartgpt-bridge/src/routes/v1/exec.ts
@@ -12,6 +12,12 @@ export function registerExecRoutes(v1: any, deps: ExecDeps = {}) {
   const ROOT_PATH = v1.ROOT_PATH;
   const run = deps.runCommand ?? runCommand;
   v1.post("/exec/run", {
+    config: {
+      rateLimit: {
+        max: 5,
+        timeWindow: "1 minute",
+      },
+    },
     schema: {
       summary: "Run a shell command",
       operationId: "runCommand",


### PR DESCRIPTION
## Summary
- replace buildfix command helpers with spawn-based execution and update dependent tests
- ensure semverguard git automation runs via argument arrays instead of interpolated shell strings
- add a per-route rate limit to the SmartGPT exec endpoint and record the change in the changelog

## Testing
- pnpm --filter @promethean/buildfix test
- pnpm --filter @promethean/semverguard test

------
https://chatgpt.com/codex/tasks/task_e_68d84462a0c083249c2a72562d5aa78d