### PR TITLE
fix(webcrawler-service): run ava through pnpm

### DIFF
--- a/changelog.d/2025.09.27.21.05.30.md
+++ b/changelog.d/2025.09.27.21.05.30.md
@@ -1,0 +1,1 @@
+- fix(webcrawler-service): run Ava via pnpm and rely on shared config globs so compiled tests are always discovered

--- a/packages/webcrawler-service/project.json
+++ b/packages/webcrawler-service/project.json
@@ -20,7 +20,7 @@
       "executor": "nx:run-commands",
       "dependsOn": ["build"],
       "options": {
-        "command": "ava --config ../../config/ava.config.mjs \"dist/**/*.test.js\"",
+        "command": "pnpm exec ava --config ../../config/ava.config.mjs",
         "cwd": "packages/webcrawler-service"
       }
     },


### PR DESCRIPTION
## Summary
- run the webcrawler-service test target through `pnpm exec ava` so the workspace binary is used
- rely on the shared AVA config globs instead of CLI patterns to keep compiled tests discoverable
- record the change in the changelog

## Testing
- pnpm exec nx run @promethean/webcrawler-service:test

------
https://chatgpt.com/codex/tasks/task_e_68d84f8c02b88324bed793bd1d39124b