### PR TITLE
Fix intention test imports to use built package output

### DIFF
--- a/changelog.d/2025.09.27.21.04.57.md
+++ b/changelog.d/2025.09.27.21.04.57.md
@@ -1,0 +1,2 @@
+## Fixed
+- update intention unit test imports to reference built package output available in repository to unblock coverage runs

--- a/tests/intention.test.js
+++ b/tests/intention.test.js
@@ -1,48 +1,48 @@
-import test from 'ava';
-import { RouterLLM } from '../shared/ts/dist/intention/router.js';
-import { extractCode } from '../shared/ts/dist/intention/utils.js';
+import test from "ava";
+import { RouterLLM } from "../packages/intention/dist/router.js";
+import { extractCode } from "../packages/intention/dist/utils.js";
 
-test('RouterLLM falls back to next provider on failure', async (t) => {
-    class BadLLM {
-        async generate() {
-            throw new Error('fail');
-        }
+test("RouterLLM falls back to next provider on failure", async (t) => {
+  class BadLLM {
+    async generate() {
+      throw new Error("fail");
     }
-    class GoodLLM {
-        async generate({ prompt }) {
-            return `ok:${prompt}`;
-        }
+  }
+  class GoodLLM {
+    async generate({ prompt }) {
+      return `ok:${prompt}`;
     }
-    const router = new RouterLLM([new BadLLM(), new GoodLLM()]);
-    const out = await router.generate({ system: '', prompt: 'hi' });
-    t.is(out, 'ok:hi');
+  }
+  const router = new RouterLLM([new BadLLM(), new GoodLLM()]);
+  const out = await router.generate({ system: "", prompt: "hi" });
+  t.is(out, "ok:hi");
 });
 
-test('RouterLLM throws when all providers fail', async (t) => {
-    class BadLLM {
-        async generate() {
-            throw new Error('fail');
-        }
+test("RouterLLM throws when all providers fail", async (t) => {
+  class BadLLM {
+    async generate() {
+      throw new Error("fail");
     }
-    const router = new RouterLLM([new BadLLM()]);
-    await t.throwsAsync(() => router.generate({ system: '', prompt: 'hi' }), {
-        message: 'fail',
-    });
+  }
+  const router = new RouterLLM([new BadLLM()]);
+  await t.throwsAsync(() => router.generate({ system: "", prompt: "hi" }), {
+    message: "fail",
+  });
 });
 
-test('extractCode strips fences', (t) => {
-    const s = '```js\nconsole.log(1);\n```';
-    t.is(extractCode(s), 'console.log(1);\n');
+test("extractCode strips fences", (t) => {
+  const s = "```js\nconsole.log(1);\n```";
+  t.is(extractCode(s), "console.log(1);\n");
 });
 
-test('extractCode splits on triple-dash', (t) => {
-    const s = 'console.log(1);\n---\nmore';
-    t.is(extractCode(s), 'console.log(1);');
+test("extractCode splits on triple-dash", (t) => {
+  const s = "console.log(1);\n---\nmore";
+  t.is(extractCode(s), "console.log(1);");
 });
 
-test('RouterLLM throws when no providers', async (t) => {
-    const router = new RouterLLM([]);
-    await t.throwsAsync(() => router.generate({ system: '', prompt: 'hi' }), {
-        message: 'No providers responded',
-    });
+test("RouterLLM throws when no providers", async (t) => {
+  const router = new RouterLLM([]);
+  await t.throwsAsync(() => router.generate({ system: "", prompt: "hi" }), {
+    message: "No providers responded",
+  });
 });


### PR DESCRIPTION
## Summary
- update the intention unit test to load RouterLLM and extractCode from the built package outputs
- add a changelog entry describing the test import fix

## Testing
- pnpm exec ava tests/intention.test.js
- pnpm exec ava tests/llmChat.test.js
- pnpm exec eslint tests/intention.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d84ea64e7483249f51c5c88634e015