### PR TITLE
Handle Windows stacktrace paths

### DIFF
--- a/changelog.d/2025.09.28.00.01.47.md
+++ b/changelog.d/2025.09.28.00.01.47.md
@@ -1,0 +1,1 @@
+- Fix stacktrace locator to accept Windows drive paths and normalize path separators, ensuring file snippets resolve correctly across platforms.

--- a/packages/smartgpt-bridge/src/files.ts
+++ b/packages/smartgpt-bridge/src/files.ts
@@ -100,11 +100,15 @@ export async function viewFile(
 }
 
 const RX: Record<string, RegExp> = {
-  nodeA: /\(?(?<file>[^():\n]+?):(?<line>\d+):(?<col>\d+)\)?/g,
+  nodeA: /\(?(?<file>(?:[A-Za-z]:)?[^():\n]+?):(?<line>\d+):(?<col>\d+)\)?/g,
   nodeB: /at\s+.*?\((?<file>[^()]+?):(?<line>\d+):(?<col>\d+)\)/g,
   py: /File\s+"(?<file>[^"]+)",\s+line\s+(?<line>\d+)/g,
-  go: /(?<file>[^\s:]+?):(?<line>\d+)/g,
+  go: /(?<file>(?:[A-Za-z]:)?[^\s:]+?):(?<line>\d+)/g,
 };
+
+function normalizeStacktracePath(file: string): string {
+  return file.replace(/\\/g, "/");
+}
 
 export async function locateStacktrace(
   ROOT_PATH: string,
@@ -119,7 +123,7 @@ export async function locateStacktrace(
       m = re.exec(text);
       if (!m) break;
       const g = m.groups as Record<string, string> | undefined;
-      const file = g?.file;
+      const file = g?.file ? normalizeStacktracePath(g.file) : undefined;
       const line = Number(g?.line || 1);
       const col = g?.col ? Number(g.col) : undefined;
       if (!file) continue;

--- a/packages/smartgpt-bridge/src/tests/integration/server.files.test.ts
+++ b/packages/smartgpt-bridge/src/tests/integration/server.files.test.ts
@@ -5,6 +5,7 @@ import test from "ava";
 import { withServer } from "../helpers/server.js";
 
 const ROOT = path.join(process.cwd(), "tests", "fixtures");
+const windowsOnlyTest = process.platform === "win32" ? test : test.skip;
 
 test("GET /v0/files/view returns snippet", async (t) => {
   await withServer(ROOT, async (req) => {
@@ -59,6 +60,23 @@ test("POST /stacktrace/locate resolves file:line:col", async (t) => {
     t.true(res.body.results[0].snippet.length > 0);
   });
 });
+
+windowsOnlyTest(
+  "POST /stacktrace/locate resolves Windows drive paths",
+  async (t) => {
+    const trace = `${path.resolve(ROOT, "hello.ts")}:2:10`;
+    await withServer(ROOT, async (req) => {
+      const res = await req
+        .post("/v0/stacktrace/locate")
+        .send({ text: trace, context: 1 })
+        .expect(200);
+      t.true(res.body.ok);
+      t.true(res.body.results.length >= 1);
+      t.true(res.body.results[0].resolved);
+      t.true(res.body.results[0].snippet.length > 0);
+    });
+  },
+);
 
 test("POST /grep invalid or missing pattern returns 400", async (t) => {
   await withServer(ROOT, async (req) => {


### PR DESCRIPTION
## Summary
- normalize parsed stacktrace paths and allow drive letters so Windows stack traces resolve correctly
- cover the drive-letter case with a Windows-only integration test for the files route
- note the fix in the changelog entry for this session

## Testing
- pnpm --filter @promethean/smartgpt-bridge build
- pnpm exec ava dist/tests/integration/server.files.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d8780a9a3c83249744661a20fbd419