### PR TITLE
Fix symbols integration test path resolution

### DIFF
--- a/changelog.d/2025.09.28.00.03.28.md
+++ b/changelog.d/2025.09.28.00.03.28.md
@@ -1,0 +1,1 @@
+- fix: point symbols integration test at package fixtures and tighten response typing

--- a/packages/smartgpt-bridge/src/tests/integration/server.symbols.test.ts
+++ b/packages/smartgpt-bridge/src/tests/integration/server.symbols.test.ts
@@ -1,28 +1,83 @@
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 
 import test from "ava";
 
 import { withServer } from "../helpers/server.js";
 
-const ROOT = path.join(process.cwd(), "tests", "fixtures");
+const ROOT = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../../../tests/fixtures",
+);
+
+type TestResponse<TBody> = Readonly<{ status: number; body: TBody }>;
+
+type TestRequest = {
+  query(params?: Readonly<Record<string, unknown>>): TestRequest;
+  send(
+    body:
+      | Readonly<Record<string, unknown>>
+      | ReadonlyArray<unknown>
+      | string
+      | number
+      | boolean
+      | null,
+  ): TestRequest;
+  set(key: string, value: string): TestRequest;
+  expect<TBody>(code: number): Promise<TestResponse<TBody>>;
+};
+
+type TestClient = {
+  get(path: string): TestRequest;
+  post(path: string): TestRequest;
+  put(path: string): TestRequest;
+};
+
+type SymbolsIndexResponse = {
+  ok: boolean;
+  indexed: number;
+  info: number;
+};
+
+type SymbolsFindResult = Readonly<{
+  path: string;
+  name: string;
+  kind: string;
+  startLine: number;
+  endLine: number;
+}>;
+
+type SymbolsFindResponse = {
+  ok: boolean;
+  results: readonly SymbolsFindResult[];
+};
+
+const INDEX_SYMBOLS_PAYLOAD = {
+  paths: ["**/*.ts"],
+} as const satisfies Readonly<Record<string, unknown>>;
+
+const FIND_SYMBOLS_PAYLOAD = {
+  query: "User",
+  kind: "class",
+} as const satisfies Readonly<Record<string, unknown>>;
 
 test.serial("POST /v0/symbols/index then /v0/symbols/find", async (t) => {
   t.timeout(20_000);
-  await withServer(ROOT, async (req) => {
-    const idx = await req
+  await withServer(ROOT, async (client: Readonly<TestClient>) => {
+    const idx = await client
       .post("/v0/symbols/index")
-      .send({ paths: ["**/*.ts"] })
-      .expect(200);
+      .send(INDEX_SYMBOLS_PAYLOAD)
+      .expect<SymbolsIndexResponse>(200);
     t.true(idx.body.ok);
-    const res = await req
+    const res = await client
       .post("/v0/symbols/find")
-      .send({ query: "User", kind: "class" })
-      .expect(200);
+      .send(FIND_SYMBOLS_PAYLOAD)
+      .expect<SymbolsFindResponse>(200);
     t.true(res.body.ok);
-    t.true(
-      res.body.results.some(
-        (r: any) => r.name === "User" && r.path.endsWith("multiSymbols.ts"),
-      ),
+    const hasUserSymbol = res.body.results.some(
+      ({ name, path }: Readonly<Pick<SymbolsFindResult, "name" | "path">>) =>
+        name === "User" && path.endsWith("multiSymbols.ts"),
     );
+    t.true(hasUserSymbol);
   });
 });


### PR DESCRIPTION
## Summary
- resolve the smartgpt-bridge symbols integration test fixtures relative to the package instead of the repo root
- add local test client and response typings so the test exercises the REST responses without eslint warnings
- document the fix in the changelog

## Testing
- pnpm --filter @promethean/smartgpt-bridge build
- pnpm exec ava packages/smartgpt-bridge/dist/tests/integration/server.symbols.test.js
- pnpm exec eslint packages/smartgpt-bridge/src/tests/integration/server.symbols.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d87817a2f883249ef3186b66508fdd