### PR TITLE
fix(piper): avoid worker chdir in output dir test

### DIFF
--- a/changelog.d/2025.09.28.00.11.21.md
+++ b/changelog.d/2025.09.28.00.11.21.md
@@ -1,0 +1,1 @@
+- Fix piper output directory test to avoid changing process cwd in worker threads.

--- a/packages/piper/src/tests/output-dir.test.ts
+++ b/packages/piper/src/tests/output-dir.test.ts
@@ -14,47 +14,46 @@ async function withTmp(fn: (dir: string) => Promise<void>) {
     String(Date.now()) + "-" + Math.random().toString(36).slice(2),
   );
   await fs.mkdir(dir, { recursive: true });
-  await fs.writeFile(path.join(dir, SCHEMA), JSON.stringify({ type: "object" }), "utf8");
-  try {
-    await fn(dir);
-  } finally {
-    await fs.rm(dir, { recursive: true, force: true });
-  }
+  await fs.writeFile(
+    path.join(dir, SCHEMA),
+    JSON.stringify({ type: "object" }),
+    "utf8",
+  );
+  await Promise.resolve(fn(dir)).finally(() =>
+    fs.rm(dir, { recursive: true, force: true }),
+  );
 }
 
 test("runPipeline creates output directories", async (t) => {
   await withTmp(async (dir) => {
-    const prevCwd = process.cwd();
-    process.chdir(dir);
-    try {
-      const cfg = {
-        pipelines: [
-          {
-            name: "demo",
-            steps: [
-              {
-                id: "write",
-                cwd: ".",
-                deps: [],
-                inputs: [],
-                outputs: ["nested/out.txt"],
-                inputSchema: SCHEMA,
-                outputSchema: SCHEMA,
-                shell: "echo hi > nested/out.txt",
-              },
-            ],
-          },
-        ],
-      };
-      const pipelinesPath = path.join(dir, "pipelines.json");
-      await fs.writeFile(pipelinesPath, JSON.stringify(cfg, null, 2), "utf8");
-      const res = await runPipeline(pipelinesPath, "demo", { concurrency: 1 });
-      const step = res[0]!;
-      t.is(step.exitCode, 0);
-      const content = await fs.readFile(path.join(dir, "nested", "out.txt"), "utf8");
-      t.is(content.trim(), "hi");
-    } finally {
-      process.chdir(prevCwd);
-    }
+    const cfg = {
+      pipelines: [
+        {
+          name: "demo",
+          steps: [
+            {
+              id: "write",
+              cwd: ".",
+              deps: [],
+              inputs: [],
+              outputs: ["nested/out.txt"],
+              inputSchema: SCHEMA,
+              outputSchema: SCHEMA,
+              shell: "echo hi > nested/out.txt",
+            },
+          ],
+        },
+      ],
+    };
+    const pipelinesPath = path.join(dir, "pipelines.json");
+    await fs.writeFile(pipelinesPath, JSON.stringify(cfg, null, 2), "utf8");
+    const res = await runPipeline(pipelinesPath, "demo", { concurrency: 1 });
+    const step = res[0]!;
+    t.is(step.exitCode, 0);
+    const content = await fs.readFile(
+      path.join(dir, "nested", "out.txt"),
+      "utf8",
+    );
+    t.is(content.trim(), "hi");
   });
 });


### PR DESCRIPTION
## Summary
- stop mutating process.cwd() in the output directory test so it can run inside worker threads
- use promise.finally for tmp directory cleanup to satisfy eslint's functional style rule
- add a changelog entry describing the test fix

## Testing
- pnpm exec eslint packages/piper/src/tests/output-dir.test.ts
- pnpm exec ava dist/tests/output-dir.test.js --match "runPipeline creates output directories"


------
https://chatgpt.com/codex/tasks/task_e_68d8789156b083248ce66aa174d6e3b8