### PR TITLE
Fix js-step worker test tmp directory handling

### DIFF
--- a/changelog.d/2025.09.28.00.08.56.md
+++ b/changelog.d/2025.09.28.00.08.56.md
@@ -1,0 +1,1 @@
+- Fix js-step worker reload test to avoid using `process.chdir` so it runs under worker threads.

--- a/packages/piper/src/tests/js-step.test.ts
+++ b/packages/piper/src/tests/js-step.test.ts
@@ -13,8 +13,6 @@ async function withTmp(fn: (dir: string) => Promise<void>) {
   const parent = path.join(process.cwd(), "test-tmp");
   await fs.mkdir(parent, { recursive: true });
   const dir = await fs.mkdtemp(path.join(parent, "piper-"));
-  const prevCwd = process.cwd();
-  process.chdir(dir);
   try {
     await fs.writeFile(
       path.join(dir, SCHEMA),
@@ -25,7 +23,6 @@ async function withTmp(fn: (dir: string) => Promise<void>) {
     // small grace period for any async file watchers/flushes
     await sleep(50);
   } finally {
-    process.chdir(prevCwd);
     await fs.rm(dir, { recursive: true, force: true });
   }
 }


### PR DESCRIPTION
## Summary
- stop the js-step test helper from calling `process.chdir`, keeping worker-based runs compatible
- document the worker test fix in the changelog

## Testing
- pnpm --filter @promethean/piper exec -- ava packages/piper/src/tests/js-step.test.ts --match "worker js step: reload reflects dependency change between runs"


------
https://chatgpt.com/codex/tasks/task_e_68d8787d676c832490266f62d3fab7cc