### PR TITLE
fix: avoid worker chdir in piper parse error test

### DIFF
--- a/changelog.d/2024.05.18.00.00.00.md
+++ b/changelog.d/2024.05.18.00.00.00.md
@@ -1,0 +1,1 @@
+- fix(piper): avoid worker-incompatible cwd change in input parse error test

--- a/packages/piper/src/tests/input-parse-error.test.ts
+++ b/packages/piper/src/tests/input-parse-error.test.ts
@@ -12,59 +12,45 @@ async function withTmp(fn: (dir: string) => Promise<void>) {
     String(Date.now()) + "-" + Math.random().toString(36).slice(2),
   );
   await fs.mkdir(dir, { recursive: true });
-  try {
-    await fn(dir);
-  } finally {
-    await fs.rm(dir, { recursive: true, force: true });
-  }
+  await fn(dir).finally(() => fs.rm(dir, { recursive: true, force: true }));
 }
 
 test.serial("validateFiles includes path on JSON parse error", async (t) => {
   await withTmp(async (dir) => {
-    const prevCwd = process.cwd();
-    process.chdir(dir);
-    try {
-      await fs.writeFile("bad.json", "{not json", "utf8");
-      await fs.writeFile(
-        "schema.json",
-        JSON.stringify({ type: "object" }),
-        "utf8",
-      );
-      const cfg = {
-        pipelines: [
-          {
-            name: "demo",
-            steps: [
-              {
-                id: "noop",
-                cwd: ".",
-                deps: [],
-                inputs: ["bad.json"],
-                inputSchema: "schema.json",
-                outputs: [],
-                cache: "content",
-                shell: "echo hi",
-              },
-            ],
-          },
-        ],
-      };
-      await fs.writeFile(
-        "pipelines.json",
-        JSON.stringify(cfg, null, 2),
-        "utf8",
-      );
-      const err = await t.throwsAsync(
-        () =>
-          runPipeline("pipelines.json", "demo", {
-            concurrency: 1,
-            contentHash: true,
-          }),
-        { instanceOf: StepError },
-      );
-      t.true(err?.message.includes("bad.json"));
-    } finally {
-      process.chdir(prevCwd);
-    }
+    const badPath = path.join(dir, "bad.json");
+    const schemaPath = path.join(dir, "schema.json");
+    const pipelinesPath = path.join(dir, "pipelines.json");
+
+    await fs.writeFile(badPath, "{not json", "utf8");
+    await fs.writeFile(schemaPath, JSON.stringify({ type: "object" }), "utf8");
+    const cfg = {
+      pipelines: [
+        {
+          name: "demo",
+          steps: [
+            {
+              id: "noop",
+              cwd: ".",
+              deps: [],
+              inputs: ["bad.json"],
+              inputSchema: "schema.json",
+              outputs: [],
+              cache: "content",
+              shell: "echo hi",
+            },
+          ],
+        },
+      ],
+    };
+    await fs.writeFile(pipelinesPath, JSON.stringify(cfg, null, 2), "utf8");
+    const err = await t.throwsAsync(
+      () =>
+        runPipeline(pipelinesPath, "demo", {
+          concurrency: 1,
+          contentHash: true,
+        }),
+      { instanceOf: StepError },
+    );
+    t.true(err?.message.includes("bad.json"));
   });
 });


### PR DESCRIPTION
## Summary
- update the input parse error test to avoid worker-incompatible `process.chdir`
- rely on promise finalizers for temp cleanup and add a changelog entry

## Testing
- pnpm exec eslint packages/piper/src/tests/input-parse-error.test.ts
- pnpm --filter @promethean/piper test

------
https://chatgpt.com/codex/tasks/task_e_68d87854e7b48324b89767029eb83901