### PR TITLE
Fix heartbeat metrics logging and stabilize tests

### DIFF
--- a/changelog.d/2025.09.28.02.02.01.md
+++ b/changelog.d/2025.09.28.02.02.01.md
@@ -1,0 +1,4 @@
+## Summary
+- silence missing-process metric warnings in the heartbeat service while keeping network stats optional
+- tighten heartbeat integration tests to use shared sleep helpers and longer timeouts for instance throttling
+- port markdown-graph tests to JS with teardown cleanup so builds exit reliably

--- a/packages/heartbeat/tests/heartbeat.integration.test.js
+++ b/packages/heartbeat/tests/heartbeat.integration.test.js
@@ -5,6 +5,7 @@ import { spawn } from "child_process";
 import path from "path";
 import { fileURLToPath } from "url";
 import { BrokerClient } from "@promethean/legacy/brokerClient.js";
+import { sleep } from "@promethean/utils";
 import { start, stop } from "../index.js";
 
 let pers;
@@ -17,7 +18,7 @@ if (process.env.SKIP_NETWORK_TESTS === "1") {
     const bc = new BrokerClient({ url: process.env.BROKER_URL });
     await bc.connect();
     bc.publish("heartbeat", { pid, name });
-    await new Promise((r) => setTimeout(r, 50));
+    await sleep(20);
     bc.disconnect();
     for (let i = 0; i < 10; i++) {
       const doc = await pers.mongo
@@ -27,7 +28,7 @@ if (process.env.SKIP_NETWORK_TESTS === "1") {
         .toArray()
         .then((d) => d.find((x) => x.pid === pid));
       if (doc) break;
-      await new Promise((r) => setTimeout(r, 50));
+      await sleep(20);
     }
   }
 
@@ -38,7 +39,7 @@ if (process.env.SKIP_NETWORK_TESTS === "1") {
       "../fixtures/ecosystem.fixture.config.cjs",
     );
     pers = installInMemoryPersistence();
-    process.env.HEARTBEAT_TIMEOUT = "100";
+    process.env.HEARTBEAT_TIMEOUT = "500";
     process.env.CHECK_INTERVAL = "50";
     process.env.BROKER_URL = "memory://hb";
     await start();
@@ -59,7 +60,7 @@ if (process.env.SKIP_NETWORK_TESTS === "1") {
       }
     });
     await publish(child.pid, "kill-app");
-    await new Promise((r) => setTimeout(r, 500));
+    await sleep(500);
     const doc = (
       await pers.mongo
         .db("heartbeat_db")


### PR DESCRIPTION
## Summary
- ignore missing-process failures when collecting heartbeat metrics and skip network polling if the pid has exited
- refresh heartbeat integration tests to use shared sleep helpers and a longer timeout so throttling assertions are stable
- move the markdown-graph tests to JavaScript with teardown cleanup to avoid hanging builds

## Testing
- pnpm --filter heartbeat-service test
- pnpm --filter @promethean/markdown-graph test

------
https://chatgpt.com/codex/tasks/task_e_68d89419843483249937907b1715dc18