### PR TITLE
Fix piper js-step tests in worker contexts

### DIFF
--- a/changelog.d/2024.06.09.00.00.00.md
+++ b/changelog.d/2024.06.09.00.00.00.md
@@ -1,0 +1,1 @@
+- Fix piper js-step tests to avoid changing process cwd within worker threads.

--- a/packages/piper/src/tests/js-step.test.ts
+++ b/packages/piper/src/tests/js-step.test.ts
@@ -13,8 +13,6 @@ async function withTmp(fn: (dir: string) => Promise<void>) {
   const parent = path.join(process.cwd(), "test-tmp");
   await fs.mkdir(parent, { recursive: true });
   const dir = await fs.mkdtemp(path.join(parent, "piper-"));
-  const prevCwd = process.cwd();
-  process.chdir(dir);
   try {
     await fs.writeFile(
       path.join(dir, SCHEMA),
@@ -25,7 +23,6 @@ async function withTmp(fn: (dir: string) => Promise<void>) {
     // small grace period for any async file watchers/flushes
     await sleep(50);
   } finally {
-    process.chdir(prevCwd);
     await fs.rm(dir, { recursive: true, force: true });
   }
 }


### PR DESCRIPTION
## Summary
- stop changing the process working directory in the piper js-step test helper so it works in worker threads
- add a changelog entry documenting the test fix

## Testing
- pnpm --filter @promethean/piper exec ava -- "--match" "runJSFunction restores globals on timeout (in-proc)"

------
https://chatgpt.com/codex/tasks/task_e_68d87864c3788324b5e5ea5587dbcbc9