### PR TITLE
Add typing to timetravel reconstruction utilities

### DIFF
--- a/changelog.d/2025.09.30.16.13.42.md
+++ b/changelog.d/2025.09.30.16.13.42.md
@@ -1,0 +1,1 @@
+- tighten timetravel reconstruction helpers with typed store and event interfaces

--- a/packages/timetravel/src/examples.ts
+++ b/packages/timetravel/src/examples.ts
@@ -1,11 +1,16 @@
+import type { ReconstructSnapshot, TimetravelEvent, TimetravelStore } from './reconstruct.js';
 import { reconstructAt } from './reconstruct.js';
-// loosen typing to avoid cross-package type coupling
 
-export async function processAt(store: any, processId: string, atTs: number) {
-    return reconstructAt(store, {
+export type ProcessStateEvent<TState> = TimetravelEvent<TState>;
+
+export const processAt = async <TState>(
+    store: TimetravelStore<ProcessStateEvent<TState>>,
+    processId: string,
+    atTs: number,
+): Promise<ReconstructSnapshot<TState>> =>
+    reconstructAt<TState, ProcessStateEvent<TState>>(store, {
         topic: 'process.state',
         key: processId,
         atTs,
-        apply: (_prev: any, e: any) => e.payload,
+        apply: (_prev, event) => event.payload,
     });
-}

--- a/packages/timetravel/src/reconstruct.ts
+++ b/packages/timetravel/src/reconstruct.ts
@@ -1,34 +1,53 @@
-// loosen typing to avoid cross-package type coupling
+export type TimetravelEvent<TPayload> = Readonly<{
+    ts: number;
+    key: string;
+    payload: TPayload;
+}>;
 
-export type ReconstructOpts<T = any> = {
-    topic: string; // e.g., "process.state"
-    snapshotTopic?: string; // e.g., "process.state.snapshot" (optional)
-    key: string; // entity key
-    atTs: number; // target timestamp (epoch ms)
-    apply: (prev: T | null, e: any) => T | null; // reducer: apply event->state
-    fetchSnapshot?: (key: string, upTo: number) => Promise<{ state: T | null; ts: number } | null>;
-};
+export type TimetravelScanOptions = Readonly<{
+    ts: number;
+    limit: number;
+}>;
 
-export async function reconstructAt<T = any>(store: any, opts: ReconstructOpts<T>) {
-    let baseState: T | null = null;
-    let baseTs = 0;
+export type TimetravelStore<TEvent extends TimetravelEvent<unknown>> = Readonly<{
+    scan: (topic: string, opts: TimetravelScanOptions) => Promise<ReadonlyArray<TEvent>>;
+}>;
 
-    // optional snapshot as baseline
-    if (opts.fetchSnapshot) {
-        const snap = await opts.fetchSnapshot(opts.key, opts.atTs);
-        if (snap) {
-            baseState = snap.state;
-            baseTs = snap.ts;
+export type ReconstructSnapshot<TState> = Readonly<{
+    state: TState | null;
+    ts: number;
+}>;
+
+export type ReconstructOpts<TState, TEvent extends TimetravelEvent<unknown>> = Readonly<{
+    topic: string;
+    snapshotTopic?: string;
+    key: string;
+    atTs: number;
+    apply: (prev: TState | null, event: TEvent) => TState | null;
+    fetchSnapshot?: (key: string, upTo: number) => Promise<ReconstructSnapshot<TState> | null>;
+}>;
+
+export const reconstructAt = async <TState, TEvent extends TimetravelEvent<unknown>>(
+    store: TimetravelStore<TEvent>,
+    opts: ReconstructOpts<TState, TEvent>,
+): Promise<ReconstructSnapshot<TState>> => {
+    const baseline = opts.fetchSnapshot ? await opts.fetchSnapshot(opts.key, opts.atTs) : null;
+
+    const initial: ReconstructSnapshot<TState> = baseline ?? {
+        state: null,
+        ts: 0,
+    };
+
+    const events = await store.scan(opts.topic, { ts: initial.ts, limit: 1_000_000 });
+
+    return events.reduce<ReconstructSnapshot<TState>>((accumulator, event) => {
+        if (event.ts > opts.atTs || event.key !== opts.key) {
+            return accumulator;
         }
-    }
 
-    // scan events after baseline up to atTs
-    const events = await store.scan(opts.topic, { ts: baseTs, limit: 1_000_000 });
-    for (const e of events) {
-        if (e.ts > opts.atTs) break;
-        if (e.key !== opts.key) continue;
-        baseState = opts.apply(baseState, e);
-        baseTs = e.ts;
-    }
-    return { state: baseState, ts: baseTs };
-}
+        return {
+            state: opts.apply(accumulator.state, event),
+            ts: event.ts,
+        } as const;
+    }, initial);
+};


### PR DESCRIPTION
## Summary
- replace the timetravel reconstruction helpers' loose `any` usage with typed event, store, and snapshot interfaces
- update the `processAt` helper to use the new generics when invoking `reconstructAt`

## Testing
- pnpm nx run @promethean/timetravel:lint

------
https://chatgpt.com/codex/tasks/task_e_68dbfce071e48324a139ad7c501189bb