### PR TITLE
Restore NODE_ENV after SmartGPT Bridge tests

### DIFF
--- a/changelog.d/2025.09.28.21.56.32.md
+++ b/changelog.d/2025.09.28.21.56.32.md
@@ -1,0 +1,1 @@
+- Fix `withServer` test helper so SmartGPT Bridge tests restore the previous `NODE_ENV` after execution, preventing cross-suite pollution.

--- a/packages/smartgpt-bridge/src/tests/helpers/server.ts
+++ b/packages/smartgpt-bridge/src/tests/helpers/server.ts
@@ -167,12 +167,13 @@ export const withServer = async (
   fn: (client: any) => Promise<any>,
 ) => {
   const ROOT_PATH = ensureRootPath(root);
-  process.env.NODE_ENV = "test";
   const prevEnv = {
+    NODE_ENV: process.env.NODE_ENV,
     NODE_PTY_DISABLED: process.env.NODE_PTY_DISABLED,
     MONGODB_URI: process.env.MONGODB_URI,
     DUAL_WRITE_ENABLED: process.env.DUAL_WRITE_ENABLED,
   };
+  process.env.NODE_ENV = "test";
   // Avoid native addon crashes in CI/local when ABI mismatches
   if (!process.env.NODE_PTY_DISABLED) process.env.NODE_PTY_DISABLED = "1";
   // Skip Mongo unless explicitly requested via MONGODB_URI=memory
@@ -299,5 +300,7 @@ export const withServer = async (
     if (prevEnv.NODE_PTY_DISABLED === undefined)
       delete process.env.NODE_PTY_DISABLED;
     else process.env.NODE_PTY_DISABLED = prevEnv.NODE_PTY_DISABLED;
+    if (prevEnv.NODE_ENV === undefined) delete process.env.NODE_ENV;
+    else process.env.NODE_ENV = prevEnv.NODE_ENV;
   }
 };


### PR DESCRIPTION
## Summary
- capture and restore the previous NODE_ENV value in the SmartGPT Bridge test helper so integration suites do not leak environment state
- add a changelog entry documenting the environment restoration fix

## Testing
- pnpm nx test @promethean/smartgpt-bridge --skip-nx-cache


------
https://chatgpt.com/codex/tasks/task_e_68d9aac38e9c8324887a88cdf34f9242