### PR TITLE
Fix SmartGPT Bridge grep fallback for ripgrep glob errors

### DIFF
--- a/changelog.d/2024.11.20.000000.md
+++ b/changelog.d/2024.11.20.000000.md
@@ -1,0 +1,5 @@
+## Summary
+- make SmartGPT Bridge grep tolerant of ripgrep builds without negated glob support by retrying without CLI excludes and filtering matches locally
+
+## Testing
+- pnpm --filter @promethean/smartgpt-bridge test -- -m 'grep: matches ripgrep output with context and flags'

--- a/docs/agile/tasks/fix-smartgpt-bridge-grep-test.md
+++ b/docs/agile/tasks/fix-smartgpt-bridge-grep-test.md
@@ -1,0 +1,64 @@
+---
+task-id: TASK-20241120-grepfix
+title: Fix SmartGPT Bridge grep parity with ripgrep
+state: InProgress
+prev:
+txn: "2024-11-20T00:00:00Z-0001"
+owner: gpt
+priority: p2
+size: s
+epic: EPC-000
+depends_on: []
+labels:
+  - board:auto
+  - lang:ts
+due:
+links: []
+artifacts: []
+rationale: |
+  Unit tests in `@promethean/smartgpt-bridge` show flaky behavior around the
+  `grep` adapter. The first unit case reports a rejected promise, so we need to
+  tighten the implementation until it matches the contract verified against
+  ripgrep.
+proposed_transitions:
+  - New->Accepted
+  - Accepted->Breakdown
+  - Breakdown->Ready
+  - Ready->Todo
+  - Todo->InProgress
+  - InProgress->InReview
+tags:
+  - task/TASK-20241120-grepfix
+  - board/kanban
+  - state/InProgress
+  - owner/gpt
+  - priority/p2
+  - epic/EPC-000
+---
+
+## Context
+- **What changed?**: CI surfaced a failure for `grep: matches ripgrep output with context and flags`.
+- **Where?**: `packages/smartgpt-bridge` (grep adapter + fixtures).
+- **Why now?**: This check blocks pipelines; aligning our adapter with the
+  reference ripgrep behavior unblocks further work.
+
+## Inputs / Artifacts
+- Failing test log: `packages › smartgpt-bridge › dist › tests › unit › grep › grep: matches ripgrep output with context and flags`.
+- Implementation under investigation: `packages/smartgpt-bridge/src/rg.ts`.
+
+## Definition of Done
+- [ ] Identify the rejection root cause by reproducing the failure locally.
+- [ ] Patch `grep` so it gracefully handles the triggering scenario.
+- [ ] Add or adjust automated coverage if the regression path is missing.
+- [ ] Package build + targeted tests pass.
+
+## Plan
+1. Reproduce the unit failure locally and collect stack traces.
+2. Inspect `grep` error handling for the rejection signature and design a fix.
+3. Implement the adjustment plus any needed fixtures or tests.
+4. Re-run unit tests and lint for the touched files.
+5. Prepare PR notes with evidence of the fix.
+
+## Relevant Resources
+- ripgrep manual: <https://github.com/BurntSushi/ripgrep>
+- Ava docs: <https://github.com/avajs/ava>

--- a/packages/smartgpt-bridge/src/rg.ts
+++ b/packages/smartgpt-bridge/src/rg.ts
@@ -1,5 +1,6 @@
 import fs from "fs/promises";
 
+import ignore from "ignore";
 import { execa } from "execa";
 
 import { normalizeToRoot } from "./files.js";
@@ -14,17 +15,271 @@ type GrepMatch = {
   endLine: number;
 };
 
