### PR TITLE
Fix frontend-service test rebuild after clean

### DIFF
--- a/changelog.d/2025.09.27.20.23.52.md
+++ b/changelog.d/2025.09.27.20.23.52.md
@@ -1,0 +1,2 @@
+- chore(frontend-service): force TypeScript rebuilds during tests to restore missing dist output
+- chore(frontend-service): clean generated tsbuildinfo to keep test runs deterministic

--- a/packages/frontend-service/package.json
+++ b/packages/frontend-service/package.json
@@ -18,8 +18,8 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsc",
-    "clean": "rimraf dist",
+    "build": "tsc -b tsconfig.json --force",
+    "clean": "rimraf dist tsconfig.tsbuildinfo",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "test": "pnpm run build && ava",
     "testt": "pnpm run test",


### PR DESCRIPTION
## Summary
- ensure the frontend-service build script forces a TypeScript rebuild so dist output is regenerated before tests
- clean up generated tsconfig.tsbuildinfo to avoid stale incremental state and keep test runs deterministic

## Testing
- pnpm --filter @promethean/frontend-service test

References: TASK-20250927

------
https://chatgpt.com/codex/tasks/task_e_68d8442efbd08324a4413b4b57592011