### PR TITLE
Potential fix for code scanning alert no. 441: Missing rate limiting

### DIFF
--- a/packages/smartgpt-bridge/src/fastifyApp.ts
+++ b/packages/smartgpt-bridge/src/fastifyApp.ts
@@ -3,6 +3,9 @@ import Fastify from "fastify";
 import swagger from "@fastify/swagger";
 import swaggerUi from "@fastify/swagger-ui";
 
+// Rate limiting plugin for Fastify
+import rateLimit from "@fastify/rate-limit";
+
 import { createFastifyAuth } from "./fastifyAuth.js";
 import { registerV0Routes } from "./routes/v0/index.js";
 import { indexerManager as defaultIndexerManager } from "./indexer.js";
@@ -261,6 +264,11 @@ export async function buildFastifyApp(
     async (v1Scope) => {
       // Register rate limiting for v1 routes (best-effort; ignore version mismatches)
       if (!isTestEnv) {
+        // Register rate limiting with default of 100 requests per 15 minutes per IP
+        await v1Scope.register(rateLimit, {
+          max: 100,
+          timeWindow: "15 minutes"
+        });
         await registerV1Routes(v1Scope);
       }
 


### PR DESCRIPTION
Potential fix for [https://github.com/riatzukiza/promethean/security/code-scanning/441](https://github.com/riatzukiza/promethean/security/code-scanning/441)

To resolve this issue, we should add a Fastify-compatible rate limiting plugin, such as `@fastify/rate-limit`, and apply it to the `/v1` routes scope. This matches Fastify middleware best practices and the spirit of the other frameworks' solutions (e.g., express-rate-limit in Express). Only the code relating to the `/v1` registration needs to be changed—this involves importing the plugin, registering it within the `/v1` registration, and setting suitable defaults (e.g., X requests per window per IP). As we can only edit the shown `packages/smartgpt-bridge/src/fastifyApp.ts`, we'll add the import, and inside the "await app.register(...)" block for `/v1`, call `v1Scope.register(require('@fastify/rate-limit'), ...)` with an appropriate rate limiting config. This avoids changing functionality and ensures the v1 routes are protected.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
