### PR TITLE
feat(schema): add strongly typed schema helpers

### DIFF
--- a/packages/dev/src/harness.ts
+++ b/packages/dev/src/harness.ts
@@ -33,7 +33,7 @@ export async function startHarness({ wsPort = 9090, httpPort = 9091 }: HarnessOp
 
     const wss = startWSGateway(bus, wsPort, { auth: async () => ({ ok: true }) });
     const http = startHttpPublisher(bus, httpPort);
-    const stopProj = await startProcessProjector(bus);
+    const stopProjector = await startProcessProjector(bus);
 
     return {
         bus,
@@ -44,7 +44,7 @@ export async function startHarness({ wsPort = 9090, httpPort = 9091 }: HarnessOp
             await closeGracefully((handler) => {
                 wss.close(handler);
             });
-            stopProj();
+            await stopProjector();
         },
     };
 }

--- a/packages/examples/src/process/projector.ts
+++ b/packages/examples/src/process/projector.ts
@@ -1,56 +1,123 @@
-// loosen typing to avoid cross-package type coupling
 import { Topics } from '@promethean/event/topics.js';
 
 import { HeartbeatPayload, ProcessState } from './types.js';
 
 const STALE_MS = 15_000;
 
-export async function startProcessProjector(bus: any) {
-    const cache = new Map<string, ProcessState>();
+type CachedState = Readonly<ProcessState>;
 
-    function keyOf(h: HeartbeatPayload) {
-        return `${h.host}:${h.name}:${h.pid}`;
-    }
+const CACHE_STATE = new WeakMap<object, ReadonlyMap<string, CachedState>>();
+const TOPIC_NAMES = Topics as Readonly<Record<string, unknown>>;
 
-    async function publishState(ps: ProcessState) {
-        await bus.publish(Topics.ProcessState, ps, { key: ps.processId });
-    }
+type EventHeaders = Readonly<Record<string, string>>;
 
-    // subscriber
-    await bus.subscribe(
-        Topics.HeartbeatReceived,
+type ProjectorEventRecord<T> = Readonly<{
+    readonly topic: string;
+    readonly payload: T;
+    readonly ts: number;
+    readonly headers?: EventHeaders;
+}> &
+    Readonly<Record<string, unknown>>;
+
+type ProjectorPublishOptions = Readonly<{ readonly key?: string }> & Readonly<Record<string, unknown>>;
+
+type ProjectorDeliveryContext = Readonly<{
+    readonly attempt: number;
+    readonly maxAttempts: number;
+}>;
+
+type ProjectorEventBus = Readonly<{
+    publish<T>(topic: string, payload: T, options?: ProjectorPublishOptions): Promise<ProjectorEventRecord<T>>;
+    subscribe(
+        topic: string,
+        group: string,
+        handler: (event: ProjectorEventRecord<HeartbeatPayload>, ctx: ProjectorDeliveryContext) => Promise<void>,
+        options?: Readonly<Record<string, unknown>>,
+    ): Promise<() => Promise<void>>;
+}>;
+
+export type ProcessProjectorBus = ProjectorEventBus;
+export type ProcessProjectorEventRecord<T> = ProjectorEventRecord<T>;
+export type ProcessProjectorDeliveryContext = ProjectorDeliveryContext;
+export type ProcessProjectorPublishOptions = ProjectorPublishOptions;
+
+const heartbeatKey = (heartbeat: HeartbeatPayload): string => `${heartbeat.host}:${heartbeat.name}:${heartbeat.pid}`;
+
+const toProcessState = (heartbeat: HeartbeatPayload, event: ProjectorEventRecord<HeartbeatPayload>): CachedState => ({
+    processId: heartbeatKey(heartbeat),
+    name: heartbeat.name,
+    host: heartbeat.host,
+    pid: heartbeat.pid,
+    ...(heartbeat.sid !== undefined ? { sid: heartbeat.sid } : {}),
+    cpu_pct: heartbeat.cpu_pct,
+    mem_mb: heartbeat.mem_mb,
+    last_seen_ts: event.ts,
+    status: 'alive',
+});
+
+const upsertState = (
+    cache: ReadonlyMap<string, CachedState>,
+    key: string,
+    state: CachedState,
+): ReadonlyMap<string, CachedState> => new Map([...cache.entries()].filter(([k]) => k !== key).concat([[key, state]]));
+
+const updateStatuses = async (
+    cache: ReadonlyMap<string, CachedState>,
+    publish: (state: CachedState) => Promise<unknown>,
+): Promise<ReadonlyMap<string, CachedState>> => {
+    const now = Date.now();
+    const transitions = Array.from(cache.entries()).map(([key, state]) => {
+        const status = now - state.last_seen_ts > STALE_MS ? 'stale' : 'alive';
+        if (status === state.status) {
+            return { key, state, publish: undefined };
+        }
+        const nextState: CachedState = { ...state, status };
+        return { key, state: nextState, publish: publish(nextState) };
+    });
+
+    await Promise.all(transitions.flatMap((transition) => (transition.publish ? [transition.publish] : [])));
+
+    return new Map(transitions.map(({ key, state }) => [key, state] as const));
+};
+
+export async function startProcessProjector<TBus extends ProjectorEventBus>(bus: TBus): Promise<() => Promise<void>> {
+    const token = {};
+    CACHE_STATE.set(token, new Map());
+
+    const getCache = (): ReadonlyMap<string, CachedState> => CACHE_STATE.get(token) ?? new Map();
+    const setCache = (next: ReadonlyMap<string, CachedState>): ReadonlyMap<string, CachedState> => {
+        CACHE_STATE.set(token, next);
+        return next;
+    };
+
+    const processStateTopic = String(TOPIC_NAMES.ProcessState ?? 'process.state');
+    const heartbeatTopic = String(TOPIC_NAMES.HeartbeatReceived ?? 'heartbeat.received');
+
+    const publishState = (state: CachedState) => bus.publish(processStateTopic, state, { key: state.processId });
+
+    const unsubscribe = await bus.subscribe(
+        heartbeatTopic,
         'process-projector',
-        async (e: any) => {
-            const hb = e.payload as HeartbeatPayload;
-            const k = keyOf(hb);
-            const ps: ProcessState = {
-                processId: k,
-                name: hb.name,
-                host: hb.host,
-                pid: hb.pid,
-                ...(hb.sid !== undefined ? { sid: hb.sid } : {}),
-                cpu_pct: hb.cpu_pct,
-                mem_mb: hb.mem_mb,
-                last_seen_ts: e.ts,
-                status: 'alive',
-            };
-            cache.set(k, ps);
-            await publishState(ps);
+        async (event: ProjectorEventRecord<HeartbeatPayload>) => {
+            const state = toProcessState(event.payload, event);
+            const key = state.processId;
+            setCache(upsertState(getCache(), key, state));
+            await publishState(state);
         },
         { from: 'earliest' },
     );
 
-    // staleness scanner
-    const t = setInterval(async () => {
-        const now = Date.now();
-        for (const [_k, ps] of cache) {
-            const status = now - ps.last_seen_ts > STALE_MS ? 'stale' : 'alive';
-            if (status !== ps.status) {
-                ps.status = status;
-                await publishState(ps);
-            }
-        }
+    const tick = async () => {
+        setCache(await updateStatuses(getCache(), publishState));
+    };
+
+    const interval = setInterval(() => {
+        void tick();
     }, 5_000);
 
-    return () => clearInterval(t);
+    return async () => {
+        clearInterval(interval);
+        await unsubscribe();
+        CACHE_STATE.delete(token);
+    };
 }

--- a/packages/schema/src/types.ts
+++ b/packages/schema/src/types.ts
@@ -1,0 +1,30 @@
+export type EventHeaders = Readonly<Record<string, string>>;
+
+export type PublishOptions = Readonly<{ readonly headers?: EventHeaders }> & Readonly<Record<string, unknown>>;
+
+export type DeliveryContext = Readonly<{
+    readonly attempt: number;
+    readonly maxAttempts: number;
+}> &
+    Readonly<Record<string, unknown>>;
+
+export type EventRecord<T = unknown> = Readonly<{
+    readonly topic: string;
+    readonly payload: T;
+    readonly ts: number;
+    readonly headers?: EventHeaders;
+}> &
+    Readonly<Record<string, unknown>>;
+
+export type SubscribeOptions = Readonly<Record<string, unknown>>;
+
+export type SchemaEventBus = Readonly<{
+    publish<T>(topic: string, payload: T, opts?: PublishOptions): Promise<EventRecord<T>>;
+    subscribe(
+        topic: string,
+        group: string,
+        handler: (event: EventRecord, ctx: DeliveryContext) => Promise<void>,
+        opts?: SubscribeOptions,
+    ): Promise<() => Promise<void>>;
+}> &
+    Readonly<Record<string, unknown>>;


### PR DESCRIPTION
## Summary
- add dedicated schema event bus typings and reuse them across dual-write and normalization utilities to eliminate `any` usage and support schema headers
- restructure schema registry and upcast helpers around immutable updates with WeakMap-backed state while validating topics via the new types
- adopt the schema-aware bus contract for the example process projector, update its tests, and ensure the dev harness awaits projector shutdown

## Testing
- pnpm nx run @promethean/schema:lint
- pnpm nx run @promethean/examples:lint
- pnpm nx run @promethean/examples:test

------
https://chatgpt.com/codex/tasks/task_e_68dbfcd20558832483e88c8b4b39df45