-function splitCSV(s: string | undefined): string[] {
-  return (s || "")
-    .split(",")
-    .map((x) => x.trim())
-    .filter(Boolean);
+type ExecError = {
+  exitCode?: number;
+  stdout?: string;
+  stderr?: string;
+  message?: string;
+};
+type RipgrepArgs = {
+  readonly withExclude: ReadonlyArray<string>;
+  readonly withoutExclude: ReadonlyArray<string>;
+};
+type RipgrepRunResult = { readonly stdout: string; readonly error?: ExecError };
+type ParsedMatch = {
+  readonly path: string;
+  readonly lineNumber: number;
+  readonly lineText: string;
+  readonly column: number;
+};
+type CacheState = ReadonlyMap<string, ReadonlyArray<string>>;
+type CollectOptions = {
+  readonly context: number;
+  readonly maxMatches: number;
+  readonly root: string;
+  readonly ignorer: ReturnType<typeof ignore> | null;
+};
+type BuildArgsInput = {
+  readonly pattern: string;
+  readonly flags: string;
+  readonly paths: ReadonlyArray<string>;
+  readonly excludeGlobs: ReadonlyArray<string>;
+  readonly maxMatches: number;
+  readonly context: number;
+};
+type PathReduction = {
+  readonly includeArgs: ReadonlyArray<string>;
+  readonly searchPaths: ReadonlyArray<string>;
+};
+
+const GLOB_CHARS = /[?*{}\[\]]/;
+
+function splitCSV(input: string | undefined): ReadonlyArray<string> {
+  return Object.freeze(
+    (input || "")
+      .split(",")
+      .map((value) => value.trim())
+      .filter((value) => value.length > 0),
+  );
 }
-function defaultExcludes(): string[] {
+
+const hasGlob = (value: string): boolean => GLOB_CHARS.test(value);
+
+function defaultExcludes(): ReadonlyArray<string> {
   const env = splitCSV(process.env.EXCLUDE_GLOBS);
-  return env.length
+  return env.length > 0
     ? env
     : ["node_modules/**", ".git/**", "dist/**", "build/**", ".obsidian/**"];
+}
+
+const formatRipgrepError = (err: ExecError): string => {
+  const stderr = err.stderr?.trim();
+  if (stderr) return stderr;
+  const message = err.message?.trim();
+  return message || "unknown ripgrep error";
+};
+
+const isGlobError = (err: ExecError): boolean =>
+  /\bglob\b/.test(`${err.stderr ?? ""} ${err.message ?? ""}`.toLowerCase());
+
+const tryRunRipgrep = (
+  args: ReadonlyArray<string>,
+  cwd: string,
+): Promise<RipgrepRunResult> =>
+  execa("rg", args, { cwd })
+    .then(({ stdout }) => ({ stdout }))
+    .catch((error: ExecError) =>
+      error.exitCode === 1 && typeof error.stdout === "string"
+        ? { stdout: error.stdout }
+        : { stdout: "", error },
+    );
+
+const normalizeForIgnore = (pathname: string): string =>
+  pathname.replace(/\\/g, "/");
+
+const freezeStrings = (values: string[]): ReadonlyArray<string> =>
+  Object.freeze(values);
+
+function createBaseArgs(config: BuildArgsInput): ReadonlyArray<string> {
+  const base = freezeStrings([
+    "--json",
+    "--max-count",
+    String(config.maxMatches),
+    "-C",
+    String(config.context),
+  ]);
+  return config.flags.includes("i") ? base.concat("-i") : base;
+}
+
+function reducePaths(
+  initial: ReadonlyArray<string>,
+  paths: ReadonlyArray<string>,
+): PathReduction {
+  return paths.reduce<PathReduction>(
+    (state, entry) =>
+      hasGlob(entry)
+        ? {
+            includeArgs: state.includeArgs.concat(["--glob", entry]),
+            searchPaths: state.searchPaths,
+          }
+        : {
+            includeArgs: state.includeArgs,
+            searchPaths: state.searchPaths.concat([entry]),
+          },
+    { includeArgs: initial, searchPaths: [] },
+  );
+}
+
+function applyExcludes(
+  args: ReadonlyArray<string>,
+  excludeGlobs: ReadonlyArray<string>,
+): ReadonlyArray<string> {
+  return excludeGlobs.reduce<ReadonlyArray<string>>(
+    (acc, glob) => acc.concat(["--glob", `!${glob}`]),
+    args,
+  );
+}
+
+function appendPattern(
+  args: ReadonlyArray<string>,
+  pattern: string,
+  paths: ReadonlyArray<string>,
+): ReadonlyArray<string> {
+  const searchTargets = paths.length > 0 ? paths : ["."];
+  return args.concat([pattern]).concat(searchTargets);
+}
+
+function buildRipgrepArgs(config: BuildArgsInput): RipgrepArgs {
+  const baseArgs = createBaseArgs(config);
+  const pathReduction = reducePaths(baseArgs, config.paths);
+  const withExclude = applyExcludes(
+    pathReduction.includeArgs,
+    config.excludeGlobs,
+  );
+  return {
+    withExclude: appendPattern(
+      withExclude,
+      config.pattern,
+      pathReduction.searchPaths,
+    ),
+    withoutExclude: appendPattern(
+      pathReduction.includeArgs,
+      config.pattern,
+      pathReduction.searchPaths,
+    ),
+  };
+}
+
+async function collectMatches(
+  lines: ReadonlyArray<string>,
+  options: CollectOptions,
+): Promise<ReadonlyArray<GrepMatch>> {
+  const iterate = async (
+    index: number,
+    cache: CacheState,
+    acc: ReadonlyArray<GrepMatch>,
+  ): Promise<ReadonlyArray<GrepMatch>> => {
+    if (index >= lines.length || acc.length >= options.maxMatches) {
+      return acc;
+    }
+    const currentLine = lines[index];
+    if (typeof currentLine !== "string") {
+      return iterate(index + 1, cache, acc);
+    }
+    const parsed = parseMatchLine(currentLine);
+    if (!parsed) {
+      return iterate(index + 1, cache, acc);
+    }
+    if (options.ignorer?.ignores(normalizeForIgnore(parsed.path)) === true) {
+      return iterate(index + 1, cache, acc);
+    }
+    const { cache: nextCache, lines: fileLines } = await readFileLines(
+      options.root,
+      parsed.path,
+      cache,
+    );
+    if (!fileLines) {
+      return iterate(index + 1, nextCache, acc);
+    }
+    const nextMatch = createMatch(parsed, fileLines, options.context);
+    return iterate(index + 1, nextCache, acc.concat([nextMatch]));
+  };
+  return iterate(0, new Map<string, ReadonlyArray<string>>(), []);
+}
+
+function parseMatchLine(line: string): ParsedMatch | null {
+  const raw: unknown = JSON.parse(line);
+  if (!isRecord(raw) || raw.type !== "match") return null;
+  const data = raw.data;
+  if (!isRecord(data)) return null;
+  const pathInfo = data.path;
+  const linesInfo = data.lines;
+  const lineNumber = data.line_number;
+  if (!isRecord(pathInfo) || typeof pathInfo.text !== "string") return null;
+  if (!isRecord(linesInfo) || typeof linesInfo.text !== "string") return null;
+  if (typeof lineNumber !== "number") return null;
+  const column = firstSubmatchColumn(data.submatches);
+  return {
+    path: pathInfo.text.startsWith("./")
+      ? pathInfo.text.slice(2)
+      : pathInfo.text,
+    lineNumber,
+    lineText: linesInfo.text.replace(/\n$/, ""),
+    column,
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function firstSubmatchColumn(input: unknown): number {
+  if (!Array.isArray(input)) {
+    return 1;
+  }
+  const start = input
+    .filter(isRecord)
+    .map((record) => record.start)
+    .find((value): value is number => typeof value === "number");
+  return (start ?? 0) + 1;
+}
+
+function readFileLines(
+  root: string,
+  relPath: string,
+  cache: CacheState,
+): Promise<{ cache: CacheState; lines: ReadonlyArray<string> | null }> {
+  const existing = cache.get(relPath);
+  if (existing) {
+    return Promise.resolve({ cache, lines: existing });
+  }
+  const absolute = normalizeToRoot(root, relPath);
+  return fs
+    .readFile(absolute, "utf8")
+    .then((text) => {
+      const segments = freezeStrings(text.split(/\r?\n/));
+      const nextCache: CacheState = new Map([...cache, [relPath, segments]]);
+      return { cache: nextCache, lines: segments };
+    })
+    .catch(() => ({ cache, lines: null }));
+}
+
+function createMatch(
+  parsed: ParsedMatch,
+  lines: ReadonlyArray<string>,
+  context: number,
+): GrepMatch {
+  const start = Math.max(0, parsed.lineNumber - 1 - context);
+  const end = Math.min(lines.length, parsed.lineNumber - 1 + context + 1);
+  return {
+    path: parsed.path,
+    line: parsed.lineNumber,
+    column: parsed.column,
+    lineText: parsed.lineText,
+    snippet: lines.slice(start, end).join("\n"),
+    startLine: start + 1,
+    endLine: end,
+  };
 }
 
 type GrepOptions = {
@@ -48,87 +303,35 @@ export async function grep(
     maxMatches = 200,
     context = 2,
   } = opts || {};
-  if (!pattern || typeof pattern !== "string")
+  if (!pattern || typeof pattern !== "string") {
     throw new Error("Missing regex 'pattern'");
-  const args = [
-    "--json",
-    "--max-count",
-    String(maxMatches),
-    "-C",
-    String(context),
-  ];
-  if (flags.includes("i")) args.push("-i");
-  exclude.forEach((ex) => args.push("--glob", `!${ex}`));
-  const searchPaths: string[] = [];
-  for (const p of paths) {
-    if (/[?*{}\[\]]/.test(p)) {
-      args.push("--glob", p);
-    } else {
-      searchPaths.push(p);
-    }
   }
-  args.push(pattern);
-  if (searchPaths.length) {
-    args.push(...searchPaths);
-  } else {
-    args.push(".");
+  const excludeGlobs = exclude.length > 0 ? exclude : [];
+  const ignorer = excludeGlobs.length > 0 ? ignore().add(excludeGlobs) : null;
+  const args = buildRipgrepArgs({
+    pattern,
+    flags,
+    paths,
+    excludeGlobs,
+    maxMatches,
+    context,
+  });
+  const primary = await tryRunRipgrep(args.withExclude, ROOT_PATH);
+  const resolved =
+    primary.error && excludeGlobs.length > 0 && isGlobError(primary.error)
+      ? await tryRunRipgrep(args.withoutExclude, ROOT_PATH)
+      : primary;
+  if (resolved.error) {
+    throw new Error("rg error: " + formatRipgrepError(resolved.error));
   }
-  let stdout: string;
-  try {
-    ({ stdout } = await execa("rg", args, { cwd: ROOT_PATH }));
-  } catch (err: unknown) {
-    // rg exits with code 1 when no matches are found. In that case the
-    // stdout still contains a JSON summary which we can treat as an empty
-    // result set.
-    const e = err as {
-      exitCode?: number;
-      stdout?: string;
-      stderr?: string;
-      message?: string;
-    };
-    if (e.exitCode === 1 && e.stdout) {
-      stdout = e.stdout;
-    } else {
-      const msg = e.stderr || e.message || String(err);
-      throw new Error("rg error: " + msg);
-    }
-  }
-  const lines = stdout.split(/\r?\n/).filter(Boolean);
-  const out: GrepMatch[] = [];
-  const cache = new Map<string, string[]>();
-  for (const line of lines) {
-    const obj = JSON.parse(line);
-    if (obj.type !== "match") continue;
-    const relPath = obj.data.path.text.startsWith("./")
-      ? obj.data.path.text.slice(2)
-      : obj.data.path.text;
-    let fileLines = cache.get(relPath);
-    if (!fileLines) {
-      const abs = normalizeToRoot(ROOT_PATH, relPath);
-      try {
-        const text = await fs.readFile(abs, "utf8");
-        fileLines = text.split(/\r?\n/);
-        cache.set(relPath, fileLines);
-      } catch {
-        continue;
-      }
-    }
-    const lineNumber: number = obj.data.line_number;
-    const lineText: string = obj.data.lines.text.replace(/\n$/, "");
-    const column: number = (obj.data.submatches?.[0]?.start ?? 0) + 1;
-    const start = Math.max(0, lineNumber - 1 - context);
-    const end = Math.min(fileLines.length, lineNumber - 1 + context + 1);
-    const snippet = fileLines.slice(start, end).join("\n");
-    out.push({
-      path: relPath,
-      line: lineNumber,
-      column,
-      lineText,
-      snippet,
-      startLine: start + 1,
-      endLine: end,
-    });
-    if (out.length >= maxMatches) break;
-  }
-  return out;
+  const lines = freezeStrings(
+    resolved.stdout.split(/\r?\n/).filter((entry) => entry.length > 0),
+  );
+  const matches = await collectMatches(lines, {
+    context,
+    maxMatches,
+    root: ROOT_PATH,
+    ignorer,
+  });
+  return [...matches];
 }


### PR DESCRIPTION
## Summary
- restructure the SmartGPT Bridge grep helper to build ripgrep arguments immutably and retry without negative globs when older binaries fail, while filtering matches locally with ignore semantics
- add a recursive match collector that parses ripgrep JSON into typed results and enforces path exclusions even on fallback output
- document the change in the changelog and log the task context in the agile board notes

## Testing
- pnpm --filter @promethean/smartgpt-bridge build
- pnpm --filter @promethean/smartgpt-bridge test -- -m 'grep: matches ripgrep output with context and flags'
- pnpm exec eslint packages/smartgpt-bridge/src/rg.ts

------
https://chatgpt.com/codex/tasks/task_e_68d8603d6a448324a3e9afe0811414d7