### PR TITLE
fix(docops): validate pipeline step keys

### DIFF
--- a/changelog.d/2025.09.29.02.47.38.md
+++ b/changelog.d/2025.09.29.02.47.38.md
@@ -1,0 +1,1 @@
+- fix(docops): validate docops step names before execution

--- a/packages/docops/src/lib/pipeline.ts
+++ b/packages/docops/src/lib/pipeline.ts
@@ -157,7 +157,15 @@ export async function runDocopsStep(
     },
   };
 
-  await stepFn[step](args);
+  if (!Object.prototype.hasOwnProperty.call(stepFn, step)) {
+    const validSteps = Object.keys(stepFn).join(", ");
+    throw new Error(
+      `Unknown docops step "${String(step)}". Expected one of: ${validSteps}`,
+    );
+  }
+
+  const handler = stepFn[step];
+  await handler(args);
 }
 
 export async function runDocopsPipeline(


### PR DESCRIPTION
## Summary
- guard docops pipeline step execution with runtime validation to prevent calling undefined handlers
- add changelog entry documenting the fix

## Testing
- pnpm exec eslint packages/docops/src/lib/pipeline.ts --no-warn-ignored

------
https://chatgpt.com/codex/tasks/task_e_68d9eeaa95b48324af7300180ce471a2