### PR TITLE
feat(mcp): generate session ids without uuid

### DIFF
--- a/changelog.d/2025.09.28.02.03.27.md
+++ b/changelog.d/2025.09.28.02.03.27.md
@@ -1,0 +1,1 @@
+- ensure the MCP fastify transport generates session ids without requiring the uuid package and cover the fallback logic with tests

--- a/packages/mcp/src/core/transports/fastify.ts
+++ b/packages/mcp/src/core/transports/fastify.ts
@@ -4,6 +4,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import { isInitializeRequest } from "@modelcontextprotocol/sdk/types.js";
 import crypto from "node:crypto";
+import { createSessionIdGenerator } from "./session-id.js";
 
 type ServerEntries = ReadonlyArray<readonly [string, McpServer]>;
 
@@ -84,7 +85,7 @@ const createRouteHandler = (
 
         const t: StreamableHTTPServerTransport =
           new StreamableHTTPServerTransport({
-            sessionIdGenerator: crypto.randomUUID?.bind(crypto),
+            sessionIdGenerator: createSessionIdGenerator(crypto),
             onsessioninitialized: (sid: string): void => {
               sessions.set(sid, self);
             },

--- a/packages/mcp/src/core/transports/session-id.ts
+++ b/packages/mcp/src/core/transports/session-id.ts
@@ -1,0 +1,49 @@
+import type crypto from "node:crypto";
+
+type CryptoModule = Readonly<Pick<typeof crypto, "randomUUID" | "randomBytes">>;
+
+type RandomUuid = () => string;
+
+type SessionIdGenerator = () => string;
+
+const toUuidString = (bytes: readonly number[]): string => {
+  const hex = Buffer.from(bytes).toString("hex");
+  const sections = [
+    hex.slice(0, 8),
+    hex.slice(8, 12),
+    hex.slice(12, 16),
+    hex.slice(16, 20),
+    hex.slice(20),
+  ];
+  return sections.join("-");
+};
+
+const fallbackGenerator = (
+  randomBytes: CryptoModule["randomBytes"],
+): SessionIdGenerator => {
+  return () => {
+    const values = Array.from(randomBytes(16), (value, index) => {
+      if (index === 6) {
+        return ((value ?? 0) & 0x0f) | 0x40;
+      }
+      if (index === 8) {
+        return ((value ?? 0) & 0x3f) | 0x80;
+      }
+      return value ?? 0;
+    });
+
+    return toUuidString(values);
+  };
+};
+
+export const createSessionIdGenerator = (
+  cryptoModule: CryptoModule,
+): SessionIdGenerator => {
+  const { randomUUID } = cryptoModule;
+  if (typeof randomUUID === "function") {
+    const generator: RandomUuid = randomUUID.bind(cryptoModule);
+    return () => generator();
+  }
+
+  return fallbackGenerator(cryptoModule.randomBytes.bind(cryptoModule));
+};

--- a/packages/mcp/src/tests/fastify.test.ts
+++ b/packages/mcp/src/tests/fastify.test.ts
@@ -1,0 +1,36 @@
+import type crypto from "node:crypto";
+
+import test from "ava";
+
+import { createSessionIdGenerator } from "../core/transports/session-id.js";
+
+test("createSessionIdGenerator uses randomUUID when provided", (t) => {
+  const generator = createSessionIdGenerator({
+    randomUUID: () => "uuid-from-randomUUID",
+    randomBytes: () => {
+      throw new Error(
+        "randomBytes should not be called when randomUUID exists",
+      );
+    },
+  } as unknown as Pick<typeof crypto, "randomUUID" | "randomBytes">);
+
+  t.is(generator(), "uuid-from-randomUUID");
+});
+
+test("createSessionIdGenerator falls back to RFC4122 v4 format", (t) => {
+  const bytes = Buffer.from([
+    0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb,
+    0xcc, 0xdd, 0xee, 0xff,
+  ]);
+
+  const generator = createSessionIdGenerator({
+    randomUUID: undefined,
+    randomBytes: () => Buffer.from(bytes),
+  } as unknown as Pick<typeof crypto, "randomUUID" | "randomBytes">);
+
+  const id = generator();
+  t.regex(
+    id,
+    /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/,
+  );
+});


### PR DESCRIPTION
## Summary
- add a crypto-backed session ID generator with a UUID v4 fallback
- update the fastify transport to use the internal generator instead of relying on the uuid package
- add focused tests for the generator behaviour and document the change in the changelog

## Testing
- pnpm --filter @promethean/mcp test
- pnpm exec eslint packages/mcp/src/core/transports/session-id.ts packages/mcp/src/tests/fastify.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d8940998388324aa5ad1a05c12790a