### PR TITLE
fix: satisfy @promethean/effects lint requirements

### DIFF
--- a/changelog.d/2025.09.29.22.13.16.md
+++ b/changelog.d/2025.09.29.22.13.16.md
@@ -1,0 +1,1 @@
+- fix effects lint configuration by adding explicit return types and immutable typing helpers

--- a/packages/effects/src/chroma.ts
+++ b/packages/effects/src/chroma.ts
@@ -1,4 +1,8 @@
-export function chromaForTenant(ns: string) {
+export type ChromaConnection = {
+    readonly ns: string;
+};
+
+export function chromaForTenant(ns: string): ChromaConnection {
     // stubbed
     return { ns };
 }

--- a/packages/effects/src/http.ts
+++ b/packages/effects/src/http.ts
@@ -1,3 +1,5 @@
-export async function httpFetch(url: string, opts?: RequestInit) {
+import type { ReadonlyDeep } from 'type-fest';
+
+export async function httpFetch(url: string, opts?: ReadonlyDeep<RequestInit>): Promise<Response> {
     return fetch(url, opts);
 }

--- a/packages/effects/src/mongo.ts
+++ b/packages/effects/src/mongo.ts
@@ -1,4 +1,9 @@
-export function mongoForTenant(tenant: string, db: string) {
+export type MongoConnection = {
+    readonly tenant: string;
+    readonly db: string;
+};
+
+export function mongoForTenant(tenant: string, db: string): MongoConnection {
     // stubbed
     return { db, tenant };
 }

--- a/packages/effects/src/rest.ts
+++ b/packages/effects/src/rest.ts
@@ -1,4 +1,18 @@
-export function restRequest(provider: string, tenant: string, route: string, body: any) {
+import type { ReadonlyDeep } from 'type-fest';
+
+export type RestRequestPayload<TBody> = {
+    readonly provider: string;
+    readonly tenant: string;
+    readonly route: string;
+    readonly body: TBody;
+};
+
+export function restRequest<TBody>(
+    provider: string,
+    tenant: string,
+    route: string,
+    body: ReadonlyDeep<TBody>,
+): RestRequestPayload<ReadonlyDeep<TBody>> {
     // stub: publish to bus
     return { provider, tenant, route, body };
 }


### PR DESCRIPTION
## Summary
- add explicit types for stubbed effect helpers to satisfy ESLint rules
- ensure HTTP and REST helpers accept immutable options and payloads
- record the lint fix in the changelog

## Testing
- pnpm nx run @promethean/effects:lint

------
https://chatgpt.com/codex/tasks/task_e_68db0064cc848324af67a82b16245793