### PR TITLE
Fix examples projector lint

### DIFF
--- a/changelog.d/2025.09.29.22.35.13.md
+++ b/changelog.d/2025.09.29.22.35.13.md
@@ -1,0 +1,1 @@
+- Refined the process projector to use typed event handling and immutable state updates so the examples lint suite passes.

--- a/packages/examples/src/process/projector.ts
+++ b/packages/examples/src/process/projector.ts
@@ -1,56 +1,130 @@
-// loosen typing to avoid cross-package type coupling
 import { Topics } from '@promethean/event/topics.js';
+import type { ReadonlyDeep } from 'type-fest';
 
-import { HeartbeatPayload, ProcessState } from './types.js';
+import type { HeartbeatPayload, ProcessState } from './types.js';
 
 const STALE_MS = 15_000;
 
-export async function startProcessProjector(bus: any) {
-    const cache = new Map<string, ProcessState>();
+const topics = Topics as Readonly<{ HeartbeatReceived: string; ProcessState: string }>;
 
-    function keyOf(h: HeartbeatPayload) {
-        return `${h.host}:${h.name}:${h.pid}`;
+type ProjectorState = ReadonlyDeep<ProcessState>;
+type ProcessCache = ReadonlyDeep<Map<string, ProjectorState>>;
+
+type PublishOptionsSubset = Readonly<{ key: string }>;
+type SubscribeOptionsSubset = Readonly<{ from?: 'latest' | 'earliest' | 'ts' | 'afterId' }>;
+
+type ProcessBus = Readonly<{
+    publish: (topic: string, payload: ProjectorState, options: PublishOptionsSubset) => Promise<unknown>;
+    subscribe: (
+        topic: string,
+        group: string,
+        handler: (event: unknown, context: unknown) => Promise<void>,
+        options: SubscribeOptionsSubset,
+    ) => Promise<(() => Promise<void>) | void>;
+}>;
+
+type CacheComputation = {
+    readonly nextCache: ProcessCache;
+    readonly updates: ReadonlyArray<ProjectorState>;
+};
+
+const isRecord = (value: unknown): value is Record<string, unknown> => typeof value === 'object' && value !== null;
+
+const isHeartbeatPayload = (payload: unknown): payload is ReadonlyDeep<HeartbeatPayload> => {
+    if (!isRecord(payload)) {
+        return false;
     }
+    const { pid, name, host, cpu_pct: cpuPct, mem_mb: memMb, sid } = payload;
+    const isNumber = (input: unknown): input is number => typeof input === 'number' && Number.isFinite(input);
+    return (
+        isNumber(pid) &&
+        typeof name === 'string' &&
+        typeof host === 'string' &&
+        isNumber(cpuPct) &&
+        isNumber(memMb) &&
+        (sid === undefined || typeof sid === 'string')
+    );
+};
 
-    async function publishState(ps: ProcessState) {
-        await bus.publish(Topics.ProcessState, ps, { key: ps.processId });
-    }
+const keyOf = (heartbeat: ReadonlyDeep<HeartbeatPayload>): string =>
+    `${heartbeat.host}:${heartbeat.name}:${heartbeat.pid}`;
 
-    // subscriber
-    await bus.subscribe(
-        Topics.HeartbeatReceived,
+const toProcessState = (heartbeat: ReadonlyDeep<HeartbeatPayload>, timestamp: number): ProjectorState => {
+    const sid = heartbeat.sid;
+    const state = {
+        processId: keyOf(heartbeat),
+        name: heartbeat.name,
+        host: heartbeat.host,
+        pid: heartbeat.pid,
+        ...(sid === undefined ? {} : { sid }),
+        cpu_pct: heartbeat.cpu_pct,
+        mem_mb: heartbeat.mem_mb,
+        last_seen_ts: timestamp,
+        status: 'alive',
+    } satisfies ProcessState;
+    return Object.freeze(state) as ProjectorState;
+};
+
+const createInitialCache = (): ProcessCache => Object.freeze(new Map<string, ProjectorState>()) as ProcessCache;
+
+const upsertCache = (cache: ProcessCache, state: ProjectorState): ProcessCache => {
+    const entries = Array.from(cache.entries()).filter(([key]) => key !== state.processId);
+    return Object.freeze(new Map<string, ProjectorState>([...entries, [state.processId, state]])) as ProcessCache;
+};
+
+const computeUpdatedState = (state: ProjectorState, status: ProcessState['status']): ProjectorState =>
+    status === state.status ? state : (Object.freeze({ ...state, status }) as ProjectorState);
+
+const computeStaleness = (cache: ProcessCache, now: number): CacheComputation => {
+    const entries = Array.from(cache.entries()).map(([key, state]) => {
+        const status: ProcessState['status'] = now - state.last_seen_ts > STALE_MS ? 'stale' : 'alive';
+        const nextState = computeUpdatedState(state, status);
+        return { key, state: nextState, changed: nextState !== state };
+    });
+    const nextCache = Object.freeze(
+        new Map<string, ProjectorState>(entries.map(({ key, state }) => [key, state] as const)),
+    ) as ProcessCache;
+    const updates = entries.filter(({ changed }) => changed).map(({ state }) => state);
+    return { nextCache, updates };
+};
+
+export async function startProcessProjector(bus: ProcessBus): Promise<() => void> {
+    // eslint-disable-next-line functional/no-let
+    let cache: ProcessCache = createInitialCache();
+
+    const publishState = async (state: ProjectorState): Promise<void> => {
+        await bus.publish(topics.ProcessState, state, { key: state.processId });
+    };
+
+    const unsubscribe = await bus.subscribe(
+        topics.HeartbeatReceived,
         'process-projector',
-        async (e: any) => {
-            const hb = e.payload as HeartbeatPayload;
-            const k = keyOf(hb);
-            const ps: ProcessState = {
-                processId: k,
-                name: hb.name,
-                host: hb.host,
-                pid: hb.pid,
-                ...(hb.sid !== undefined ? { sid: hb.sid } : {}),
-                cpu_pct: hb.cpu_pct,
-                mem_mb: hb.mem_mb,
-                last_seen_ts: e.ts,
-                status: 'alive',
-            };
-            cache.set(k, ps);
-            await publishState(ps);
+        async (event: unknown, _context: unknown) => {
+            if (!isRecord(event)) {
+                return;
+            }
+            const { payload, ts } = event;
+            if (!isHeartbeatPayload(payload) || typeof ts !== 'number') {
+                return;
+            }
+            const processState = toProcessState(payload, ts);
+            cache = upsertCache(cache, processState);
+            await publishState(processState);
         },
         { from: 'earliest' },
     );
 
-    // staleness scanner
-    const t = setInterval(async () => {
+    const timer = setInterval(async () => {
         const now = Date.now();
-        for (const [_k, ps] of cache) {
-            const status = now - ps.last_seen_ts > STALE_MS ? 'stale' : 'alive';
-            if (status !== ps.status) {
-                ps.status = status;
-                await publishState(ps);
-            }
-        }
+        const { nextCache, updates } = computeStaleness(cache, now);
+        cache = nextCache;
+        await Promise.all(updates.map(publishState));
     }, 5_000);
 
-    return () => clearInterval(t);
+    return () => {
+        clearInterval(timer);
+        if (typeof unsubscribe === 'function') {
+            void unsubscribe();
+        }
+    };
 }

--- a/packages/examples/src/tests/process/projector.test.ts
+++ b/packages/examples/src/tests/process/projector.test.ts
@@ -40,7 +40,7 @@ type PublishCall = {
     readonly options: { readonly key: string };
 };
 
-type EventHandler = (event: Readonly<{ payload: HeartbeatPayload; ts: number }>) => Promise<void>;
+type EventHandler = (event: Readonly<{ payload: HeartbeatPayload; ts: number }>, context?: unknown) => Promise<void>;
 
 type SubscriptionRecord = {
     readonly topic: string;
@@ -117,8 +117,16 @@ function createBus() {
             }
             throw new Error('received more publish calls than expected');
         },
-        async subscribe(topic: string, group: string, onEvent: EventHandler, options: unknown): Promise<void> {
+        async subscribe(
+            topic: string,
+            group: string,
+            onEvent: EventHandler,
+            options: unknown,
+        ): Promise<() => Promise<void>> {
             subscription.resolve({ topic, group, options, handler: onEvent });
+            return async () => {
+                // no-op
+            };
         },
     } as const;
 


### PR DESCRIPTION
## Summary
- harden the examples process projector with typed bus helpers, immutable cache updates, and runtime payload validation so lint stops flagging `any` usage
- expose a narrow publish/subscribe contract and ensure stale-state scanning works without mutating shared state
- update the projector unit tests and changelog entry to reflect the stricter interface

## Testing
- pnpm nx run @promethean/examples:lint
- pnpm nx run @promethean/examples:test

------
https://chatgpt.com/codex/tasks/task_e_68db005439048324b6b277d1167e8665