### PR TITLE
Fix stacktrace fixture resolution in smartgpt-bridge tests

### DIFF
--- a/packages/smartgpt-bridge/src/tests/unit/files.more.test.ts
+++ b/packages/smartgpt-bridge/src/tests/unit/files.more.test.ts
@@ -1,4 +1,5 @@
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 
 import test from "ava";
 
@@ -9,31 +10,40 @@ import {
   normalizeToRoot,
 } from "../../files.js";
 
-const ROOT = path.join(process.cwd(), "tests", "fixtures");
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.join(HERE, "../../..", "tests", "fixtures");
 
 test("locateStacktrace: Node style with function (nodeB)", async (t) => {
   const p = path.join(ROOT, "hello.ts");
   const trace = `Error at Greeter.greet (${p}:2:5)`;
-  const res = await locateStacktrace(ROOT, trace, 1);
+  const res = (await locateStacktrace(ROOT, trace, 1)) as Array<{
+    resolved: boolean;
+    path: string;
+  }>;
   t.true(res.length >= 1);
-  t.true(res[0].resolved);
-  t.is(res[0].path.endsWith("hello.ts"), true);
+  const first = res[0]!;
+  t.true(first.resolved);
+  t.is(first.path.endsWith("hello.ts"), true);
 });
 
 test("locateStacktrace: Python File:line unresolved", async (t) => {
-  const res = await locateStacktrace(
+  const res = (await locateStacktrace(
     ROOT,
     'File "/no/such/file.py", line 12',
     1,
-  );
+  )) as Array<{ resolved: boolean }>;
   t.true(res.length >= 1);
-  t.false(res[0].resolved);
+  const first = res[0]!;
+  t.false(first.resolved);
 });
 
 test("locateStacktrace: Go file:line unresolved", async (t) => {
-  const res = await locateStacktrace(ROOT, "cmd/main.go:45", 1);
+  const res = (await locateStacktrace(ROOT, "cmd/main.go:45", 1)) as Array<{
+    resolved: boolean;
+  }>;
   t.true(res.length >= 1);
-  t.false(res[0].resolved);
+  const first = res[0]!;
+  t.false(first.resolved);
 });
 
 test("resolvePath returns null for non-existent", async (t) => {


### PR DESCRIPTION
## Summary
- resolve the smartgpt-bridge stacktrace tests against the package fixture directory rather than process cwd
- add explicit typing helpers in the locateStacktrace tests to satisfy eslint and ts checks

## Testing
- pnpm --filter @promethean/smartgpt-bridge test

------
https://chatgpt.com/codex/tasks/task_e_68d8781e03588324859a1aae08591fcf