### PR TITLE
fix: harden platform provider registry

### DIFF
--- a/changelog.d/2025.09.29.22.09.49.md
+++ b/changelog.d/2025.09.29.22.09.49.md
@@ -1,0 +1,2 @@
+- harden the platform provider registry immutability and allow injecting a readonly env map for tests
+- annotate topic/urn helpers and replace loose payload types so `nx lint @promethean/platform` succeeds

--- a/packages/platform/src/events.ts
+++ b/packages/platform/src/events.ts
@@ -7,7 +7,7 @@ export type SocialMessageCreated = {
     created_at: string;
     provider: string;
     tenant: string;
-    provider_payload?: any;
+    provider_payload?: unknown;
 };
 
 export type PostMessage = {

--- a/packages/platform/src/provider-registry.ts
+++ b/packages/platform/src/provider-registry.ts
@@ -1,14 +1,21 @@
 import path from 'node:path';
 
 import { z } from 'zod';
+import type { ReadonlyDeep } from 'type-fest';
 import { fileBackedRegistry as makeFileBackedRegistry } from '@promethean/utils';
 
 // Define the schema first, then infer the TS type from it to
 // keep runtime validation and static types perfectly aligned.
 
+type MutableProviderTenant = z.infer<typeof ProviderTenantSchema>;
+
+export type ProviderTenant = ReadonlyDeep<MutableProviderTenant>;
+
+export type ProviderEnv = ReadonlyDeep<Record<string, string | undefined>>;
+
 export type ProviderRegistry = {
     get(provider: string, tenant: string): Promise<ProviderTenant>;
-    list(provider?: string): Promise<readonly ProviderTenant[]>;
+    list(provider?: string): Promise<ReadonlyArray<ProviderTenant>>;
 };
 
 const CredentialsSchema = z.record(z.string());
@@ -30,27 +37,54 @@ const ProviderTenantSchema = z.object({
             bucket_overrides: z.record(z.string()).optional(),
         })
         .optional(),
-    extra: z.record(z.any()).optional(),
+    extra: z.record(z.unknown()).optional(),
 });
 
-export type ProviderTenant = z.infer<typeof ProviderTenantSchema>;
-
 export const ProvidersFileSchema = z.object({ providers: z.array(ProviderTenantSchema) });
+const defaultConfigPath = path.resolve(process.cwd(), 'config/providers.yml');
 
