### PR TITLE
Normalize smartgpt-bridge tests to shared fixture helper

### DIFF
--- a/changelog.d/2025.02.26.smartgpt-fixtures.md
+++ b/changelog.d/2025.02.26.smartgpt-fixtures.md
@@ -1,0 +1,1 @@
+- normalize smartgpt-bridge tests to use a shared fixture root helper to avoid cwd-dependent failures

--- a/packages/smartgpt-bridge/src/tests/helpers/fixtures.ts
+++ b/packages/smartgpt-bridge/src/tests/helpers/fixtures.ts
@@ -1,0 +1,33 @@
+import { existsSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const PACKAGE_ROOT = path.resolve(
+  fileURLToPath(new URL("../../..", import.meta.url)),
+);
+const PACKAGE_FIXTURES = path.join(PACKAGE_ROOT, "tests", "fixtures");
+const CWD_FIXTURES = path.join(process.cwd(), "tests", "fixtures");
+
+function hasCoreFixture(dir: string): boolean {
+  return existsSync(path.join(dir, "readme.md"));
+}
+
+export function resolveFixturesRoot(): string {
+  const candidates = [CWD_FIXTURES, PACKAGE_FIXTURES];
+  for (const candidate of candidates) {
+    if (hasCoreFixture(candidate)) {
+      return path.resolve(candidate);
+    }
+  }
+  return PACKAGE_FIXTURES;
+}
+
+export const FIXTURES_ROOT = resolveFixturesRoot();
+
+export function fixturePath(...parts: string[]): string {
+  return path.join(FIXTURES_ROOT, ...parts);
+}
+
+export function packageRoot(): string {
+  return PACKAGE_ROOT;
+}

--- a/packages/smartgpt-bridge/src/tests/integration/auth.static.test.ts
+++ b/packages/smartgpt-bridge/src/tests/integration/auth.static.test.ts
@@ -1,10 +1,9 @@
-import path from "node:path";
-
 import test from "ava";
 
+import { FIXTURES_ROOT } from "../helpers/fixtures.js";
 import { withServer } from "../helpers/server.js";
 
-const ROOT = path.join(process.cwd(), "tests", "fixtures");
+const ROOT = FIXTURES_ROOT;
 
 test.serial("auth disabled by default allows access", async (t) => {
   t.timeout(180000);

--- a/packages/smartgpt-bridge/src/tests/integration/server.agent.stubs.test.ts
+++ b/packages/smartgpt-bridge/src/tests/integration/server.agent.stubs.test.ts
@@ -1,12 +1,12 @@
-import path from "node:path";
-
 import test from "ava";
 import sinon from "sinon";
 
+import { FIXTURES_ROOT, packageRoot } from "../helpers/fixtures.js";
 import { withServer } from "../helpers/server.js";
 import { supervisor as defaultSupervisor } from "../../agent.js";
 
-const ROOT = path.join(process.cwd(), "tests", "fixtures");
+const ROOT = FIXTURES_ROOT;
+const PKG_ROOT = packageRoot();
 
 test("agent endpoints success paths via stubbed supervisor", async (t) => {
   const s = sinon.createSandbox();
@@ -15,7 +15,7 @@ test("agent endpoints success paths via stubbed supervisor", async (t) => {
     id: "S1",
     cmd: "codex",
     args: ["exec"],
-    cwd: process.cwd(),
+    cwd: PKG_ROOT,
     startedAt: Date.now(),
     exited: false,
     code: null,

--- a/packages/smartgpt-bridge/src/tests/integration/server.agent.test.ts
+++ b/packages/smartgpt-bridge/src/tests/integration/server.agent.test.ts
@@ -1,10 +1,9 @@
-import path from "node:path";
-
 import test from "ava";
 
+import { FIXTURES_ROOT } from "../helpers/fixtures.js";
 import { withServer } from "../helpers/server.js";
 
-const ROOT = path.join(process.cwd(), "tests", "fixtures");
+const ROOT = FIXTURES_ROOT;
 
 test("agent endpoints basic flows without starting a process", async (t) => {
   await withServer(ROOT, async (req) => {

--- a/packages/smartgpt-bridge/src/tests/integration/server.exec.auth.test.ts
+++ b/packages/smartgpt-bridge/src/tests/integration/server.exec.auth.test.ts
@@ -1,10 +1,9 @@
-import path from "node:path";
-
 import test from "ava";
 
+import { FIXTURES_ROOT } from "../helpers/fixtures.js";
 import { withServer } from "../helpers/server.js";
 
-const ROOT = path.join(process.cwd(), "tests", "fixtures");
+const ROOT = FIXTURES_ROOT;
 
 test.serial(
   "exec requires auth when enabled and allows with token",

--- a/packages/smartgpt-bridge/src/tests/integration/server.exec.cwd.security.test.ts
+++ b/packages/smartgpt-bridge/src/tests/integration/server.exec.cwd.security.test.ts
@@ -1,10 +1,9 @@
-import path from "node:path";
-
 import test from "ava";
 
+import { FIXTURES_ROOT } from "../helpers/fixtures.js";
 import { withServer } from "../helpers/server.js";
 
-const ROOT = path.join(process.cwd(), "tests", "fixtures");
+const ROOT = FIXTURES_ROOT;
 
 test.serial("exec run blocks cwd outside root", async (t) => {
   const prev = { EXEC_ENABLED: process.env.EXEC_ENABLED };

--- a/packages/smartgpt-bridge/src/tests/integration/server.exec.flag.test.ts
+++ b/packages/smartgpt-bridge/src/tests/integration/server.exec.flag.test.ts
@@ -1,10 +1,9 @@
-import path from "node:path";
-
 import test from "ava";
 
+import { FIXTURES_ROOT } from "../helpers/fixtures.js";
 import { withServer } from "../helpers/server.js";
 
-const ROOT = path.join(process.cwd(), "tests", "fixtures");
+const ROOT = FIXTURES_ROOT;
 
 test.serial(
   "POST /exec/run returns 403 when EXEC_ENABLED is false",

--- a/packages/smartgpt-bridge/src/tests/integration/server.files.list.security.test.ts
+++ b/packages/smartgpt-bridge/src/tests/integration/server.files.list.security.test.ts
@@ -1,10 +1,9 @@
-import path from "node:path";
-
 import test from "ava";
 
+import { FIXTURES_ROOT } from "../helpers/fixtures.js";
 import { withServer } from "../helpers/server.js";
 
-const ROOT = path.join(process.cwd(), "tests", "fixtures");
+const ROOT = FIXTURES_ROOT;
 
 test("GET /v0/files/list blocks traversal outside root", async (t) => {
   await withServer(ROOT, async (req) => {

--- a/packages/smartgpt-bridge/src/tests/integration/server.files.test.ts
+++ b/packages/smartgpt-bridge/src/tests/integration/server.files.test.ts
@@ -2,9 +2,10 @@ import path from "node:path";
 
 import test from "ava";
 
+import { FIXTURES_ROOT } from "../helpers/fixtures.js";
 import { withServer } from "../helpers/server.js";
 
-const ROOT = path.join(process.cwd(), "tests", "fixtures");
+const ROOT = FIXTURES_ROOT;
 
 test("GET /v0/files/view returns snippet", async (t) => {
   await withServer(ROOT, async (req) => {

--- a/packages/smartgpt-bridge/src/tests/integration/server.files.tree.test.ts
+++ b/packages/smartgpt-bridge/src/tests/integration/server.files.tree.test.ts
@@ -1,10 +1,9 @@
-import path from "node:path";
-
 import test from "ava";
 
+import { FIXTURES_ROOT } from "../helpers/fixtures.js";
 import { withServer } from "../helpers/server.js";
 
-const ROOT = path.join(process.cwd(), "tests", "fixtures");
+const ROOT = FIXTURES_ROOT;
 
 test("GET /v0/files/tree returns nested directory tree", async (t) => {
   t.timeout(180000);

--- a/packages/smartgpt-bridge/src/tests/integration/server.files.view.security.test.ts
+++ b/packages/smartgpt-bridge/src/tests/integration/server.files.view.security.test.ts
@@ -1,10 +1,9 @@
-import path from "node:path";
-
 import test from "ava";
 
+import { FIXTURES_ROOT } from "../helpers/fixtures.js";
 import { withServer } from "../helpers/server.js";
 
-const ROOT = path.join(process.cwd(), "tests", "fixtures");
+const ROOT = FIXTURES_ROOT;
 
 test("GET /v0/files/view blocks traversal outside root", async (t) => {
   await withServer(ROOT, async (req) => {

--- a/packages/smartgpt-bridge/src/tests/integration/server.openapi.auth.test.ts
+++ b/packages/smartgpt-bridge/src/tests/integration/server.openapi.auth.test.ts
@@ -1,10 +1,9 @@
-import path from "node:path";
-
 import test from "ava";
 
+import { FIXTURES_ROOT } from "../helpers/fixtures.js";
 import { withServer } from "../helpers/server.js";
 
-const ROOT = path.join(process.cwd(), "tests", "fixtures");
+const ROOT = FIXTURES_ROOT;
 
 test.serial("openapi shows bearer security when auth enabled", async (t) => {
   const prev = {

--- a/packages/smartgpt-bridge/src/tests/integration/server.openapi.test.ts
+++ b/packages/smartgpt-bridge/src/tests/integration/server.openapi.test.ts
@@ -1,10 +1,9 @@
-import path from "node:path";
-
 import test from "ava";
 
+import { FIXTURES_ROOT } from "../helpers/fixtures.js";
 import { withServer } from "../helpers/server.js";
 
-const ROOT = path.join(process.cwd(), "tests", "fixtures");
+const ROOT = FIXTURES_ROOT;
 
 test("GET /openapi.json includes servers, schemas, and paths", async (t) => {
   const prev = process.env.PUBLIC_BASE_URL;

--- a/packages/smartgpt-bridge/src/tests/integration/server.reindex.success.test.ts
+++ b/packages/smartgpt-bridge/src/tests/integration/server.reindex.success.test.ts
@@ -1,8 +1,7 @@
-import path from "node:path";
-
 import test from "ava";
 import type { UpsertRecordsParams } from "chromadb";
 
+import { FIXTURES_ROOT } from "../helpers/fixtures.js";
 import { withServer } from "../helpers/server.js";
 import {
   setChromaClient,
@@ -10,7 +9,7 @@ import {
   resetChroma,
 } from "../../indexer.js";
 
-const ROOT = path.join(process.cwd(), "tests", "fixtures");
+const ROOT = FIXTURES_ROOT;
 
 class CollectingCollection {
   calls = 0;

--- a/packages/smartgpt-bridge/src/tests/integration/server.search.errors.test.ts
+++ b/packages/smartgpt-bridge/src/tests/integration/server.search.errors.test.ts
@@ -1,7 +1,6 @@
-import path from "node:path";
-
 import test from "ava";
 
+import { FIXTURES_ROOT } from "../helpers/fixtures.js";
 import { withServer } from "../helpers/server.js";
 import {
   setChromaClient,
@@ -9,7 +8,7 @@ import {
   resetChroma,
 } from "../../indexer.js";
 
-const ROOT = path.join(process.cwd(), "tests", "fixtures");
+const ROOT = FIXTURES_ROOT;
 
 class ThrowingChroma {
   async getOrCreateCollection(): Promise<any> {

--- a/packages/smartgpt-bridge/src/tests/integration/server.search.test.ts
+++ b/packages/smartgpt-bridge/src/tests/integration/server.search.test.ts
@@ -1,8 +1,7 @@
-import path from "node:path";
-
 import test from "ava";
 import type { QueryRecordsParams, UpsertRecordsParams } from "chromadb";
 
+import { FIXTURES_ROOT } from "../helpers/fixtures.js";
 import { withServer } from "../helpers/server.js";
 import {
   setChromaClient,
@@ -10,7 +9,7 @@ import {
   resetChroma,
 } from "../../indexer.js";
 
-const ROOT = path.join(process.cwd(), "tests", "fixtures");
+const ROOT = FIXTURES_ROOT;
 
 class FakeCollection {
   async query(_args: QueryRecordsParams) {

--- a/packages/smartgpt-bridge/src/tests/integration/server.symbols.test.ts
+++ b/packages/smartgpt-bridge/src/tests/integration/server.symbols.test.ts
@@ -1,10 +1,9 @@
-import path from "node:path";
-
 import test from "ava";
 
+import { FIXTURES_ROOT } from "../helpers/fixtures.js";
 import { withServer } from "../helpers/server.js";
 
-const ROOT = path.join(process.cwd(), "tests", "fixtures");
+const ROOT = FIXTURES_ROOT;
 
 test.serial("POST /v0/symbols/index then /v0/symbols/find", async (t) => {
   t.timeout(20_000);

--- a/packages/smartgpt-bridge/src/tests/integration/server.v1.files.put.test.ts
+++ b/packages/smartgpt-bridge/src/tests/integration/server.v1.files.put.test.ts
@@ -3,9 +3,10 @@ import path from "node:path";
 
 import test from "ava";
 
+import { FIXTURES_ROOT } from "../helpers/fixtures.js";
 import { withServer } from "../helpers/server.js";
 
-const ROOT = path.join(process.cwd(), "tests", "fixtures");
+const ROOT = FIXTURES_ROOT;
 const FILE_WRITE = "putfile.write.test.txt";
 const FILE_EDIT = "putfile.edit.test.txt";
 const FILE_MISSING = "putfile.missing.test.txt";

--- a/packages/smartgpt-bridge/src/tests/integration/server.v1.openapi.test.ts
+++ b/packages/smartgpt-bridge/src/tests/integration/server.v1.openapi.test.ts
@@ -1,10 +1,9 @@
-import path from "node:path";
-
 import test from "ava";
 
+import { FIXTURES_ROOT } from "../helpers/fixtures.js";
 import { withServer } from "../helpers/server.js";
 
-const ROOT = path.join(process.cwd(), "tests", "fixtures");
+const ROOT = FIXTURES_ROOT;
 
 function countOperations(
   paths: Record<string, Record<string, unknown>>,

--- a/packages/smartgpt-bridge/src/tests/integration/server.v1.routes.test.ts
+++ b/packages/smartgpt-bridge/src/tests/integration/server.v1.routes.test.ts
@@ -1,10 +1,9 @@
-import path from "node:path";
-
 import test from "ava";
 
+import { FIXTURES_ROOT } from "../helpers/fixtures.js";
 import { withServer } from "../helpers/server.js";
 
-const ROOT = path.join(process.cwd(), "tests", "fixtures");
+const ROOT = FIXTURES_ROOT;
 
 test("GET /v1/files/ returns flat file list", async (t) => {
   await withServer(ROOT, async (req) => {

--- a/packages/smartgpt-bridge/src/tests/unit/files.more.test.ts
+++ b/packages/smartgpt-bridge/src/tests/unit/files.more.test.ts
@@ -8,8 +8,10 @@ import {
   viewFile,
   normalizeToRoot,
 } from "../../files.js";
+import { FIXTURES_ROOT, packageRoot } from "../helpers/fixtures.js";
 
-const ROOT = path.join(process.cwd(), "tests", "fixtures");
+const ROOT = FIXTURES_ROOT;
+const PKG_ROOT = packageRoot();
 
 test("locateStacktrace: Node style with function (nodeB)", async (t) => {
   const p = path.join(ROOT, "hello.ts");
@@ -52,18 +54,18 @@ test("viewFile throws when file missing", async (t) => {
 });
 
 test("normalizeToRoot treats leading slash as repo root", (t) => {
-  const p1 = normalizeToRoot(process.cwd(), "tests/fixtures/readme.md");
-  const p2 = normalizeToRoot(process.cwd(), "/tests/fixtures/readme.md");
+  const p1 = normalizeToRoot(PKG_ROOT, "tests/fixtures/readme.md");
+  const p2 = normalizeToRoot(PKG_ROOT, "/tests/fixtures/readme.md");
   t.is(p1, p2);
 });
 
 test('normalizeToRoot resolves "/" to repo root', (t) => {
-  const p = normalizeToRoot(process.cwd(), "/");
-  t.is(p, path.resolve(process.cwd()));
+  const p = normalizeToRoot(PKG_ROOT, "/");
+  t.is(p, path.resolve(PKG_ROOT));
 });
 
 test("normalizeToRoot allows absolute paths inside root", (t) => {
-  const abs = path.join(process.cwd(), "tests", "fixtures", "hello.ts");
-  const normalized = normalizeToRoot(process.cwd(), abs);
+  const abs = path.join(PKG_ROOT, "tests", "fixtures", "hello.ts");
+  const normalized = normalizeToRoot(PKG_ROOT, abs);
   t.is(normalized, abs);
 });

--- a/packages/smartgpt-bridge/src/tests/unit/files.test.ts
+++ b/packages/smartgpt-bridge/src/tests/unit/files.test.ts
@@ -3,8 +3,9 @@ import path from "node:path";
 import test from "ava";
 
 import { viewFile, resolvePath } from "../../files.js";
+import { FIXTURES_ROOT } from "../helpers/fixtures.js";
 
-const ROOT = path.join(process.cwd(), "tests", "fixtures");
+const ROOT = FIXTURES_ROOT;
 
 test("viewFile: returns correct window around line", async (t) => {
   const out = await viewFile(ROOT, "readme.md", 3, 2);

--- a/packages/smartgpt-bridge/src/tests/unit/grep.more.test.ts
+++ b/packages/smartgpt-bridge/src/tests/unit/grep.more.test.ts
@@ -1,10 +1,9 @@
-import path from "node:path";
-
 import test from "ava";
 
 import { grep } from "../../grep.js";
+import { FIXTURES_ROOT } from "../helpers/fixtures.js";
 
-const ROOT = path.join(process.cwd(), "tests", "fixtures");
+const ROOT = FIXTURES_ROOT;
 
 test("grep: maxMatches limits results", async (t) => {
   const results = await grep(ROOT, {

--- a/packages/smartgpt-bridge/src/tests/unit/grep.test.ts
+++ b/packages/smartgpt-bridge/src/tests/unit/grep.test.ts
@@ -5,8 +5,9 @@ import test from "ava";
 import { execa } from "execa";
 
 import { grep } from "../../grep.js";
+import { FIXTURES_ROOT } from "../helpers/fixtures.js";
 
-const ROOT = path.join(process.cwd(), "tests", "fixtures");
+const ROOT = FIXTURES_ROOT;
 
 type Opts = {
   flags?: string;

--- a/packages/smartgpt-bridge/src/tests/unit/indexer.branches.test.ts
+++ b/packages/smartgpt-bridge/src/tests/unit/indexer.branches.test.ts
@@ -12,8 +12,9 @@ import {
   reindexAll,
   resetChroma,
 } from "../../indexer.js";
+import { FIXTURES_ROOT } from "../helpers/fixtures.js";
 
-const ROOT = path.join(process.cwd(), "tests", "fixtures");
+const ROOT = FIXTURES_ROOT;
 
 class EmptyCollection {
   async query(_args?: QueryRecordsParams) {

--- a/packages/smartgpt-bridge/src/tests/unit/indexer.test.ts
+++ b/packages/smartgpt-bridge/src/tests/unit/indexer.test.ts
@@ -12,8 +12,9 @@ import {
   search,
   resetChroma,
 } from "../../indexer.js";
+import { FIXTURES_ROOT } from "../helpers/fixtures.js";
 
-const ROOT = path.join(process.cwd(), "tests", "fixtures");
+const ROOT = FIXTURES_ROOT;
 
 class FakeCollection {
   upserts: UpsertRecordsParams[] = [];

--- a/packages/smartgpt-bridge/src/tests/unit/symbols.util.test.ts
+++ b/packages/smartgpt-bridge/src/tests/unit/symbols.util.test.ts
@@ -1,10 +1,9 @@
-import path from "node:path";
-
 import test from "ava";
 
 import { symbolsIndex, symbolsFind } from "../../symbols.js";
+import { FIXTURES_ROOT } from "../helpers/fixtures.js";
 
-const ROOT = path.join(process.cwd(), "tests", "fixtures");
+const ROOT = FIXTURES_ROOT;
 
 test.serial(
   "symbols: indexes small TS fixtures and finds Greeter class",


### PR DESCRIPTION
## Summary
- add a fixtures helper that resolves the smartgpt-bridge package root regardless of cwd
- update integration and unit tests to consume the shared FIXTURES_ROOT constant
- record the change in the changelog

## Testing
- pnpm --filter @promethean/smartgpt-bridge build
- pnpm --filter @promethean/smartgpt-bridge test -- --match "GET /v0/files/view returns snippet"

------
https://chatgpt.com/codex/tasks/task_e_68d87800ef108324ba3fbc7ae1da260e