### PR TITLE
Add rate limiting to DocOps metadata endpoints

### DIFF
--- a/changelog.d/2025.09.29.02.35.55.md
+++ b/changelog.d/2025.09.29.02.35.55.md
@@ -1,0 +1,1 @@
+- docops dev-ui: add endpoint-level rate limiting for docs and status APIs


### PR DESCRIPTION
## Summary
- add shared rate limit configs for DocOps Dev UI metadata endpoints
- apply per-route throttling to /api/docs and /api/status responses
- document the change in the changelog

## Testing
- pnpm exec eslint packages/docops/src/dev-ui.ts

------
https://chatgpt.com/codex/tasks/task_e_68d9ee889888832495851da731b97f6e