### PR TITLE
Serialize Piper cache writes to avoid race conditions

### DIFF
--- a/changelog.d/2025.09.28.19.42.24.md
+++ b/changelog.d/2025.09.28.19.42.24.md
@@ -1,0 +1,1 @@
+- Ensure Piper pipeline state writes are serialized to avoid lost cache entries when multiple steps finish together.


### PR DESCRIPTION
## Summary
- serialize Piper state persistence so concurrent steps queue Level cache writes instead of racing
- document the change in the changelog rollup

## Testing
- pnpm nx test @promethean/piper --skip-nx-cache

------
https://chatgpt.com/codex/tasks/task_e_68d9899448448324beb7637f556c845b