### PR TITLE
Ensure task templates surface required sections

### DIFF
--- a/docs/agile/templates/task.stub.template.md
+++ b/docs/agile/templates/task.stub.template.md
@@ -34,23 +34,26 @@ tags:
 
 Here's a suggested revision of your context section:
 
-## Context
-### Changes and Updates
-- **What changed?**: [Describe the key changes that have occurred, e.g., updated requirements, new feature added]
-- **Where?**: [Specify the location or scope where these changes are relevant, e.g., specific project, department]
-- **Why now?**: [Explain why these changes are necessary at this time, e.g., due to deadline, feedback from stakeholders]
+## Description
+- **What changed?** [Describe the key changes that have occurred, e.g., updated requirements, new feature added]
+- **Where is the impact?** [Specify the location or scope where these changes are relevant, e.g., specific project, department]
+- **Why now?** [Explain why these changes are necessary at this time, e.g., due to deadline, feedback from stakeholders]
+- **Supporting context** ([link or path] to relevant documentation, data, or assets)
 
-## Inputs / Artifacts
-- ([link or path] to relevant documentation, data, or assets)
+## Goals
+- [Outline the measurable outcomes or success criteria for this task]
+- [List any dependencies, stakeholders, or milestones that must be coordinated]
 
-## Definition of Done
-- [ ] test X passes: [ Briefly describe the testing scenario]
+## Requirements
+- [ ] test X passes: [Briefly describe the testing scenario]
 - [ ] doc Y updated: [Mention the specific documentation or resource that has been updated]
 - [ ] PR merged: ([link to the PR] with a brief summary of changes)
+- [ ] Additional constraints or non-functional requirements are addressed: [List or link to relevant specifications]
 
-## Plan
-1. … [ Outline the high-level steps for completing this task, including any dependencies or resources required]
+## Subtasks
+1. … [Outline the high-level steps for completing this task, including any dependencies or resources required]
 2. …
+3. …
 
 ## Relevant Resources
 

--- a/docs/templates/textgenerator/templates/local/smart_task_templater_md.md
+++ b/docs/templates/textgenerator/templates/local/smart_task_templater_md.md
@@ -28,22 +28,26 @@ temperature: 0.7
 ---
 <hr class="__chatgpt_plugin">
 
-### Changes and Updates
-- **What changed?**: [Describe the key changes that have occurred, e.g., updated requirements, new feature added]
-- **Where?**: [Specify the location or scope where these changes are relevant, e.g., specific project, department]
-- **Why now?**: [Explain why these changes are necessary at this time, e.g., due to deadline, feedback from stakeholders]
+## Description
+- **What changed?** [Describe the key changes that have occurred, e.g., updated requirements, new feature added]
+- **Where is the impact?** [Specify the location or scope where these changes are relevant, e.g., specific project, department]
+- **Why now?** [Explain why these changes are necessary at this time, e.g., due to deadline, feedback from stakeholders]
+- **Supporting context** ([link or path] to relevant documentation, data, or assets)
 
-## Inputs / Artifacts
-- ([link or path] to relevant documentation, data, or assets)
+## Goals
+- [Outline the measurable outcomes or success criteria for this task]
+- [List any dependencies, stakeholders, or milestones that must be coordinated]
 
-## Definition of Done
-- [ ] test X passes: [ Briefly describe the testing scenario]
+## Requirements
+- [ ] test X passes: [Briefly describe the testing scenario]
 - [ ] doc Y updated: [Mention the specific documentation or resource that has been updated]
 - [ ] PR merged: ([link to the PR] with a brief summary of changes)
+- [ ] Additional constraints or non-functional requirements are addressed: [List or link to relevant specifications]
 
-## Plan
-1. … [ Outline the high-level steps for completing this task, including any dependencies or resources required]
+## Subtasks
+1. … [Outline the high-level steps for completing this task, including any dependencies or resources required]
 2. …
+3. …
 
 ## Relevant Resources
 


### PR DESCRIPTION
## Summary
- restructure the smart task templater markdown to provide Description, Goals, Requirements, and Subtasks headings with updated prompts
- mirror the new section layout in the generated task stub template so downstream tasks adopt the same structure

## Testing
- pnpm lint:tasks *(fails: existing docs/agile/tasks entries are missing the required sections and status hashtags)*

------
https://chatgpt.com/codex/tasks/task_e_68dc36284f388324b2002cb120b82ed7