### PR TITLE
feat(docops): restore dev ui server

### DIFF
--- a/changelog.d/2025.02.14.01.00.00.md
+++ b/changelog.d/2025.02.14.01.00.00.md
@@ -1,0 +1,2 @@
+## Added
+- Restored DocOps development UI server and static assets so integration tests can launch `dist/dev-ui.js` again.

--- a/packages/docops/src/dev-ui.ts
+++ b/packages/docops/src/dev-ui.ts
@@ -1,0 +1,479 @@
+/* eslint-disable functional/no-try-statements, functional/immutable-data, functional/no-loop-statements, functional/prefer-immutable-types, @typescript-eslint/prefer-readonly-parameter-types, max-lines, max-lines-per-function, @typescript-eslint/no-unnecessary-type-assertion, @typescript-eslint/no-unsafe-assignment */
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+
+import fastifyFactory from "fastify";
+import fastifyStatic from "@fastify/static";
+
+import { openDB } from "./db.js";
+import type { DBs } from "./db.js";
+import { buildFileTree } from "./lib/files.js";
+import { computeDocStatus } from "./lib/status.js";
+import { runDocopsStep, type RunArgs, type StepId } from "./lib/pipeline.js";
+import { sseInit, log as writeSse } from "./lib/sse.js";
+import { computePreview } from "./preview-front.js";
+import type { Chunk } from "./types.js";
+import { parseArgs } from "./utils.js";
+
+type FilesQuery = {
+  readonly dir?: string;
+  readonly maxDepth?: string;
+  readonly maxEntries?: string;
+  readonly exts?: string;
+  readonly includeMeta?: string;
+};
+
+type ReadQuery = {
+  readonly file?: string;
+};
+
+type PreviewQuery = {
+  readonly file?: string;
+  readonly uuid?: string;
+  readonly docT?: string;
+  readonly refT?: string;
+};
+
+type StatusQuery = {
+  readonly dir?: string;
+  readonly limit?: string;
+  readonly page?: string;
+  readonly onlyIncomplete?: string;
+};
+
+type ChunksQuery = {
+  readonly uuid?: string;
+  readonly file?: string;
+};
+
+type ChunkHitsQuery = {
+  readonly id?: string;
+};
+
+type SearchQuery = {
+  readonly q?: string;
+  readonly collection?: string;
+  readonly k?: string;
+};
+
+type RunStepQuery = RunArgs & { readonly step?: StepId };
+
+const args = parseArgs({
+  "--dir": "docs/unique",
+  "--collection": "docs-cosine",
+  "--host": "127.0.0.1",
+  "--port": "3939",
+});
+
+const ROOT_DIR = path.resolve(args["--dir"] ?? "docs/unique");
+const COLLECTION = String(args["--collection"] ?? "docs-cosine");
+const HOST = String(args["--host"] ?? "127.0.0.1");
+const PORT_RAW = Number(args["--port"] ?? "3939");
+const PORT = Number.isFinite(PORT_RAW) ? PORT_RAW : 3939;
+
+const DEFAULT_EXTS = [".md", ".mdx", ".markdown", ".txt"] as const;
+const MAX_DEPTH_DEFAULT = 4;
+const MAX_ENTRIES_DEFAULT = 200;
+
+const UI_ROOT = path.resolve(path.dirname(path.dirname(import.meta.url)), "ui");
+const JS_ROOT = path.join(UI_ROOT, "js");
+
+const ONE_PIXEL_PNG = Buffer.from(
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==",
+  "base64",
+);
+
+const clamp = (value: number, lo: number, hi: number) =>
+  Math.min(Math.max(value, lo), hi);
+
+const asBool = (value: string | undefined) => value === "1" || value === "true";
+
+const ensureInDir = (candidate: string) => {
+  const abs = path.resolve(candidate);
+  if (abs === ROOT_DIR) return abs;
+  if (abs.startsWith(`${ROOT_DIR}${path.sep}`)) return abs;
+  throw new Error("File outside configured dir");
+};
+
+const toExtList = (exts: string | undefined) => {
+  if (!exts) return [...DEFAULT_EXTS];
+  return exts
+    .split(",")
+    .map((ext) => ext.trim())
+    .filter(Boolean)
+    .map((ext) =>
+      ext.startsWith(".") ? ext.toLowerCase() : `.${ext.toLowerCase()}`,
+    );
+};
+
+const loadDocs = async (db: DBs) => {
+  const docs: Array<{ uuid: string; path: string; title: string }> = [];
+  for await (const [uuid, info] of db.docs.iterator()) {
+    const data = info as { path?: string; title?: string };
+    if (!data?.path) continue;
+    try {
+      const abs = ensureInDir(data.path);
+      docs.push({ uuid, path: abs, title: data.title ?? path.basename(abs) });
+    } catch {}
+  }
+  return docs;
+};
+
+const readChunks = async (db: DBs, uuid: string) =>
+  ((await db.chunks.get(uuid).catch(() => [])) as Chunk[]).map((chunk) => ({
+    id: chunk.id,
+    docUuid: chunk.docUuid,
+    docPath: chunk.docPath,
+    text: chunk.text ?? "",
+    startLine: chunk.startLine,
+  }));
+
+const buildSearchIndex = async (db: DBs) => {
+  const docs = await loadDocs(db);
+  const results: Array<{ uuid: string; path: string; text: string }> = [];
+  await Promise.all(
+    docs.map(async (doc) => {
+      try {
+        const txt = await fs.readFile(doc.path, "utf8");
+        results.push({ uuid: doc.uuid, path: doc.path, text: txt });
+      } catch {}
+    }),
+  );
+  return results;
+};
+
+const app = fastifyFactory({ logger: false });
+
+await app.register(fastifyStatic, {
+  root: UI_ROOT,
+  prefix: "/ui",
+});
+
+await app.register(fastifyStatic, {
+  root: JS_ROOT,
+  prefix: "/js",
+  decorateReply: false,
+});
+
+const db = await openDB();
+
+const docsCachePromise = loadDocs(db);
+const searchCachePromise = buildSearchIndex(db);
+
+app.get("/favicon.ico", async (_req, reply) => {
+  reply.header("content-type", "image/png");
+  reply.send(ONE_PIXEL_PNG);
+});
+
+app.get("/", async (_req, reply) => {
+  try {
+    const html = await fs.readFile(path.join(UI_ROOT, "index.html"), "utf8");
+    reply.header("content-type", "text/html; charset=utf-8");
+    reply.send(html);
+  } catch (error) {
+    reply.code(500).send({ error: String((error as Error)?.message ?? error) });
+  }
+});
+
+app.get("/health", async () => ({ ok: true }));
+
+app.get("/api/config", async () => ({
+  dir: ROOT_DIR,
+  collection: COLLECTION,
+  ws: false,
+}));
+
+app.get<{ Querystring: FilesQuery }>("/api/files", async (request, reply) => {
+  const query = request.query;
+  const targetDir = (() => {
+    try {
+      if (query.dir) return ensureInDir(query.dir);
+      return ROOT_DIR;
+    } catch (error) {
+      reply.code(400);
+      throw error;
+    }
+  })();
+
+  const maxDepth = clamp(
+    Number.isFinite(Number(query.maxDepth))
+      ? Number(query.maxDepth)
+      : MAX_DEPTH_DEFAULT,
+    0,
+    16,
+  );
+  const maxEntries = clamp(
+    Number.isFinite(Number(query.maxEntries))
+      ? Number(query.maxEntries)
+      : MAX_ENTRIES_DEFAULT,
+    1,
+    500,
+  );
+  const exts = toExtList(query.exts);
+  const includeMeta = asBool(query.includeMeta);
+
+  reply.header("cache-control", "no-store, no-cache, must-revalidate");
+  try {
+    const tree = await buildFileTree(targetDir, {
+      maxDepth,
+      maxEntries,
+      includeMeta,
+      exts,
+    });
+    return { dir: targetDir, tree };
+  } catch (error) {
+    reply.code(500);
+    return { error: String((error as Error)?.message ?? error) };
+  }
+});
+
+app.get<{ Querystring: ReadQuery }>("/api/read", async (request, reply) => {
+  const file = request.query.file;
+  if (!file) {
+    reply.code(400);
+    return { error: "file parameter required" };
+  }
+  try {
+    const abs = ensureInDir(file);
+    const ext = path.extname(abs).toLowerCase();
+    if (!DEFAULT_EXTS.includes(ext as (typeof DEFAULT_EXTS)[number])) {
+      reply.code(400);
+      return { error: "only markdown and text files allowed" };
+    }
+    const txt = await fs.readFile(abs, "utf8");
+    reply.header("content-type", "text/plain; charset=utf-8");
+    return txt;
+  } catch (error) {
+    reply.code(400);
+    return { error: String((error as Error)?.message ?? error) };
+  }
+});
+
+app.get("/api/docs", async () => {
+  const docs = await docsCachePromise;
+  return docs.map((doc) => ({
+    uuid: doc.uuid,
+    path: doc.path,
+    title: doc.title,
+  }));
+});
+
+app.get<{ Querystring: PreviewQuery }>(
+  "/api/preview",
+  async (request, reply) => {
+    const query = request.query;
+    if (!query.uuid && !query.file) {
+      reply.code(400);
+      return { error: "uuid or file parameter required" };
+    }
+    try {
+      const file = query.file ? ensureInDir(query.file) : undefined;
+      const result = await computePreview(
+        { uuid: query.uuid, file },
+        {
+          dir: ROOT_DIR,
+          docThreshold: Number.isFinite(Number(query.docT))
+            ? Number(query.docT)
+            : 0.78,
+          refThreshold: Number.isFinite(Number(query.refT))
+            ? Number(query.refT)
+            : 0.85,
+        },
+        db,
+      );
+      return result;
+    } catch (error) {
+      reply.code(400);
+      return { error: String((error as Error)?.message ?? error) };
+    }
+  },
+);
+
+app.get<{ Querystring: StatusQuery }>("/api/status", async (request, reply) => {
+  const query = request.query;
+  const docs = await docsCachePromise;
+  const limit = clamp(
+    Number.isFinite(Number(query.limit)) ? Number(query.limit) : 25,
+    1,
+    200,
+  );
+  const pageRaw = Number.isFinite(Number(query.page)) ? Number(query.page) : 1;
+  const page = pageRaw >= 1 ? pageRaw : 1;
+  const onlyIncomplete = asBool(query.onlyIncomplete);
+
+  const statuses = await Promise.all(
+    docs.map((doc) => computeDocStatus(db, doc)),
+  );
+  const filtered = onlyIncomplete
+    ? statuses.filter(
+        (status) =>
+          !status.frontmatter.done ||
+          status.embed.chunks === 0 ||
+          status.query.withHits === 0 ||
+          !status.relations.present ||
+          !status.footers.present,
+      )
+    : statuses;
+
+  const start = (page - 1) * limit;
+  const slice = filtered.slice(start, start + limit);
+  const hasMore = start + slice.length < filtered.length;
+
+  reply.header("cache-control", "no-store, no-cache, must-revalidate");
+  return { items: slice, page, hasMore, total: filtered.length };
+});
+
+app.get<{ Querystring: ChunksQuery }>("/api/chunks", async (request, reply) => {
+  const query = request.query;
+  const docs = await docsCachePromise;
+  if (!query.uuid && !query.file) {
+    reply.code(400);
+    return { error: "uuid or file parameter required" };
+  }
+  try {
+    const uuid = (() => {
+      if (query.uuid) return query.uuid;
+      if (!query.file) return "";
+      const abs = ensureInDir(query.file);
+      const match = docs.find((doc) => doc.path === abs);
+      if (!match) throw new Error("file not indexed");
+      return match.uuid;
+    })();
+    const items = await readChunks(db, uuid);
+    return { uuid, items };
+  } catch (error) {
+    reply.code(400);
+    return { error: String((error as Error)?.message ?? error) };
+  }
+});
+
+app.get<{ Querystring: ChunkHitsQuery }>(
+  "/api/chunk-hits",
+  async (request, reply) => {
+    const id = request.query.id;
+    if (!id) {
+      reply.code(400);
+      return { error: "id parameter required" };
+    }
+    const items = (await db.q.get(id).catch(() => [])) as unknown[];
+    return { id, items };
+  },
+);
+
+app.get<{ Querystring: SearchQuery }>("/api/search", async (request) => {
+  const q = (request.query.q ?? "").trim();
+  if (!q) return { items: [] };
+  const k = clamp(
+    Number.isFinite(Number(request.query.k)) ? Number(request.query.k) : 10,
+    1,
+    50,
+  );
+  const haystack = await searchCachePromise;
+  const matches = haystack
+    .map((doc) => {
+      const idx = doc.text.toLowerCase().indexOf(q.toLowerCase());
+      if (idx < 0) return null;
+      const start = Math.max(0, idx - 40);
+      const end = Math.min(doc.text.length, idx + q.length + 40);
+      const snippet = doc.text.slice(start, end).replace(/\s+/g, " ");
+      return { uuid: doc.uuid, path: doc.path, snippet };
+    })
+    .filter((x): x is { uuid: string; path: string; snippet: string } => !!x)
+    .slice(0, k);
+  return { items: matches };
+});
+
+app.get<{ Querystring: RunStepQuery }>(
+  "/api/run-step",
+  async (request, reply) => {
+    const {
+      step: stepParam,
+      files: filesRaw,
+      dir,
+      collection,
+      ...rest
+    } = request.query;
+    const step = stepParam as StepId | undefined;
+    if (!step) {
+      reply.code(400);
+      return { error: "step parameter required" };
+    }
+    const send = sseInit(reply);
+    const sendLine = (line: string) => writeSse(send, line);
+
+    const selectedDir = (() => {
+      if (!dir) return ROOT_DIR;
+      try {
+        return ensureInDir(dir);
+      } catch {
+        return ROOT_DIR;
+      }
+    })();
+
+    const files = (() => {
+      if (!filesRaw) return undefined;
+      try {
+        const parsed = JSON.parse(String(filesRaw));
+        if (!Array.isArray(parsed)) return undefined;
+        const safe = parsed
+          .map((item) => {
+            try {
+              return ensureInDir(String(item));
+            } catch {
+              return null;
+            }
+          })
+          .filter((x): x is string => !!x);
+        return safe.length ? safe : undefined;
+      } catch {
+        return undefined;
+      }
+    })();
+
+    sendLine(`Running step=${step}...`);
+    try {
+      await runDocopsStep(
+        db,
+        step,
+        {
+          ...rest,
+          dir: selectedDir,
+          collection: collection ?? COLLECTION,
+          files,
+        },
+        (progress) => {
+          const payload = JSON.stringify({
+            step: progress.step,
+            percent: progress.percent,
+            done: progress.done,
+            total: progress.total,
+            message: progress.message,
+          });
+          sendLine(`PROGRESS ${payload}`);
+        },
+      );
+      sendLine(`Step '${step}' completed.`);
+    } catch (error) {
+      sendLine(`ERROR ${String((error as Error)?.message ?? error)}`);
+    } finally {
+      reply.raw.end();
+    }
+    return reply;
+  },
+);
+
+process.on("SIGINT", async () => {
+  await db.root.close().catch(() => {});
+  process.exit(0);
+});
+
+app
+  .listen({ port: PORT, host: HOST })
+  .then(() => {
+    const shownHost = HOST === "0.0.0.0" ? "localhost" : HOST;
+    console.log(`DocOps Dev UI running on http://${shownHost}:${PORT}`);
+  })
+  .catch((error) => {
+    console.error("Failed to start DocOps Dev UI", error);
+    process.exit(1);
+  });

