### PR TITLE
Fix llm chat test import path

### DIFF
--- a/changelog.d/2025.09.27.21.01.58.md
+++ b/changelog.d/2025.09.27.21.01.58.md
@@ -1,0 +1,1 @@
+- Updated the LLM chat test to import tools from the source bundle so it no longer depends on an unbuilt dist artifact.

--- a/tests/llmChat.test.js
+++ b/tests/llmChat.test.js
@@ -2,7 +2,7 @@ import test from "ava";
 import {
   parseToolCall,
   callTool,
-} from "@promethean/llm-chat-frontend/dist/frontend/tools.js";
+} from "@promethean/llm-chat-frontend/src/frontend/tools.js";
 
 test("parseToolCall returns tool object for valid JSON", (t) => {
   const tool = parseToolCall('{"tool":"codeSearch","args":{"q":"test"}}');


### PR DESCRIPTION
## Summary
- update the LLM chat test to import the tools module from the package sources so it no longer depends on built artifacts
- record the change in the changelog

## Testing
- pnpm exec ava tests/llmChat.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d84f08f0048324bfa983a3844c5512