### PR TITLE
Fix markdown graph frontend test import path

### DIFF
--- a/changelog.d/2025.09.27.21.02.42.md
+++ b/changelog.d/2025.09.27.21.02.42.md
@@ -1,0 +1,1 @@
+- Fix markdown graph frontend tests by importing directly from the source module to avoid missing build artifacts.

--- a/tests/sites/markdown_graph_frontend.test.mjs
+++ b/tests/sites/markdown_graph_frontend.test.mjs
@@ -1,6 +1,6 @@
 import test from "ava";
 import http from "node:http";
-import { fetchGraph } from "@promethean/markdown-graph-frontend/dist/frontend/graph.mjs";
+import { fetchGraph } from "@promethean/markdown-graph-frontend/src/frontend/graph.mjs";
 
 function closeServer(server) {
   return new Promise((resolve, reject) => {


### PR DESCRIPTION
## Summary
- update the markdown graph frontend site test to import the frontend graph helper from the source tree so it works without a build artifact
- document the change in the changelog

## Testing
- pnpm exec eslint tests/sites/markdown_graph_frontend.test.mjs
- pnpm exec ava tests/sites/markdown_graph_frontend.test.mjs --verbose

------
https://chatgpt.com/codex/tasks/task_e_68d84f21fe5883248eb4aac41473781f