--- a/packages/docops/ui/index.html
+++ b/packages/docops/ui/index.html
@@ -1,0 +1,90 @@
+<!doctype html>
+<meta charset="utf-8" />
+<title>DocOps – Pipeline Dev UI</title>
+<link rel="stylesheet" href="/ui/style.css" />
+<script type="module" src="/js/main.js"></script>
+<body>
+  <header>
+    <h1>DocOps – Pipeline Dev UI</h1>
+  </header>
+  <main>
+    <section id="config">
+      <h2>Configuration</h2>
+      <div class="grid">
+        <label>
+          Docs dir
+          <input id="dir" name="dir" type="text" autocomplete="off" />
+        </label>
+        <label>
+          Collection
+          <input id="collection" name="collection" type="text" autocomplete="off" />
+        </label>
+        <label>
+          Doc Threshold
+          <input id="docT" name="docT" type="number" step="0.01" />
+        </label>
+        <label>
+          Ref Threshold
+          <input id="refT" name="refT" type="number" step="0.01" />
+        </label>
+        <label>
+          Search term
+          <input id="searchTerm" name="searchTerm" type="text" autocomplete="off" />
+        </label>
+        <label>
+          Search k
+          <input id="searchK" name="searchK" type="number" value="5" min="1" />
+        </label>
+      </div>
+      <div class="actions">
+        <button id="refresh">Refresh Docs</button>
+        <button id="renderMd">Render Selected File</button>
+        <button id="preview">Preview Frontmatter</button>
+        <button id="searchBtn">Search</button>
+        <button id="statusRefresh">Refresh Status</button>
+      </div>
+    </section>
+
+    <section id="explorer">
+      <h2>Files</h2>
+      <file-tree id="fileTree"></file-tree>
+    </section>
+
+    <section id="docs">
+      <h2>Docs</h2>
+      <select id="doclist" size="6"></select>
+    </section>
+
+    <section id="markdown">
+      <h2>Markdown Render</h2>
+      <pre id="mdRender">(no file selected)</pre>
+    </section>
+
+    <section id="previewOut">
+      <h2>Frontmatter Preview</h2>
+      <pre id="out">(no preview)</pre>
+    </section>
+
+    <section id="searchResultsSection">
+      <h2>Search Results</h2>
+      <pre id="searchResults">(no results)</pre>
+    </section>
+
+    <section id="status">
+      <h2>Pipeline Status</h2>
+      <pre id="statusTable">(not loaded)</pre>
+    </section>
+
+    <section id="steps">
+      <h2>Steps</h2>
+      <div class="steps-grid">
+        <docops-step step="frontmatter" title="Frontmatter"></docops-step>
+        <docops-step step="embed" title="Embed"></docops-step>
+        <docops-step step="query" title="Query"></docops-step>
+        <docops-step step="relations" title="Relations"></docops-step>
+        <docops-step step="footers" title="Footers"></docops-step>
+        <docops-step step="rename" title="Rename"></docops-step>
+      </div>
+    </section>
+  </main>
+</body>

