### PR TITLE
Add fallback HTTP proxy when dependency missing

### DIFF
--- a/changelog.d/2025.09.27.22.22.47.md
+++ b/changelog.d/2025.09.27.22.22.47.md
@@ -1,0 +1,1 @@
+- add an internal HTTP forwarding fallback so the proxy service works when the optional http-proxy dependency is absent.

--- a/services/js/proxy/index.js
+++ b/services/js/proxy/index.js
@@ -1,8 +1,31 @@
 import http from "node:http";
 import { readFile } from "node:fs/promises";
-import { fileURLToPath } from "node:url";
+import { EventEmitter } from "node:events";
 import { dirname, join } from "node:path";
-import httpProxy from "http-proxy";
+import { fileURLToPath } from "node:url";
+
+const httpProxyPromise = import("http-proxy")
+  .then((mod) => (mod?.default ? mod.default : mod))
+  .catch((error) => {
+    if (
+      error &&
+      (error.code === "ERR_MODULE_NOT_FOUND" ||
+        error.message?.includes("Cannot find package 'http-proxy'"))
+    ) {
+      return null;
+    }
+    throw error;
+  });
+
+let warnedAboutMissingHttpProxy = false;
+
+function warnMissingHttpProxy() {
+  if (warnedAboutMissingHttpProxy) return;
+  warnedAboutMissingHttpProxy = true;
+  console.warn(
+    "[services/js/proxy] Optional dependency 'http-proxy' not found; falling back to built-in HTTP forwarding (WebSocket proxying disabled).",
+  );
+}
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const repoRoot = join(__dirname, "../../..");
@@ -104,6 +127,151 @@ let currentServer = null;
 let currentProxy = null;
 let currentRoutes = [];
 
+const hopByHopHeaders = new Set([
+  "connection",
+  "keep-alive",
+  "proxy-authenticate",
+  "proxy-authorization",
+  "te",
+  "trailers",
+  "transfer-encoding",
+  "upgrade",
+]);
+
+function normaliseHeaders(headers) {
+  return Object.fromEntries(
+    Object.entries(headers || {})
+      .filter(([, value]) => typeof value !== "undefined")
+      .map(([key, value]) => [
+        key,
+        Array.isArray(value) ? value.join(", ") : String(value ?? ""),
+      ]),
+  );
+}
+
+async function collectRequestBody(req, method) {
+  if (!method || method === "GET" || method === "HEAD") {
+    return undefined;
+  }
+
+  const chunks = [];
+  for await (const chunk of req) {
+    chunks.push(typeof chunk === "string" ? Buffer.from(chunk) : chunk);
+  }
+  if (chunks.length === 0) return undefined;
+  return Buffer.concat(chunks);
+}
+
+async function forwardHttpRequest(req, res, options) {
+  const target = options?.target;
+  if (!target) {
+    throw new Error("proxy target is required");
+  }
+
+  const base = new URL(target);
+  const forwardUrl = new URL(req.url || "/", base);
+  const method = req.method || "GET";
+
+  const headers = normaliseHeaders(req.headers);
+  for (const header of hopByHopHeaders) {
+    delete headers[header];
+  }
+  if (options?.changeOrigin) {
+    headers.host = forwardUrl.host;
+  }
+
+  const body = await collectRequestBody(req, method);
+  if (!body) {
+    delete headers["content-length"];
+  } else {
+    headers["content-length"] = String(body.length);
+  }
+
+  const init = {
+    method,
+    headers,
+  };
+  if (body && body.length > 0) {
+    init.body = body;
+    init.duplex = "half";
+  }
+
+  const response = await fetch(forwardUrl, init);
+
+  res.statusCode = response.status;
+  res.statusMessage = response.statusText;
+
+  const setCookie = response.headers.getSetCookie?.() ?? [];
+  response.headers.forEach((value, key) => {
+    if (key === "set-cookie" || hopByHopHeaders.has(key)) return;
+    res.setHeader(key, value);
+  });
+  if (setCookie.length > 0) {
+    res.setHeader("set-cookie", setCookie);
+  }
+
+  if (
+    method === "HEAD" ||
+    response.status === 204 ||
+    response.status === 304 ||
+    !response.body
+  ) {
+    res.end();
+    return;
+  }
+
+  const buffer = Buffer.from(await response.arrayBuffer());
+  res.end(buffer);
+}
+
+function createFallbackProxy() {
+  warnMissingHttpProxy();
+  const emitter = new EventEmitter();
+
+  return {
+    web(req, res, options) {
+      forwardHttpRequest(req, res, options).catch((error) => {
+        emitter.emit("error", error, req, res);
+      });
+    },
+    ws(req, socket) {
+      const error = new Error(
+        "WebSocket proxying requires the optional 'http-proxy' dependency.",
+      );
+      emitter.emit("error", error, req, undefined);
+      if (socket.writable) {
+        socket.write(
+          "HTTP/1.1 502 Bad Gateway\r\n" +
+            "Content-Type: application/json\r\n" +
+            "Connection: close\r\n\r\n" +
+            JSON.stringify({
+              error: "proxy_ws_unavailable",
+              message: error.message,
+            }),
+        );
+      }
+      socket.destroy();
+    },
+    close() {
+      emitter.removeAllListeners();
+    },
+    on(event, listener) {
+      emitter.on(event, listener);
+    },
+    off(event, listener) {
+      emitter.off(event, listener);
+    },
+  };
+}
+
+async function createProxyServer(options) {
+  const httpProxy = await httpProxyPromise;
+  if (httpProxy) {
+    return httpProxy.createProxyServer(options);
+  }
+  return createFallbackProxy();
+}
+
 function buildRouteTable(routes) {
   return Object.entries(routes || {})
     .filter(
@@ -131,13 +299,13 @@ async function tryServeStatic(req, res) {
   return true;
 }
 
-export function start(port = 0, routes = {}) {
+export async function start(port = 0, routes = {}) {
   if (currentServer) {
     throw new Error("proxy already running; call stop() before starting again");
   }
 
   currentRoutes = buildRouteTable(routes);
-  currentProxy = httpProxy.createProxyServer({ changeOrigin: true, ws: true });
+  currentProxy = await createProxyServer({ changeOrigin: true, ws: true });
 
   currentProxy.on("error", (err, req, res) => {
     if (!res || res.headersSent) return;


### PR DESCRIPTION
## Summary
- add an optional fallback implementation so the proxy service can forward HTTP requests when the `http-proxy` package is absent
- note the behaviour change in the changelog

## Testing
- pnpm exec eslint services/js/proxy/index.js
- pnpm exec ava tests/sites/llm_chat_frontend.test.mjs tests/sites/smartgpt_dashboard_frontend.test.mjs

------
https://chatgpt.com/codex/tasks/task_e_68d8609a851c83248e1bb8e6892888c4