### PR TITLE
fix: harden utils slug generation

### DIFF
--- a/changelog.d/2025.09.29.02.33.38.md
+++ b/changelog.d/2025.09.29.02.33.38.md
@@ -1,0 +1,1 @@
+- Hardened `@promethean/utils` slug generation to avoid regex-based slowdowns and added coverage for edge cases.

--- a/packages/utils/src/slug.ts
+++ b/packages/utils/src/slug.ts
@@ -1,8 +1,50 @@
+const isLowerAlphaNumeric = (char: string): boolean => {
+  const code = char.codePointAt(0);
+  if (code === undefined) {
+    return false;
+  }
+
+  const isDigit = code >= 0x30 && code <= 0x39; // 0-9
+  const isLower = code >= 0x61 && code <= 0x7a; // a-z
+
+  return isDigit || isLower;
+};
+
+type SlugAccumulator = {
+  readonly result: string;
+  readonly pendingHyphen: boolean;
+};
+
+const appendSlugChar = (
+  acc: SlugAccumulator,
+  char: string,
+): SlugAccumulator => {
+  if (isLowerAlphaNumeric(char)) {
+    const hyphen = acc.pendingHyphen ? "-" : "";
+    return {
+      result: `${acc.result}${hyphen}${char}`,
+      pendingHyphen: false,
+    };
+  }
+
+  if (acc.result.length === 0) {
+    return acc;
+  }
+
+  return {
+    result: acc.result,
+    pendingHyphen: true,
+  };
+};
+
 export function slug(s: string): string {
-  return s
-    .trim()
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, "-")
-    .replace(/^-+/, "")
-    .replace(/-+$/, "");
+  const { result } = Array.from(s.trim().toLowerCase()).reduce<SlugAccumulator>(
+    appendSlugChar,
+    {
+      result: "",
+      pendingHyphen: false,
+    },
+  );
+
+  return result;
 }

--- a/packages/utils/src/tests/slug.test.ts
+++ b/packages/utils/src/tests/slug.test.ts
@@ -6,3 +6,16 @@ test("slug basic rules", (t) => {
   t.is(slug(" Hello, World! "), "hello-world");
   t.is(slug("O'Reilly"), "o-reilly");
 });
+
+test("slug collapses consecutive separators", (t) => {
+  t.is(slug("A___B---C"), "a-b-c");
+});
+
+test("slug trims leading and trailing separators", (t) => {
+  t.is(slug("***Promethean***"), "promethean");
+  t.is(slug("***"), "");
+});
+
+test("slug keeps digits", (t) => {
+  t.is(slug(" Version 2.0 "), "version-2-0");
+});


### PR DESCRIPTION
## Summary
- replace the slug regex with a linear-time reducer to avoid regex-based slowdowns
- expand slug utility tests to cover separator collapsing, trimming, and numeric cases
- document the hardening in the changelog

## Testing
- pnpm exec eslint --max-warnings=0 packages/utils/src/slug.ts packages/utils/src/tests/slug.test.ts
- pnpm --filter @promethean/utils test

------
https://chatgpt.com/codex/tasks/task_e_68d9ee8dbd708324b07493fe5adb68de