### PR TITLE
Fix Piper dev UI tests to locate package dist path

### DIFF
--- a/packages/piper/src/tests/frontend/devui.runjs.args.test.ts
+++ b/packages/piper/src/tests/frontend/devui.runjs.args.test.ts
@@ -1,10 +1,16 @@
 import * as path from "node:path";
+import { fileURLToPath } from "node:url";
 import { promises as fs } from "node:fs";
 
 import test from "ava";
 import { startProcessWithPort, shutdown } from "@promethean/test-utils";
 
-const PKG_ROOT = process.cwd();
+const PKG_ROOT = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "..",
+  "..",
+);
 
 const SCHEMA = "schema-empty.json";
 

--- a/packages/piper/src/tests/frontend/filetree.lazy-cache.test.ts
+++ b/packages/piper/src/tests/frontend/filetree.lazy-cache.test.ts
@@ -1,4 +1,5 @@
 import * as path from "node:path";
+import { fileURLToPath } from "node:url";
 import { promises as fs } from "node:fs";
 
 import test from "ava";
@@ -10,7 +11,12 @@ import {
 } from "@promethean/test-utils";
 import type { Route, Response } from "playwright";
 
-const PKG_ROOT = process.cwd();
+const PKG_ROOT = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "..",
+  "..",
+);
 
 async function write(p: string, s: string) {
   await fs.mkdir(path.dirname(p), { recursive: true });


### PR DESCRIPTION
## Summary
- resolve the Piper dev UI frontend tests' package root from import.meta.url so the dist/dev-ui.js executable is found when run from the repo root

## Testing
- pnpm --filter @promethean/piper test -- --match "file-tree lazy loads and caches directory contents"

------
https://chatgpt.com/codex/tasks/task_e_68d877ec8a6883248e501a25f9db8dab