### PR TITLE
fix: enforce default route limits and harden pipeline sanitization

### DIFF
--- a/changelog.d/2025.09.29.18.19.22.md
+++ b/changelog.d/2025.09.29.18.19.22.md
@@ -1,0 +1,3 @@
+- Add default per-route Fastify rate limits across bridge, DocOps, and Piper dev servers to satisfy CodeQL.
+- Replace DocOps pipeline dynamic dispatch with a typed step handler map to eliminate unvalidated method calls.
+- Harden indexer path handling with relative path sanitization and root-confined realpath resolution.

--- a/changelog.d/2025.09.29.19.27.53.md
+++ b/changelog.d/2025.09.29.19.27.53.md
@@ -1,0 +1,1 @@
+- fix docops pipeline anchor style typing to satisfy TypeScript

--- a/changelog.d/2025.09.29.20.32.11.md
+++ b/changelog.d/2025.09.29.20.32.11.md
@@ -1,0 +1,1 @@
+- Prevent the indexer drain loop from reusing a cleared root path so resets no longer crash the server during bootstrap completion.

--- a/packages/docops/src/dev-ui.ts
+++ b/packages/docops/src/dev-ui.ts
@@ -179,6 +179,18 @@ await app.register(fastifyRateLimit, {
   timeWindow: "15 minutes",
 });
 
+const DEFAULT_ROUTE_RATE_LIMIT = { max: 60, timeWindow: "1 minute" } as const;
+app.addHook("onRoute", (routeOptions) => {
+  const existingConfig = (routeOptions.config ?? {}) as Record<string, unknown>;
+  if (Object.hasOwn(existingConfig, "rateLimit")) {
+    return;
+  }
+  routeOptions.config = {
+    ...existingConfig,
+    rateLimit: { ...DEFAULT_ROUTE_RATE_LIMIT },
+  };
+});
+
 const db = await openDB();
 
 app.get(

--- a/packages/docops/src/lib/pipeline.ts
+++ b/packages/docops/src/lib/pipeline.ts
@@ -38,7 +38,7 @@ export type RunArgs = {
   genModel?: string;
   k?: number;
   force?: boolean;
-  anchorStyle?: string;
+  anchorStyle?: FootersOptions["anchorStyle"];
   // relations tuning
   maxRelated?: number;
   maxReferences?: number;

--- a/packages/smartgpt-bridge/src/fastifyApp.ts
+++ b/packages/smartgpt-bridge/src/fastifyApp.ts
@@ -255,6 +255,20 @@ export async function buildFastifyApp(
     rateLimitOptions.allowList = allowList;
   }
   await app.register(rateLimit, rateLimitOptions);
+  const defaultRouteRateLimit = { max: 60, timeWindow: "1 minute" } as const;
+  app.addHook("onRoute", (routeOptions) => {
+    const existingConfig = (routeOptions.config ?? {}) as Record<
+      string,
+      unknown
+    >;
+    if (Object.hasOwn(existingConfig, "rateLimit")) {
+      return;
+    }
+    routeOptions.config = {
+      ...existingConfig,
+      rateLimit: { ...defaultRouteRateLimit },
+    };
+  });
   registerSchema(app);
 
   const baseUrl =

--- a/packages/smartgpt-bridge/src/fastifyAuth.ts
+++ b/packages/smartgpt-bridge/src/fastifyAuth.ts
@@ -341,6 +341,21 @@ export function createFastifyAuth() {
       );
     }
 
+    const defaultRouteRateLimit = { max: 60, timeWindow: "1 minute" } as const;
+    fastify.addHook("onRoute", (routeOptions: any) => {
+      const existingConfig = (routeOptions.config ?? {}) as Record<
+        string,
+        unknown
+      >;
+      if (Object.hasOwn(existingConfig, "rateLimit")) {
+        return;
+      }
+      routeOptions.config = {
+        ...existingConfig,
+        rateLimit: { ...defaultRouteRateLimit },
+      };
+    });
+
     fastify.get(
       "/auth/me",
       {


### PR DESCRIPTION
## Summary
- add default per-route rate limits when registering SmartGPT bridge, DocOps, and Piper Fastify routes so CodeQL sees explicit limits
- replace DocOps pipeline dynamic dispatch with a typed step handler map
- sanitize indexer relative paths and confine realpath resolution inside the repository root

## Testing
- pnpm exec eslint packages/smartgpt-bridge/src/fastifyApp.ts packages/smartgpt-bridge/src/fastifyAuth.ts packages/docops/src/dev-ui.ts packages/docops/src/lib/pipeline.ts packages/piper/src/dev-ui.ts packages/indexer-core/src/indexer.ts *(fails on pre-existing lint debt)*

------
https://chatgpt.com/codex/tasks/task_e_68dacacd8ac88324bde51110a499aa56