### PR TITLE
Fix indexer removal path await

### DIFF
--- a/changelog.d/2025.02.14.20.46.00.md
+++ b/changelog.d/2025.02.14.20.46.00.md
@@ -1,0 +1,1 @@
+- fix indexer removal path resolution by awaiting the asynchronous resolver so builds succeed

--- a/packages/indexer-core/src/indexer.ts
+++ b/packages/indexer-core/src/indexer.ts
@@ -335,7 +335,7 @@ export async function removeFileFromIndex(_rootPath: string, rel: string) {
   };
   const col = await collectionForFamily(family, version, cfg);
   try {
-    const { rel: safeRel } = resolveWithinRoot(_rootPath, rel);
+    const { rel: safeRel } = await resolveWithinRoot(_rootPath, rel);
     await col.delete({ where: { path: safeRel } });
     return { ok: true };
   } catch (e: any) {


### PR DESCRIPTION
## Summary
- await the asynchronous path resolver when removing files from the index so the TypeScript build succeeds
- record the fix in the changelog

## Testing
- pnpm exec nx run @promethean/indexer-core:build --skip-nx-cache
- pnpm exec nx run @promethean/piper:test --skip-nx-cache
- pnpm exec eslint packages/indexer-core/src/indexer.ts *(fails: numerous pre-existing lint violations in the file)*

------
https://chatgpt.com/codex/tasks/task_e_68d99a0b544c8324b1e701a1d7b1958a