### PR TITLE
Add markdown fixture for SmartGPT bridge grep test

### DIFF
--- a/changelog.d/2025.09.28.00.13.07.md
+++ b/changelog.d/2025.09.28.00.13.07.md
@@ -1,0 +1,2 @@
+## Fixed
+- Added a markdown fixture so SmartGPT bridge grep tests have searchable content when limiting matches.

--- a/tests/fixtures/sample.md
+++ b/tests/fixtures/sample.md
@@ -1,0 +1,3 @@
+# Fixture Document
+
+This file ensures the grep tests have at least one markdown target.


### PR DESCRIPTION
## Summary
- add a markdown fixture under tests/fixtures so the SmartGPT bridge grep test has searchable content
- document the change in the changelog

## Testing
- pnpm --filter @promethean/smartgpt-bridge test -- --match "grep: maxMatches limits results"

------
https://chatgpt.com/codex/tasks/task_e_68d878c66cf883248dfa0b1b14aa7585