### PR TITLE
feat(docops): add fake services for e2e tests

### DIFF
--- a/changelog.d/2025.09.28.00.04.34.md
+++ b/changelog.d/2025.09.28.00.04.34.md
@@ -1,0 +1,2 @@
+- docops e2e tests now fall back to in-process fake Ollama/Chroma services when local instances are unavailable.
+- added a shared fake service layer to keep embedding and query flows working during tests.

--- a/packages/docops/src/02-embed.ts
+++ b/packages/docops/src/02-embed.ts
@@ -104,13 +104,13 @@ const changedIds = async (
   return pairs.filter((x): x is readonly [Chunk, string, string] => !!x);
 };
 
-const ollamaClient = createOllamaClient();
 const embedBatch = async (
   model: string,
   texts: string[],
   timeoutMs = 120_000,
 ) => {
   if (texts.length === 0) return [] as number[][];
+  const ollamaClient = createOllamaClient();
   // Official API uses `.embed({ model, input })`
   const p = ollamaClient.embed({ model, input: texts }) as Promise<any>;
   const withTimeout = new Promise<any>((_resolve, reject) => {

--- a/packages/docops/src/02-embed.ts
+++ b/packages/docops/src/02-embed.ts
@@ -5,15 +5,14 @@ import { createHash } from "node:crypto";
 import { pathToFileURL } from "node:url";
 
 import matter from "gray-matter";
-import { Ollama } from "ollama";
-import { ChromaClient } from "chromadb";
-import { OllamaEmbeddingFunction } from "@chroma-core/ollama";
 import { scanFiles } from "@promethean/file-indexer";
 import type { IndexedFile, ScanProgress } from "@promethean/file-indexer";
 
 import { DBs } from "./db.js";
-import { parseArgs, parseMarkdownChunks, OLLAMA_URL } from "./utils.js";
+import { parseArgs, parseMarkdownChunks } from "./utils.js";
 import { Chunk } from "./types.js";
+import { createOllamaClient } from "./lib/services.js";
+import { getChromaCollection } from "./lib/chroma.js";
 // CLI entry
 
 type Front = { uuid?: string; filename?: string };
@@ -105,7 +104,7 @@ const changedIds = async (
   return pairs.filter((x): x is readonly [Chunk, string, string] => !!x);
 };
 
-const ollamaClient = new Ollama({ host: OLLAMA_URL });
+const ollamaClient = createOllamaClient();
 const embedBatch = async (
   model: string,
   texts: string[],
@@ -278,17 +277,11 @@ if (isDirect) {
   // CLI path builds its own DB+collection when invoked directly
   const { openDB } = await import("./db.js");
   const db = await openDB();
-  const client = new ChromaClient({});
   const embedModel = args["--embed-model"] ?? "nomic-embed-text:latest";
   const collection = args["--collection"] ?? "docs";
-  const embedder = new OllamaEmbeddingFunction({
-    model: embedModel,
-    url: OLLAMA_URL,
-  });
-  const coll = await client.getOrCreateCollection({
-    name: collection,
-    metadata: { embed_model: embedModel, "hnsw:space": "cosine" },
-    embeddingFunction: embedder,
+  const { coll } = await getChromaCollection({
+    collection,
+    embedModel,
   });
   const dir = args["--dir"] ?? "docs/unique";
   const extsArg = args["--ext"] ?? ".md,.mdx,.txt";

--- a/packages/docops/src/lib/chroma.ts
+++ b/packages/docops/src/lib/chroma.ts
@@ -1,10 +1,15 @@
 // Lightweight helpers to get a Chroma collection with Ollama embedding function
 import { OLLAMA_URL } from "../utils.js";
+import { getFakeChroma, usingFakeServices } from "./services.js";
 
 export async function getChromaCollection(opts: {
   collection: string;
   embedModel: string;
 }) {
+  if (usingFakeServices()) {
+    return getFakeChroma(opts);
+  }
+
   const { ChromaClient } = await import("chromadb");
   const { OllamaEmbeddingFunction } = await import("@chroma-core/ollama");
   const client = new ChromaClient({});

--- a/packages/docops/src/lib/services.ts
+++ b/packages/docops/src/lib/services.ts
@@ -1,0 +1,194 @@
+import type { ChromaCollection as QueryCollection } from "./query.js";
+import { OLLAMA_URL } from "../utils.js";
+import { Ollama } from "ollama";
+
+type EmbeddingLike = readonly number[];
+
+type StoredRecord = {
+  readonly id: string;
+  readonly embedding: EmbeddingLike;
+  readonly document?: string;
+  readonly metadata?: Record<string, unknown> | null;
+};
+
+const FLAG = "DOCOPS_FAKE_SERVICES";
+
+export const usingFakeServices = () => process.env[FLAG] === "1";
+
+class FakeOllamaClient {
+  async list(): Promise<{ models: readonly { name: string }[] }> {
+    return { models: [{ name: "fake-docops" }] };
+  }
+
+  async embed({ input }: { input: readonly string[] | string }) {
+    const texts = Array.isArray(input) ? input : [input];
+    return { embeddings: texts.map(fakeEmbedding) };
+  }
+
+  async embeddings(request: { input: readonly string[] | string }) {
+    return this.embed(request);
+  }
+}
+
+type FakeStore = Map<string, StoredRecord>;
+
+type FakeState = {
+  readonly collections: Map<string, FakeStore>;
+};
+
+const getState = (): FakeState => {
+  const g = globalThis as typeof globalThis & {
+    __DOCOPS_FAKE_STATE__?: FakeState;
+  };
+  if (!g.__DOCOPS_FAKE_STATE__) {
+    g.__DOCOPS_FAKE_STATE__ = {
+      collections: new Map<string, FakeStore>(),
+    };
+  }
+  return g.__DOCOPS_FAKE_STATE__;
+};
+
+const ensureStore = (name: string): FakeStore => {
+  const state = getState();
+  let store = state.collections.get(name);
+  if (!store) {
+    store = new Map();
+    state.collections.set(name, store);
+  }
+  return store;
+};
+
+const norm = (vec: EmbeddingLike) =>
+  Math.sqrt(vec.reduce((sum, v) => sum + v * v, 0));
+
+const cosineDistance = (a: EmbeddingLike, b: EmbeddingLike) => {
+  const na = norm(a);
+  const nb = norm(b);
+  if (na === 0 || nb === 0) return 1;
+  const dot = a.reduce((sum, v, i) => sum + v * (b[i] ?? 0), 0);
+  const cos = dot / (na * nb);
+  const bounded = Math.max(-1, Math.min(1, cos));
+  return 1 - (bounded + 1) / 2;
+};
+
+const fakeEmbedding = (text: string): number[] => {
+  const dims = 8;
+  const out = new Array<number>(dims).fill(0);
+  for (let i = 0; i < text.length; i++) {
+    const code = text.charCodeAt(i);
+    const idx = i % dims;
+    out[idx] += (code % 97) / 97;
+  }
+  const n = norm(out);
+  if (n === 0) return out;
+  return out.map((v) => v / n);
+};
+
+class FakeChromaCollection implements QueryCollection {
+  readonly #store: FakeStore;
+  constructor(readonly name: string) {
+    this.#store = ensureStore(name);
+  }
+
+  async upsert(input: {
+    ids: readonly string[];
+    embeddings: readonly EmbeddingLike[];
+    documents?: readonly string[];
+    metadatas?: readonly (Record<string, unknown> | null | undefined)[];
+  }) {
+    input.ids.forEach((id, idx) => {
+      const embedding = input.embeddings[idx] ?? fakeEmbedding("");
+      const document = input.documents?.[idx] ?? null;
+      const metadata = input.metadatas?.[idx] ?? null;
+      this.#store.set(id, {
+        id,
+        embedding: [...embedding],
+        document: document ?? undefined,
+        metadata: metadata ?? null,
+      });
+    });
+    return { ids: [...input.ids] };
+  }
+
+  async get(input: {
+    ids: readonly string[];
+    include?: readonly ("metadatas" | "documents" | "embeddings")[];
+  }) {
+    const include = new Set(input.include ?? []);
+    const ids = input.ids.map((id) => id);
+    const result: any = { ids };
+    if (include.has("embeddings")) {
+      result.embeddings = ids.map((id) =>
+        this.#store.get(id)?.embedding
+          ? [...(this.#store.get(id)!.embedding as number[])]
+          : null,
+      );
+    }
+    if (include.has("documents")) {
+      result.documents = ids.map((id) => this.#store.get(id)?.document ?? null);
+    }
+    if (include.has("metadatas")) {
+      result.metadatas = ids.map((id) => this.#store.get(id)?.metadata ?? null);
+    }
+    return result;
+  }
+
+  async query(input: {
+    queryEmbeddings: readonly EmbeddingLike[];
+    nResults: number;
+    where?: Record<string, unknown>;
+  }) {
+    const all = [...this.#store.values()];
+    const ids: string[][] = [];
+    const distances: number[][] = [];
+    const documents: (string | null)[][] = [];
+    const metadatas: (Record<string, unknown> | null)[][] = [];
+    for (const q of input.queryEmbeddings) {
+      const scored = all.map((entry) => ({
+        id: entry.id,
+        distance: cosineDistance(q, entry.embedding),
+        document: entry.document ?? null,
+        metadata: entry.metadata ?? null,
+      }));
+      scored.sort((a, b) => a.distance - b.distance);
+      const top = scored.slice(0, input.nResults);
+      ids.push(top.map((item) => item.id));
+      distances.push(top.map((item) => item.distance));
+      documents.push(top.map((item) => item.document));
+      metadatas.push(top.map((item) => item.metadata));
+    }
+    return { ids, distances, documents, metadatas };
+  }
+}
+
+class FakeChromaClient {
+  async heartbeat(): Promise<number> {
+    return Date.now();
+  }
+
+  async getOrCreateCollection(input: { name: string }) {
+    return new FakeChromaCollection(input.name);
+  }
+}
+
+export type OllamaClient = InstanceType<typeof Ollama> | FakeOllamaClient;
+
+export const createOllamaClient = (): OllamaClient => {
+  if (usingFakeServices()) return new FakeOllamaClient();
+  return new Ollama({ host: OLLAMA_URL });
+};
+
+export const getFakeChroma = async (opts: {
+  collection: string;
+  embedModel: string;
+}) => {
+  const client = new FakeChromaClient();
+  const coll = await client.getOrCreateCollection({ name: opts.collection });
+  return { client, coll } as const;
+};
+
+export const ensureFakeServices = () => {
+  process.env[FLAG] = "1";
+};
+
+export { fakeEmbedding };

--- a/packages/docops/src/tests/helpers/services.ts
+++ b/packages/docops/src/tests/helpers/services.ts
@@ -1,17 +1,25 @@
 import { Ollama } from "ollama";
 import { ChromaClient } from "chromadb";
 
+import { ensureFakeServices, usingFakeServices } from "../../lib/services.js";
+
 /**
  * Ensure Ollama and ChromaDB services are reachable before running tests.
  */
 export async function ensureServices() {
+  if (usingFakeServices()) return;
+
   const ollamaUrl = process.env.OLLAMA_URL ?? "http://localhost:11434";
   try {
     const ollamaClient = new Ollama({ host: ollamaUrl });
     await ollamaClient.list();
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
-    throw new Error(`Ollama server unavailable at ${ollamaUrl}: ${msg}`);
+    console.warn(
+      `Falling back to fake services: Ollama unavailable at ${ollamaUrl}: ${msg}`,
+    );
+    ensureFakeServices();
+    return;
   }
 
   const chromaUrl = process.env.CHROMA_URL ?? "http://localhost:8000";
@@ -20,6 +28,9 @@ export async function ensureServices() {
     await chromaClient.heartbeat();
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
-    throw new Error(`ChromaDB server unavailable at ${chromaUrl}: ${msg}`);
+    console.warn(
+      `Falling back to fake services: ChromaDB unavailable at ${chromaUrl}: ${msg}`,
+    );
+    ensureFakeServices();
   }
 }


### PR DESCRIPTION
## Summary
- add an in-process fake Ollama/Chroma implementation for DocOps when real services are unavailable
- update the embed pipeline helpers and CLI to reuse the new service layer
- teach test helpers to switch to the fake services instead of failing pre-run checks
- record the change in the shared changelog

## Testing
- pnpm --filter @promethean/docops build
- pnpm --filter @promethean/docops test
- pnpm exec ava packages/docops/dist/tests/e2e/*.spec.js --config config/ava.config.mjs *(fails: dist/dev-ui.js missing)*
- pnpm exec eslint packages/docops/src/lib/services.ts packages/docops/src/lib/chroma.ts packages/docops/src/02-embed.ts packages/docops/src/tests/helpers/services.ts *(fails: existing lint violations)*

------
https://chatgpt.com/codex/tasks/task_e_68d877ab71d48324840d4e13b8787f98