### PR TITLE
Fix smartgpt-bridge viewFile fixture resolution

### DIFF
--- a/changelog.d/2025.09.28.00.03.33.md
+++ b/changelog.d/2025.09.28.00.03.33.md
@@ -1,0 +1,1 @@
+- Fix smartgpt-bridge file viewing tests by resolving fixtures relative to the test file instead of process cwd.

--- a/packages/smartgpt-bridge/src/tests/unit/files.test.ts
+++ b/packages/smartgpt-bridge/src/tests/unit/files.test.ts
@@ -1,10 +1,14 @@
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 
 import test from "ava";
 
 import { viewFile, resolvePath } from "../../files.js";
 
-const ROOT = path.join(process.cwd(), "tests", "fixtures");
+const ROOT = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../../../tests/fixtures",
+);
 
 test("viewFile: returns correct window around line", async (t) => {
   const out = await viewFile(ROOT, "readme.md", 3, 2);


### PR DESCRIPTION
## Summary
- resolve smartgpt-bridge unit test fixtures relative to the test file so they work from dist builds
- document the fix in the changelog

## Testing
- pnpm --filter @promethean/smartgpt-bridge test


------
https://chatgpt.com/codex/tasks/task_e_68d878bfb83c83248af09fabeaa56e45