### PR TITLE
Fix .gitignore handling in file tree endpoint

### DIFF
--- a/changelog.d/2025.09.27.23.58.25.md
+++ b/changelog.d/2025.09.27.23.58.25.md
@@ -1,0 +1,1 @@
+- Fix `/v0/files/tree` to respect nested paths when applying `.gitignore` filters so integration tests pass.

--- a/packages/smartgpt-bridge/src/files.ts
+++ b/packages/smartgpt-bridge/src/files.ts
@@ -216,8 +216,9 @@ export async function treeDirectory(
   const raw = await buildTree(abs, {
     includeHidden,
     maxDepth: depth,
-    predicate: (absPath, dirent) => {
-      const relPath = path.relative(ROOT_PATH, path.join(absPath, dirent.name));
+    predicate: (absPath) => {
+      const relPath = path.relative(ROOT_PATH, absPath);
+      if (!relPath) return true;
       return !ig.ignores(relPath);
     },
   });


### PR DESCRIPTION
## Summary
- ensure the v0 file tree endpoint filters entries using absolute paths so nested directories survive `.gitignore` evaluation
- document the change in the changelog archive

## Testing
- pnpm --filter @promethean/smartgpt-bridge build
- pnpm --filter @promethean/smartgpt-bridge exec ava dist/tests/integration/server.files.tree.test.js --config ../../config/ava.config.mjs
- pnpm exec eslint packages/smartgpt-bridge/src/files.ts

------
https://chatgpt.com/codex/tasks/task_e_68d8780f16308324b93e8b6391ad044d