### PR TITLE
Fix SmartGPT bridge test teardown caching

### DIFF
--- a/changelog.d/2025.09.28.04.20.md
+++ b/changelog.d/2025.09.28.04.20.md
@@ -1,0 +1,4 @@
+## @promethean/smartgpt-bridge
+- Reset the smartgpt bridge test server helper to restore Mongo env vars and
+  clear cached persistence clients so integration tests no longer hang after
+  teardown.

--- a/docs/agile/tasks/fix-smartgpt-bridge-tests.md
+++ b/docs/agile/tasks/fix-smartgpt-bridge-tests.md
@@ -1,0 +1,68 @@
+---
+task-id: TASK-20250928-041600
+title: Fix hanging SmartGPT bridge tests
+state: InProgress
+prev:
+txn: "2025-09-28T04:16:00Z-1a2b"
+owner: err
+priority: p2
+size: s
+epic: EPC-000
+depends_on: []
+labels:
+  - board:auto
+  - lang:ts
+due:
+links: []
+artifacts: []
+rationale: >-
+  SmartGPT bridge integration tests intermittently hang because the in-memory
+  Mongo client from prior runs stays cached after teardown, leaving later
+  suites talking to a closed connection. Restoring clean teardown should
+  stabilize the suite.
+proposed_transitions:
+  - New->Accepted
+  - Accepted->Breakdown
+  - Breakdown->Ready
+  - Ready->Todo
+  - Todo->InProgress
+  - InProgress->InReview
+  - InReview->Document
+  - Document->Done
+  - InReview->InProgress
+  - InProgress->Todo
+tags:
+  - task/TASK-20250928-041600
+  - board/kanban
+  - state/InProgress
+  - owner/err
+  - priority/p2
+  - epic/EPC-000
+---
+
+## Context
+
+### Changes and Updates
+- **What changed?**: Integration tests for `@promethean/smartgpt-bridge` now stall after
+  a Mongo-backed suite because cached clients point at a torn-down
+  `MongoMemoryServer` instance.
+- **Where?**: `packages/smartgpt-bridge/src/tests/helpers/server.ts`.
+- **Why now?**: Latest CI run showed the suite hanging; stabilizing tests is
+  prerequisite for further bridge work.
+
+### Inputs / Artifacts
+- `packages/smartgpt-bridge/src/tests/helpers/server.ts`
+- `packages/persistence/src/clients.ts`
+
+## Definition of Done
+- [ ] SmartGPT bridge tests finish without hanging locally.
+- [ ] Helper resets cached persistence clients during teardown.
+- [ ] Added regression coverage (implicit via existing tests) and changelog
+      entry.
+- [ ] PR merged.
+
+## Plan
+1. Audit `withServer` teardown and persistence client cache behaviour.
+2. Reset cached Mongo/Chroma clients and restore env vars after each test run.
+3. Run `pnpm --filter @promethean/smartgpt-bridge test` to ensure stability.
+4. Document change in `changelog.d` and prepare PR summary.

--- a/packages/smartgpt-bridge/src/tests/helpers/server.ts
+++ b/packages/smartgpt-bridge/src/tests/helpers/server.ts
@@ -129,6 +129,11 @@ export const withServer = async (
   fn: (client: any) => Promise<any>,
 ) => {
   process.env.NODE_ENV = "test";
+  const prevEnv = {
+    NODE_PTY_DISABLED: process.env.NODE_PTY_DISABLED,
+    MONGODB_URI: process.env.MONGODB_URI,
+    DUAL_WRITE_ENABLED: process.env.DUAL_WRITE_ENABLED,
+  };
   // Avoid native addon crashes in CI/local when ABI mismatches
   if (!process.env.NODE_PTY_DISABLED) process.env.NODE_PTY_DISABLED = "1";
   // Skip Mongo unless explicitly requested via MONGODB_URI=memory
@@ -231,14 +236,29 @@ export const withServer = async (
     await app.close();
     if (mms) await mms.stop();
     const mongoUri = String(process.env.MONGODB_URI || "");
+    let persistenceClients:
+      | typeof import("@promethean/persistence/clients.js")
+      | undefined;
     if (mongoUri && mongoUri !== "disabled") {
       try {
-        const { getMongoClient } = await import(
-          "@promethean/persistence/clients.js"
-        );
-        const mongo = await getMongoClient();
+        persistenceClients = await import("@promethean/persistence/clients.js");
+        const mongo = await persistenceClients.getMongoClient();
         await mongo.close();
       } catch {}
     }
+    try {
+      (
+        persistenceClients ||
+        (await import("@promethean/persistence/clients.js"))
+      ).__resetPersistenceClientsForTests?.();
+    } catch {}
+    if (prevEnv.MONGODB_URI === undefined) delete process.env.MONGODB_URI;
+    else process.env.MONGODB_URI = prevEnv.MONGODB_URI;
+    if (prevEnv.DUAL_WRITE_ENABLED === undefined)
+      delete process.env.DUAL_WRITE_ENABLED;
+    else process.env.DUAL_WRITE_ENABLED = prevEnv.DUAL_WRITE_ENABLED;
+    if (prevEnv.NODE_PTY_DISABLED === undefined)
+      delete process.env.NODE_PTY_DISABLED;
+    else process.env.NODE_PTY_DISABLED = prevEnv.NODE_PTY_DISABLED;
   }
 };


### PR DESCRIPTION
## Summary
- preserve and restore environment overrides in the smartgpt-bridge test helper
- close and reset cached persistence clients so later tests no longer hang
- log the work in changelog.d and add the coordinating agile task note

## Testing
- pnpm --filter @promethean/smartgpt-bridge test

------
https://chatgpt.com/codex/tasks/task_e_68d8b34f03b083249389bb38726de06b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Tests
  - Improved test stability by resetting persistence clients between runs and restoring key environment variables after execution, preventing hangs and lingering connections.
- Documentation
  - Added a task document outlining the issue with hanging tests, the rationale, and the remediation plan for future reference.
- Chores
  - Updated the changelog to record the test stability improvements for the SmartGPT bridge package.

No user-facing changes; these updates enhance reliability and maintainability of the test suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->