### PR TITLE
fix(alias-rewrite): force rebuild before nx tests

### DIFF
--- a/changelog.d/2025.09.28.20.32.43.md
+++ b/changelog.d/2025.09.28.20.32.43.md
@@ -1,0 +1,1 @@
+- Fix `nx run @promethean/alias-rewrite:test` by forcing the package build to re-emit outputs even when incremental metadata exists.

--- a/packages/alias-rewrite/package.json
+++ b/packages/alias-rewrite/package.json
@@ -22,7 +22,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsc -b tsconfig.json",
+    "build": "tsc -b --force tsconfig.json",
     "test": "pnpm run build && ava --config ../../config/ava.config.mjs",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "clean": "rimraf dist tsconfig.tsbuildinfo",

--- a/packages/alias-rewrite/project.json
+++ b/packages/alias-rewrite/project.json
@@ -6,12 +6,10 @@
     "build": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "tsc -b",
+        "command": "tsc -b --force",
         "cwd": "packages/alias-rewrite"
       },
-      "outputs": [
-        "{projectRoot}/dist"
-      ]
+      "outputs": ["{projectRoot}/dist"]
     },
     "typecheck": {
       "executor": "nx:run-commands",
@@ -38,7 +36,5 @@
       }
     }
   },
-  "tags": [
-    "scope:packages"
-  ]
+  "tags": ["scope:packages"]
 }


### PR DESCRIPTION
## Summary
- force @promethean/alias-rewrite builds to re-emit outputs even when incremental metadata exists
- update nx project configuration to run the forced build and document the fix in the changelog

## Testing
- pnpm nx run @promethean/alias-rewrite:test

------
https://chatgpt.com/codex/tasks/task_e_68d994057d64832499c31eb1a09d7736