### PR TITLE
Fix normalizeToRoot absolute path handling

### DIFF
--- a/changelog.d/2025.09.27.22.24.28.md
+++ b/changelog.d/2025.09.27.22.24.28.md
@@ -1,0 +1,2 @@
+- fix `normalizeToRoot` handling of absolute paths within the repo to keep symbol indexing from skipping files
+- add a unit test covering absolute paths passed to `normalizeToRoot`

--- a/packages/smartgpt-bridge/src/files.ts
+++ b/packages/smartgpt-bridge/src/files.ts
@@ -23,9 +23,19 @@ export function normalizeToRoot(
   const base = path.resolve(ROOT_PATH);
   const p = String(inputPath || "");
   if (p === "/" || p === "") return base;
-  const candidate = path.isAbsolute(p)
-    ? path.resolve(base, p.slice(1))
-    : path.resolve(base, p.replace(/^[\\/]+/, ""));
+  let candidate: string;
+  if (path.isAbsolute(p)) {
+    const absolute = path.resolve(p);
+    if (isInsideRoot(ROOT_PATH, absolute)) {
+      candidate = absolute;
+    } else if (p.startsWith(path.sep)) {
+      candidate = path.resolve(base, p.slice(1));
+    } else {
+      throw new Error("path outside root");
+    }
+  } else {
+    candidate = path.resolve(base, p.replace(/^[\\/]+/, ""));
+  }
   const relToBase = path.relative(base, candidate);
   if (relToBase.startsWith("..") || path.isAbsolute(relToBase)) {
     throw new Error("path outside root");

--- a/packages/smartgpt-bridge/src/tests/unit/files.more.test.ts
+++ b/packages/smartgpt-bridge/src/tests/unit/files.more.test.ts
@@ -61,3 +61,9 @@ test('normalizeToRoot resolves "/" to repo root', (t) => {
   const p = normalizeToRoot(process.cwd(), "/");
   t.is(p, path.resolve(process.cwd()));
 });
+
+test("normalizeToRoot allows absolute paths inside root", (t) => {
+  const abs = path.join(process.cwd(), "tests", "fixtures", "hello.ts");
+  const normalized = normalizeToRoot(process.cwd(), abs);
+  t.is(normalized, abs);
+});


### PR DESCRIPTION
## Summary
- ensure `normalizeToRoot` preserves absolute paths that stay within the workspace
- add a unit test that covers passing absolute paths to `normalizeToRoot`
- document the change in the changelog

## Testing
- pnpm --filter @promethean/smartgpt-bridge test -- --match "normalizeToRoot allows absolute paths inside root"


------
https://chatgpt.com/codex/tasks/task_e_68d8602f8d488324af99fe2279744700