### PR TITLE
Fix cookbook report escaping

### DIFF
--- a/changelog.d/2025.09.29.02.46.03.md
+++ b/changelog.d/2025.09.29.02.46.03.md
@@ -1,0 +1,1 @@
+- Fix Markdown escaping in the cookbook report generator to safely render table cells and inline code values.


### PR DESCRIPTION
## Summary
- escape Markdown table cells and inline code in the cookbook report generator to avoid malformed output
- document the escaping fix in the changelog

## Testing
- pnpm exec eslint packages/cookbookflow/src/08-report.ts
- pnpm --filter @promethean/cookbookflow build

------
https://chatgpt.com/codex/tasks/task_e_68d9eeef99e08324a0091952eaa3ded2