### PR TITLE
Fix fixture path resolution for smartgpt-bridge tests

### DIFF
--- a/changelog.d/2024.10.27.12.00.00.md
+++ b/changelog.d/2024.10.27.12.00.00.md
@@ -1,0 +1,1 @@
+- Fix smartgpt-bridge integration tests by resolving fixtures path via `import.meta.url`.

--- a/packages/smartgpt-bridge/src/tests/integration/server.v1.routes.test.ts
+++ b/packages/smartgpt-bridge/src/tests/integration/server.v1.routes.test.ts
@@ -1,10 +1,10 @@
-import path from "node:path";
+import { fileURLToPath } from "node:url";
 
 import test from "ava";
 
 import { withServer } from "../helpers/server.js";
 
-const ROOT = path.join(process.cwd(), "tests", "fixtures");
+const ROOT = fileURLToPath(new URL("../../../tests/fixtures", import.meta.url));
 
 test("GET /v1/files/ returns flat file list", async (t) => {
   await withServer(ROOT, async (req) => {


### PR DESCRIPTION
## Summary
- resolve the smartgpt-bridge integration test fixtures path via `import.meta.url`
- note the fix in the changelog stream

## Testing
- pnpm --filter @promethean/smartgpt-bridge test -- --match "GET /v1/files/readme.md returns file snippet"

------
https://chatgpt.com/codex/tasks/task_e_68d878cb21008324867d7acb7fad1bc8