### PR TITLE
Refine markdown image link parsing

### DIFF
--- a/changelog.d/2024.07.05.15.30.00.md
+++ b/changelog.d/2024.07.05.15.30.00.md
@@ -1,0 +1,2 @@
+- Fix markdown image parsing to avoid inefficient regular expressions in `@promethean/web-utils`.
+- Add functional parsing helpers and tests covering bracketed URLs and escaped spaces.

--- a/packages/web-utils/src/tests/image-links.test.ts
+++ b/packages/web-utils/src/tests/image-links.test.ts
@@ -8,18 +8,29 @@ import { findBrokenImageLinks, fixBrokenImageLinks } from "../image-links.js";
 
 test("finds broken markdown and org image links", async (t) => {
   const dir = await mkdtemp(path.join(os.tmpdir(), "img-test-"));
-  await writeFile(path.join(dir, "doc.md"), "![cat](cat.png)");
+  await writeFile(
+    path.join(dir, "doc.md"),
+    [
+      "![cat](cat.png)",
+      "![space](<cat picture.png>)",
+      '![escaped](cat\\ image.png "title")',
+    ].join("\n"),
+  );
   await writeFile(path.join(dir, "doc.org"), "[[file:dog.png][dog]]");
   const links = await findBrokenImageLinks(dir);
-  t.deepEqual(links.map((l) => l.url).sort(), ["cat.png", "dog.png"]);
+  t.deepEqual(links.map((l) => l.url).sort(), [
+    "cat image.png",
+    "cat picture.png",
+    "cat.png",
+    "dog.png",
+  ]);
 });
 
 test("fixBrokenImageLinks generates files using provided generator", async (t) => {
   const dir = await mkdtemp(path.join(os.tmpdir(), "img-test-"));
   await writeFile(path.join(dir, "doc.md"), "![cat](cat.png)");
-  const generated: string[] = [];
   const generator = async (_prompt: string, outPath: string): Promise<void> => {
-    generated.push(outPath);
+    t.is(outPath, path.join(dir, "cat.png"));
     await writeFile(outPath, "fake-image");
   };
   const links = await fixBrokenImageLinks(dir, generator);
@@ -28,5 +39,4 @@ test("fixBrokenImageLinks generates files using provided generator", async (t) =
     .then(() => true)
     .catch(() => false);
   t.true(fileExists);
-  t.deepEqual(generated, [path.join(dir, "cat.png")]);
 });


### PR DESCRIPTION
## Summary
- replace the markdown image regex with a functional parser that avoids catastrophic backtracking and adds helper utilities for immutable processing
- cover bracketed and escaped image references with new tests and document the change in the changelog

## Testing
- pnpm exec eslint packages/web-utils/src/image-links.ts packages/web-utils/src/tests/image-links.test.ts
- pnpm --filter @promethean/web-utils test

------
https://chatgpt.com/codex/tasks/task_e_68d9ee7cf46483249a8120955d957a0d