### PR TITLE
Fix auth integration env restoration

### DIFF
--- a/changelog.d/2025.09.28.00.27.47.md
+++ b/changelog.d/2025.09.28.00.27.47.md
@@ -1,0 +1,3 @@
+## Fixed
+- Added a helper to snapshot and restore environment variables in bridge integration tests to avoid leaking `AUTH_*` state.
+- Updated auth and exec integration tests to use the helper, preventing false negatives from "undefined" env resets.

--- a/packages/smartgpt-bridge/src/tests/helpers/env.ts
+++ b/packages/smartgpt-bridge/src/tests/helpers/env.ts
@@ -1,0 +1,19 @@
+/* eslint-disable functional/immutable-data */
+
+export type EnvSnapshot = Readonly<Record<string, string | undefined>>;
+
+export function captureEnv(keys: readonly string[]): EnvSnapshot {
+  return Object.fromEntries(
+    keys.map((key) => [key, process.env[key]] as const),
+  ) as EnvSnapshot;
+}
+
+export function restoreEnv(snapshot: EnvSnapshot): void {
+  Object.entries(snapshot).forEach(([key, value]) => {
+    if (typeof value === "undefined") {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  });
+}

--- a/packages/smartgpt-bridge/src/tests/integration/auth.static.test.ts
+++ b/packages/smartgpt-bridge/src/tests/integration/auth.static.test.ts
@@ -1,29 +1,33 @@
+/* eslint-disable functional/no-try-statements, functional/immutable-data, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access */
+
 import path from "node:path";
 
 import test from "ava";
 
 import { withServer } from "../helpers/server.js";
+import { captureEnv, restoreEnv } from "../helpers/env.js";
 
 const ROOT = path.join(process.cwd(), "tests", "fixtures");
 
 test.serial("auth disabled by default allows access", async (t) => {
   t.timeout(180000);
-  delete process.env.AUTH_ENABLED;
-  await withServer(ROOT, async (req) => {
-    const res = await req
-      .get("/v0/files/view")
-      .query({ path: "readme.md", line: 1, context: 1 })
-      .expect(200);
-    t.true(res.body.ok);
-  });
+  const prev = captureEnv(["AUTH_ENABLED"]);
+  try {
+    delete process.env.AUTH_ENABLED;
+    await withServer(ROOT, async (req) => {
+      const res = await req
+        .get("/v0/files/view")
+        .query({ path: "readme.md", line: 1, context: 1 })
+        .expect(200);
+      t.true(res.body.ok);
+    });
+  } finally {
+    restoreEnv(prev);
+  }
 });
 
 test.serial("auth static token blocks/permits access", async (t) => {
-  const prev = {
-    AUTH_ENABLED: process.env.AUTH_ENABLED,
-    AUTH_MODE: process.env.AUTH_MODE,
-    AUTH_TOKENS: process.env.AUTH_TOKENS,
-  };
+  const prev = captureEnv(["AUTH_ENABLED", "AUTH_MODE", "AUTH_TOKENS"]);
   try {
     t.timeout(180000);
     process.env.AUTH_ENABLED = "true";
@@ -44,8 +48,6 @@ test.serial("auth static token blocks/permits access", async (t) => {
       t.true(ok.body.ok);
     });
   } finally {
-    process.env.AUTH_ENABLED = prev.AUTH_ENABLED;
-    process.env.AUTH_MODE = prev.AUTH_MODE;
-    process.env.AUTH_TOKENS = prev.AUTH_TOKENS;
+    restoreEnv(prev);
   }
 });

--- a/packages/smartgpt-bridge/src/tests/integration/server.exec.cwd.security.test.ts
+++ b/packages/smartgpt-bridge/src/tests/integration/server.exec.cwd.security.test.ts
@@ -1,13 +1,16 @@
+/* eslint-disable functional/no-try-statements, functional/immutable-data, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access */
+
 import path from "node:path";
 
 import test from "ava";
 
 import { withServer } from "../helpers/server.js";
+import { captureEnv, restoreEnv } from "../helpers/env.js";
 
 const ROOT = path.join(process.cwd(), "tests", "fixtures");
 
 test.serial("exec run blocks cwd outside root", async (t) => {
-  const prev = { EXEC_ENABLED: process.env.EXEC_ENABLED };
+  const prev = captureEnv(["EXEC_ENABLED"]);
   try {
     t.timeout(180000);
     process.env.EXEC_ENABLED = "true";
@@ -17,9 +20,9 @@ test.serial("exec run blocks cwd outside root", async (t) => {
         .send({ command: "pwd", cwd: "/" })
         .expect(200);
       t.false(res.body.ok);
-      t.regex(res.body.error || "", /cwd outside root/i);
+      t.regex(String(res.body.error || ""), /cwd outside root/i);
     });
   } finally {
-    process.env.EXEC_ENABLED = prev.EXEC_ENABLED;
+    restoreEnv(prev);
   }
 });

--- a/packages/smartgpt-bridge/src/tests/integration/server.openapi.auth.test.ts
+++ b/packages/smartgpt-bridge/src/tests/integration/server.openapi.auth.test.ts
@@ -1,17 +1,16 @@
+/* eslint-disable functional/no-try-statements, functional/immutable-data, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access */
+
 import path from "node:path";
 
 import test from "ava";
 
 import { withServer } from "../helpers/server.js";
+import { captureEnv, restoreEnv } from "../helpers/env.js";
 
 const ROOT = path.join(process.cwd(), "tests", "fixtures");
 
 test.serial("openapi shows bearer security when auth enabled", async (t) => {
-  const prev = {
-    AUTH_ENABLED: process.env.AUTH_ENABLED,
-    AUTH_MODE: process.env.AUTH_MODE,
-    OPENAPI_PUBLIC: process.env.OPENAPI_PUBLIC,
-  };
+  const prev = captureEnv(["AUTH_ENABLED", "AUTH_MODE", "OPENAPI_PUBLIC"]);
   process.env.AUTH_ENABLED = "true";
   process.env.AUTH_MODE = "static";
   process.env.OPENAPI_PUBLIC = "true";
@@ -24,17 +23,12 @@ test.serial("openapi shows bearer security when auth enabled", async (t) => {
       t.deepEqual(res.body.security, [{ bearerAuth: [] }]);
     });
   } finally {
-    process.env.AUTH_ENABLED = prev.AUTH_ENABLED;
-    process.env.AUTH_MODE = prev.AUTH_MODE;
-    process.env.OPENAPI_PUBLIC = prev.OPENAPI_PUBLIC;
+    restoreEnv(prev);
   }
 });
 
 test.serial("/auth/me requires valid token when enabled", async (t) => {
-  const prev = {
-    AUTH_ENABLED: process.env.AUTH_ENABLED,
-    AUTH_MODE: process.env.AUTH_MODE,
-  };
+  const prev = captureEnv(["AUTH_ENABLED", "AUTH_MODE"]);
   process.env.AUTH_ENABLED = "true";
   process.env.AUTH_MODE = "static";
   try {
@@ -48,7 +42,6 @@ test.serial("/auth/me requires valid token when enabled", async (t) => {
       t.false(res.body.ok);
     });
   } finally {
-    process.env.AUTH_ENABLED = prev.AUTH_ENABLED;
-    process.env.AUTH_MODE = prev.AUTH_MODE;
+    restoreEnv(prev);
   }
 });


### PR DESCRIPTION
## Summary
- add a reusable helper to snapshot and restore env vars for smartgpt-bridge integration tests
- update auth-related integration specs to use the helper and coerce regex inputs to strings for eslint
- document the fix in the changelog entry for the bridge package

## Testing
- pnpm exec eslint packages/smartgpt-bridge/src/tests/helpers/env.ts packages/smartgpt-bridge/src/tests/integration/auth.static.test.ts packages/smartgpt-bridge/src/tests/integration/server.exec.auth.test.ts packages/smartgpt-bridge/src/tests/integration/server.exec.cwd.security.test.ts packages/smartgpt-bridge/src/tests/integration/server.openapi.auth.test.ts
- pnpm --filter smartgpt-bridge test -- --match "auth static token blocks/permits access"
- pnpm --filter smartgpt-bridge test -- --match "exec requires auth when enabled and allows with token"
- pnpm --filter smartgpt-bridge test -- --match "exec run blocks cwd outside root"
- pnpm --filter smartgpt-bridge test -- --match "openapi shows bearer security when auth enabled"
- pnpm --filter smartgpt-bridge test -- --match "/auth/me requires valid token when enabled"

------
https://chatgpt.com/codex/tasks/task_e_68d877f81bd08324be9315c17650f6bc