### PR TITLE
Fix smart task templater delay implementation

### DIFF
--- a/docs/templates/textgenerator/templates/local/smart_task_templater_md.md
+++ b/docs/templates/textgenerator/templates/local/smart_task_templater_md.md
@@ -76,6 +76,6 @@ Using this title write a reasonable task kanban task document: <% tp.file.title 
 
 
 
-await sleep(20)
+await tp.system.sleep(20000);
 app.commands.executeCommandById("chatgpt-md:call-chatgpt-api")
 %> 


### PR DESCRIPTION
## Summary
- replace the unsupported `await sleep(20)` call in the smart task templater with `tp.system.sleep(20000)`
- keep the follow-up command so the ChatGPT API still triggers after the delay

## Testing
- not run (Obsidian environment required to exercise the template)

------
https://chatgpt.com/codex/tasks/task_e_68dc365cb9e88324930dc24dd53bae95