### PR TITLE
Fix headerToStatus parenthetical handling

### DIFF
--- a/changelog.d/2024.05.07.00.00.00.md
+++ b/changelog.d/2024.05.07.00.00.00.md
@@ -1,0 +1,1 @@
+- Hardened `headerToStatus` to avoid polynomial regular expressions and added tests for nested parentheticals.

--- a/packages/markdown/src/statuses.ts
+++ b/packages/markdown/src/statuses.ts
@@ -15,11 +15,73 @@ export const STATUS_ORDER = [
 
 export const STATUS_SET = new Set(STATUS_ORDER);
 
+const TRAILING_WHITESPACE = /\s+$/;
+
+function stripTrailingParenthetical(value: string): string {
+    const trimmedEnd = value.replace(TRAILING_WHITESPACE, '');
+
+    if (!trimmedEnd.endsWith(')')) {
+        return trimmedEnd;
+    }
+
+    const openingIndex = findBalancedOpeningIndex(trimmedEnd);
+
+    if (openingIndex < 0) {
+        return trimmedEnd;
+    }
+
+    const beforeParenthetical = trimmedEnd.slice(0, openingIndex);
+    return beforeParenthetical.replace(TRAILING_WHITESPACE, '');
+}
+
+type ParentheticalState = {
+    readonly depth: number;
+    readonly openingIndex: number;
+};
+
+function findBalancedOpeningIndex(text: string): number {
+    const initialState: ParentheticalState = { depth: 0, openingIndex: -1 };
+
+    const result = Array.from(text).reduceRight<ParentheticalState>((state, char, index) => {
+        if (state.openingIndex !== -1) {
+            return state;
+        }
+
+        if (char === ')') {
+            return {
+                depth: state.depth + 1,
+                openingIndex: -1,
+            };
+        }
+
+        if (char === '(') {
+            if (state.depth <= 0) {
+                return state;
+            }
+
+            if (state.depth === 1) {
+                return {
+                    depth: 0,
+                    openingIndex: index,
+                };
+            }
+
+            return {
+                depth: state.depth - 1,
+                openingIndex: -1,
+            };
+        }
+
+        return state;
+    }, initialState);
+
+    return result.openingIndex;
+}
+
 export function headerToStatus(header: string): string {
-    // strip trailing parenthetical (allow trailing spaces) and trim
-    let h = header.replace(/\s*\(.*\)\s*$/, '').trim();
-    // remove leading non-alphanumerics
-    h = h.replace(/^[^A-Za-z0-9]+/, '');
-    const norm = h.replace(/\s+/g, '-').toLowerCase();
+    const withoutParenthetical = stripTrailingParenthetical(header);
+    const trimmed = withoutParenthetical.trim();
+    const withoutLeading = trimmed.replace(/^[^A-Za-z0-9]+/, '');
+    const norm = withoutLeading.replace(/\s+/g, '-').toLowerCase();
     return norm ? `#${norm}` : '';
 }

--- a/packages/tests/src/markdown.statuses.test.ts
+++ b/packages/tests/src/markdown.statuses.test.ts
@@ -1,7 +1,14 @@
-import test from 'ava';
+import test, { type ExecutionContext } from 'ava';
+import type { ReadonlyDeep } from 'type-fest';
 import { headerToStatus, STATUS_ORDER, STATUS_SET } from '@promethean/markdown/statuses.js';
 
-test('headerToStatus normalizes headers to status hashtag', (t) => {
+type TestAssertions = ReadonlyDeep<Pick<ExecutionContext<unknown>, 'is' | 'true' | 'false'>>;
+
+const assertStatus = (t: TestAssertions, input: string, expected: string) => {
+    t.is(headerToStatus(input), expected);
+};
+
+test('headerToStatus normalizes headers to status hashtag', (t: TestAssertions) => {
     t.is(headerToStatus('Todo'), '#todo');
     t.is(headerToStatus('In Progress'), '#in-progress');
     t.is(headerToStatus('  Ice Box  (12) '), '#ice-box');
@@ -9,8 +16,22 @@ test('headerToStatus normalizes headers to status hashtag', (t) => {
     t.is(headerToStatus(''), '');
 });
 
-test('status set contains known statuses and is stable', (t) => {
-    for (const s of STATUS_ORDER) t.true(STATUS_SET.has(s));
+test('headerToStatus safely removes trailing parentheticals', (t: TestAssertions) => {
+    assertStatus(t, 'Focus (phase (alpha))', '#focus');
+    assertStatus(t, 'Research (alpha (beta))   ', '#research');
+    assertStatus(t, 'Status (notes) more details', '#status-(notes)-more-details');
+    assertStatus(t, 'Edge (case', '#edge-(case');
+});
+
+test('headerToStatus handles large nested parentheticals', (t: TestAssertions) => {
+    const nested = `Goal ${'('.repeat(10)}details${')'.repeat(10)}`;
+    assertStatus(t, nested, '#goal');
+});
+
+test('status set contains known statuses and is stable', (t: TestAssertions) => {
+    STATUS_ORDER.forEach((status) => {
+        t.true(STATUS_SET.has(status));
+    });
     t.true(STATUS_SET.has('#todo'));
     t.true(STATUS_SET.has('#in-progress'));
     t.false(STATUS_SET.has('#unknown'));

--- a/packages/tests/src/shims.d.ts
+++ b/packages/tests/src/shims.d.ts
@@ -3,7 +3,11 @@ declare module '@promethean/dev/harness.js';
 declare module '@promethean/fs/fileExplorer.js';
 declare module '@promethean/markdown/kanban.js';
 declare module '@promethean/markdown/sync.js';
-declare module '@promethean/markdown/statuses.js';
+declare module '@promethean/markdown/statuses.js' {
+    export const STATUS_ORDER: readonly string[];
+    export const STATUS_SET: ReadonlySet<string>;
+    export function headerToStatus(header: string): string;
+}
 declare module '@promethean/markdown/task.js';
 declare module '@promethean/parity/normalizers.js';
 declare module '@promethean/parity/runner.js';


### PR DESCRIPTION
## Summary
- replace the trailing parenthetical stripping regex in `headerToStatus` with a deterministic scanner to avoid polynomial-time backtracking
- extend markdown status tests for nested and edge-case parentheticals and add typings so the suite remains type-safe
- record the change in the changelog

## Testing
- pnpm exec eslint packages/markdown/src/statuses.ts packages/tests/src/markdown.statuses.test.ts
- pnpm --filter @promethean/markdown build
- pnpm --filter @promethean/tests test -- --match "*headerToStatus*"


------
https://chatgpt.com/codex/tasks/task_e_68d9ee722e888324b25051465c635ae8