### PR TITLE
fix(buildfix): sanitize gh pr creation

### DIFF
--- a/changelog.d/2025.09.29.02.45.13.md
+++ b/changelog.d/2025.09.29.02.45.13.md
@@ -1,0 +1,1 @@
+- Hardened buildfix git utilities by running `gh pr create` via `spawn` with safe argument handling and added explicit return types.

--- a/packages/buildfix/src/iter/git.ts
+++ b/packages/buildfix/src/iter/git.ts
@@ -1,11 +1,64 @@
+import { spawn } from "node:child_process";
+import { once } from "node:events";
+import { text } from "node:stream/consumers";
+
 import { git, isGitRepo, sanitizeBranch } from "../utils.js";
 
-export async function ensureBranch(branch: string) {
+type ClosedProcess = {
+  readonly status: "closed";
+  readonly code: number | null;
+  readonly signal: NodeJS.Signals | null;
+};
+
+type FailedProcess = {
+  readonly status: "error";
+};
+
+type ProcessState = ClosedProcess | FailedProcess;
+
+async function runGhCommand(
+  args: readonly string[],
+): Promise<string | undefined> {
+  const child = spawn("gh", args, { stdio: ["ignore", "pipe", "inherit"] });
+
+  const stdoutPromise = child.stdout
+    ? text(child.stdout).catch(() => "")
+    : Promise.resolve("");
+
+  const closeEvent = once(child, "close") as Promise<
+    [number | null, NodeJS.Signals | null]
+  >;
+  const errorEvent = once(child, "error") as Promise<[unknown]>;
+
+  const outcomePromise = Promise.race([
+    closeEvent.then(
+      ([code, signal]): ProcessState => ({
+        status: "closed",
+        code,
+        signal,
+      }),
+    ),
+    errorEvent.then((): ProcessState => ({ status: "error" })),
+  ]);
+
+  const [outcome, output] = await Promise.all([outcomePromise, stdoutPromise]);
+
+  if (outcome.status !== "closed" || outcome.signal || outcome.code !== 0) {
+    return undefined;
+  }
+
+  const trimmed = output.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+export async function ensureBranch(branch: string): Promise<void> {
   const chk = await git(["rev-parse", "--verify", branch]);
   if (chk.code !== 0) await git(["checkout", "-b", branch]);
   else await git(["checkout", branch]);
 }
-export async function commitIfChanges(message: string) {
+export async function commitIfChanges(
+  message: string,
+): Promise<string | undefined> {
   const st = await git(["status", "--porcelain"]);
   if (!st.out) return undefined;
   await git(["add", "-A"]);
@@ -14,27 +67,30 @@ export async function commitIfChanges(message: string) {
   const sha = await git(["rev-parse", "HEAD"]);
   return sha.out || undefined;
 }
-export async function pushBranch(branch: string, remote: string) {
+export async function pushBranch(
+  branch: string,
+  remote: string,
+): Promise<boolean> {
   return (await git(["push", remote, branch])).code === 0;
 }
 export async function createPR(
   branch: string,
   title: string,
   bodyPath: string,
-) {
-  const { exec } = await import("child_process");
-  return new Promise<string | undefined>((resolve) => {
-    exec(
-      `gh pr create --fill --title "${title.replace(
-        /"/g,
-        '\\"',
-      )}" --body-file "${bodyPath}" --head ${branch}`,
-      {},
-      (err, stdout) => resolve(err ? undefined : String(stdout).trim()),
-    );
-  });
+): Promise<string | undefined> {
+  return runGhCommand([
+    "pr",
+    "create",
+    "--fill",
+    "--title",
+    title,
+    "--body-file",
+    bodyPath,
+    "--head",
+    branch,
+  ]);
 }
-export async function rollbackWorktree() {
+export async function rollbackWorktree(): Promise<void> {
   // hard reset unstaged/staged changes; also drop untracked new files (e.g., snippets accidentally written in src/)
   await git(["reset", "--hard"]);
   await git(["clean", "-fd"]);


### PR DESCRIPTION
## Summary
- run `gh pr create` through `spawn` with structured arguments to avoid shell escaping issues and capture output safely
- add explicit return types to the buildfix git helpers for stricter typing
- document the change in the changelog

## Testing
- pnpm exec eslint packages/buildfix/src/iter/git.ts

------
https://chatgpt.com/codex/tasks/task_e_68d9ef0628308324a609c9c47367aa16