--- a/packages/docops/ui/js/main.js
+++ b/packages/docops/ui/js/main.js
@@ -1,0 +1,360 @@
+const state = {
+  config: { dir: "", collection: "" },
+  selectedFile: null,
+  docs: [],
+};
+
+const byId = (id) => document.getElementById(id);
+
+function setText(id, value) {
+  const el = byId(id);
+  if (el) el.textContent = value;
+}
+
+async function fetchJSON(url, init) {
+  const res = await fetch(url, init);
+  if (!res.ok) {
+    const data = await res.json().catch(() => ({}));
+    throw new Error(data.error || res.statusText);
+  }
+  return res.json();
+}
+
+function currentDir() {
+  const dirInput = byId("dir");
+  const value = dirInput?.value?.trim();
+  return value || state.config.dir || "";
+}
+
+function currentCollection() {
+  const input = byId("collection");
+  const value = input?.value?.trim();
+  return value || state.config.collection || "";
+}
+
+function currentDocThreshold() {
+  const input = byId("docT");
+  const value = Number(input?.value);
+  return Number.isFinite(value) && value > 0 ? value : 0.78;
+}
+
+function currentRefThreshold() {
+  const input = byId("refT");
+  const value = Number(input?.value);
+  return Number.isFinite(value) && value > 0 ? value : 0.85;
+}
+
+function formatJSON(data) {
+  try {
+    return JSON.stringify(data, null, 2);
+  } catch {
+    return String(data);
+  }
+}
+
+class FileTree extends HTMLElement {
+  constructor() {
+    super();
+    this.attachShadow({ mode: "open" });
+    this.container = document.createElement("div");
+    this.container.setAttribute("role", "tree");
+    this.container.style.display = "block";
+    this.container.style.maxHeight = "320px";
+    this.container.style.overflow = "auto";
+    this.container.style.padding = "8px";
+    this.shadowRoot.appendChild(this.container);
+    this._tree = [];
+    this._selected = null;
+  }
+
+  set tree(data) {
+    this._tree = Array.isArray(data) ? data : [];
+    this.render();
+  }
+
+  render() {
+    this.container.innerHTML = "";
+    const rootList = document.createElement("ul");
+    rootList.style.listStyle = "none";
+    rootList.style.paddingLeft = "0";
+    this.container.appendChild(rootList);
+    this._tree.forEach((node) => this.renderNode(node, rootList));
+  }
+
+  renderNode(node, parent) {
+    const item = document.createElement("li");
+    item.style.marginBottom = "4px";
+    if (node.type === "dir" && Array.isArray(node.children)) {
+      const summary = document.createElement("details");
+      summary.open = false;
+      const header = document.createElement("summary");
+      header.textContent = node.name;
+      summary.appendChild(header);
+      const list = document.createElement("ul");
+      list.style.listStyle = "none";
+      list.style.paddingLeft = "18px";
+      node.children.forEach((child) => this.renderNode(child, list));
+      summary.appendChild(list);
+      item.appendChild(summary);
+    } else if (node.type === "file" && node.path) {
+      const btn = document.createElement("button");
+      btn.type = "button";
+      btn.textContent = node.name;
+      btn.dataset.path = node.path;
+      btn.setAttribute("role", "treeitem");
+      btn.style.background =
+        this._selected === node.path ? "#0ea5e9" : "#e2e8f0";
+      btn.style.color = this._selected === node.path ? "#fff" : "#0f172a";
+      btn.style.border = "none";
+      btn.style.padding = "6px 10px";
+      btn.style.borderRadius = "6px";
+      btn.style.cursor = "pointer";
+      btn.addEventListener("click", () => this.selectFile(node.path));
+      item.appendChild(btn);
+    }
+    parent.appendChild(item);
+  }
+
+  selectFile(path) {
+    this._selected = path;
+    this.dispatchEvent(
+      new CustomEvent("file-selected", { detail: { path }, bubbles: true }),
+    );
+    this.render();
+  }
+}
+
+customElements.define("file-tree", FileTree);
+
+class DocopsStep extends HTMLElement {
+  constructor() {
+    super();
+    this.attachShadow({ mode: "open" });
+    const wrapper = document.createElement("div");
+    wrapper.style.display = "flex";
+    wrapper.style.flexDirection = "column";
+    wrapper.style.gap = "8px";
+
+    const title = document.createElement("strong");
+    title.textContent =
+      this.getAttribute("title") || this.getAttribute("step") || "Step";
+    wrapper.appendChild(title);
+
+    const run = document.createElement("button");
+    run.id = "runBtn";
+    run.type = "button";
+    run.textContent = "Run";
+    run.style.alignSelf = "flex-start";
+    run.addEventListener("click", () => this.runStep());
+    wrapper.appendChild(run);
+
+    const pre = document.createElement("pre");
+    pre.id = "log";
+    pre.textContent = "(idle)";
+    pre.style.margin = "0";
+    pre.style.minHeight = "120px";
+    wrapper.appendChild(pre);
+
+    this.shadowRoot.appendChild(wrapper);
+  }
+
+  appendLog(line) {
+    const pre = this.shadowRoot.getElementById("log");
+    if (!pre) return;
+    pre.textContent =
+      pre.textContent === "(idle)" ? `${line}` : `${pre.textContent}\n${line}`;
+  }
+
+  async runStep() {
+    const step = this.getAttribute("step");
+    if (!step) return;
+    const pre = this.shadowRoot.getElementById("log");
+    if (pre) pre.textContent = "Running...";
+
+    const params = new URLSearchParams({
+      step,
+      dir: currentDir(),
+      collection: currentCollection(),
+      docT: String(currentDocThreshold()),
+      refT: String(currentRefThreshold()),
+    });
+    if (state.selectedFile) {
+      params.set("files", JSON.stringify([state.selectedFile]));
+    }
+
+    await new Promise((resolve) => {
+      const es = new EventSource(`/api/run-step?${params.toString()}`);
+      es.onmessage = (ev) => {
+        this.appendLog(ev.data);
+        if (/Step '\w+' completed\./.test(ev.data) || /^ERROR/.test(ev.data)) {
+          es.close();
+          resolve();
+        }
+      };
+      es.onerror = () => {
+        this.appendLog("Connection closed.");
+        es.close();
+        resolve();
+      };
+    });
+  }
+}
+
+customElements.define("docops-step", DocopsStep);
+
+async function loadConfig() {
+  try {
+    const config = await fetchJSON("/api/config");
+    state.config = config;
+    if (byId("dir")) byId("dir").value = config.dir || "";
+    if (byId("collection")) byId("collection").value = config.collection || "";
+  } catch (error) {
+    console.warn("failed to load config", error);
+  }
+}
+
+async function loadDocs() {
+  try {
+    const docs = await fetchJSON("/api/docs");
+    state.docs = Array.isArray(docs) ? docs : [];
+    const select = byId("doclist");
+    if (select) {
+      select.innerHTML = "";
+      state.docs.forEach((doc) => {
+        const opt = document.createElement("option");
+        opt.value = doc.uuid;
+        opt.textContent = doc.title || doc.path;
+        select.appendChild(opt);
+      });
+    }
+  } catch (error) {
+    console.warn("failed to load docs", error);
+  }
+}
+
+async function loadFiles() {
+  const params = new URLSearchParams({
+    dir: currentDir(),
+    maxDepth: "4",
+    maxEntries: "200",
+    includeMeta: "1",
+  });
+  try {
+    const data = await fetchJSON(`/api/files?${params.toString()}`);
+    const tree = byId("fileTree");
+    if (tree && "tree" in tree) tree.tree = data.tree || [];
+  } catch (error) {
+    console.warn("failed to load files", error);
+  }
+}
+
+async function renderMarkdown() {
+  if (!state.selectedFile) {
+    setText("mdRender", "(no file selected)");
+    return;
+  }
+  try {
+    const params = new URLSearchParams({ file: state.selectedFile });
+    const res = await fetch(`/api/read?${params.toString()}`);
+    if (!res.ok) throw new Error(await res.text());
+    const text = await res.text();
+    setText("mdRender", text);
+  } catch (error) {
+    setText("mdRender", String(error.message || error));
+  }
+}
+
+async function previewFrontmatter() {
+  const params = new URLSearchParams({
+    dir: currentDir(),
+    docT: String(currentDocThreshold()),
+    refT: String(currentRefThreshold()),
+  });
+  if (state.selectedFile) params.set("file", state.selectedFile);
+  const select = byId("doclist");
+  if (!state.selectedFile && select?.value) params.set("uuid", select.value);
+  try {
+    const data = await fetchJSON(`/api/preview?${params.toString()}`);
+    setText("out", formatJSON(data));
+  } catch (error) {
+    setText("out", String(error.message || error));
+  }
+}
+
+async function runSearch() {
+  const term = byId("searchTerm")?.value?.trim() ?? "";
+  const k = byId("searchK")?.value || "5";
+  if (!term) {
+    setText("searchResults", "(enter a query)");
+    return;
+  }
+  const params = new URLSearchParams({
+    q: term,
+    k: String(k),
+    collection: currentCollection(),
+  });
+  try {
+    const data = await fetchJSON(`/api/search?${params.toString()}`);
+    const lines = (data.items || []).map(
+      (item) => `• ${item.path || item.uuid}: ${item.snippet || ""}`,
+    );
+    setText("searchResults", lines.length ? lines.join("\n") : "(no results)");
+  } catch (error) {
+    setText("searchResults", String(error.message || error));
+  }
+}
+
+async function loadStatus() {
+  const params = new URLSearchParams({
+    dir: currentDir(),
+    limit: "25",
+    page: "1",
+    onlyIncomplete: "0",
+  });
+  try {
+    const data = await fetchJSON(`/api/status?${params.toString()}`);
+    const lines = (data.items || []).map((item) => {
+      const ok = item.frontmatter?.done ? "done" : "todo";
+      return `${item.title || item.path} – frontmatter:${ok}`;
+    });
+    setText("statusTable", lines.length ? lines.join("\n") : "(no items)");
+  } catch (error) {
+    setText("statusTable", String(error.message || error));
+  }
+}
+
+function wireEvents() {
+  byId("refresh")?.addEventListener("click", async () => {
+    await Promise.all([loadDocs(), loadFiles()]);
+  });
+  byId("renderMd")?.addEventListener("click", () => {
+    void renderMarkdown();
+  });
+  byId("preview")?.addEventListener("click", () => {
+    void previewFrontmatter();
+  });
+  byId("searchBtn")?.addEventListener("click", () => {
+    void runSearch();
+  });
+  byId("statusRefresh")?.addEventListener("click", () => {
+    void loadStatus();
+  });
+
+  byId("fileTree")?.addEventListener("file-selected", (event) => {
+    const path = event.detail?.path;
+    if (path) {
+      state.selectedFile = path;
+      void renderMarkdown();
+    }
+  });
+}
+
+async function init() {
+  wireEvents();
+  await loadConfig();
+  await Promise.all([loadDocs(), loadFiles(), loadStatus()]);
+}
+
+document.addEventListener("DOMContentLoaded", () => {
+  void init();
+});

