### PR TITLE
feat: enforce global rate limiting for smartgpt bridge

### DIFF
--- a/changelog.d/2025.09.29.02.38.03.md
+++ b/changelog.d/2025.09.29.02.38.03.md
@@ -1,0 +1,2 @@
+- Hardened SmartGPT Bridge by enabling configurable global Fastify rate limits with sensible defaults.
+- Added regression coverage to ensure rate limit configuration throttles excessive requests.

--- a/packages/smartgpt-bridge/src/fastifyApp.ts
+++ b/packages/smartgpt-bridge/src/fastifyApp.ts
@@ -25,6 +25,14 @@ type BridgeDeps = {
     | undefined;
 };
 
+type BridgeConfig = {
+  readonly rateLimit?: {
+    readonly max?: number;
+    readonly timeWindow?: string | number;
+    readonly allowList?: ReadonlyArray<string>;
+  };
+};
+
 export const globalSchema = [
   {
     $id: "GrepRequest",
@@ -164,6 +172,7 @@ export function registerSchema(app: Readonly<Fastify.FastifyInstance>): void {
 export async function buildFastifyApp(
   ROOT_PATH: string,
   deps: BridgeDeps = {},
+  config: BridgeConfig = {},
 ) {
   const registerSinks = deps.registerSinks || defaultRegisterSinks;
   const authFactory = deps.createFastifyAuth || createFastifyAuth;
@@ -188,7 +197,54 @@ export async function buildFastifyApp(
   });
   app.decorate("ROOT_PATH", ROOT_PATH);
   app.register(mongoChromaLogger);
-  await app.register(rateLimit, { global: false });
+  const fallbackRateLimitMax = 300;
+  const configuredRateLimitMax = Number.parseInt(
+    String(process.env.BRIDGE_RATE_LIMIT_MAX || "").trim(),
+    10,
+  );
+  const envRateLimitMax =
+    Number.isFinite(configuredRateLimitMax) && configuredRateLimitMax > 0
+      ? configuredRateLimitMax
+      : fallbackRateLimitMax;
+  const rateLimitMax =
+    typeof config.rateLimit?.max === "number" && config.rateLimit.max > 0
+      ? config.rateLimit.max
+      : envRateLimitMax;
+  const configuredWindow = String(
+    process.env.BRIDGE_RATE_LIMIT_WINDOW || "",
+  ).trim();
+  const numericWindow = Number.parseInt(configuredWindow, 10);
+  const envRateLimitWindow =
+    Number.isFinite(numericWindow) && numericWindow > 0
+      ? numericWindow
+      : configuredWindow || "1 minute";
+  const rateLimitWindow =
+    typeof config.rateLimit?.timeWindow !== "undefined"
+      ? config.rateLimit.timeWindow
+      : envRateLimitWindow;
+  const envAllowList = String(process.env.BRIDGE_RATE_LIMIT_ALLOWLIST || "")
+    .split(",")
+    .map((value) => value.trim())
+    .filter(Boolean);
+  const allowList =
+    config.rateLimit?.allowList?.map((value) => value.trim()).filter(Boolean) ||
+    envAllowList;
+  const rateLimitOptions: Record<string, unknown> = {
+    global: true,
+    max: rateLimitMax,
+    timeWindow: rateLimitWindow,
+    hook: "preHandler",
+    addHeaders: {
+      "x-ratelimit-limit": true,
+      "x-ratelimit-remaining": true,
+      "x-ratelimit-reset": true,
+      "retry-after": true,
+    },
+  };
+  if (allowList.length > 0) {
+    rateLimitOptions.allowList = allowList;
+  }
+  await app.register(rateLimit, rateLimitOptions);
   registerSchema(app);
 
   const baseUrl =

--- a/packages/smartgpt-bridge/src/tests/unit/fastifyApp.rate-limit.test.ts
+++ b/packages/smartgpt-bridge/src/tests/unit/fastifyApp.rate-limit.test.ts
@@ -1,0 +1,36 @@
+import test from "ava";
+
+import { buildFastifyApp } from "../../fastifyApp.js";
+
+test.serial("buildFastifyApp enforces configurable rate limits", async (t) => {
+  const app = await buildFastifyApp(
+    process.cwd(),
+    {},
+    {
+      rateLimit: { max: 2, timeWindow: 1000 },
+    },
+  );
+  t.teardown(async () => {
+    await app.close();
+  });
+  app.get("/__rate-limit-test", async () => ({ ok: true }));
+  await app.ready();
+
+  const first = await app.inject({
+    method: "GET",
+    url: "/__rate-limit-test",
+  });
+  t.is(first.statusCode, 200);
+
+  const second = await app.inject({
+    method: "GET",
+    url: "/__rate-limit-test",
+  });
+  t.is(second.statusCode, 200);
+
+  const third = await app.inject({
+    method: "GET",
+    url: "/__rate-limit-test",
+  });
+  t.is(third.statusCode, 429);
+});


### PR DESCRIPTION
## Summary
- enforce a configurable global Fastify rate limit in the SmartGPT Bridge app with environment-driven defaults and optional overrides
- allow tests to inject rate-limit overrides and add regression coverage to verify throttling behavior
- record the change in the changelog for visibility

## Testing
- pnpm exec eslint --cache --max-warnings=0 packages/smartgpt-bridge/src/tests/unit/fastifyApp.rate-limit.test.ts
- pnpm exec eslint --cache --max-warnings=0 packages/smartgpt-bridge/src/fastifyApp.ts *(fails: pre-existing lint violations in fastifyApp.ts)*
- pnpm --filter @promethean/smartgpt-bridge test -- --match "configurable rate limits" *(fails: upstream TypeScript errors in @promethean/indexer-core build)*
- pnpm --filter @promethean/smartgpt-bridge exec ava -- "--match" "configurable rate limits" *(fails: existing SyntaxError: Identifier 'abs' has already been declared in compiled test outputs)*

------
https://chatgpt.com/codex/tasks/task_e_68d9ee778d748324b2615c34d7385789