### PR TITLE
Refactor monitoring metrics lint

### DIFF
--- a/changelog.d/2025.09.29.22.23.09.md
+++ b/changelog.d/2025.09.29.22.23.09.md
@@ -1,0 +1,2 @@
+- Refactored monitoring metrics helper to avoid mutable caches and unsafe any usage.
+- Added safe fallbacks when Prometheus client is unavailable and enforced readonly parameter contracts.


### PR DESCRIPTION
## Summary
- refactor the monitoring metrics helper to use prom-client registry lookups without mutable caches or any-typed fallbacks
- add strongly typed no-op metric implementations and a metrics exposure helper that handles missing prom-client modules

## Testing
- pnpm nx run @promethean/monitoring:lint

------
https://chatgpt.com/codex/tasks/task_e_68db0048ab388324b36b70da7c8a59e7