### PR TITLE
Fix grep unit test to respect ripgrep defaults

### DIFF
--- a/changelog.d/2025.09.27.22.19.56.md
+++ b/changelog.d/2025.09.27.22.19.56.md
@@ -1,0 +1,1 @@
+- Hardened the smartgpt bridge grep unit test to respect EXCLUDE_GLOBS defaults and handle ripgrep's no-match exit code.


### PR DESCRIPTION
## Summary
- update the smartgpt bridge grep unit test helper to mirror the production default exclude glob logic
- treat ripgrep's exit code for no matches as an empty result set so the comparison helper does not reject
- add a changelog entry capturing the test hardening

## Testing
- pnpm --filter @promethean/smartgpt-bridge test -- --match "grep: matches ripgrep output with context and flags"


------
https://chatgpt.com/codex/tasks/task_e_68d8602618a083249b35ffbf37c05086