### PR TITLE
Use in-memory indexer state store during SmartGPT Bridge tests

### DIFF
--- a/changelog.d/2025.09.28.23.34.22.md
+++ b/changelog.d/2025.09.28.23.34.22.md
@@ -1,0 +1,1 @@
+- Use in-memory indexer state store for SmartGPT Bridge tests to avoid LevelDB overhead.

--- a/packages/smartgpt-bridge/src/tests/helpers/bootstrap.ts
+++ b/packages/smartgpt-bridge/src/tests/helpers/bootstrap.ts
@@ -3,6 +3,13 @@ import { statSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
+import test from "ava";
+
+import {
+  createMemoryStateStore,
+  setIndexerStateStore,
+} from "../../indexerState.js";
+
 function pathExists(dir: string): boolean {
   try {
     return statSync(dir).isDirectory();
@@ -72,3 +79,17 @@ await ensureFixturesDir().catch((err) => {
     console.error("Failed to prepare test fixtures", err);
   }
 });
+
+const shouldForceLevelDb =
+  String(
+    process.env.SMARTGPT_BRIDGE_INDEXER_STATE_STORE || "",
+  ).toLowerCase() === "leveldb";
+
+if (!shouldForceLevelDb) {
+  const resetStore = () => {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+    setIndexerStateStore(createMemoryStateStore());
+  };
+  resetStore();
+  test.beforeEach(resetStore);
+}


### PR DESCRIPTION
## Summary
- configure the SmartGPT Bridge test bootstrap to default to the in-memory indexer state store unless explicitly forced to LevelDB
- reset the store before each AVA case so tests run without cross-test state sharing
- document the change in the changelog

## Testing
- pnpm exec nx run @promethean/smartgpt-bridge:test --skip-nx-cache *(fails: missing @promethean/* type declarations during dependent builds)*

------
https://chatgpt.com/codex/tasks/task_e_68d9c1333bf48324846dd3eea7b9bcbc