### PR TITLE
Fix broker client test imports

### DIFF
--- a/changelog.d/2024.06.01.00.00.00.md
+++ b/changelog.d/2024.06.01.00.00.00.md
@@ -1,0 +1,1 @@
+- fix: broker client unit tests import memory broker helpers from `@promethean/test-utils`

--- a/tests/brokerClient.tasks.unit.test.js
+++ b/tests/brokerClient.tasks.unit.test.js
@@ -5,7 +5,7 @@ import { BrokerClient } from "@promethean/legacy/brokerClient.js";
 import {
   getMemoryBroker,
   resetMemoryBroker,
-} from "@shared/ts/dist/test-utils/broker.js";
+} from "@promethean/test-utils/broker.js";
 
 test.beforeEach(() => {
   resetMemoryBroker("unit-tasks");


### PR DESCRIPTION
## Summary
- update the broker client unit test to consume the memory broker helpers from `@promethean/test-utils`
- record the test import fix in the changelog

## Testing
- pnpm exec ava tests/brokerClient.tasks.unit.test.js
- pnpm exec eslint tests/brokerClient.tasks.unit.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d84eed69b48324851189c47f098c69