### PR TITLE
Harden indexer path resolution

### DIFF
--- a/changelog.d/2024.06.03.00.00.00.md
+++ b/changelog.d/2024.06.03.00.00.00.md
@@ -1,0 +1,2 @@
+## Security
+- Hardened indexer path resolution to reject traversal attempts before touching the filesystem.

--- a/packages/indexer-core/src/indexer.ts
+++ b/packages/indexer-core/src/indexer.ts
@@ -134,16 +134,25 @@ function isPathMissingError(value: unknown): value is NodeJS.ErrnoException {
   return code === "ENOENT" || code === "ENOTDIR";
 }
 
+const isPathWithinRoot = (rootAbs: string, candidate: string) => {
+  const relative = path.relative(rootAbs, candidate);
+  return (
+    relative === "" ||
+    (!relative.startsWith("..") && !path.isAbsolute(relative))
+  );
+};
+
 const realpathOrNull = async (rootPath: string, targetPath: string) => {
   const rootAbs = path.resolve(rootPath);
   const candidate = path.resolve(rootAbs, targetPath);
+  if (!isPathWithinRoot(rootAbs, candidate)) {
+    return null;
+  }
   try {
     const resolved = await fs.realpath(candidate);
     // Ensure the resolved path is strictly under the root directory.
     // Avoids cases like root '/a/foo' and candidate '/a/foobar' by using path sep.
-    const isUnderRoot =
-      resolved === rootAbs || resolved.startsWith(rootAbs + path.sep);
-    if (!isUnderRoot) {
+    if (!isPathWithinRoot(rootAbs, resolved)) {
       return null;
     }
     return resolved;
@@ -157,8 +166,11 @@ const realpathOrNull = async (rootPath: string, targetPath: string) => {
 
 async function resolveWithinRoot(rootPath: string, rel: string) {
   const rootAbs = path.resolve(rootPath);
-  const candidate = path.resolve(rootAbs, rel);
   const rootReal = await fs.realpath(rootAbs);
+  const candidate = path.resolve(rootReal, rel);
+  if (!isPathWithinRoot(rootReal, candidate)) {
+    throw new Error("Path escapes index root");
+  }
 
   const candidateReal = await realpathOrNull(rootReal, candidate).then(
     async (resolved) => {
@@ -174,28 +186,18 @@ async function resolveWithinRoot(rootPath: string, rel: string) {
         attempted = path.normalize(candidate);
       }
       // Explicitly check fallback against the canonical root
-      const rootCheck = path.resolve(rootReal);
       const absAttempted = path.resolve(attempted);
-      const relAttempted = path.relative(rootCheck, absAttempted);
-      const escapesRootAttempted =
-        relAttempted.length > 0 &&
-        (relAttempted.startsWith("..") || path.isAbsolute(relAttempted));
-      if (escapesRootAttempted) {
+      if (!isPathWithinRoot(rootReal, absAttempted)) {
         throw new Error("Path escapes index root (fallback)");
       }
       return absAttempted;
     },
   );
 
-  const relativeToRoot = path.relative(rootReal, candidateReal);
-  const absWithSep = rootReal.endsWith(path.sep)
-    ? rootReal
-    : rootReal + path.sep;
-  const isUnderRoot =
-    candidateReal === rootReal || candidateReal.startsWith(absWithSep);
-  if (!isUnderRoot) {
+  if (!isPathWithinRoot(rootReal, candidateReal)) {
     throw new Error("Path escapes index root");
   }
+  const relativeToRoot = path.relative(rootReal, candidateReal);
   const normalizedRel = toPosixPath(relativeToRoot);
   return { abs: candidateReal, rel: normalizedRel };
 }


### PR DESCRIPTION
## Summary
- short-circuit indexer realpath lookups when candidates escape the configured root
- validate fallback resolutions and normalized targets stay within the workspace root
- note the security hardening in the changelog entry

## Testing
- pnpm exec eslint --cache --max-warnings=0 packages/indexer-core/src/indexer.ts *(fails: repository has pre-existing lint violations in this file)*

------
https://chatgpt.com/codex/tasks/task_e_68d9ee67d8ec832485cf412a97b4fd4e