### PR TITLE
docs: document markdown helpers for scripts

### DIFF
--- a/changelog.d/2025.09.30.19.46.38.md
+++ b/changelog.d/2025.09.30.19.46.38.md
@@ -1,0 +1,1 @@
+- document markdown helper usage for scripts README.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -11,3 +11,24 @@ This folder contains utility scripts grouped by purpose. Most scripts are safe t
 
 Use make targets or pnpm/python directly as indicated in subfolder READMEs.
 
+### Markdown automation helpers
+
+Scripts that touch our kanban or task markdown should prefer the utilities in
+`@promethean/markdown`. The package exposes helpers for parsing and persisting
+board and task structures (`MarkdownBoard`, `MarkdownTask`), manipulating
+frontmatter metadata, and chunking markdown bodies for downstream processing.
+
+```ts
+import { MarkdownBoard } from "@promethean/markdown/kanban.js";
+
+const board = await MarkdownBoard.fromPath("docs/agile/boards/kanban.md");
+// ... mutate board.columns/tasks as needed ...
+await board.write();
+```
+
+When authoring or updating scripts, lint them with the directory specific
+instructions and format documentation using:
+
+```bash
+pnpm exec prettier --write scripts/README.md
+```


### PR DESCRIPTION
## Summary
- document the @promethean/markdown helper utilities for script authors in scripts/README.md
- add a changelog entry referencing the documentation update

## Testing
- pnpm exec prettier --write scripts/README.md

------
https://chatgpt.com/codex/tasks/task_e_68dc31abad208324af0b17b3e90dbf7a