### PR TITLE
Fix kanban regex escaping for section updates

### DIFF
--- a/changelog.d/2025.02.14.21.00.00.md
+++ b/changelog.d/2025.02.14.21.00.00.md
@@ -1,0 +1,1 @@
+- Fix kanban regex escaping to keep relationship updates safe and allow builds to succeed.

--- a/packages/kanban/src/lib/kanban.ts
+++ b/packages/kanban/src/lib/kanban.ts
@@ -916,7 +916,7 @@ const BLOCKED_BY_HEADING = "## ⛓️ Blocked By";
 const BLOCKS_HEADING = "## ⛓️ Blocks";
 
 const escapeRegExp = (value: string): string =>
-  value.replace(/[\\-/\^$*+?.()|[\]{}]/g, "\\$&");
+  value.replace(/[\\/\-^$*+?.()|[\]{}]/g, "\\$&");
 
 const formatSectionBlock = (
   heading: string,


### PR DESCRIPTION
## Summary
- escape the hyphen in the kanban regex character class so section updates remain safe and builds succeed
- record the fix in the changelog for visibility

## Testing
- pnpm --filter @promethean/kanban test -- --match "createTask"
- pnpm --filter @promethean/kanban build

------
https://chatgpt.com/codex/tasks/task_e_68dc53ad9c58832489ad71d99a06c152