### PR TITLE
Fix ui-components lint warnings

### DIFF
--- a/.nxignore
+++ b/.nxignore
@@ -1,0 +1,1 @@
+packages/kanban-cli

--- a/docs/agile/tasks/fix_ui_components_lint.md
+++ b/docs/agile/tasks/fix_ui_components_lint.md
@@ -10,25 +10,30 @@ updated_at: '2025-02-14T00:30:00.000Z'
 # Fix `@promethean/ui-components` lint failures
 
 ## Context
+
 - `nx run @promethean/ui-components:lint` currently fails and blocks the lint stage.
 - We need the lint target clean so Nx pipelines succeed.
 
 ## Acceptance Criteria
+
 - [x] `nx run @promethean/ui-components:lint` completes without errors.
 - [x] No new lint errors introduced in other packages.
 - [x] Document lint root cause and fix in this task note.
 
 ## Plan
+
 1. Reproduce the lint failure and capture the errors.
 2. Update source files to satisfy the reported lint rules.
 3. Re-run the lint command to verify it passes.
 4. Prepare code review notes summarizing the fix.
 
 ## Notes
+
 - Scope limited to `packages/ui-components` package.
 - Avoid modifying shared eslint config unless required by rule.
 
 ## Outcome
+
 - Migrated the `UiChatPanel` and `UiFileExplorer` components to use shadow DOM templates instead of mutating host element style properties, satisfying the functional immutability rules.
 - Tightened tests to accumulate lint-friendly immutable tuples.
 - Added `.nxignore` to exclude the duplicate `packages/kanban-cli` stub so the Nx project graph resolves and allows lint runs.

--- a/docs/agile/tasks/fix_ui_components_lint.md
+++ b/docs/agile/tasks/fix_ui_components_lint.md
@@ -1,0 +1,35 @@
+---
+uuid: f4e15fe7-e616-4e34-94a6-a4ca655f4f4c
+title: Fix `@promethean/ui-components` lint failures
+status: in-review
+priority: P2
+labels: [codex-task]
+created_at: '2025-02-14T00:00:00.000Z'
+updated_at: '2025-02-14T00:30:00.000Z'
+---
+# Fix `@promethean/ui-components` lint failures
+
+## Context
+- `nx run @promethean/ui-components:lint` currently fails and blocks the lint stage.
+- We need the lint target clean so Nx pipelines succeed.
+
+## Acceptance Criteria
+- [x] `nx run @promethean/ui-components:lint` completes without errors.
+- [x] No new lint errors introduced in other packages.
+- [x] Document lint root cause and fix in this task note.
+
+## Plan
+1. Reproduce the lint failure and capture the errors.
+2. Update source files to satisfy the reported lint rules.
+3. Re-run the lint command to verify it passes.
+4. Prepare code review notes summarizing the fix.
+
+## Notes
+- Scope limited to `packages/ui-components` package.
+- Avoid modifying shared eslint config unless required by rule.
+
+## Outcome
+- Migrated the `UiChatPanel` and `UiFileExplorer` components to use shadow DOM templates instead of mutating host element style properties, satisfying the functional immutability rules.
+- Tightened tests to accumulate lint-friendly immutable tuples.
+- Added `.nxignore` to exclude the duplicate `packages/kanban-cli` stub so the Nx project graph resolves and allows lint runs.
+- `pnpm nx run @promethean/ui-components:lint` now reports a clean run.

--- a/packages/ui-components/src/chat-panel.ts
+++ b/packages/ui-components/src/chat-panel.ts
@@ -4,8 +4,18 @@ const Base = (
 
 export class UiChatPanel extends Base {
   connectedCallback(): void {
-    if (!this.isConnected) return;
-    this.innerHTML = '<div class="chat-panel"><slot></slot></div>';
-    this.style.display = "block";
+    if (!this.isConnected || this.shadowRoot !== null) return;
+    const shadow = this.attachShadow({ mode: "open" });
+    const style = document.createElement("style");
+    style.append(
+      document.createTextNode(
+        [":host { display: block; }", ".chat-panel { display: flex; flex-direction: column; }"]
+          .join(" "),
+      ),
+    );
+    const wrapper = document.createElement("div");
+    wrapper.classList.add("chat-panel");
+    wrapper.append(document.createElement("slot"));
+    shadow.append(style, wrapper);
   }
 }

--- a/packages/ui-components/src/file-explorer.ts
+++ b/packages/ui-components/src/file-explorer.ts
@@ -4,8 +4,11 @@ const Base = (
 
 export class UiFileExplorer extends Base {
   connectedCallback(): void {
-    if (!this.isConnected) return;
-    this.innerHTML = "<slot></slot>";
-    this.style.display = "block";
+    if (!this.isConnected || this.shadowRoot !== null) return;
+    const shadow = this.attachShadow({ mode: "open" });
+    const style = document.createElement("style");
+    style.append(document.createTextNode(":host { display: block; }"));
+    const slot = document.createElement("slot");
+    shadow.append(style, slot);
   }
 }

--- a/packages/ui-components/src/tests/ui-components.test.ts
+++ b/packages/ui-components/src/tests/ui-components.test.ts
@@ -8,11 +8,11 @@ import {
 
 test("applyDesignTokens sets CSS variables", (t) => {
   // eslint-disable-next-line functional/no-let
-  let styleEntries: Array<[string, string]> = [];
+  let styleEntries: ReadonlyArray<readonly [string, string]> = [];
   const root = {
     style: {
       setProperty: (k: string, v: string): void => {
-        styleEntries = [...styleEntries, [k, v]];
+        styleEntries = [...styleEntries, [k, v] as const];
       },
     },
   } as unknown as HTMLElement;
@@ -29,10 +29,10 @@ test("registerUiComponents registers custom elements", (t) => {
     readonly get: (n: string) => CustomElementConstructor | undefined;
   };
   // eslint-disable-next-line functional/no-let
-  let registry: Array<[string, CustomElementConstructor]> = [];
+  let registry: ReadonlyArray<readonly [string, CustomElementConstructor]> = [];
   const customEls: SimpleRegistry = {
     define: (n, c) => {
-      registry = [...registry, [n, c]];
+      registry = [...registry, [n, c] as const];
     },
     get: (n) => registry.find(([name]) => name === n)?.[1],
   };


### PR DESCRIPTION
## Summary
- replace direct DOM mutations in the UI chat panel and file explorer with shadow DOM templates that satisfy the immutable-data lint rules
- adjust the ui-components tests to accumulate immutable tuple data so the prefer-immutable-types rule passes
- exclude the duplicate kanban CLI stub from Nx project detection and record the work in the task note

## Testing
- pnpm nx run @promethean/ui-components:lint --verbose

------
https://chatgpt.com/codex/tasks/task_e_68db009a26948324a6c79516ffc87806

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - No user-facing features added.

- Refactor
  - Chat Panel and File Explorer now render via Shadow DOM for more consistent styling and isolation.

- Tests
  - Strengthened test typings with immutable tuples for greater stability.

- Documentation
  - Added guidance for fixing lint issues in UI components.

- Chores
  - Updated workspace configuration to ignore a non-essential package, improving project graph stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->