### PR TITLE
Fix await usage in removeFileFromIndex

### DIFF
--- a/changelog.d/2025.09.28.20.43.39.md
+++ b/changelog.d/2025.09.28.20.43.39.md
@@ -1,0 +1,2 @@
+## Fixed
+- Await path resolution before deleting files from the index to prevent TypeScript build failures.

--- a/packages/indexer-core/src/indexer.ts
+++ b/packages/indexer-core/src/indexer.ts
@@ -335,7 +335,7 @@ export async function removeFileFromIndex(_rootPath: string, rel: string) {
   };
   const col = await collectionForFamily(family, version, cfg);
   try {
-    const { rel: safeRel } = resolveWithinRoot(_rootPath, rel);
+    const { rel: safeRel } = await resolveWithinRoot(_rootPath, rel);
     await col.delete({ where: { path: safeRel } });
     return { ok: true };
   } catch (e: any) {


### PR DESCRIPTION
## Summary
- await the resolveWithinRoot helper when removing files to keep the indexer-core build green
- document the fix in the changelog

## Testing
- pnpm nx run @promethean/indexer-core:build
- pnpm nx run heartbeat-service:test

------
https://chatgpt.com/codex/tasks/task_e_68d99c89ef7883249787a688115afb52