### PR TITLE
Fix kanban build to compile markdown dependency

### DIFF
--- a/changelog.d/2025.02.14.14.45.00.md
+++ b/changelog.d/2025.02.14.14.45.00.md
@@ -1,0 +1,1 @@
+- Ensure the kanban build compiles its markdown dependency before TypeScript emits by enabling project references and build mode.

--- a/packages/kanban/package.json
+++ b/packages/kanban/package.json
@@ -6,7 +6,7 @@
     "kanban": "dist/index.js"
   },
   "scripts": {
-    "build": "tsc -p tsconfig.json",
+    "build": "tsc -b tsconfig.json",
     "test": "pnpm run build && ava"
   },
   "dependencies": {

--- a/packages/kanban/tsconfig.json
+++ b/packages/kanban/tsconfig.json
@@ -2,7 +2,13 @@
   "extends": "../../config/tsconfig.base.json",
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "dist"
+    "outDir": "dist",
+    "composite": true
   },
-  "include": ["src"]
+  "include": ["src"],
+  "references": [
+    {
+      "path": "../markdown"
+    }
+  ]
 }


### PR DESCRIPTION
## Summary
- enable project references in the kanban tsconfig so TypeScript builds @promethean/markdown before emitting
- switch the package build script to use `tsc -b` and record the change in the changelog

## Testing
- pnpm --filter @promethean/kanban build

------
https://chatgpt.com/codex/tasks/task_e_68dc3d92431083248f3cbf78213c0b7d