### PR TITLE
Fix file-tree dev UI test cleanup

### DIFF
--- a/changelog.d/2025.09.28.23.39.43.md
+++ b/changelog.d/2025.09.28.23.39.43.md
@@ -1,0 +1,1 @@
+- Fixed Piper runner caching by persisting both content and mtime output hashes and aligning skip logic with the stored mode.

--- a/changelog.d/2025.09.29.00.13.31.md
+++ b/changelog.d/2025.09.29.00.13.31.md
@@ -1,0 +1,2 @@
+- ensure the Piper file-tree UI test starts/stops the dev server lazily so filtered test runs exit cleanly
+- track API calls via sessionStorage to satisfy functional lint rules while asserting cached behavior

--- a/docs/agile/tasks/fix-piper-pipeline-caching.md
+++ b/docs/agile/tasks/fix-piper-pipeline-caching.md
@@ -1,0 +1,40 @@
+---
+uuid: 8b57e951-99d2-4242-a56d-578a3f11cda6
+title: Fix Piper pipeline caching regressions
+status: in-progress
+priority: P2
+labels:
+  - piper
+  - pipelines
+created_at: '2025-09-28T23:20:35.509916+00:00'
+updated_at: '2025-09-29T00:13:42+00:00'
+---
+## 🛠️ Task: Fix Piper pipeline caching regressions
+
+### Context
+- AVA runner tests `runPipeline executes steps and caches on second run` and `runPipeline re-executes only affected steps when an intermediate input changes` are failing.
+- Both failures report that the second pipeline run does not read from cache (expected `true`, observed `false`).
+- Resolving this is necessary to keep Piper's caching contract intact and unblock the test suite.
+
+### Definition of Done
+- [x] Identify the regression preventing cache hits on the second pipeline run.
+- [ ] Add or update automated coverage to guard against the regression.
+- [x] Ensure `pnpm test --filter @promethean/piper` passes locally.
+- [x] Document findings and remediation in this task note.
+
+### Plan
+1. Reproduce the failing AVA tests locally and trace pipeline cache metadata for the affected steps.
+2. Inspect Piper runner cache key generation and cache read logic for regressions introduced since the last passing state.
+3. Implement fixes ensuring pipeline steps skip execution when cached data is valid.
+4. Update or extend tests if needed and re-run the Piper package test suite.
+
+### References
+- `packages/piper/src/runner.ts`
+- `packages/piper/src/tests/runner.test.ts`
+- `packages/piper/src/cache/*`
+
+### Notes
+- Persist both content and mtime output hashes for each step so cache mode changes do not invalidate stored fingerprints.
+- `shouldSkip` now compares against hash values keyed by mode, preventing mismatches when switching between content and mtime hashing.
+- Reworked the file-tree dev-ui test to spin up the server lazily and record API calls via `sessionStorage`, eliminating orphaned watchers when filtering test runs.
+- Re-ran the previously failing runner tests and the dev-ui file-tree scenario to confirm caching and watcher behaviour are both green.

--- a/packages/piper/src/lib/state.ts
+++ b/packages/piper/src/lib/state.ts
@@ -10,6 +10,9 @@ export type Step = Readonly<{
   endedAt: string;
   exitCode: number | null;
   outputHash?: string;
+  outputHashContent?: string;
+  outputHashMtime?: string;
+  outputHashMode?: "content" | "mtime";
 }>;
 
 export const isValidStep = (val: unknown): val is Step =>
