### PR TITLE
Fix LLM test harness to avoid hanging servers

### DIFF
--- a/changelog.d/2025.09.28.00.00.03.md
+++ b/changelog.d/2025.09.28.00.00.03.md
@@ -1,0 +1,3 @@
+# Summary
+- Ensure LLM tests set NODE_ENV before importing compiled modules so the service does not auto-start during AVA runs.
+- Allow tests to reset broker state and refactor module import fallback to satisfy functional lint rules.

--- a/packages/llm/src/tests/basic.test.js
+++ b/packages/llm/src/tests/basic.test.js
@@ -1,6 +1,18 @@
 import test from 'ava';
 import express from 'express';
-import { loadModel } from '../dist/index.js';
+
+let loadModel;
+
+test.before(async () => {
+    process.env.NODE_ENV = 'test';
+    ({ loadModel } = await import('../../dist/index.js'));
+});
+
+test.after.always(() => {
+    delete process.env.NODE_ENV;
+    delete process.env.LLM_DRIVER;
+    delete process.env.LLM_MODEL;
+});
 
 test('loadModel resolves a driver', async (t) => {
     process.env.LLM_DRIVER = 'ollama';

--- a/packages/llm/src/tests/drivers.test.js
+++ b/packages/llm/src/tests/drivers.test.js
@@ -1,21 +1,36 @@
 import test from 'ava';
-import { loadDriver } from '../dist/drivers/index.js';
 import ollama from 'ollama';
+
+let loadDriver;
+
+test.before(async () => {
+    process.env.NODE_ENV = 'test';
+    ({ loadDriver } = await import('../../dist/drivers/index.js'));
+});
+
+test.after.always(() => {
+    delete process.env.NODE_ENV;
+    delete process.env.LLM_DRIVER;
+    delete process.env.LLM_MODEL;
+});
 
 test('loads ollama driver and generates', async (t) => {
     process.env.LLM_DRIVER = 'ollama';
     process.env.LLM_MODEL = 'test';
     const orig = ollama.chat;
-    ollama.chat = async () => ({ message: { content: 'hello' } });
-    const driver = await loadDriver();
-    const res = await driver.generate({
-        prompt: 'hi',
-        context: [],
-        format: null,
-        tools: [],
-    });
-    t.is(res, 'hello');
-    ollama.chat = orig;
+    try {
+        ollama.chat = async () => ({ message: { content: 'hello' } });
+        const driver = await loadDriver();
+        const res = await driver.generate({
+            prompt: 'hi',
+            context: [],
+            format: null,
+            tools: [],
+        });
+        t.is(res, 'hello');
+    } finally {
+        ollama.chat = orig;
+    }
 });
 
 test('loads huggingface driver and generates', async (t) => {
@@ -23,13 +38,16 @@ test('loads huggingface driver and generates', async (t) => {
     process.env.LLM_MODEL = 'test';
     const driver = await loadDriver();
     const orig = driver.client;
-    driver.client = { textGeneration: async () => ({ generated_text: 'hi' }) };
-    const res = await driver.generate({
-        prompt: 'hi',
-        context: [],
-        format: null,
-        tools: [],
-    });
-    t.is(res, 'hi');
-    driver.client = orig;
+    try {
+        driver.client = { textGeneration: async () => ({ generated_text: 'hi' }) };
+        const res = await driver.generate({
+            prompt: 'hi',
+            context: [],
+            format: null,
+            tools: [],
+        });
+        t.is(res, 'hi');
+    } finally {
+        driver.client = orig;
+    }
 });

--- a/packages/llm/src/tests/template.test.js
+++ b/packages/llm/src/tests/template.test.js
@@ -1,5 +1,23 @@
 import test from 'ava';
-import { handleTask, setGenerateFn, setBroker } from '../dist/index.js';
+
+let handleTask;
+let setGenerateFn;
+let setBroker;
+let loadModel;
+
+test.before(async () => {
+    process.env.NODE_ENV = 'test';
+    ({ handleTask, setGenerateFn, setBroker, loadModel } = await import('../../dist/index.js'));
+});
+
+test.after.always(async () => {
+    delete process.env.NODE_ENV;
+    setBroker(null);
+    setGenerateFn(async ({ prompt, context = [], format = null, tools = [] }) => {
+        const driver = await loadModel();
+        return driver.generate({ prompt, context, format, tools });
+    });
+});
 
 test('handleTask publishes reply using broker', async (t) => {
     const messages = [];


### PR DESCRIPTION
## Summary
- ensure the LLM service broker can be cleared and make the fallback importer functional-friendly to satisfy linting
- defer compiled module imports in AVA tests until after the environment is marked as NODE_ENV=test to stop the service from auto-starting during tests
- document the change in the changelog

## Testing
- pnpm exec eslint packages/llm/src/tests/basic.test.js packages/llm/src/tests/drivers.test.js packages/llm/src/tests/template.test.js packages/llm/src/index.ts
- pnpm --filter @promethean/llm build
- pnpm exec ava packages/llm/src/tests/basic.test.js packages/llm/src/tests/drivers.test.js packages/llm/src/tests/template.test.js --timeout 10s

------
https://chatgpt.com/codex/tasks/task_e_68d877b964888324b22428ee95ecf5e4