### PR TITLE
Fix smartgpt-bridge viewFile test fixture resolution

### DIFF
--- a/changelog.d/2025.09.28.00.09.32.md
+++ b/changelog.d/2025.09.28.00.09.32.md
@@ -1,0 +1,1 @@
+- Fix smartgpt-bridge viewFile unit test by resolving fixtures relative to the test file instead of relying on process cwd.

--- a/packages/smartgpt-bridge/src/tests/unit/files.test.ts
+++ b/packages/smartgpt-bridge/src/tests/unit/files.test.ts
@@ -1,10 +1,12 @@
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 
 import test from "ava";
 
 import { viewFile, resolvePath } from "../../files.js";
 
-const ROOT = path.join(process.cwd(), "tests", "fixtures");
+const TEST_DIR = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(TEST_DIR, "..", "..", "..", "tests", "fixtures");
 
 test("viewFile: returns correct window around line", async (t) => {
   const out = await viewFile(ROOT, "readme.md", 3, 2);


### PR DESCRIPTION
## Summary
- resolve the smartgpt-bridge viewFile unit test fixtures relative to the test file location so it works regardless of cwd
- document the change in a new changelog entry

## Testing
- pnpm exec ava dist/tests/unit/files.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d87823b1188324aca77b69dfa9b070