### PR TITLE
fix: run frontend-service build from project root

### DIFF
--- a/changelog.d/2025.09.28.23.18.29.md
+++ b/changelog.d/2025.09.28.23.18.29.md
@@ -1,0 +1,1 @@
+- fix `@promethean/frontend-service` Nx build to run from the package root so compiled tests exist before executing Ava.

--- a/changelog.d/2025.09.28.23.56.03.md
+++ b/changelog.d/2025.09.28.23.56.03.md
@@ -1,0 +1,1 @@
+- fix: add @promethean/web-utils as a TypeScript project reference for the frontend-service build

--- a/packages/frontend-service/project.json
+++ b/packages/frontend-service/project.json
@@ -6,11 +6,10 @@
     "build": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "tsc -b"
+        "command": "tsc -b",
+        "cwd": "{projectRoot}"
       },
-      "outputs": [
-        "{projectRoot}/dist"
-      ]
+      "outputs": ["{projectRoot}/dist"]
     },
     "typecheck": {
       "executor": "nx:run-commands",
@@ -20,9 +19,7 @@
     },
     "test": {
       "executor": "nx:run-commands",
-      "dependsOn": [
-        "build"
-      ],
+      "dependsOn": ["build"],
       "options": {
         "command": "ava",
         "env": {
@@ -38,7 +35,5 @@
       }
     }
   },
-  "tags": [
-    "scope:packages"
-  ]
+  "tags": ["scope:packages"]
 }

--- a/packages/frontend-service/tsconfig.json
+++ b/packages/frontend-service/tsconfig.json
@@ -7,5 +7,9 @@
     "declaration": true
   },
   "include": ["src/**/*"],
-  "references": []
+  "references": [
+    {
+      "path": "../web-utils"
+    }
+  ]
 }


### PR DESCRIPTION
## Summary
- run the frontend-service Nx build target from the package root so TypeScript tests compile before AVA executes
- add a changelog entry documenting the build fix

## Testing
- pnpm --filter @promethean/frontend-service build
- pnpm nx run @promethean/frontend-service:test

------
https://chatgpt.com/codex/tasks/task_e_68d9c04e4a6883249f3971a095b8b309