### PR TITLE
Enable AVA mock API in tests

### DIFF
--- a/config/ava-mock-polyfill.cjs
+++ b/config/ava-mock-polyfill.cjs
@@ -1,0 +1,59 @@
+const { pathToFileURL } = require("node:url");
+
+async function patch() {
+  try {
+    const path = require("node:path");
+    const entryPath = require.resolve("ava");
+    const entryDir = path.dirname(entryPath);
+    const packageDir = path.dirname(entryDir);
+    const moduleUrl = pathToFileURL(path.join(packageDir, "lib/test.js"));
+    const mod = await import(moduleUrl.href);
+    const TestClass = mod?.default;
+    if (
+      !TestClass ||
+      typeof TestClass.prototype.createExecutionContext !== "function"
+    ) {
+      return;
+    }
+    const original = TestClass.prototype.createExecutionContext;
+    if (original.__avaMockPolyfillApplied) {
+      return;
+    }
+    const attachMockApi = (ctx) => {
+      if (!ctx || typeof ctx !== "object" || ctx.mock) {
+        return ctx;
+      }
+      const method = function method(target, property, implementation) {
+        if (typeof target !== "object" || target === null) {
+          throw new TypeError("mock.method target must be an object");
+        }
+        if (typeof implementation !== "function") {
+          throw new TypeError("mock.method implementation must be a function");
+        }
+        const originalValue = target[property];
+        const restore = () => {
+          target[property] = originalValue;
+        };
+        target[property] = implementation;
+        return { restore };
+      };
+      Object.defineProperty(ctx, "mock", {
+        configurable: true,
+        enumerable: false,
+        value: { method },
+        writable: false,
+      });
+      return ctx;
+    };
+    const patched = function patchedCreateExecutionContext(...args) {
+      const ctx = original.apply(this, args);
+      return attachMockApi(ctx);
+    };
+    patched.__avaMockPolyfillApplied = true;
+    TestClass.prototype.createExecutionContext = patched;
+  } catch (error) {
+    console.warn("Failed to patch AVA ExecutionContext for mock API:", error);
+  }
+}
+
+patch();

--- a/config/ava.config.mjs
+++ b/config/ava.config.mjs
@@ -12,6 +12,7 @@ const searchRoots = [
   path.resolve(repoRoot, "../shared"),
   path.resolve(repoRoot, "../tests"),
 ];
+const mockPolyfillPath = path.join(repoRoot, "ava-mock-polyfill.cjs");
 const testFileMatchers = [
   (name) => name.endsWith(".test.js"),
   (name) => name.endsWith(".spec.js"),
@@ -99,6 +100,13 @@ if (!hasCompiledTests) {
   throw new Error(instructions.join("\n"));
 }
 
+const nodeArguments = ["--enable-source-maps"];
+
+// Enable Node's module mocking API so AVA exposes t.mock in ExecutionContext.
+if (!nodeArguments.includes("--experimental-test-module-mocks")) {
+  nodeArguments.push("--experimental-test-module-mocks");
+}
+
 export default {
   files: [
     // Compiled TS tests
@@ -109,5 +117,6 @@ export default {
   ],
   timeout: "30s",
   failFast: false,
-  nodeArguments: ["--enable-source-maps"],
+  require: [mockPolyfillPath],
+  nodeArguments,
 };


### PR DESCRIPTION
## Summary
- add an AVA config hook that enables Node's module mocks flag and loads a custom polyfill
- provide a mock API polyfill so `t.mock` is available for console stubbing in the Piper tests

## Testing
- pnpm --filter @promethean/piper test -- --match "failing steps log stderr once"

------
https://chatgpt.com/codex/tasks/task_e_68d86c9a604c8324ad36ef4bc4fa2920