### PR TITLE
fix(fs): guard tree logger format string

### DIFF
--- a/changelog.d/2025.09.29.02.45.23.md
+++ b/changelog.d/2025.09.29.02.45.23.md
@@ -1,0 +1,1 @@
+- fix(fs): guard tree error logger against format string injection

--- a/packages/fs/src/tree.ts
+++ b/packages/fs/src/tree.ts
@@ -40,7 +40,7 @@ export async function buildTree(root: string, opts: TreeOptions = {}): Promise<T
         maxDepth = Infinity,
         followSymlinks = false,
         typeFilter = 'any',
-        onError = (e, p) => console.warn(`fsTree: ${p}:`, e),
+        onError = (e, p) => console.warn('fsTree:', { path: p, error: e }),
         predicate,
     } = opts;
 


### PR DESCRIPTION
## Summary
- guard the fs tree default error handler from interpreting user-controlled paths as format strings
- record the security fix in the changelog inventory

## Testing
- pnpm exec eslint packages/fs/src/tree.ts *(fails: pre-existing functional style violations in tree.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68d9ee9cb84483248ed930977a67a7bc