### PR TITLE
fix: handle agent stream validation in smartgpt bridge

### DIFF
--- a/packages/smartgpt-bridge/src/routes/v0/agent.ts
+++ b/packages/smartgpt-bridge/src/routes/v0/agent.ts
@@ -316,9 +316,11 @@ export function registerAgentRoutes(fastify: any) {
       },
       response: { 200: { type: "string" } },
     },
+    attachValidation: true,
     handler: async (req: any, reply: any) => {
       const id = String(req.query?.id || "");
-      if (!id) return reply.code(400).send();
+      if ((req as any).validationError || !id)
+        return reply.code(400).send({ ok: false, error: "id is required" });
       reply.raw.writeHead(200, {
         "Content-Type": "text/event-stream",
         "Cache-Control": "no-cache",


### PR DESCRIPTION
## Summary
- guard the /v0/agent/stream endpoint with attachValidation so the handler controls missing id responses
- return a structured 400 response when id is absent to avoid fastify validation errors bubbling into logs

## Testing
- pnpm --filter @promethean/smartgpt-bridge test

------
https://chatgpt.com/codex/tasks/task_e_68d893e2c21483248ff3f8e281c6e4ca