### PR TITLE
Adjust OVMS gRPC port mapping

### DIFF
--- a/changelog.d/2024.07.05.00.00.00.md
+++ b/changelog.d/2024.07.05.00.00.00.md
@@ -1,0 +1,1 @@
+- Clarified OVMS port usage by moving gRPC to 9001 and updating the ML stack docs.

--- a/docs/notes/promethean-full-stack-docker-setup.md
+++ b/docs/notes/promethean-full-stack-docker-setup.md
@@ -395,9 +395,10 @@ services:
     restart: unless-stopped
 
   # ---------- OVMS (Intel iGPU/NPU) ----------
+  # REST:9000 (nginx /asr/npu/) | gRPC:9001
   ovms-npu:
     image: openvino/model_server:latest
-    command: --config_path /config/config.json --rest_port 9000 --port 9000
+    command: --config_path /config/config.json --rest_port 9000 --port 9001
     volumes:
       - ./infra/ovms/config.json:/config/config.json:ro
       - ./models/ov:/opt/models:ro

--- a/infrastructure/compose/ml.yaml
+++ b/infrastructure/compose/ml.yaml
@@ -112,9 +112,10 @@ services:
     restart: unless-stopped
 
   # ---------- OVMS (Intel iGPU/NPU) ----------
+  # REST:9000 (nginx /asr/npu/) | gRPC:9001
   ovms-npu:
     image: openvino/model_server:latest
-    command: --config_path /config/config.json --rest_port 9000 --port 9000
+    command: --config_path /config/config.json --rest_port 9000 --port 9001
     volumes:
       - ./infra/ovms/config.json:/config/config.json:ro
       - ./models/ov:/opt/models:ro


### PR DESCRIPTION
## Summary
- move the ovms-npu gRPC endpoint to port 9001 while leaving REST on 9000
- document the REST/gRPC split alongside the ml compose snippet and changelog

## Testing
- docker compose -f infrastructure/compose/ml.yaml up -d --no-deps edge ovms-npu *(fails: docker is not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dc351a87308324956f5a90af10b3ce