### PR TITLE
Fix Mermaid label escaping in symdocs graphs

### DIFF
--- a/changelog.d/2025.09.29.02.40.29.md
+++ b/changelog.d/2025.09.29.02.40.29.md
@@ -1,0 +1,1 @@
+- Escape backslashes when generating Mermaid graph labels in symdocs output.

--- a/packages/symdocs/src/04-graph.ts
+++ b/packages/symdocs/src/04-graph.ts
@@ -429,7 +429,7 @@ function relativeToPkgReadmeLink(fromFolder: string, toFolder: string) {
 /* ---------- Mermaid builders ---------- */
 
 function esc(s: string) {
-  return s.replace(/"/g, '\\"');
+  return s.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
 }
 
 function buildMermaidGlobal(


### PR DESCRIPTION
## Summary
- escape Mermaid graph labels by handling backslashes before quotes to avoid malformed nodes
- record the symdocs graph escaping fix in the changelog

## Testing
- pnpm exec eslint packages/symdocs/src/04-graph.ts

------
https://chatgpt.com/codex/tasks/task_e_68d9eefe586483249e628d87a09b8141