### PR TITLE
fix: stabilize server file snippet test

### DIFF
--- a/changelog.d/2025.09.28.00.08.30.md
+++ b/changelog.d/2025.09.28.00.08.30.md
@@ -1,0 +1,1 @@
+- fix server.v1 file read integration test by resolving fixtures relative to the test file so builds run from any cwd

--- a/packages/smartgpt-bridge/src/tests/integration/server.v1.routes.test.ts
+++ b/packages/smartgpt-bridge/src/tests/integration/server.v1.routes.test.ts
@@ -1,10 +1,13 @@
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 
 import test from "ava";
 
 import { withServer } from "../helpers/server.js";
 
-const ROOT = path.join(process.cwd(), "tests", "fixtures");
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const ROOT = path.resolve(__dirname, "../../../tests/fixtures");
 
 test("GET /v1/files/ returns flat file list", async (t) => {
   await withServer(ROOT, async (req) => {


### PR DESCRIPTION
## Summary
- resolve the integration test fixture path relative to the test file so it works regardless of cwd
- document the fix in the changelog

## Testing
- pnpm --filter @promethean/smartgpt-bridge test -- --match "GET /v1/files/readme.md returns file snippet"


------
https://chatgpt.com/codex/tasks/task_e_68d878380e2c83249bf93a014e09bf90