### PR TITLE
Fix Piper JS step tests for worker compatibility

### DIFF
--- a/changelog.d/2025.09.28.00.04.27.md
+++ b/changelog.d/2025.09.28.00.04.27.md
@@ -1,0 +1,1 @@
+- Fix piper JS step tests to avoid changing the working directory inside worker threads.

--- a/packages/piper/src/tests/js-step.test.ts
+++ b/packages/piper/src/tests/js-step.test.ts
@@ -13,8 +13,6 @@ async function withTmp(fn: (dir: string) => Promise<void>) {
   const parent = path.join(process.cwd(), "test-tmp");
   await fs.mkdir(parent, { recursive: true });
   const dir = await fs.mkdtemp(path.join(parent, "piper-"));
-  const prevCwd = process.cwd();
-  process.chdir(dir);
   try {
     await fs.writeFile(
       path.join(dir, SCHEMA),
@@ -25,7 +23,6 @@ async function withTmp(fn: (dir: string) => Promise<void>) {
     // small grace period for any async file watchers/flushes
     await sleep(50);
   } finally {
-    process.chdir(prevCwd);
     await fs.rm(dir, { recursive: true, force: true });
   }
 }


### PR DESCRIPTION
## Summary
- stop changing the global working directory in Piper's js-step tests so worker threads remain supported
- add a changelog entry noting the worker test fix

## Testing
- pnpm --filter @promethean/piper test -- --match "worker js step: export name is respected (one/two)" *(hangs on shutdown after logging the matching test; aborted once output confirmed)*

------
https://chatgpt.com/codex/tasks/task_e_68d878787e748324a117983ba67359c9