### PR TITLE
Disable Nx Cloud integration to prevent cache retrieval crash

### DIFF
--- a/changelog.d/2025.09.28.13.45.00.md
+++ b/changelog.d/2025.09.28.13.45.00.md
@@ -1,0 +1,2 @@
+### Fixed
+- disable Nx Cloud integration to prevent `cacheError` retrieval crashes when running workspace tasks.

--- a/nx.json
+++ b/nx.json
@@ -30,6 +30,5 @@
     "portfolio-frontend": "packages/portfolio-frontend",
     "smart-chat-frontend": "packages/smart-chat-frontend",
     "smartgpt-dashboard-frontend": "packages/smartgpt-dashboard-frontend"
-  },
-  "nxCloudId": "68d96f4023ed6608f31dc1d6"
+  }
 }


### PR DESCRIPTION
## Summary
- remove the workspace's Nx Cloud identifier so tasks no longer attempt to download the remote cache bundle that crashes when `cacheError` is missing
- document the fix in the changelog fragments directory

## Testing
- pnpm exec nx list

------
https://chatgpt.com/codex/tasks/task_e_68d97492a5748324bc0ff723ca3c46bf