### PR TITLE
Add rate limiting to legacy v0 exec endpoint

### DIFF
--- a/changelog.d/2025.09.29.02.43.11.md
+++ b/changelog.d/2025.09.29.02.43.11.md
@@ -1,0 +1,1 @@
+- add rate limiting to legacy v0 exec endpoint and harden plugin registration

--- a/packages/smartgpt-bridge/src/routes/v0/exec.ts
+++ b/packages/smartgpt-bridge/src/routes/v0/exec.ts
@@ -12,6 +12,12 @@ export function registerExecRoutes(fastify: any, deps: ExecDeps = {}) {
   const run = deps.runCommand ?? runCommand;
   const ROOT_PATH = fastify.ROOT_PATH;
   fastify.post("/exec/run", {
+    config: {
+      rateLimit: {
+        max: 5,
+        timeWindow: "1 minute",
+      },
+    },
     schema: {
       summary: "Run a shell command",
       operationId: "runCommand",


### PR DESCRIPTION
## Summary
- ensure the legacy /v0 scope logs rate-limit plugin registration failures instead of silently swallowing them
- add a per-request rate limit to the /v0/exec/run endpoint to deter abuse
- document the change in the changelog

## Testing
- pnpm exec eslint packages/smartgpt-bridge/src/routes/v0/index.ts packages/smartgpt-bridge/src/routes/v0/exec.ts *(fails: existing lint violations in legacy code)*

------
https://chatgpt.com/codex/tasks/task_e_68d9eef494e0832481ac04b4dde82b4a