### PR TITLE
fix: avoid implicit mongodb memory usage in tests

### DIFF
--- a/changelog.d/2025.09.28.21.10.00.md
+++ b/changelog.d/2025.09.28.21.10.00.md
@@ -1,0 +1,1 @@
+- prevent test runs from auto-spawning mongodb-memory-server when `MONGODB_URI` is unset, avoiding CI crashes.

--- a/packages/smartgpt-bridge/src/mongo.ts
+++ b/packages/smartgpt-bridge/src/mongo.ts
@@ -10,13 +10,23 @@ export async function initMongo() {
   // In tests, if MONGODB_URI is not provided or explicitly set to 'memory',
   // spin up an in-memory server and connect mongoose to it.
   const isTest = String(process.env.NODE_ENV || "").toLowerCase() === "test";
-  const wantsMemory =
-    !process.env.MONGODB_URI || process.env.MONGODB_URI === "memory";
   let uri = process.env.MONGODB_URI;
+
+  if (!uri && isTest) {
+    // Historical behaviour attempted to start mongodb-memory-server when the
+    // variable was missing. That spawned full mongod instances during test
+    // runs, which easily exhausted memory in CI when multiple packages ran
+    // concurrently. Default to an inert "disabled" marker instead so callers
+    // must opt-in explicitly when they really need a database.
+    uri = "disabled";
+    process.env.MONGODB_URI = uri;
+  }
 
   if (uri && /^disabled$/i.test(uri)) {
     return mongoose;
   }
+
+  const wantsMemory = uri === "memory";
 
   // TODO: No testing logic in business logic
   if (isTest && wantsMemory) {
@@ -28,6 +38,12 @@ export async function initMongo() {
     uri = _memory.uri;
     // expose a usable URI for any downstream that reads process.env
     process.env.MONGODB_URI = uri;
+  }
+
+  if (wantsMemory && !isTest) {
+    throw new Error(
+      "In-memory MongoDB is only supported in tests; set NODE_ENV=test or provide MONGODB_URI",
+    );
   }
 
   if (!uri) throw new Error("No mongo URI provided");


### PR DESCRIPTION
## Summary
- stop `initMongo` from launching `mongodb-memory-server` when `MONGODB_URI` is unset and default tests to a disabled marker instead
- add a changelog entry documenting the change

## Testing
- `pnpm nx test @promethean/smartgpt-bridge --skip-nx-cache`
- `pnpm exec eslint packages/smartgpt-bridge/src/mongo.ts` *(fails: existing functional style violations in mongo.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68d9a0b95fac83249757981cfdede4d8