### PR TITLE
fix: load cephalon ava config in nx tests

### DIFF
--- a/changelog.d/2025.09.28.20.09.17.md
+++ b/changelog.d/2025.09.28.20.09.17.md
@@ -1,0 +1,1 @@
+- ensure `@promethean/cephalon` AVA runs via workspace config so `nx run ...:test` loads compiled dist tests

--- a/packages/cephalon/ava.config.mjs
+++ b/packages/cephalon/ava.config.mjs
@@ -1,0 +1,1 @@
+export { default } from "../../config/ava.config.mjs";


### PR DESCRIPTION
## Summary
- add a package-scoped AVA config so the cephalon tests reuse the workspace defaults when run via Nx
- record the change in the running changelog entry

## Testing
- pnpm nx run @promethean/cephalon:test

------
https://chatgpt.com/codex/tasks/task_e_68d993f805e88324958f82738d87956f