### PR TITLE
Stabilize indexer incremental integration test cleanup

### DIFF
--- a/changelog.d/2025.09.28.02.16.54.md
+++ b/changelog.d/2025.09.28.02.16.54.md
@@ -1,0 +1,2 @@
+## Summary
+- Hardened the indexer incremental integration test setup/teardown to clean temporary bootstrap state and fixture directories.


### PR DESCRIPTION
## Summary
- ensure the incremental indexer integration test resets its temporary root before bootstrapping
- clear cached bootstrap state during teardown to avoid stale cursors between runs
- log the stabilization work in the changelog

## Testing
- pnpm --filter @promethean/smartgpt-bridge exec ava --config ava.config.mjs dist/tests/integration/indexer.incremental.test.js --serial

------
https://chatgpt.com/codex/tasks/task_e_68d895940cb48324b4763f91ad03b89b