### PR TITLE
refactor(dlq): add immutable typings and cleanup

### DIFF
--- a/packages/dlq/src/replay.ts
+++ b/packages/dlq/src/replay.ts
@@ -1,23 +1,51 @@
-// Loosen types to decouple cross-package declarations at build time
 import { dlqTopic } from './types.js';
+import type { DeadLetterEvent, DLQBus, DLQRecord, DLQStore, StoredRecord } from './types.js';
 
-export async function replayDLQ(
-    store: any,
-    bus: any,
-    topic: string,
-    { limit = 1000, transform }: { limit?: number; transform?: (e: any) => any | void },
-) {
-    const dlq = dlqTopic(topic);
-    const batch = await store.scan(dlq, { ts: 0, limit });
-    for (const rec of batch) {
-        const orig = rec.payload?.original;
-        if (!orig) continue;
-        const tweaked = transform ? transform(orig) || orig : orig;
+type ReplayTransform = (event: DeadLetterEvent) => DeadLetterEvent | void;
+
+type ReplayOptions = Readonly<{
+    limit?: number;
+    transform?: ReplayTransform;
+}>;
+
+const isDlqRecord = (value: unknown): value is DLQRecord => {
+    if (typeof value !== 'object' || value === null) return false;
+    const candidate = value as { readonly original?: unknown; readonly topic?: unknown };
+    if (typeof candidate.topic !== 'string') return false;
+    const original = candidate.original as DeadLetterEvent | undefined;
+    return typeof original === 'object' && original !== null && typeof original.topic === 'string';
+};
+
+const republishSequentially = async (
+    bus: DLQBus,
+    records: ReadonlyArray<StoredRecord>,
+    transform?: ReplayTransform,
+    index = 0,
+): Promise<void> => {
+    if (index >= records.length) return;
+    const record = records[index];
+    if (!record) return;
+    const payload = record.payload;
+    if (isDlqRecord(payload) && payload.original) {
+        const tweaked = transform?.(payload.original) ?? payload.original;
+        const causedBy = [...(tweaked.caused_by ?? []), record.id];
         await bus.publish(tweaked.topic, tweaked.payload, {
             headers: tweaked.headers,
             key: tweaked.key,
             sid: tweaked.sid,
-            caused_by: (tweaked.caused_by || []).concat(rec.id),
+            caused_by: causedBy,
         });
     }
+    await republishSequentially(bus, records, transform, index + 1);
+};
+
+export async function replayDLQ(
+    store: DLQStore,
+    bus: DLQBus,
+    topic: string,
+    { limit = 1000, transform }: ReplayOptions = {},
+): Promise<void> {
+    const dlq = dlqTopic(topic);
+    const batch = await store.scan(dlq, { ts: 0, limit });
+    await republishSequentially(bus, batch, transform);
 }

--- a/packages/dlq/src/subscribe.ts
+++ b/packages/dlq/src/subscribe.ts
@@ -1,37 +1,88 @@
-// Using loose typing to avoid cross-package type coupling at build time
 import { dlqTopic } from './types.js';
+import type { DLQBus, DLQEvent, DLQRecord, DeliveryCtx } from './types.js';
 
-export function withDLQ(bus: any, { maxAttempts = 5, group }: { maxAttempts?: number; group: string }) {
-    return async function subscribeWithDLQ(topic: string, handler: (e: any) => Promise<void>, opts: any = {}) {
-        const attempts = new Map<string, number>();
+type WithDlqOptions = Readonly<{
+    group: string;
+    maxAttempts?: number;
+}>;
+
+type SubscribeOverrides = Readonly<Record<string, unknown>>;
+
+type EventHandler = (event: DLQEvent, ctx?: DeliveryCtx) => Promise<void>;
+
+type DeadLetterParams = Readonly<{
+    topic: string;
+    group: string;
+    event: DLQEvent;
+    err: unknown;
+    attempts: number;
+}>;
+
+const formatError = (err: unknown): string => {
+    const error = err as { readonly stack?: unknown; readonly message?: unknown };
+    const stack = typeof error?.stack === 'string' ? error.stack : undefined;
+    const message = typeof error?.message === 'string' ? error.message : undefined;
+    return stack ?? message ?? String(err);
+};
+
+const createDeadLetter = ({ topic, group, event, err, attempts }: DeadLetterParams): DLQRecord =>
+    Object.freeze({
+        topic,
+        group,
+        original: event,
+        err: formatError(err),
+        ts: Date.now(),
+        attempts,
+    });
+
+const toSubscribeOptions = (base: SubscribeOverrides, maxAttempts: number): Readonly<Record<string, unknown>> => ({
+    ...base,
+    maxAttempts,
+});
+
+type AttemptParams = Readonly<{
+    handler: EventHandler;
+    bus: DLQBus;
+    topic: string;
+    group: string;
+    attemptLimit: number;
+    event: DLQEvent;
+    ctx: DeliveryCtx;
+}>;
+
+const withAttemptLimit = ({ handler, bus, topic, group, attemptLimit, event, ctx }: AttemptParams): Promise<void> =>
+    handler(event, ctx).catch(async (err: unknown) => {
+        const attempt = ctx?.attempt ?? attemptLimit;
+        if (attempt >= attemptLimit) {
+            const deadLetter = createDeadLetter({ topic, group, event, err, attempts: attempt });
+            await bus.publish(dlqTopic(topic), deadLetter);
+            return;
+        }
+        throw err;
+    });
+
+export function withDLQ(bus: DLQBus, { maxAttempts = 5, group }: WithDlqOptions) {
+    return async function subscribeWithDLQ(
+        topic: string,
+        handler: EventHandler,
+        opts: SubscribeOverrides = {},
+    ): Promise<unknown> {
+        const subscribeOpts = toSubscribeOptions(opts, maxAttempts);
 
         return bus.subscribe(
             topic,
             group,
-            async (e: any) => {
-                const n = (attempts.get(e.id) ?? 0) + 1;
-                attempts.set(e.id, n);
-
-                try {
-                    await handler(e);
-                    attempts.delete(e.id);
-                } catch (err: any) {
-                    if (n >= maxAttempts) {
-                        await bus.publish(dlqTopic(topic), {
-                            topic,
-                            group,
-                            original: e,
-                            err: String(err?.stack ?? err?.message ?? err),
-                            ts: Date.now(),
-                            attempts: n,
-                        });
-                        attempts.delete(e.id);
-                    } else {
-                        throw err; // cause redelivery
-                    }
-                }
-            },
-            opts,
+            (event: DLQEvent, ctx?: DeliveryCtx) =>
+                withAttemptLimit({
+                    handler,
+                    bus,
+                    topic,
+                    group,
+                    attemptLimit: Math.max(maxAttempts, ctx?.maxAttempts ?? maxAttempts),
+                    event,
+                    ctx: ctx ?? { attempt: 0, maxAttempts },
+                }),
+            subscribeOpts,
         );
     };
 }

--- a/packages/dlq/src/types.ts
+++ b/packages/dlq/src/types.ts
@@ -1,10 +1,56 @@
-export type DLQRecord = {
+export type DeadLetterEvent = Readonly<{
+    id?: string;
+    sid?: string;
+    topic: string;
+    key?: string;
+    headers?: Readonly<Record<string, unknown>>;
+    payload: unknown;
+    caused_by?: ReadonlyArray<string>;
+    tags?: ReadonlyArray<string>;
+    ts?: number;
+}>;
+
+export type DLQRecord = Readonly<{
     topic: string;
     group?: string;
-    original: any; // original EventRecord
-    err: string; // error message/stack
+    original: DeadLetterEvent;
+    err: string;
     ts: number;
     attempts?: number;
-};
+}>;
+
+export type DLQScanParams = Readonly<{
+    afterId?: string;
+    ts?: number;
+    limit?: number;
+}>;
+
+export type StoredRecord = Readonly<{
+    id: string;
+    payload?: unknown;
+}>;
+
+export type DLQStore = Readonly<{
+    scan(topic: string, params: DLQScanParams): Promise<ReadonlyArray<StoredRecord>>;
+}>;
+
+export type DeliveryCtx = Readonly<{
+    attempt: number;
+    maxAttempts: number;
+}>;
+
+export type DLQEvent = DeadLetterEvent & Readonly<{ id: string }>;
+
+export type DLQBus = Readonly<{
+    publish(topic: string, payload: unknown, opts?: Readonly<Record<string, unknown>>): Promise<unknown>;
+    subscribe(
+        topic: string,
+        group: string,
+        handler: (event: DLQEvent, ctx?: DeliveryCtx) => Promise<void>,
+        opts?: Readonly<Record<string, unknown>>,
+    ): Promise<unknown>;
+}>;
+
 export const DLQ_TOPIC_PREFIX = 'dlq.';
-export const dlqTopic = (t: string) => `${DLQ_TOPIC_PREFIX}${t}`;
+
+export const dlqTopic = (t: string): string => `${DLQ_TOPIC_PREFIX}${t}`;


### PR DESCRIPTION
## Summary
- define local DLQ event, bus, and store interfaces to eliminate any-typed parameters
- rewrite replayDLQ to validate stored records and republish using the typed bus contract
- refactor withDLQ to use delivery context attempts, emit immutable dead-letter payloads, and drop mutable tracking

## Testing
- pnpm exec tsc -p packages/dlq/tsconfig.json
- pnpm nx run @promethean/dlq:lint

------
https://chatgpt.com/codex/tasks/task_e_68dbfd1d10c48324b503499f42e9460e