### PR TITLE
fix(readmeflow): align fallback license string

### DIFF
--- a/changelog.d/2025.09.28.20.15.57.md
+++ b/changelog.d/2025.09.28.20.15.57.md
@@ -1,0 +1,1 @@
+- fix(readmeflow): align fallback license text with package license

--- a/packages/readmeflow/src/02-outline.ts
+++ b/packages/readmeflow/src/02-outline.ts
@@ -83,7 +83,7 @@ export async function fetchOutline(
         sections: [
           { heading: "Install", body: `pnpm add ${pkg.name}` },
           { heading: "Usage", body: "(coming soon)" },
-          { heading: "License", body: "GPLv3" },
+          { heading: "License", body: "GPL-3.0-only" },
         ],
       };
 

--- a/packages/readmeflow/src/tests/outline.test.ts
+++ b/packages/readmeflow/src/tests/outline.test.ts
@@ -7,7 +7,7 @@ import { openLevelCache } from "@promethean/level-cache";
 import { outline } from "../02-outline.js";
 import type { OutlinesFile } from "../types.js";
 
-test("outline fallback uses GPLv3 license", async (t) => {
+test("outline fallback uses GPL-3.0-only license", async (t) => {
   const cacheDir = path.join(".cache", "readmeflow-outline-test");
   const cache = await openLevelCache({ path: cacheDir });
   await cache.set("scan", {
@@ -34,7 +34,7 @@ test("outline fallback uses GPLv3 license", async (t) => {
   const license = out.outlines["@promethean/example"]?.sections.find(
     (s) => s.heading === "License",
   );
-  t.is(license?.body, "GPLv3");
+  t.is(license?.body, "GPL-3.0-only");
 
   await fs.rm(cacheDir, { recursive: true, force: true });
 });


### PR DESCRIPTION
## Summary
- ensure the readmeflow outline fallback uses the GPL-3.0-only license label
- update the regression test and changelog entry to reflect the new fallback wording

## Testing
- pnpm nx run @promethean/readmeflow:test

------
https://chatgpt.com/codex/tasks/task_e_68d99410de948324b0d3e6def12439c0