### PR TITLE
fix(piper): isolate pipeline cache namespaces

### DIFF
--- a/changelog.d/2025.09.28.20.16.00.md
+++ b/changelog.d/2025.09.28.20.16.00.md
@@ -1,0 +1,1 @@
+- Fix Piper caching to key pipeline state by config path, preventing cross-run interference.

--- a/packages/piper/src/status.ts
+++ b/packages/piper/src/status.ts
@@ -3,7 +3,7 @@ import { promises as fs } from "fs";
 
 import { FileSchema, PiperFile } from "./types.js";
 import { fingerprintFromGlobs } from "./hash.js";
-import { loadState } from "./lib/state.js";
+import { loadState, makePipelineNamespace } from "./lib/state.js";
 import { listOutputsExist } from "./fsutils.js";
 
 async function readConfig(p: string): Promise<PiperFile> {
@@ -19,7 +19,8 @@ export async function showStatus(configPath: string, pipelineName: string) {
   const cfg = await readConfig(configPath);
   const pipeline = cfg.pipelines.find((p) => p.name === pipelineName);
   if (!pipeline) throw new Error(`pipeline '${pipelineName}' not found`);
-  const state = await loadState(pipeline.name);
+  const stateKey = makePipelineNamespace(configPath, pipeline.name);
+  const state = await loadState(stateKey);
 
   console.log(`# Pipeline: ${pipeline.name}`);
   console.log("| Step | Cached | Outputs | Note |");


### PR DESCRIPTION
## Summary
- key Piper run-state namespaces by the pipeline config path to avoid collisions between concurrent runs
- update the status reporter to use the new namespace helper and document the change in the changelog

## Testing
- `pnpm nx run @promethean/piper:test`


------
https://chatgpt.com/codex/tasks/task_e_68d993fcfcf48324930a1301e727aecf