--- a/packages/docops/ui/style.css
+++ b/packages/docops/ui/style.css
@@ -1,0 +1,91 @@
+body {
+  margin: 0;
+  font-family: system-ui, sans-serif;
+  background: #f7f8fb;
+  color: #1f2933;
+}
+
+header {
+  background: #1f2933;
+  color: #fff;
+  padding: 16px 24px;
+}
+
+main {
+  padding: 16px 24px 64px;
+  display: grid;
+  gap: 16px;
+}
+
+section {
+  background: #fff;
+  border-radius: 8px;
+  padding: 16px;
+  box-shadow: 0 2px 4px rgba(15, 23, 42, 0.1);
+}
+
+h1, h2 {
+  margin: 0 0 12px;
+}
+
+.grid {
+  display: grid;
+  gap: 12px;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+label {
+  display: flex;
+  flex-direction: column;
+  font-size: 14px;
+  gap: 6px;
+}
+
+input {
+  padding: 8px;
+  border-radius: 6px;
+  border: 1px solid #cbd5e1;
+  font-size: 14px;
+}
+
+.actions {
+  margin-top: 12px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+button {
+  padding: 8px 14px;
+  border-radius: 6px;
+  border: none;
+  background: #2563eb;
+  color: #fff;
+  cursor: pointer;
+  font-size: 14px;
+}
+
+button:hover {
+  background: #1d4ed8;
+}
+
+pre {
+  background: #f1f5f9;
+  padding: 12px;
+  border-radius: 6px;
+  max-height: 280px;
+  overflow: auto;
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+select {
+  width: 100%;
+  min-height: 160px;
+}
+
+.steps-grid {
+  display: grid;
+  gap: 12px;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}


### PR DESCRIPTION
## Summary
- add a Fastify-powered DocOps dev UI server that restores the /api endpoints used by integration tests
- ship lightweight static UI assets so the dev server can render forms, file browser, and docops-step controls
- document the change in the changelog

## Testing
- pnpm --filter @promethean/docops build
- pnpm exec eslint packages/docops/src/dev-ui.ts

------
https://chatgpt.com/codex/tasks/task_e_68d877cad36483249338223c296afefc