### PR TITLE
fix monitoring tests for ava dist lookup

### DIFF
--- a/changelog.d/2025.09.28.20.13.41.md
+++ b/changelog.d/2025.09.28.20.13.41.md
@@ -1,0 +1,1 @@
+- migrate @promethean/monitoring tests to TypeScript so ava uses dist outputs

--- a/packages/monitoring/ava.config.mjs
+++ b/packages/monitoring/ava.config.mjs
@@ -1,2 +1,1 @@
-import base from "../../config/ava.config.mjs";
-export default { ...base, files: ["tests/**/*.test.js"] };
+export { default } from "../../config/ava.config.mjs";

--- a/packages/monitoring/package.json
+++ b/packages/monitoring/package.json
@@ -21,9 +21,9 @@
     "build": "tsc",
     "clean": "rimraf dist",
     "typecheck": "tsc -p tsconfig.json --noEmit",
-    "test": "pnpm run build && ava tests/**/*.test.js",
+    "test": "pnpm run build && ava --config ../../config/ava.config.mjs",
     "lint": "pnpm exec eslint .",
-    "coverage": "pnpm run build && c8 ava tests/**/*.test.js",
+    "coverage": "pnpm run build && c8 ava --config ../../config/ava.config.mjs",
     "format": "pnpm exec prettier --write ."
   },
   "module": "dist/index.js",

--- a/packages/monitoring/src/tests/limiter.test.ts
+++ b/packages/monitoring/src/tests/limiter.test.ts
@@ -1,17 +1,24 @@
 import test from "ava";
 
-import { TokenBucket } from "../dist/limiter.js";
+import { TokenBucket } from "../limiter.js";
 
-const createClock = () => {
+type FakeClock = Readonly<{
+  now: () => number;
+  advance: (ms: number) => number;
+}>;
+
+/* eslint-disable functional/no-let */
+const createClock = (): FakeClock => {
   let now = 0;
   return {
     now: () => now,
-    advance: (ms) => {
+    advance: (ms: number) => {
       now += ms;
       return now;
     },
   };
 };
+/* eslint-enable functional/no-let */
 
 // ensure TokenBucket enforces capacity and returns deficit
 test("TokenBucket enforces capacity", (t) => {


### PR DESCRIPTION
## Summary
- move the monitoring limiter tests into `src/tests` as TypeScript so they compile into `dist/tests`
- drop the package-specific AVA glob override and align scripts with the shared AVA config
- add a changelog entry documenting the monitoring test migration

## Testing
- pnpm nx run @promethean/monitoring:test

------
https://chatgpt.com/codex/tasks/task_e_68d993f19260832489011d62a15969a5