### PR TITLE
Handle legacy stream title model overrides

### DIFF
--- a/changelog.d/2024.06.08.12.34.56.md
+++ b/changelog.d/2024.06.08.12.34.56.md
@@ -1,0 +1,1 @@
+- Restored legacy model string handling for stream title generation helpers and added regression tests for the options guard.


### PR DESCRIPTION
## Summary
- normalize stream title generation options so legacy model strings remain supported and invalid types throw
- accept string overrides throughout dependent helpers and document the regression fix in the changelog
- add regression coverage confirming the legacy signature, guard behavior, and compatibility with injected clients

## Testing
- pnpm nx test @promethean/stream
- pnpm nx run @promethean/stream:lint

------
https://chatgpt.com/codex/tasks/task_e_68dc3cf6a9008324899571764402a72c