### PR TITLE
Fix LLM tests to import built dist modules

### DIFF
--- a/changelog.d/2025.09.28.00.00.00.md
+++ b/changelog.d/2025.09.28.00.00.00.md
@@ -1,0 +1,1 @@
+- fixed llm test imports to reference built dist outputs correctly

--- a/packages/llm/src/tests/basic.test.js
+++ b/packages/llm/src/tests/basic.test.js
@@ -1,6 +1,6 @@
 import test from 'ava';
 import express from 'express';
-import { loadModel } from '../dist/index.js';
+import { loadModel } from '../../dist/index.js';
 
 test('loadModel resolves a driver', async (t) => {
     process.env.LLM_DRIVER = 'ollama';

--- a/packages/llm/src/tests/drivers.test.js
+++ b/packages/llm/src/tests/drivers.test.js
@@ -1,5 +1,5 @@
 import test from 'ava';
-import { loadDriver } from '../dist/drivers/index.js';
+import { loadDriver } from '../../dist/drivers/index.js';
 import ollama from 'ollama';
 
 test('loads ollama driver and generates', async (t) => {

--- a/packages/llm/src/tests/template.test.js
+++ b/packages/llm/src/tests/template.test.js
@@ -1,5 +1,5 @@
 import test from 'ava';
-import { handleTask, setGenerateFn, setBroker } from '../dist/index.js';
+import { handleTask, setGenerateFn, setBroker } from '../../dist/index.js';
 
 test('handleTask publishes reply using broker', async (t) => {
     const messages = [];


### PR DESCRIPTION
## Summary
- point LLM package tests at the compiled dist entry points so they can resolve modules during execution
- document the test import fix in the changelog

## Testing
- pnpm --filter @promethean/llm test

------
https://chatgpt.com/codex/tasks/task_e_68d8779963448324a2f9ee9b7b471ea5