### PR TITLE
Fix fetch_ovm_models CLI entry detection

### DIFF
--- a/changelog.d/2025.02.23.00.00.00.md
+++ b/changelog.d/2025.02.23.00.00.00.md
@@ -1,0 +1,2 @@
+## Fixed
+- Ensure `scripts/fetch_ovm_models.mjs` detects CLI invocation when run via relative paths so it prints configured model names.

--- a/docs/agile/tasks/align-fetch-ovm-entrypoint.md
+++ b/docs/agile/tasks/align-fetch-ovm-entrypoint.md
@@ -1,0 +1,90 @@
+---
+task-id: TASK-20250223A
+title: Align fetch_ovm_models entrypoint detection
+state: InProgress
+prev:
+txn: "2025-02-23T00:00:00Z-0000"
+owner: gpt-5-codex
+priority: p3
+size: s
+epic: EPC-000
+depends_on: []
+labels:
+  - board:auto
+  - lang:ts
+due:
+links: []
+artifacts: []
+rationale: Ensure fetch_ovm_models works when launched with a relative path.
+proposed_transitions:
+  - New->Accepted
+  - Accepted->Breakdown
+  - Breakdown->Ready
+  - Ready->Todo
+  - Todo->InProgress
+  - InProgress->InReview
+  - InReview->Done
+tags:
+  - task/TASK-20250223A
+  - board/kanban
+  - state/InProgress
+  - owner/gpt-5-codex
+  - priority/p3
+  - epic/EPC-000
+---
+<hr class="__chatgpt_plugin">
+
+<span style="font-size: small;"> (llama3.2:latest)</span>
+### role::assistant
+
+Here's a suggested revision of your context section:
+
+## Context
+### Changes and Updates
+- **What changed?**: Script should detect entry invocation using pathToFileURL comparisons.
+- **Where?**: `scripts/fetch_ovm_models.mjs` and supporting tests/logs.
+- **Why now?**: Relative path invocations currently fail to print model names, breaking developer workflow.
+
+## Inputs / Artifacts
+- (config/ovm.json)
+- (scripts/fetch_ovm_models.mjs)
+- (tests/scripts/fetch_ovm_models.test.js)
+
+## Definition of Done
+- [ ] fetch_ovm_models prints model names when run via relative path.
+- [ ] Automated test covering script remains green.
+- [ ] PR merged: (link TBD summarizing CLI guard fix.)
+
+## Plan
+1. Update CLI guard to use pathToFileURL with resolved argv path.
+2. Smoke test script via `node scripts/fetch_ovm_models.mjs`.
+3. Run relevant AVA test suite.
+
+## Relevant Resources
+
+You might find [this](link) useful while working on this task.
+
+### Smart Connections Configuration
+```smart-connections
+{
+  "render_markdown": true,
+  "show_full_path": false,
+  "exclude_blocks_from_source_connections": false,
+  "exclude_frontmatter_blocks": true,
+  "expanded_view": false,
+  "results_limit": "20",
+  "exclude_inlinks": false,
+  "exclude_outlinks": false
+}
+```
+
+### Smart ChatGPT Configuration
+```smart-chatgpt
+```
+<hr class="__chatgpt_plugin">
+
+### role::user
+
+<% tp.file.title() %>
+
+<% tp.app.commands.executeCommandById("chatgpt-md:call-chatgpt-api") %>

--- a/scripts/fetch_ovm_models.mjs
+++ b/scripts/fetch_ovm_models.mjs
@@ -1,4 +1,6 @@
 import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
 
 const DEFAULT_CONFIG_URL = new URL("../config/ovm.json", import.meta.url);
 
@@ -8,7 +10,9 @@ export async function fetchOvmModels(configUrl = DEFAULT_CONFIG_URL) {
   return model_config_list.map(({ config }) => config.name);
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+const entryPoint = process.argv[1] ? path.resolve(process.argv[1]) : undefined;
+
+if (entryPoint && import.meta.url === pathToFileURL(entryPoint).href) {
   const models = await fetchOvmModels();
   for (const name of models) {
     console.log(name);


### PR DESCRIPTION
## Summary
- import pathToFileURL and resolve process argv before comparing to import.meta.url
- ensure fetch_ovm_models emits model names when invoked with a relative path
- record the task note and changelog entry for the fix

## Testing
- node scripts/fetch_ovm_models.mjs
- pnpm exec ava tests/scripts/fetch_ovm_models.test.js

------
https://chatgpt.com/codex/tasks/task_e_68dc351891b483248a0c51e7936abd54