### PR TITLE
Adjust Piper JSONC test to run without process.chdir

### DIFF
--- a/changelog.d/2025.09.28.00.03.38.md
+++ b/changelog.d/2025.09.28.00.03.38.md
@@ -1,0 +1,1 @@
+- Fix jsonc test to operate via explicit paths so it runs in worker contexts without using `process.chdir`.


### PR DESCRIPTION
## Summary
- update the Piper JSONC test fixture to work from explicit file paths instead of mutating process.cwd
- rely on Promise.finally for temporary directory cleanup so the test stays lint-compliant
- document the change in the changelog

## Testing
- pnpm --filter @promethean/piper build
- pnpm --filter @promethean/piper exec ava dist/tests/jsonc.test.js
- pnpm exec eslint packages/piper/src/tests/jsonc.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d878883e6883248c2924a4df64a97f