### PR TITLE
Fix worker JS step tests without changing process cwd

### DIFF
--- a/changelog.d/2025.09.28.00.03.49.md
+++ b/changelog.d/2025.09.28.00.03.49.md
@@ -1,0 +1,1 @@
+- Fixed JS worker tests by keeping temporary test directories isolated without changing the worker's process.cwd().


### PR DESCRIPTION
## Summary
- stop changing the process working directory inside the js-step test helper to keep worker threads happy
- always clean up temporary test directories using a promise chain and document the change in the changelog

## Testing
- pnpm --filter @promethean/piper exec ava dist/tests/js-step.test.js --match "JS steps isolate process.env when run concurrently" --serial

------
https://chatgpt.com/codex/tasks/task_e_68d8785f1178832483ec02c31ca2aff5