### PR TITLE
Allow AVA config to run JS tests without dist requirement

### DIFF
--- a/changelog.d/2025.09.28.20.06.54.md
+++ b/changelog.d/2025.09.28.20.06.54.md
@@ -1,0 +1,2 @@
+## Fixed
+- Allow AVA config to run JavaScript-based tests without requiring precompiled dist outputs so legacy package tests succeed.


### PR DESCRIPTION
## Summary
- teach the shared AVA config to treat on-disk JavaScript tests as already compiled so they can run without dist outputs
- document the change in the changelog

## Testing
- pnpm nx run @promethean/legacy:test
- pnpm exec eslint config/ava.config.mjs

------
https://chatgpt.com/codex/tasks/task_e_68d993edca048324a70d988f78ec2895