### PR TITLE
Fix smartgpt-bridge tests to use stable fixture roots

### DIFF
--- a/changelog.d/2025.09.28.00.19.21.md
+++ b/changelog.d/2025.09.28.00.19.21.md
@@ -1,0 +1,2 @@
+## Fixed
+- SmartGPT bridge tests now resolve fixture paths relative to the compiled test files and assert stacktrace results with explicit guards to avoid flaky failures.

--- a/packages/smartgpt-bridge/src/tests/unit/files.more.test.ts
+++ b/packages/smartgpt-bridge/src/tests/unit/files.more.test.ts
@@ -1,4 +1,5 @@
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 
 import test from "ava";
 
@@ -9,31 +10,56 @@ import {
   normalizeToRoot,
 } from "../../files.js";
 
-const ROOT = path.join(process.cwd(), "tests", "fixtures");
+const TEST_DIR = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(TEST_DIR, "../../../tests/fixtures");
+
+type StacktraceHit = {
+  resolved: boolean;
+  path?: string;
+};
 
 test("locateStacktrace: Node style with function (nodeB)", async (t) => {
   const p = path.join(ROOT, "hello.ts");
   const trace = `Error at Greeter.greet (${p}:2:5)`;
-  const res = await locateStacktrace(ROOT, trace, 1);
+  const res = (await locateStacktrace(ROOT, trace, 1)) as StacktraceHit[];
   t.true(res.length >= 1);
-  t.true(res[0].resolved);
-  t.is(res[0].path.endsWith("hello.ts"), true);
+  const first = res[0];
+  if (!first) {
+    t.fail("expected stacktrace result");
+    return;
+  }
+  t.true(first.resolved);
+  t.is(Boolean(first.path && first.path.endsWith("hello.ts")), true);
 });
 
 test("locateStacktrace: Python File:line unresolved", async (t) => {
-  const res = await locateStacktrace(
+  const res = (await locateStacktrace(
     ROOT,
     'File "/no/such/file.py", line 12',
     1,
-  );
+  )) as StacktraceHit[];
   t.true(res.length >= 1);
-  t.false(res[0].resolved);
+  const first = res[0];
+  if (!first) {
+    t.fail("expected stacktrace result");
+    return;
+  }
+  t.false(first.resolved);
 });
 
 test("locateStacktrace: Go file:line unresolved", async (t) => {
-  const res = await locateStacktrace(ROOT, "cmd/main.go:45", 1);
+  const res = (await locateStacktrace(
+    ROOT,
+    "cmd/main.go:45",
+    1,
+  )) as StacktraceHit[];
   t.true(res.length >= 1);
-  t.false(res[0].resolved);
+  const first = res[0];
+  if (!first) {
+    t.fail("expected stacktrace result");
+    return;
+  }
+  t.false(first.resolved);
 });
 
 test("resolvePath returns null for non-existent", async (t) => {

--- a/packages/smartgpt-bridge/src/tests/unit/files.test.ts
+++ b/packages/smartgpt-bridge/src/tests/unit/files.test.ts
@@ -1,10 +1,12 @@
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 
 import test from "ava";
 
 import { viewFile, resolvePath } from "../../files.js";
 
-const ROOT = path.join(process.cwd(), "tests", "fixtures");
+const TEST_DIR = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(TEST_DIR, "../../../tests/fixtures");
 
 test("viewFile: returns correct window around line", async (t) => {
   const out = await viewFile(ROOT, "readme.md", 3, 2);


### PR DESCRIPTION
## Summary
- resolve the smartgpt-bridge unit test fixture root relative to the compiled test location to avoid cwd-dependent failures
- tighten stacktrace assertions in files.more.test.ts with typed guards and update formatting to satisfy linting
- document the change in the changelog

## Testing
- pnpm --filter @promethean/smartgpt-bridge test -- --match "resolvePath: fuzzy by basename"
- pnpm --filter @promethean/smartgpt-bridge test -- --match "locateStacktrace: Node style with function (nodeB)"
- pnpm exec eslint packages/smartgpt-bridge/src/tests/unit/files.test.ts packages/smartgpt-bridge/src/tests/unit/files.more.test.ts


------
https://chatgpt.com/codex/tasks/task_e_68d87828fea88324a882e07ba819d880