### PR TITLE
Avoid process.chdir in Piper tests

### DIFF
--- a/changelog.d/2025.09.28.00.16.16.md
+++ b/changelog.d/2025.09.28.00.16.16.md
@@ -1,0 +1,1 @@
+- Fixed Piper tests to avoid calling `process.chdir()` inside worker-executed contexts by using absolute paths for temporary fixtures.

--- a/packages/piper/src/tests/js-step.test.ts
+++ b/packages/piper/src/tests/js-step.test.ts
@@ -13,8 +13,6 @@ async function withTmp(fn: (dir: string) => Promise<void>) {
   const parent = path.join(process.cwd(), "test-tmp");
   await fs.mkdir(parent, { recursive: true });
   const dir = await fs.mkdtemp(path.join(parent, "piper-"));
-  const prevCwd = process.cwd();
-  process.chdir(dir);
   try {
     await fs.writeFile(
       path.join(dir, SCHEMA),
@@ -25,7 +23,6 @@ async function withTmp(fn: (dir: string) => Promise<void>) {
     // small grace period for any async file watchers/flushes
     await sleep(50);
   } finally {
-    process.chdir(prevCwd);
     await fs.rm(dir, { recursive: true, force: true });
   }
 }

--- a/packages/piper/src/tests/jsonc.test.ts
+++ b/packages/piper/src/tests/jsonc.test.ts
@@ -61,20 +61,11 @@ async function withTmp(fn: (dir: string) => Promise<void>) {
 
 test("parses commented tsconfig", async (t) => {
   await withTmp(async (dir) => {
-    const prev = process.cwd();
-    process.chdir(dir);
-    try {
-      await fs.writeFile("tsconfig.schema.json", schema, "utf8");
-      await fs.writeFile("tsconfig.json", tsconfig, "utf8");
-      await fs.writeFile(
-        "pipelines.json",
-        JSON.stringify(cfg, null, 2),
-        "utf8",
-      );
-      const res = await runPipeline("pipelines.json", "demo", {});
-      t.is(res[0]?.exitCode, 0);
-    } finally {
-      process.chdir(prev);
-    }
+    await fs.writeFile(path.join(dir, "tsconfig.schema.json"), schema, "utf8");
+    await fs.writeFile(path.join(dir, "tsconfig.json"), tsconfig, "utf8");
+    const pipelinesPath = path.join(dir, "pipelines.json");
+    await fs.writeFile(pipelinesPath, JSON.stringify(cfg, null, 2), "utf8");
+    const res = await runPipeline(pipelinesPath, "demo", {});
+    t.is(res[0]?.exitCode, 0);
   });
 });

--- a/packages/piper/src/tests/output-dir.test.ts
+++ b/packages/piper/src/tests/output-dir.test.ts
@@ -14,7 +14,11 @@ async function withTmp(fn: (dir: string) => Promise<void>) {
     String(Date.now()) + "-" + Math.random().toString(36).slice(2),
   );
   await fs.mkdir(dir, { recursive: true });
-  await fs.writeFile(path.join(dir, SCHEMA), JSON.stringify({ type: "object" }), "utf8");
+  await fs.writeFile(
+    path.join(dir, SCHEMA),
+    JSON.stringify({ type: "object" }),
+    "utf8",
+  );
   try {
     await fn(dir);
   } finally {
@@ -24,37 +28,34 @@ async function withTmp(fn: (dir: string) => Promise<void>) {
 
 test("runPipeline creates output directories", async (t) => {
   await withTmp(async (dir) => {
-    const prevCwd = process.cwd();
-    process.chdir(dir);
-    try {
-      const cfg = {
-        pipelines: [
-          {
-            name: "demo",
-            steps: [
-              {
-                id: "write",
-                cwd: ".",
-                deps: [],
-                inputs: [],
-                outputs: ["nested/out.txt"],
-                inputSchema: SCHEMA,
-                outputSchema: SCHEMA,
-                shell: "echo hi > nested/out.txt",
-              },
-            ],
-          },
-        ],
-      };
-      const pipelinesPath = path.join(dir, "pipelines.json");
-      await fs.writeFile(pipelinesPath, JSON.stringify(cfg, null, 2), "utf8");
-      const res = await runPipeline(pipelinesPath, "demo", { concurrency: 1 });
-      const step = res[0]!;
-      t.is(step.exitCode, 0);
-      const content = await fs.readFile(path.join(dir, "nested", "out.txt"), "utf8");
-      t.is(content.trim(), "hi");
-    } finally {
-      process.chdir(prevCwd);
-    }
+    const cfg = {
+      pipelines: [
+        {
+          name: "demo",
+          steps: [
+            {
+              id: "write",
+              cwd: ".",
+              deps: [],
+              inputs: [],
+              outputs: ["nested/out.txt"],
+              inputSchema: SCHEMA,
+              outputSchema: SCHEMA,
+              shell: "echo hi > nested/out.txt",
+            },
+          ],
+        },
+      ],
+    };
+    const pipelinesPath = path.join(dir, "pipelines.json");
+    await fs.writeFile(pipelinesPath, JSON.stringify(cfg, null, 2), "utf8");
+    const res = await runPipeline(pipelinesPath, "demo", { concurrency: 1 });
+    const step = res[0]!;
+    t.is(step.exitCode, 0);
+    const content = await fs.readFile(
+      path.join(dir, "nested", "out.txt"),
+      "utf8",
+    );
+    t.is(content.trim(), "hi");
   });
 });

--- a/packages/piper/src/tests/retry.test.ts
+++ b/packages/piper/src/tests/retry.test.ts
@@ -28,69 +28,63 @@ async function withTmp(fn: (dir: string) => Promise<void>) {
 
 test("runPipeline retries failed steps", async (t) => {
   await withTmp(async (dir) => {
-    const prevCwd = process.cwd();
-    process.chdir(dir);
+    const cfg = {
+      pipelines: [
+        {
+          name: "demo",
+          steps: [
+            {
+              id: "flaky",
+              cwd: ".",
+              deps: [],
+              inputs: [],
+              outputs: [],
+              inputSchema: SCHEMA,
+              outputSchema: SCHEMA,
+              cache: "content",
+              retry: 1,
+              shell:
+                "n=$(cat count 2>/dev/null || echo 0); n=$((n+1)); echo $n > count; [ $n -ge 2 ]",
+            },
+          ],
+        },
+      ],
+    };
+    const pipelinesPath = path.join(dir, "pipelines.json");
+    await fs.writeFile(pipelinesPath, JSON.stringify(cfg, null, 2), "utf8");
+
+    const events: string[] = [];
+    const origWrite = process.stdout.write.bind(process.stdout);
+    (process.stdout.write as any) = (s: string | Uint8Array) => {
+      events.push(s.toString());
+      return true;
+    };
     try {
-      const cfg = {
-        pipelines: [
-          {
-            name: "demo",
-            steps: [
-              {
-                id: "flaky",
-                cwd: ".",
-                deps: [],
-                inputs: [],
-                outputs: [],
-                inputSchema: SCHEMA,
-                outputSchema: SCHEMA,
-                cache: "content",
-                retry: 1,
-                shell:
-                  "n=$(cat count 2>/dev/null || echo 0); n=$((n+1)); echo $n > count; [ $n -ge 2 ]",
-              },
-            ],
-          },
-        ],
-      };
-      const pipelinesPath = path.join(dir, "pipelines.json");
-      await fs.writeFile(pipelinesPath, JSON.stringify(cfg, null, 2), "utf8");
-
-      const events: string[] = [];
-      const origWrite = process.stdout.write.bind(process.stdout);
-      (process.stdout.write as any) = (s: string | Uint8Array) => {
-        events.push(s.toString());
-        return true;
-      };
-      try {
-        const res = await runPipeline(pipelinesPath, "demo", {
-          concurrency: 1,
-          contentHash: true,
-          json: true,
-        });
-        t.is(res[0]?.exitCode, 0);
-      } finally {
-        (process.stdout.write as any) = origWrite;
-      }
-
-      const count = await fs.readFile(path.join(dir, "count"), "utf8");
-      t.is(count.trim(), "2");
-
-      const parsed = events
-        .map((e) => {
-          try {
-            return JSON.parse(e);
-          } catch {
-            return null;
-          }
-        })
-        .filter(Boolean);
-      const retryEvents = parsed.filter((ev) => ev.type === "retry");
-      t.is(retryEvents.length, 1);
-      t.is(retryEvents[0].attempt, 1);
-      t.is(retryEvents[0].stepId, "flaky");
+      const res = await runPipeline(pipelinesPath, "demo", {
+        concurrency: 1,
+        contentHash: true,
+        json: true,
+      });
+      t.is(res[0]?.exitCode, 0);
     } finally {
-      process.chdir(prevCwd);
+      (process.stdout.write as any) = origWrite;
     }
+
+    const count = await fs.readFile(path.join(dir, "count"), "utf8");
+    t.is(count.trim(), "2");
+
+    const parsed = events
+      .map((e) => {
+        try {
+          return JSON.parse(e);
+        } catch {
+          return null;
+        }
+      })
+      .filter(Boolean);
+    const retryEvents = parsed.filter((ev) => ev.type === "retry");
+    t.is(retryEvents.length, 1);
+    t.is(retryEvents[0].attempt, 1);
+    t.is(retryEvents[0].stepId, "flaky");
   });
 });

--- a/packages/piper/src/tests/runner.test.ts
+++ b/packages/piper/src/tests/runner.test.ts
@@ -30,77 +30,71 @@ test.serial(
   "runPipeline executes steps and caches on second run",
   async (t) => {
     await withTmp(async (dir) => {
-      const prevCwd = process.cwd();
-      process.chdir(dir);
-      try {
-        const cfg = {
-          pipelines: [
-            {
-              name: "demo",
-              steps: [
-                {
-                  id: "make",
-                  cwd: ".",
-                  deps: [],
-                  inputs: [],
-                  outputs: ["out.txt"],
-                  inputSchema: SCHEMA,
-                  outputSchema: SCHEMA,
-                  cache: "content",
-                  shell: "echo hello > out.txt",
-                },
-                {
-                  id: "cat",
-                  cwd: ".",
-                  deps: ["make"],
-                  inputs: ["out.txt"],
-                  outputs: ["out2.txt"],
-                  inputSchema: SCHEMA,
-                  outputSchema: SCHEMA,
-                  cache: "content",
-                  shell: "cat out.txt > out2.txt",
-                },
-              ],
-            },
-          ],
-        };
-        const pipelinesPath = path.join(dir, "pipelines.json");
-        await fs.writeFile(pipelinesPath, JSON.stringify(cfg, null, 2), "utf8");
+      const cfg = {
+        pipelines: [
+          {
+            name: "demo",
+            steps: [
+              {
+                id: "make",
+                cwd: ".",
+                deps: [],
+                inputs: [],
+                outputs: ["out.txt"],
+                inputSchema: SCHEMA,
+                outputSchema: SCHEMA,
+                cache: "content",
+                shell: "echo hello > out.txt",
+              },
+              {
+                id: "cat",
+                cwd: ".",
+                deps: ["make"],
+                inputs: ["out.txt"],
+                outputs: ["out2.txt"],
+                inputSchema: SCHEMA,
+                outputSchema: SCHEMA,
+                cache: "content",
+                shell: "cat out.txt > out2.txt",
+              },
+            ],
+          },
+        ],
+      };
+      const pipelinesPath = path.join(dir, "pipelines.json");
+      await fs.writeFile(pipelinesPath, JSON.stringify(cfg, null, 2), "utf8");
 
-        const res1 = await runPipeline(pipelinesPath, "demo", {
-          concurrency: 2,
-          contentHash: true,
-        });
-        t.truthy(await fs.readFile(path.join(dir, "out.txt"), "utf8"));
-        t.truthy(await fs.readFile(path.join(dir, "out2.txt"), "utf8"));
-        t.is(
-          res1.filter((r) => r.skipped).length,
-          0,
-          "first run should not skip",
-        );
+      const res1 = await runPipeline(pipelinesPath, "demo", {
+        concurrency: 2,
+        contentHash: true,
+      });
+      t.truthy(await fs.readFile(path.join(dir, "out.txt"), "utf8"));
+      t.truthy(await fs.readFile(path.join(dir, "out2.txt"), "utf8"));
+      t.is(
+        res1.filter((r) => r.skipped).length,
+        0,
+        "first run should not skip",
+      );
 
-        const res2 = await runPipeline(pipelinesPath, "demo", {
-          concurrency: 2,
-          contentHash: true,
-        });
-        t.true(
-          res2.every((r) => r.skipped),
-          "second run should skip all steps",
-        );
+      const res2 = await runPipeline(pipelinesPath, "demo", {
+        concurrency: 2,
+        contentHash: true,
+      });
+      t.true(
+        res2.every((r) => r.skipped),
+        "second run should skip all steps",
+      );
 
-        // touch input to invalidate
-        await fs.writeFile(path.join(dir, "out.txt"), "changed\n", "utf8");
-        const res3 = await runPipeline(pipelinesPath, "demo", {
-          concurrency: 2,
-          contentHash: true,
-        });
-        t.true(
-          res3.some((r) => !r.skipped),
-          "after change, at least one step should rerun",
-        );
-      } finally {
-        process.chdir(prevCwd);
-      }
+      // touch input to invalidate
+      await fs.writeFile(path.join(dir, "out.txt"), "changed\n", "utf8");
+      const res3 = await runPipeline(pipelinesPath, "demo", {
+        concurrency: 2,
+        contentHash: true,
+      });
+      t.true(
+        res3.some((r) => !r.skipped),
+        "after change, at least one step should rerun",
+      );
     });
   },
 );
@@ -111,129 +105,15 @@ test.serial(
   "runPipeline stops downstream steps when a dependency fails",
   async (t) => {
     await withTmp(async (dir) => {
-      const prevCwd = process.cwd();
-      process.chdir(dir);
-      try {
-        const cfg = {
-          pipelines: [
-            {
-              name: "fail-deps",
-              steps: [
-                {
-                  id: "make",
-                  cwd: ".",
-                  deps: [],
-                  inputs: [],
-                  outputs: ["a.txt"],
-                  inputSchema: SCHEMA,
-                  outputSchema: SCHEMA,
-                  cache: "content",
-                  shell: "echo A > a.txt",
-                },
-                {
-                  id: "boom",
-                  cwd: ".",
-                  deps: ["make"],
-                  inputs: ["a.txt"],
-                  outputs: ["b.txt"],
-                  inputSchema: SCHEMA,
-                  outputSchema: SCHEMA,
-                  cache: "content",
-                  // Force a non-zero exit to simulate failure
-                  shell: "sh -c 'echo err >&2; echo will-fail; exit 2'",
-                },
-                {
-                  id: "downstream",
-                  cwd: ".",
-                  deps: ["boom"],
-                  inputs: ["b.txt"],
-                  outputs: ["c.txt"],
-                  inputSchema: SCHEMA,
-                  outputSchema: SCHEMA,
-                  cache: "content",
-                  shell: "cat b.txt > c.txt",
-                },
-              ],
-            },
-          ],
-        };
-        const pipelinesPath = path.join(dir, "pipelines.json");
-        await fs.writeFile(pipelinesPath, JSON.stringify(cfg, null, 2), "utf8");
-
-        const err = await t.throwsAsync(
-          () =>
-            runPipeline(pipelinesPath, "fail-deps", {
-              concurrency: 2,
-              contentHash: true,
-            }),
-          { instanceOf: StepError },
-          "pipeline should throw when a step fails",
-        );
-        t.true(err.message.includes("boom"));
-        t.true(err.message.includes("echo err >&2; echo will-fail; exit 2"));
-        t.true(err.message.includes("stderr: err"));
-
-        // Upstream succeeded
-        t.truthy(await fs.readFile(path.join(dir, "a.txt"), "utf8"));
-
-        // Failed step should not have produced its output
-        await t.throwsAsync(
-          () => fs.readFile(path.join(dir, "b.txt"), "utf8"),
-          undefined,
-          "failed step should not create output",
-        );
-
-        // Downstream step should not have run
-        await t.throwsAsync(
-          () => fs.readFile(path.join(dir, "c.txt"), "utf8"),
-          undefined,
-          "downstream step must not run after dependency failure",
-        );
-      } finally {
-        process.chdir(prevCwd);
-      }
-    });
-  },
-);
-
-test.serial("runPipeline throws on unknown pipeline name", async (t) => {
-  await withTmp(async (dir) => {
-    const prevCwd = process.cwd();
-    process.chdir(dir);
-    try {
-      const cfg = { pipelines: [{ name: "known", steps: [] }] };
-      const pipelinesPath = path.join(dir, "pipelines.json");
-      await fs.writeFile(pipelinesPath, JSON.stringify(cfg, null, 2), "utf8");
-
-      await t.throwsAsync(
-        () =>
-          runPipeline(pipelinesPath, "unknown", {
-            concurrency: 1,
-            contentHash: true,
-          }),
-        { instanceOf: Error },
-        "unknown pipeline should cause an error",
-      );
-    } finally {
-      process.chdir(prevCwd);
-    }
-  });
-});
-
-test.serial("runPipeline detects cyclic dependencies", async (t) => {
-  await withTmp(async (dir) => {
-    const prevCwd = process.cwd();
-    process.chdir(dir);
-    try {
       const cfg = {
         pipelines: [
           {
-            name: "cycle",
+            name: "fail-deps",
             steps: [
               {
-                id: "a",
+                id: "make",
                 cwd: ".",
-                deps: ["c"], // cycle back from c
+                deps: [],
                 inputs: [],
                 outputs: ["a.txt"],
                 inputSchema: SCHEMA,
@@ -242,20 +122,21 @@ test.serial("runPipeline detects cyclic dependencies", async (t) => {
                 shell: "echo A > a.txt",
               },
               {
-                id: "b",
+                id: "boom",
                 cwd: ".",
-                deps: ["a"],
+                deps: ["make"],
                 inputs: ["a.txt"],
                 outputs: ["b.txt"],
                 inputSchema: SCHEMA,
                 outputSchema: SCHEMA,
                 cache: "content",
-                shell: "cat a.txt > b.txt",
+                // Force a non-zero exit to simulate failure
+                shell: "sh -c 'echo err >&2; echo will-fail; exit 2'",
               },
               {
-                id: "c",
+                id: "downstream",
                 cwd: ".",
-                deps: ["b"],
+                deps: ["boom"],
                 inputs: ["b.txt"],
                 outputs: ["c.txt"],
                 inputSchema: SCHEMA,
@@ -270,18 +151,113 @@ test.serial("runPipeline detects cyclic dependencies", async (t) => {
       const pipelinesPath = path.join(dir, "pipelines.json");
       await fs.writeFile(pipelinesPath, JSON.stringify(cfg, null, 2), "utf8");
 
-      await t.throwsAsync(
+      const err = await t.throwsAsync(
         () =>
-          runPipeline(pipelinesPath, "cycle", {
+          runPipeline(pipelinesPath, "fail-deps", {
             concurrency: 2,
             contentHash: true,
           }),
-        { instanceOf: Error },
-        "cyclic graph should be rejected",
+        { instanceOf: StepError },
+        "pipeline should throw when a step fails",
       );
-    } finally {
-      process.chdir(prevCwd);
-    }
+      t.true(err.message.includes("boom"));
+      t.true(err.message.includes("echo err >&2; echo will-fail; exit 2"));
+      t.true(err.message.includes("stderr: err"));
+
+      // Upstream succeeded
+      t.truthy(await fs.readFile(path.join(dir, "a.txt"), "utf8"));
+
+      // Failed step should not have produced its output
+      await t.throwsAsync(
+        () => fs.readFile(path.join(dir, "b.txt"), "utf8"),
+        undefined,
+        "failed step should not create output",
+      );
+
+      // Downstream step should not have run
+      await t.throwsAsync(
+        () => fs.readFile(path.join(dir, "c.txt"), "utf8"),
+        undefined,
+        "downstream step must not run after dependency failure",
+      );
+    });
+  },
+);
+
+test.serial("runPipeline throws on unknown pipeline name", async (t) => {
+  await withTmp(async (dir) => {
+    const cfg = { pipelines: [{ name: "known", steps: [] }] };
+    const pipelinesPath = path.join(dir, "pipelines.json");
+    await fs.writeFile(pipelinesPath, JSON.stringify(cfg, null, 2), "utf8");
+
+    await t.throwsAsync(
+      () =>
+        runPipeline(pipelinesPath, "unknown", {
+          concurrency: 1,
+          contentHash: true,
+        }),
+      { instanceOf: Error },
+      "unknown pipeline should cause an error",
+    );
+  });
+});
+
+test.serial("runPipeline detects cyclic dependencies", async (t) => {
+  await withTmp(async (dir) => {
+    const cfg = {
+      pipelines: [
+        {
+          name: "cycle",
+          steps: [
+            {
+              id: "a",
+              cwd: ".",
+              deps: ["c"], // cycle back from c
+              inputs: [],
+              outputs: ["a.txt"],
+              inputSchema: SCHEMA,
+              outputSchema: SCHEMA,
+              cache: "content",
+              shell: "echo A > a.txt",
+            },
+            {
+              id: "b",
+              cwd: ".",
+              deps: ["a"],
+              inputs: ["a.txt"],
+              outputs: ["b.txt"],
+              inputSchema: SCHEMA,
+              outputSchema: SCHEMA,
+              cache: "content",
+              shell: "cat a.txt > b.txt",
+            },
+            {
+              id: "c",
+              cwd: ".",
+              deps: ["b"],
+              inputs: ["b.txt"],
+              outputs: ["c.txt"],
+              inputSchema: SCHEMA,
+              outputSchema: SCHEMA,
+              cache: "content",
+              shell: "cat b.txt > c.txt",
+            },
+          ],
+        },
+      ],
+    };
+    const pipelinesPath = path.join(dir, "pipelines.json");
+    await fs.writeFile(pipelinesPath, JSON.stringify(cfg, null, 2), "utf8");
+
+    await t.throwsAsync(
+      () =>
+        runPipeline(pipelinesPath, "cycle", {
+          concurrency: 2,
+          contentHash: true,
+        }),
+      { instanceOf: Error },
+      "cyclic graph should be rejected",
+    );
   });
 });
 
@@ -289,50 +265,44 @@ test.serial(
   "runPipeline fails when a step declares a missing input",
   async (t) => {
     await withTmp(async (dir) => {
-      const prevCwd = process.cwd();
-      process.chdir(dir);
-      try {
-        const cfg = {
-          pipelines: [
-            {
-              name: "missing-input",
-              steps: [
-                {
-                  id: "lonely",
-                  cwd: ".",
-                  deps: [],
-                  inputs: ["nonexistent.txt"], // declared but not produced
-                  outputs: ["out.txt"],
-                  inputSchema: SCHEMA,
-                  outputSchema: SCHEMA,
-                  cache: "content",
-                  shell: "cat nonexistent.txt > out.txt",
-                },
-              ],
-            },
-          ],
-        };
-        const pipelinesPath = path.join(dir, "pipelines.json");
-        await fs.writeFile(pipelinesPath, JSON.stringify(cfg, null, 2), "utf8");
+      const cfg = {
+        pipelines: [
+          {
+            name: "missing-input",
+            steps: [
+              {
+                id: "lonely",
+                cwd: ".",
+                deps: [],
+                inputs: ["nonexistent.txt"], // declared but not produced
+                outputs: ["out.txt"],
+                inputSchema: SCHEMA,
+                outputSchema: SCHEMA,
+                cache: "content",
+                shell: "cat nonexistent.txt > out.txt",
+              },
+            ],
+          },
+        ],
+      };
+      const pipelinesPath = path.join(dir, "pipelines.json");
+      await fs.writeFile(pipelinesPath, JSON.stringify(cfg, null, 2), "utf8");
 
-        await t.throwsAsync(
-          () =>
-            runPipeline(pipelinesPath, "missing-input", {
-              concurrency: 1,
-              contentHash: true,
-            }),
-          { instanceOf: Error },
-          "step should fail if a declared input is missing",
-        );
+      await t.throwsAsync(
+        () =>
+          runPipeline(pipelinesPath, "missing-input", {
+            concurrency: 1,
+            contentHash: true,
+          }),
+        { instanceOf: Error },
+        "step should fail if a declared input is missing",
+      );
 
-        await t.throwsAsync(
-          () => fs.readFile(path.join(dir, "out.txt"), "utf8"),
-          undefined,
-          "output should not be created on failure",
-        );
-      } finally {
-        process.chdir(prevCwd);
-      }
+      await t.throwsAsync(
+        () => fs.readFile(path.join(dir, "out.txt"), "utf8"),
+        undefined,
+        "output should not be created on failure",
+      );
     });
   },
 );
@@ -341,110 +311,100 @@ test.serial(
   "runPipeline re-executes only affected steps when an intermediate input changes",
   async (t) => {
     await withTmp(async (dir) => {
-      const prevCwd = process.cwd();
-      process.chdir(dir);
-      try {
-        const cfg = {
-          pipelines: [
-            {
-              name: "partial-invalidate",
-              steps: [
-                {
-                  id: "make1",
-                  cwd: ".",
-                  deps: [],
-                  inputs: [],
-                  outputs: ["x.txt"],
-                  inputSchema: SCHEMA,
-                  outputSchema: SCHEMA,
-                  cache: "content",
-                  shell: "echo X > x.txt",
-                },
-                {
-                  id: "make2",
-                  cwd: ".",
-                  deps: [],
-                  inputs: [],
-                  outputs: ["y.txt"],
-                  inputSchema: SCHEMA,
-                  outputSchema: SCHEMA,
-                  cache: "content",
-                  shell: "echo Y > y.txt",
-                },
-                {
-                  id: "join",
-                  cwd: ".",
-                  deps: ["make1", "make2"],
-                  inputs: ["x.txt", "y.txt"],
-                  outputs: ["z.txt"],
-                  inputSchema: SCHEMA,
-                  outputSchema: SCHEMA,
-                  cache: "content",
-                  shell: "cat x.txt y.txt > z.txt",
-                },
-              ],
-            },
-          ],
-        };
-        const pipelinesPath = path.join(dir, "pipelines.json");
-        await fs.writeFile(pipelinesPath, JSON.stringify(cfg, null, 2), "utf8");
+      const cfg = {
+        pipelines: [
+          {
+            name: "partial-invalidate",
+            steps: [
+              {
+                id: "make1",
+                cwd: ".",
+                deps: [],
+                inputs: [],
+                outputs: ["x.txt"],
+                inputSchema: SCHEMA,
+                outputSchema: SCHEMA,
+                cache: "content",
+                shell: "echo X > x.txt",
+              },
+              {
+                id: "make2",
+                cwd: ".",
+                deps: [],
+                inputs: [],
+                outputs: ["y.txt"],
+                inputSchema: SCHEMA,
+                outputSchema: SCHEMA,
+                cache: "content",
+                shell: "echo Y > y.txt",
+              },
+              {
+                id: "join",
+                cwd: ".",
+                deps: ["make1", "make2"],
+                inputs: ["x.txt", "y.txt"],
+                outputs: ["z.txt"],
+                inputSchema: SCHEMA,
+                outputSchema: SCHEMA,
+                cache: "content",
+                shell: "cat x.txt y.txt > z.txt",
+              },
+            ],
+          },
+        ],
+      };
+      const pipelinesPath = path.join(dir, "pipelines.json");
+      await fs.writeFile(pipelinesPath, JSON.stringify(cfg, null, 2), "utf8");
 
-        const res1 = await runPipeline(pipelinesPath, "partial-invalidate", {
-          concurrency: 2,
-          contentHash: true,
-        });
-        t.is(
-          res1.filter((r) => r.skipped).length,
-          0,
-          "initial run executes all",
-        );
+      const res1 = await runPipeline(pipelinesPath, "partial-invalidate", {
+        concurrency: 2,
+        contentHash: true,
+      });
+      t.is(res1.filter((r) => r.skipped).length, 0, "initial run executes all");
 
-        const res2 = await runPipeline(pipelinesPath, "partial-invalidate", {
-          concurrency: 2,
-          contentHash: true,
-        });
-        t.true(
-          res2.every((r) => r.skipped),
-          "second run is fully cached",
-        );
+      const res2 = await runPipeline(pipelinesPath, "partial-invalidate", {
+        concurrency: 2,
+        contentHash: true,
+      });
+      t.true(
+        res2.every((r) => r.skipped),
+        "second run is fully cached",
+      );
 
-        // Change only x.txt to invalidate make1 and join; make2 should remain cached
-        await fs.writeFile(path.join(dir, "x.txt"), "X-changed\n", "utf8");
+      // Change only x.txt to invalidate make1 and join; make2 should remain cached
+      await fs.writeFile(path.join(dir, "x.txt"), "X-changed\n", "utf8");
 
-        const res3 = await runPipeline(pipelinesPath, "partial-invalidate", {
-          concurrency: 2,
-          contentHash: true,
-        });
+      const res3 = await runPipeline(pipelinesPath, "partial-invalidate", {
+        concurrency: 2,
+        contentHash: true,
+      });
 
-        const byId = new Map(res3.map((r) => [r.id ?? "", r]));
-        // We expect make1 and join to re-run (not skipped); make2 stays skipped
-        t.true(
-          Array.from(byId.values()).some(
-            (r) => r.skipped === false && r.exitCode === 0,
-          ),
-          "at least one step re-executes after input change",
-        );
+      const byId = new Map(res3.map((r) => [r.id ?? "", r]));
+      // We expect make1 and join to re-run (not skipped); make2 stays skipped
+      t.true(
+        Array.from(byId.values()).some(
+          (r) => r.skipped === false && r.exitCode === 0,
+        ),
+        "at least one step re-executes after input change",
+      );
 
-        const make1 = byId.get("make1");
-        const make2 = byId.get("make2");
-        const join = byId.get("join");
+      const make1 = byId.get("make1");
+      const make2 = byId.get("make2");
+      const join = byId.get("join");
 
-        if (make1) {
-          t.false(make1.skipped, "make1 should re-execute");
-          t.is(make1.exitCode, 0);
-        }
-        if (make2) t.true(make2.skipped, "make2 should remain cached");
-        if (join) {
-          t.false(join.skipped, "join should re-execute due to changed input");
-          t.is(join.exitCode, 0);
-        }
-
-        // Validate outputs were regenerated
-        const z = await fs.readFile(path.join(dir, "z.txt"), "utf8");
-        t.is(z, "X\nY\n", "z.txt should include regenerated X content");
-      } finally {
-        process.chdir(prevCwd);
+      if (make1) {
+        t.false(make1.skipped, "make1 should re-execute");
+        t.is(make1.exitCode, 0);
       }
+      if (make2) t.true(make2.skipped, "make2 should remain cached");
+      if (join) {
+        t.false(join.skipped, "join should re-execute due to changed input");
+        t.is(join.exitCode, 0);
+      }
+
+      // Validate outputs were regenerated
+      const z = await fs.readFile(path.join(dir, "z.txt"), "utf8");
+      t.is(z, "X\nY\n", "z.txt should include regenerated X content");
     });
   },
 );

--- a/packages/piper/src/tests/runner.worker.smoke.test.ts
+++ b/packages/piper/src/tests/runner.worker.smoke.test.ts
@@ -12,8 +12,6 @@ async function withTmp(fn: (dir: string) => Promise<void>) {
   const parent = path.join(process.cwd(), "test-tmp");
   await fs.mkdir(parent, { recursive: true });
   const dir = await fs.mkdtemp(path.join(parent, "piper-"));
-  const prevCwd = process.cwd();
-  process.chdir(dir);
   try {
     await fs.writeFile(
       path.join(dir, SCHEMA),
@@ -23,7 +21,6 @@ async function withTmp(fn: (dir: string) => Promise<void>) {
     await fn(dir);
     await sleep(50);
   } finally {
-    process.chdir(prevCwd);
     await fs.rm(dir, { recursive: true, force: true });
   }
 }

--- a/packages/piper/src/tests/schema.test.ts
+++ b/packages/piper/src/tests/schema.test.ts
@@ -23,85 +23,83 @@ async function withTmp(fn: (dir: string) => Promise<void>) {
 
 test.serial("fails when input schema mismatches", async (t) => {
   await withTmp(async (dir) => {
-    const prevCwd = process.cwd();
-    process.chdir(dir);
-    try {
-      const schema = {
-        type: "object",
-        required: ["foo"],
-        properties: { foo: { type: "string" } },
-      };
-      await fs.writeFile("schema.json", JSON.stringify(schema), "utf8");
-      await fs.writeFile("in.json", JSON.stringify({ foo: 123 }), "utf8");
+    const schema = {
+      type: "object",
+      required: ["foo"],
+      properties: { foo: { type: "string" } },
+    };
+    await fs.writeFile(
+      path.join(dir, "schema.json"),
+      JSON.stringify(schema),
+      "utf8",
+    );
+    await fs.writeFile(
+      path.join(dir, "in.json"),
+      JSON.stringify({ foo: 123 }),
+      "utf8",
+    );
 
-      const cfg = {
-        pipelines: [
-          {
-            name: "demo",
-            steps: [
-              {
-                id: "s1",
-                shell: "cp in.json out.json",
-                inputs: ["in.json"],
-                outputs: ["out.json"],
-                inputSchema: "schema.json",
-                outputSchema: "schema.json",
-              },
-            ],
-          },
-        ],
-      };
-      await fs.writeFile(
-        "pipelines.json",
-        JSON.stringify(cfg, null, 2),
-        "utf8",
-      );
+    const cfg = {
+      pipelines: [
+        {
+          name: "demo",
+          steps: [
+            {
+              id: "s1",
+              shell: "cp in.json out.json",
+              inputs: ["in.json"],
+              outputs: ["out.json"],
+              inputSchema: "schema.json",
+              outputSchema: "schema.json",
+            },
+          ],
+        },
+      ],
+    };
+    const pipelinesPath = path.join(dir, "pipelines.json");
+    await fs.writeFile(pipelinesPath, JSON.stringify(cfg, null, 2), "utf8");
 
-      await t.throwsAsync(() => runPipeline("pipelines.json", "demo", {}));
-    } finally {
-      process.chdir(prevCwd);
-    }
+    await t.throwsAsync(() => runPipeline(pipelinesPath, "demo", {}));
   });
 });
 
 test.serial("fails when output schema mismatches", async (t) => {
   await withTmp(async (dir) => {
-    const prevCwd = process.cwd();
-    process.chdir(dir);
-    try {
-      const schema = {
-        type: "object",
-        required: ["foo"],
-        properties: { foo: { type: "string" } },
-      };
-      await fs.writeFile("schema.json", JSON.stringify(schema), "utf8");
-      await fs.writeFile("in.json", JSON.stringify({ foo: "ok" }), "utf8");
+    const schema = {
+      type: "object",
+      required: ["foo"],
+      properties: { foo: { type: "string" } },
+    };
+    await fs.writeFile(
+      path.join(dir, "schema.json"),
+      JSON.stringify(schema),
+      "utf8",
+    );
+    await fs.writeFile(
+      path.join(dir, "in.json"),
+      JSON.stringify({ foo: "ok" }),
+      "utf8",
+    );
 
-      const cfg = {
-        pipelines: [
-          {
-            name: "demo",
-            steps: [
-              {
-                id: "s1",
-                shell: "echo '{}' > out.json",
-                inputs: ["in.json"],
-                outputs: ["out.json"],
-                outputSchema: "schema.json",
-              },
-            ],
-          },
-        ],
-      };
-      await fs.writeFile(
-        "pipelines.json",
-        JSON.stringify(cfg, null, 2),
-        "utf8",
-      );
+    const cfg = {
+      pipelines: [
+        {
+          name: "demo",
+          steps: [
+            {
+              id: "s1",
+              shell: "echo '{}' > out.json",
+              inputs: ["in.json"],
+              outputs: ["out.json"],
+              outputSchema: "schema.json",
+            },
+          ],
+        },
+      ],
+    };
+    const pipelinesPath = path.join(dir, "pipelines.json");
+    await fs.writeFile(pipelinesPath, JSON.stringify(cfg, null, 2), "utf8");
 
-      await t.throwsAsync(() => runPipeline("pipelines.json", "demo", {}));
-    } finally {
-      process.chdir(prevCwd);
-    }
+    await t.throwsAsync(() => runPipeline(pipelinesPath, "demo", {}));
   });
 });


### PR DESCRIPTION
## Summary
- stop using `process.chdir()` in Piper test helpers so AVA worker threads can run them
- update pipeline fixture setup code to operate on absolute paths and clean up formatting
- record the change in the changelog

## Testing
- pnpm --filter @promethean/piper test

------
https://chatgpt.com/codex/tasks/task_e_68d878835c6883249ab2e40c07fd0de0