### PR TITLE
Improve AVA feedback when dist tests are missing

### DIFF
--- a/changelog.d/2025.09.27.21.01.53.md
+++ b/changelog.d/2025.09.27.21.01.53.md
@@ -1,0 +1,1 @@
+- Improve AVA configuration to detect missing compiled test outputs and provide a clear build-first error message instead of the generic "No tests found" failure.

--- a/config/ava.config.mjs
+++ b/config/ava.config.mjs
@@ -16,6 +16,7 @@ const testFileMatchers = [
   (name) => name.endsWith(".test.js"),
   (name) => name.endsWith(".spec.js"),
 ];
+const distTestDirNames = new Set(["tests", "test"]);
 
 const shouldSkipDir = (entryName) =>
   entryName === "node_modules" || entryName.startsWith(".");
@@ -38,10 +39,17 @@ function distContainsTests(distDir) {
         continue;
       }
 
-      if (
-        entry.isFile() &&
-        testFileMatchers.some((matcher) => matcher(entry.name))
-      ) {
+      if (!entry.isFile()) {
+        continue;
+      }
+
+      if (testFileMatchers.some((matcher) => matcher(entry.name))) {
+        return true;
+      }
+
+      const relativePath = path.relative(distDir, fullPath);
+      const [topLevelDir] = relativePath.split(path.sep);
+      if (distTestDirNames.has(topLevelDir) && entry.name.endsWith(".js")) {
         return true;
       }
     }

--- a/config/ava.config.mjs
+++ b/config/ava.config.mjs
@@ -1,5 +1,96 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
 // Centralized AVA config for the monorepo
 // Applies consistent file globs and a default timeout to prevent hanging tests.
+
+const repoRoot = path.dirname(fileURLToPath(import.meta.url));
+const searchRoots = [
+  path.resolve(repoRoot, "../packages"),
+  path.resolve(repoRoot, "../services"),
+  path.resolve(repoRoot, "../shared"),
+  path.resolve(repoRoot, "../tests"),
+];
+const testFileMatchers = [
+  (name) => name.endsWith(".test.js"),
+  (name) => name.endsWith(".spec.js"),
+];
+
+const shouldSkipDir = (entryName) =>
+  entryName === "node_modules" || entryName.startsWith(".");
+
+function distContainsTests(distDir) {
+  const stack = [distDir];
+  while (stack.length > 0) {
+    const current = stack.pop();
+    let entries;
+    try {
+      entries = fs.readdirSync(current, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+
+    for (const entry of entries) {
+      const fullPath = path.join(current, entry.name);
+      if (entry.isDirectory()) {
+        stack.push(fullPath);
+        continue;
+      }
+
+      if (
+        entry.isFile() &&
+        testFileMatchers.some((matcher) => matcher(entry.name))
+      ) {
+        return true;
+      }
+    }
+  }
+
+  return false;
+}
+
+function findCompiledTests(rootDir) {
+  let entries;
+  try {
+    entries = fs.readdirSync(rootDir, { withFileTypes: true });
+  } catch {
+    return false;
+  }
+
+  for (const entry of entries) {
+    if (!entry.isDirectory() || shouldSkipDir(entry.name)) {
+      continue;
+    }
+
+    if (
+      entry.name === "dist" &&
+      distContainsTests(path.join(rootDir, entry.name))
+    ) {
+      return true;
+    }
+
+    if (findCompiledTests(path.join(rootDir, entry.name))) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+const hasCompiledTests = searchRoots.some((rootDir) =>
+  findCompiledTests(rootDir),
+);
+
+if (!hasCompiledTests) {
+  const instructions = [
+    "No compiled test files were found. AVA expects JavaScript tests under dist/.",
+    "Run the package build step before executing tests (e.g. `pnpm --filter <pkg> build`).",
+    "If you intended to run TypeScript tests directly, build first to generate dist outputs.",
+  ];
+  throw new Error(instructions.join("\n"));
+}
+
 export default {
   files: [
     // Compiled TS tests


### PR DESCRIPTION
## Summary
- detect whether any compiled test files exist under dist/ before running AVA
- raise an actionable build-first error message when no compiled tests are found
- log the change in changelog.d

## Testing
- pnpm --filter @promethean/tests test

------
https://chatgpt.com/codex/tasks/task_e_68d84f19415c83248dfad61c3811b776