### PR TITLE
fix: stabilize smartgpt-bridge symbols snapshot

### DIFF
--- a/changelog.d/2024.09.28.00.24.00.md
+++ b/changelog.d/2024.09.28.00.24.00.md
@@ -1,0 +1,1 @@
+- Improve smartgpt-bridge symbol indexing to build local snapshots and expose them via `symbolsIndex`, preventing concurrent scans from clobbering results and updating unit tests to assert against the returned snapshot.

--- a/packages/smartgpt-bridge/src/tests/unit/symbols.util.test.ts
+++ b/packages/smartgpt-bridge/src/tests/unit/symbols.util.test.ts
@@ -11,7 +11,10 @@ test.serial(
   async (t) => {
     const info = await symbolsIndex(ROOT, { paths: ["**/*.ts"] });
     t.true(info.files >= 1);
-    const res = await symbolsFind("Greeter", { kind: "class" });
+    const res = await symbolsFind("Greeter", {
+      kind: "class",
+      snapshot: info.snapshot,
+    });
     t.true(
       res.some((r) => r.name === "Greeter" && r.path.endsWith("hello.ts")),
     );
@@ -19,8 +22,11 @@ test.serial(
 );
 
 test.serial("symbols: tolerates broken TS file without crashing", async (t) => {
-  await symbolsIndex(ROOT, { paths: ["broken.ts"] });
-  const res = await symbolsFind("Broken", { kind: "class" });
+  const info = await symbolsIndex(ROOT, { paths: ["broken.ts"] });
+  const res = await symbolsFind("Broken", {
+    kind: "class",
+    snapshot: info.snapshot,
+  });
   // May or may not be found, but should not throw and returns array
   t.true(Array.isArray(res));
 });


### PR DESCRIPTION
## Summary
- add a reusable `SymbolsSnapshot` so `symbolsIndex` builds a local snapshot and `symbolsFind` can search the same dataset without race conditions
- update the symbols utility tests to assert against the indexed snapshot for determinism
- note the snapshot-based indexing change in the changelog

## Testing
- pnpm exec eslint packages/smartgpt-bridge/src/symbols.ts packages/smartgpt-bridge/src/tests/unit/symbols.util.test.ts
- pnpm --filter @promethean/smartgpt-bridge test

------
https://chatgpt.com/codex/tasks/task_e_68d878405e44832498f513b5882eed61