### PR TITLE
Fix SmartGPT Bridge fixture bootstrap and v1 root propagation

### DIFF
--- a/changelog.d/2025.09.27.22.23.44.md
+++ b/changelog.d/2025.09.27.22.23.44.md
@@ -1,0 +1,2 @@
+- Ensure SmartGPT Bridge tests find their fixture directory when executed from the workspace root.
+- Propagate the configured repository root into v1 Fastify routes so file APIs read from the correct tree.

--- a/packages/smartgpt-bridge/src/routes/v1/index.ts
+++ b/packages/smartgpt-bridge/src/routes/v1/index.ts
@@ -19,6 +19,19 @@ export async function registerV1Routes(
   // Everything defined here will be reachable under /v1 because of the prefix in fastifyApp.js
   await app.register(
     async function v1(v1: FastifyInstance) {
+      type RootedFastify = FastifyInstance & { ROOT_PATH?: string };
+      const parent = app as RootedFastify;
+      const scoped = v1 as RootedFastify;
+      const rootPath = parent.ROOT_PATH ?? process.cwd();
+      const canDecorate = typeof scoped.decorate === "function";
+      const hasRootPath =
+        typeof scoped.hasDecorator === "function" &&
+        scoped.hasDecorator("ROOT_PATH");
+      if (canDecorate && !hasRootPath) {
+        scoped.decorate("ROOT_PATH", rootPath);
+      } else {
+        scoped.ROOT_PATH = rootPath;
+      }
       // Swagger JUST for v1 (encapsulation keeps it scoped)
 
       await v1.register(rateLimit, {


### PR DESCRIPTION
## Summary
- update the SmartGPT Bridge test bootstrap to locate fixture directories using the package location and fill missing copies under either cwd or the package path
- propagate the configured ROOT_PATH decoration into the v1 Fastify scope so file APIs continue to operate when the app is mounted from different working directories
- record the changes in the changelog

## Testing
- pnpm --filter @promethean/smartgpt-bridge test -- --fail-fast

------
https://chatgpt.com/codex/tasks/task_e_68d8601a77d083248ee6569c08e0e0be