### PR TITLE
Fix fixture root resolution for smartgpt-bridge tests

### DIFF
--- a/changelog.d/2025.09.28.00.10.12.md
+++ b/changelog.d/2025.09.28.00.10.12.md
@@ -1,0 +1,1 @@
+- Fix smartgpt-bridge test harness resolving fixture root when executed from dist builds.


### PR DESCRIPTION
## Summary
- resolve the smartgpt-bridge test server root by falling back to the package fixtures directory when the provided path is missing
- record the change in the changelog

## Testing
- pnpm --filter @promethean/smartgpt-bridge test -- --match 'auth static token blocks/permits access'


------
https://chatgpt.com/codex/tasks/task_e_68d878ab99d88324b9ed7952f21bc01a