-export function fileBackedRegistry(configPath = path.resolve(process.cwd(), 'config/providers.yml')): ProviderRegistry {
+export function fileBackedRegistry(
+    configPath: string = defaultConfigPath,
+    env: ProviderEnv = process.env,
+): ProviderRegistry {
     return makeFileBackedRegistry<ProviderTenant>({
         configPath,
         schema: ProvidersFileSchema,
-        map: (p) => ({
-            ...(p as ProviderTenant),
-            credentials: Object.fromEntries(
-                Object.entries((p as ProviderTenant).credentials).map(([k, v]) => [k, expandEnv(String(v))]),
-            ),
-        }),
+        map: (provider) => toProviderTenant(provider, env),
     });
 }
 
-export function expandEnv(value: string): string {
+const toProviderTenant = (provider: unknown, env: ProviderEnv): ProviderTenant => {
+    const parsed = ProviderTenantSchema.parse(provider);
+
+    const credentials = Object.fromEntries(
+        Object.entries(parsed.credentials).map(([key, rawValue]) => [key, expandEnv(String(rawValue), env)]),
+    );
+
+    return freezeDeep({
+        ...parsed,
+        credentials,
+    });
+};
+
+const freezeDeep = <T>(value: T): ReadonlyDeep<T> => {
+    if (typeof value !== 'object' || value === null) {
+        return value as ReadonlyDeep<T>;
+    }
+
+    if (Array.isArray(value)) {
+        return Object.freeze((value as unknown[]).map((item) => freezeDeep(item)) as unknown as T) as ReadonlyDeep<T>;
+    }
+
+    const frozenEntries = Object.entries(value as Record<PropertyKey, unknown>).map(([key, inner]) => [
+        key,
+        freezeDeep(inner),
+    ]);
+
+    return Object.freeze(Object.fromEntries(frozenEntries) as unknown as T) as ReadonlyDeep<T>;
+};
+
+export function expandEnv(value: string, env: ProviderEnv = process.env): string {
     // supports ${VAR} expansion; leaves unknowns as-is
-    return value.replace(/\$\{([A-Z0-9_]+)\}/g, (_: string, name: string) => process.env[name] ?? '');
+    return value.replace(/\$\{([A-Z0-9_]+)\}/g, (_: string, name: string) => env[name] ?? '');
 }

--- a/packages/platform/src/tests/provider-registry.test.ts
+++ b/packages/platform/src/tests/provider-registry.test.ts
@@ -3,11 +3,15 @@ import path from 'node:path';
 import test from 'ava';
 
 import { fileBackedRegistry } from '../provider-registry.js';
+import type { ProviderEnv } from '../provider-registry.js';
 
 test('loads providers.yml and expands env', async (t) => {
     const configPath = path.resolve(process.cwd(), '../../config/providers.yml');
-    process.env.DISCORD_TOKEN_DUCK = 'x.test.token';
-    const reg = fileBackedRegistry(configPath);
+    const env: ProviderEnv = Object.freeze({
+        ...process.env,
+        DISCORD_TOKEN_DUCK: 'x.test.token',
+    });
+    const reg = fileBackedRegistry(configPath, env);
     const one = await reg.get('discord', 'duck');
     t.is(one.provider, 'discord');
     t.is(one.tenant, 'duck');

--- a/packages/platform/src/topic.ts
+++ b/packages/platform/src/topic.ts
@@ -1,2 +1,11 @@
-export const topic = (p: { provider: string; tenant: string; area: string; name: string }) =>
-    `promethean.p.${p.provider}.t.${p.tenant}.${p.area}.${p.name}`;
+import type { ReadonlyDeep } from 'type-fest';
+
+export type TopicParts = ReadonlyDeep<{
+    provider: string;
+    tenant: string;
+    area: string;
+    name: string;
+}>;
+
+export const topic = (parts: TopicParts): string =>
+    `promethean.p.${parts.provider}.t.${parts.tenant}.${parts.area}.${parts.name}`;

--- a/packages/platform/src/urn.ts
+++ b/packages/platform/src/urn.ts
@@ -1,7 +1,19 @@
-export const toUrn = (provider: string, kind: string, tenant: string, id: string) =>
+export const toUrn = (provider: string, kind: string, tenant: string, id: string): string =>
     `urn:${provider}:${kind}:${tenant}:${id}`;
 
-export const fromUrn = (urn: string) => {
-    const [_, provider, kind, tenant, id] = urn.split(':');
+export type UrnParts = {
+    readonly provider: string;
+    readonly kind: string;
+    readonly tenant: string;
+    readonly id: string;
+};
+
+export const fromUrn = (urn: string): UrnParts => {
+    const [prefix, provider, kind, tenant, id] = urn.split(':');
+
+    if (prefix !== 'urn' || provider === undefined || kind === undefined || tenant === undefined || id === undefined) {
+        throw new Error(`Invalid provider URN: ${urn}`);
+    }
+
     return { provider, kind, tenant, id };
 };


### PR DESCRIPTION
## Summary
- enforce deep-readonly provider registry outputs and allow injecting a readonly env map for tests
- tighten platform topic/URN helpers and event payload types so the lint target passes
- record the lint stabilization in the changelog

## Testing
- pnpm nx run @promethean/platform:lint
- pnpm --filter @promethean/platform build

------
https://chatgpt.com/codex/tasks/task_e_68db0008e1dc83248e327bbc7a2522b3