@@ -20,7 +23,14 @@ export const isValidStep = (val: unknown): val is Step =>
   (typeof (val as any).exitCode === "number" ||
     (val as any).exitCode === null) &&
   ((val as any).outputHash === undefined ||
-    typeof (val as any).outputHash === "string");
+    typeof (val as any).outputHash === "string") &&
+  ((val as any).outputHashContent === undefined ||
+    typeof (val as any).outputHashContent === "string") &&
+  ((val as any).outputHashMtime === undefined ||
+    typeof (val as any).outputHashMtime === "string") &&
+  ((val as any).outputHashMode === undefined ||
+    (val as any).outputHashMode === "content" ||
+    (val as any).outputHashMode === "mtime");
 
 export type RunState = {
   steps: Record<string, Step>;

--- a/packages/piper/src/tests/frontend/filetree.lazy-cache.test.ts
+++ b/packages/piper/src/tests/frontend/filetree.lazy-cache.test.ts
@@ -9,7 +9,8 @@ import {
   withPage,
   Deps,
 } from "@promethean/test-utils";
-import type { Route, Response } from "playwright";
+import type { ReadonlyDeep } from "type-fest";
+import type { Page, Route, Response } from "playwright";
 
 const PKG_ROOT = path.resolve(
   path.dirname(fileURLToPath(import.meta.url)),
@@ -29,67 +30,117 @@ const dir2 = path.join(dir1, "lazy-2");
 const dir3 = path.join(dir2, "lazy-3");
 const leaf = path.join(dir3, "deep.md");
 const cfgPath = path.join(treeRoot, "pipelines.json");
-const { stop, baseUrl } = await startProcessWithPort({
-  cmd: "node",
-  args: [
-    path.join(PKG_ROOT, "dist/dev-ui.js"),
-    "--config",
-    cfgPath,
-    "--port",
-    ":PORT",
-  ],
-  cwd: PKG_ROOT,
-  ready: {
-    kind: "http",
-    url: "http://localhost:PORT/health",
-    timeoutMs: 60_000,
-  },
-  port: { mode: "free" },
-  baseUrlTemplate: (p) => `http://127.0.0.1:${p}/`,
-});
-// Verifies lazy-loading (fetch on expand), loading indicator, and caching (no refetch on re-open)
-// using the <file-tree> component rendered by the dev-ui.
+const CALL_STORAGE_KEY = "__piper_file_calls";
+const EMPTY_PIPELINES = JSON.stringify({ pipelines: [] }, null, 2);
 
-test.serial(
-  "file-tree lazy loads and caches directory contents",
-  withPage,
-  { baseUrl: () => baseUrl },
-  // eslint-disable-next-line max-lines-per-function
-  async (t, { pageGoto, page }: Deps) => {
-    // Count API calls to /api/files
+type DevUiProc = Readonly<{ stop: () => Promise<void>; baseUrl: string }>;
 
-    await write(cfgPath, JSON.stringify({ pipelines: [] }, null, 2));
+type Assertions = Readonly<{
+  assertTrue: (value: boolean, message: string) => void;
+  assertFalse: (value: boolean, message: string) => void;
+}>;
 
-    await write(leaf, "# deep file\n");
+const prepareWorkdir = async () => {
+  await fs.rm(treeRoot, { recursive: true, force: true });
+  await write(cfgPath, EMPTY_PIPELINES);
+};
 
-    // Minimal pipelines to satisfy dev-ui start (not used by file-tree)
-    await write(cfgPath, JSON.stringify({ pipelines: [] }, null, 2));
-    const apiCalls: string[] = [];
-    await page.route("**/api/files**", (route: Route) => {
-      apiCalls.push(route.request().url());
-      void route.continue();
-    });
+const startDevUi = async (): Promise<DevUiProc> => {
+  await prepareWorkdir();
+  const started = await startProcessWithPort({
+    cmd: "node",
+    args: [
+      path.join(PKG_ROOT, "dist/dev-ui.js"),
+      "--config",
+      cfgPath,
+      "--port",
+      ":PORT",
+    ],
+    cwd: PKG_ROOT,
+    ready: {
+      kind: "http",
+      url: "http://localhost:PORT/health",
+      timeoutMs: 60_000,
+    },
+    port: { mode: "free" },
+    baseUrlTemplate: (p) => `http://127.0.0.1:${p}/`,
+  });
+  const baseUrl = started.baseUrl;
+  if (!baseUrl) {
+    throw new Error("dev-ui start did not return a baseUrl");
+  }
+  return { stop: started.stop, baseUrl };
+};
 
-    await pageGoto("/");
-    await page.waitForResponse((r: Response) => {
-      return r.url().includes("/api/files") && r.ok();
-    });
+const stopDevUi = async (devUi: DevUiProc) => {
+  await devUi.stop();
+  await shutdown().catch(() => {});
+  await fs.rm(treeRoot, { recursive: true, force: true });
+};
 
-    // Expand test-tmp
-    await page.waitForSelector("file-tree");
-    // Work inside shadow DOM by label (robust against absolute path differences)
-    const clickDirByLabel = async (label: string) => {
-      await page.waitForFunction((text: string) => {
-        const el = document.querySelector("file-tree");
-        const root = el?.shadowRoot;
-        if (!root) return false;
-        const dirs = Array.from(root.querySelectorAll(".dir-line"));
-        return !!dirs.find(
-          (d) =>
-            (d.querySelector(".dir-name") as HTMLElement)?.textContent === text,
-        );
-      }, label);
-      await page.evaluate((text: string) => {
+const usingDevUi = async (fn: (devUi: ReadonlyDeep<DevUiProc>) => unknown) => {
+  const devUi = await startDevUi();
+  const result = fn(
+    devUi as ReadonlyDeep<DevUiProc>,
+  ) as PromiseLike<void> | void;
+  return Promise.resolve(result).then(
+    async () => {
+      await stopDevUi(devUi);
+    },
+    async (error: unknown) => {
+      await stopDevUi(devUi);
+      throw error;
+    },
+  );
+};
+
+const seedFileTree = async () => {
+  await write(cfgPath, EMPTY_PIPELINES);
+  await write(leaf, "# deep file\n");
+  await write(cfgPath, EMPTY_PIPELINES);
+};
+
+const initCallTracking = async (page: ReadonlyDeep<Page>) => {
+  await page.addInitScript((key: string) => {
+    sessionStorage.setItem(key, "[]");
+  }, CALL_STORAGE_KEY);
+  await page.route("**/api/files**", (route: ReadonlyDeep<Route>) => {
+    const url = route.request().url();
+    void page.evaluate(
+      ({
+        capturedUrl,
+        storageKey,
+      }: ReadonlyDeep<{ capturedUrl: string; storageKey: string }>) => {
+        const raw = sessionStorage.getItem(storageKey) ?? "[]";
+        const parsed = JSON.parse(raw) as string[];
+        const next = [...parsed, capturedUrl];
+        sessionStorage.setItem(storageKey, JSON.stringify(next));
+      },
+      { capturedUrl: url, storageKey: CALL_STORAGE_KEY },
+    );
+    void route.continue();
+  });
+};
+
+const waitForFilesResponse = (page: ReadonlyDeep<Page>) =>
+  page.waitForResponse(
+    (r: ReadonlyDeep<Response>) => r.url().includes("/api/files") && r.ok(),
+  );
+
+const clickDirByLabel = (page: ReadonlyDeep<Page>, label: string) =>
+  page
+    .waitForFunction((text: string) => {
+      const el = document.querySelector("file-tree");
+      const root = el?.shadowRoot;
+      if (!root) return false;
+      const dirs = Array.from(root.querySelectorAll(".dir-line"));
+      return dirs.some(
+        (d) =>
+          (d.querySelector(".dir-name") as HTMLElement)?.textContent === text,
+      );
+    }, label)
+    .then(() =>
+      page.evaluate((text: string) => {
         const el = document.querySelector("file-tree")!;
         const root = el.shadowRoot!;
         const dirs = Array.from(root.querySelectorAll(".dir-line"));
@@ -99,65 +150,104 @@ test.serial(
         ) as HTMLElement | undefined;
         if (!target) throw new Error("dir not found: " + text);
         target.click();
-      }, label);
-    };
+      }, label),
+    );
 
-    // Click to expand test-tmp, lazy-1, lazy-2, lazy-3 in sequence
-    await clickDirByLabel("test-tmp");
-    await clickDirByLabel("lazy-load-root");
-    await clickDirByLabel("lazy-1");
-    await clickDirByLabel("lazy-2");
+const sawLoadingIndicator = async (page: ReadonlyDeep<Page>) =>
+  page
+    .waitForFunction(
+      () => {
+        const el = document.querySelector("file-tree");
+        const root = el?.shadowRoot;
+        return Boolean(root?.querySelector(".loading"));
+      },
+      { timeout: 1500 },
+    )
+    .then(() => true)
+    .catch(() => false);
 
-    // When expanding lazy-2, its sub UL should momentarily show a loading indicator
-    // We check existence of any .loading element at some point during expansion
-    const sawLoading = await page
-      .waitForFunction(
-        () => {
-          const el = document.querySelector("file-tree");
-          const root = el?.shadowRoot;
-          return !!root?.querySelector(".loading");
+const waitForLeafRender = (page: ReadonlyDeep<Page>) =>
+  page.waitForFunction(() => {
+    const el = document.querySelector("file-tree");
+    const root = el?.shadowRoot;
+    if (!root) return false;
+    return Array.from(root.querySelectorAll(".file")).some(
+      (n) => (n as HTMLElement).textContent?.trim() === "deep.md",
+    );
+  });
+
+const leafIsVisible = (page: ReadonlyDeep<Page>) =>
+  page.evaluate(() => {
+    const el = document.querySelector("file-tree")!;
+    const root = el.shadowRoot!;
+    return Array.from(root.querySelectorAll(".file")).some(
+      (n) => (n as HTMLElement).textContent?.trim() === "deep.md",
+    );
+  });
+
+const readCallCount = (page: ReadonlyDeep<Page>) =>
+  page.evaluate((key: string) => {
+    const raw = sessionStorage.getItem(key) ?? "[]";
+    return (JSON.parse(raw) as string[]).length;
+  }, CALL_STORAGE_KEY);
+
+const readNewCalls = (page: ReadonlyDeep<Page>, start: number) =>
+  page.evaluate(
+    ({ key, offset }: ReadonlyDeep<{ key: string; offset: number }>) => {
+      const raw = sessionStorage.getItem(key) ?? "[]";
+      return (JSON.parse(raw) as string[]).slice(offset);
+    },
+    { key: CALL_STORAGE_KEY, offset: start },
+  ) as Promise<readonly string[]>;
+
+const reopenLeaf = async (page: ReadonlyDeep<Page>) => {
+  await clickDirByLabel(page, "lazy-3");
+  await clickDirByLabel(page, "lazy-3");
+};
+
+const runScenario = async (
+  assertions: Assertions,
+  deps: ReadonlyDeep<Deps>,
+) => {
+  const { assertTrue, assertFalse } = assertions;
+  const { pageGoto, page } = deps;
+  await seedFileTree();
+  await initCallTracking(page);
+  await pageGoto("/");
+  await waitForFilesResponse(page);
+  await page.waitForSelector("file-tree");
+  await clickDirByLabel(page, "test-tmp");
+  await clickDirByLabel(page, "lazy-load-root");
+  await clickDirByLabel(page, "lazy-1");
+  await clickDirByLabel(page, "lazy-2");
+  const sawLoading = await sawLoadingIndicator(page);
+  assertTrue(sawLoading, "shows loading indicator during fetch");
+  await clickDirByLabel(page, "lazy-3");
+  await waitForLeafRender(page);
+  const leafVisible = await leafIsVisible(page);
+  assertTrue(leafVisible, "deep leaf file is visible after nested expands");
+  const callCount = await readCallCount(page);
+  await reopenLeaf(page);
+  const newCalls = await readNewCalls(page, callCount);
+  const reFetchedSameDir = newCalls.some((u) => u.includes("lazy-3"));
+  assertFalse(reFetchedSameDir, "re-open uses cache without refetching");
+};
+
+// Verifies lazy-loading (fetch on expand), loading indicator, and caching (no refetch on re-open)
+// using the <file-tree> component rendered by the dev-ui.
+
+test.serial("file-tree lazy loads and caches directory contents", async (t) => {
+  await usingDevUi((devUi) =>
+    withPage.exec(t, { baseUrl: devUi.baseUrl }, (tt, deps) => {
+      const assertions: Assertions = {
+        assertTrue: (value, message) => {
+          tt.true(value, message);
         },
-        { timeout: 1500 },
-      )
-      .then(() => true)
-      .catch(() => false);
-    t.true(sawLoading, "shows loading indicator during fetch");
-
-    await clickDirByLabel("lazy-3");
-    // Wait for leaf to render inside the shadow DOM
-    await page.waitForFunction(() => {
-      const el = document.querySelector("file-tree");
-      const root = el?.shadowRoot;
-      if (!root) return false;
-      return Array.from(root.querySelectorAll(".file")).some(
-        (n) => (n as HTMLElement).textContent?.trim() === "deep.md",
-      );
-    });
-
-    // Leaf should now be visible
-    const leafVisible = await page.evaluate(() => {
-      const el = document.querySelector("file-tree")!;
-      const root = el.shadowRoot!;
-      const file = Array.from(root.querySelectorAll(".file")).find(
-        (n) => (n as HTMLElement).textContent?.trim() === "deep.md",
-      );
-      return !!file;
-    });
-    t.true(leafVisible, "deep leaf file is visible after nested expands");
-
-    const callsAfterFirstOpen = apiCalls.slice();
-
-    // Collapse and re-open lazy-3; should not trigger another /api/files for the same dir
-    await clickDirByLabel("lazy-3"); // collapse
-    await clickDirByLabel("lazy-3"); // reopen -> should use cache
-
-    const newCalls = apiCalls.slice(callsAfterFirstOpen.length);
-    const reFetchedSameDir = newCalls.some((u) => u.includes("lazy-3"));
-    t.false(reFetchedSameDir, "re-open uses cache without refetching");
-  },
-);
-
-test.after.always(async () => {
-  await stop();
-  await shutdown().catch(() => {});
+        assertFalse: (value, message) => {
+          tt.false(value, message);
+        },
+      };
+      return runScenario(assertions, deps as ReadonlyDeep<Deps>);
+    }),
+  );
 });


### PR DESCRIPTION
## Summary
- refactor the Piper file-tree dev-ui test to start/stop the server lazily and record API requests via sessionStorage so filtered runs exit cleanly
- document the watcher fix in the caching task log and note the change in the changelog entry

## Testing
- pnpm exec eslint packages/piper/src/tests/frontend/filetree.lazy-cache.test.ts
- pnpm --filter @promethean/piper test -- --match "file-tree lazy loads and caches directory contents"
- pnpm --filter @promethean/piper test -- --match "runPipeline executes steps and caches on second run"
- pnpm --filter @promethean/piper test -- --match "runPipeline re-executes only affected steps when an intermediate input changes"

------
https://chatgpt.com/codex/tasks/task_e_68d9c0e9bdd08324b42fbc2a1386349f