### PR TITLE
Fix Promethean CLI bundle extension for ESM entrypoints

### DIFF
--- a/bin/promethean.js
+++ b/bin/promethean.js
@@ -10,7 +10,7 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const bundlePath = path.resolve(
   __dirname,
-  "../packages/promethean-cli/dist/promethean_cli.js",
+  "../packages/promethean-cli/dist/promethean_cli.cjs",
 );
 
 async function run() {

--- a/changelog.d/2025.01.17.00.00.00.md
+++ b/changelog.d/2025.01.17.00.00.00.md
@@ -1,0 +1,1 @@
+- Fix Promethean CLI distribution to emit a CommonJS bundle (`promethean_cli.cjs`) so it runs under Node's ESM loader without `require` errors.

--- a/package.json
+++ b/package.json
@@ -30,8 +30,8 @@
     "nx": "nx"
   },
   "bin": {
-    "prom": "./packages/promethean-cli/dist/promethean_cli.js",
-    "promethean": "./packages/promethean-cli/dist/promethean_cli.js"
+    "prom": "./packages/promethean-cli/dist/promethean_cli.cjs",
+    "promethean": "./packages/promethean-cli/dist/promethean_cli.cjs"
   },
   "dependencies": {
     "@promethean/health-dashboard-frontend": "workspace:*",

--- a/packages/promethean-cli/README.md
+++ b/packages/promethean-cli/README.md
@@ -29,7 +29,7 @@ options to help you recover quickly.
 ## Development
 
 - Source lives in [`src/promethean/cli`](./src/promethean/cli/).
-- Builds are produced with `shadow-cljs` and written to `dist/promethean_cli.js`.
+- Builds are produced with `shadow-cljs` and written to `dist/promethean_cli.cjs`.
 - Tests live under [`tests/scripts`](../../tests/scripts/) and can be run with:
 
   ```sh

--- a/packages/promethean-cli/package.json
+++ b/packages/promethean-cli/package.json
@@ -7,7 +7,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "shadow-cljs release promethean-cli && chmod +x dist/promethean_cli.js",
+    "build": "shadow-cljs release promethean-cli && chmod +x dist/promethean_cli.cjs",
     "watch": "shadow-cljs watch promethean-cli",
     "clean": "rimraf dist"
   },

--- a/scripts/ensure-cli-perms.mjs
+++ b/scripts/ensure-cli-perms.mjs
@@ -15,7 +15,7 @@ export const defaultTargets = [
     "packages",
     "promethean-cli",
     "dist",
-    "promethean_cli.js",
+    "promethean_cli.cjs",
   ),
 ];
 

--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -3,6 +3,6 @@
  {:promethean-cli
   {:target :node-script
    :main promethean.cli.core/-main
-   :output-to "packages/promethean-cli/dist/promethean_cli.js"
+   :output-to "packages/promethean-cli/dist/promethean_cli.cjs"
    :compiler-options {:infer-externs :auto
                       :source-map true}}}}

--- a/tests/scripts/promethean-cli.test.js
+++ b/tests/scripts/promethean-cli.test.js
@@ -7,7 +7,7 @@ const CLI_PATH = path.resolve(
   "packages",
   "promethean-cli",
   "dist",
-  "promethean_cli.js",
+  "promethean_cli.cjs",
 );
 
 const SOURCE_PATH = path.resolve(


### PR DESCRIPTION
## Summary
- change the Promethean CLI build to emit a CommonJS bundle with a .cjs extension so it works with the repository-wide ESM configuration
- update repository bin aliases, permission tooling, and documentation to reference the new bundle name and add a changelog entry

## Testing
- pnpm exec ava tests/scripts/promethean-cli.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d86d0847108324b650a4fb082b8a32