### PR TITLE
Fix /grep case sensitivity with smart-case ripgrep configs

### DIFF
--- a/changelog.d/2025.09.27.23.58.00.md
+++ b/changelog.d/2025.09.27.23.58.00.md
@@ -1,0 +1,1 @@
+- Ensure `POST /v0/grep` remains case-sensitive when ripgrep smart-case config is present and add regression test coverage.

--- a/packages/smartgpt-bridge/src/rg.ts
+++ b/packages/smartgpt-bridge/src/rg.ts
@@ -101,14 +101,18 @@ const freezeStrings = (values: string[]): ReadonlyArray<string> =>
   Object.freeze(values);
 
 function createBaseArgs(config: BuildArgsInput): ReadonlyArray<string> {
-  const base = freezeStrings([
+  const normalizedFlags = config.flags.toLowerCase();
+  const base = [
     "--json",
     "--max-count",
     String(config.maxMatches),
     "-C",
     String(config.context),
-  ]);
-  return config.flags.includes("i") ? base.concat("-i") : base;
+  ];
+  const caseArgs = normalizedFlags.includes("i")
+    ? ["-i"]
+    : ["--case-sensitive"];
+  return freezeStrings([...base, ...caseArgs]);
 }
 
 function reducePaths(

--- a/packages/smartgpt-bridge/src/tests/unit/grep.test.ts
+++ b/packages/smartgpt-bridge/src/tests/unit/grep.test.ts
@@ -123,6 +123,40 @@ test("grep: matches ripgrep output with context and flags", async (t) => {
   t.deepEqual(results, expected);
 });
 
+test("grep: case-sensitive search overrides smart-case config", async (t) => {
+  const rcPath = path.join(
+    process.cwd(),
+    "tests",
+    "fixtures",
+    "ripgrep-smart-case.rc",
+  );
+  const previous = process.env.RIPGREP_CONFIG_PATH;
+  process.env.RIPGREP_CONFIG_PATH = rcPath;
+  t.teardown(() => {
+    if (previous === undefined) {
+      delete process.env.RIPGREP_CONFIG_PATH;
+    } else {
+      process.env.RIPGREP_CONFIG_PATH = previous;
+    }
+  });
+
+  const caseSensitive = await grep(ROOT, {
+    pattern: "heading",
+    flags: "g",
+    paths: ["**/*.md"],
+    context: 1,
+  });
+  t.is(caseSensitive.length, 0);
+
+  const caseInsensitive = await grep(ROOT, {
+    pattern: "heading",
+    flags: "i",
+    paths: ["**/*.md"],
+    context: 1,
+  });
+  t.true(caseInsensitive.length >= 1);
+});
+
 test("grep: invalid regex throws error", async (t) => {
   await t.throwsAsync(() =>
     grep(ROOT, { pattern: "(*invalid", paths: ["**/*.md"] }),

--- a/packages/smartgpt-bridge/tests/fixtures/ripgrep-smart-case.rc
+++ b/packages/smartgpt-bridge/tests/fixtures/ripgrep-smart-case.rc
@@ -1,0 +1,1 @@
+--smart-case


### PR DESCRIPTION
## Summary
- force ripgrep invocations from `/v0/grep` to add `--case-sensitive` when the request omits the `i` flag so local smart-case configs cannot change semantics
- add a regression test (with fixture) that simulates a smart-case ripgrep configuration and document the change in the changelog

## Testing
- pnpm --filter @promethean/smartgpt-bridge test -- --match "grep: case-sensitive search overrides smart-case config"
- pnpm --filter @promethean/smartgpt-bridge test -- --match "POST /grep returns match and respects flags"

------
https://chatgpt.com/codex/tasks/task_e_68d87805ebc88324acb60f4a6842b16f