### PR TITLE
feat(kanban): load CLI board paths from config

### DIFF
--- a/changelog.d/2025.10.01.18.18.34.md
+++ b/changelog.d/2025.10.01.18.18.34.md
@@ -1,0 +1,3 @@
+## Changed
+- Updated kanban CLI to load board/task paths from project configuration and support legacy flags and environment variables.
+- Added regression test to ensure CLI regeneration respects configured board paths.

--- a/packages/kanban/src/index.ts
+++ b/packages/kanban/src/index.ts
@@ -1,6 +1,4 @@
 #!/usr/bin/env node
-import { resolve } from "node:path";
-import { parseArgs } from "node:util";
 import {
   loadBoard,
   countTasks,
@@ -18,19 +16,48 @@ import {
   searchTasks,
 } from "./lib/kanban.js";
 import { printJSONL } from "./lib/jsonl.js";
+import { loadKanbanConfig } from "./board/config.js";
 
-const { values, positionals } = parseArgs({
-  args: process.argv.slice(2),
-  options: {
-    kanban: { type: "string", default: "docs/agile/boards/kanban.md" },
-    tasks: { type: "string", default: "docs/agile/tasks" },
-    help: { type: "boolean", default: false },
-  },
-  allowPositionals: true,
-});
+const LEGACY_FLAG_MAP = Object.freeze(
+  new Map<string, string>([
+    ["--kanban", "--board-file"],
+    ["--tasks", "--tasks-dir"],
+  ]),
+);
 
-const KANBAN = resolve(process.cwd(), process.env.KANBAN_PATH || values.kanban);
-const TASKS = resolve(process.cwd(), process.env.TASKS_PATH || values.tasks);
+const normalizeLegacyArgs = (
+  args: ReadonlyArray<string>,
+): ReadonlyArray<string> =>
+  args.map((token) => {
+    for (const [legacy, current] of LEGACY_FLAG_MAP.entries()) {
+      if (token === legacy) {
+        return current;
+      }
+      if (token.startsWith(`${legacy}=`)) {
+        return `${current}=${token.slice(legacy.length + 1)}`;
+      }
+    }
+    return token;
+  });
+
+const applyLegacyEnv = (
+  env: Readonly<NodeJS.ProcessEnv>,
+): NodeJS.ProcessEnv => {
+  const nextEnv: NodeJS.ProcessEnv = { ...env };
+  if (
+    typeof env.KANBAN_PATH === "string" &&
+    typeof env.KANBAN_BOARD_FILE !== "string"
+  ) {
+    nextEnv.KANBAN_BOARD_FILE = env.KANBAN_PATH;
+  }
+  if (
+    typeof env.TASKS_PATH === "string" &&
+    typeof env.KANBAN_TASKS_DIR !== "string"
+  ) {
+    nextEnv.KANBAN_TASKS_DIR = env.TASKS_PATH;
+  }
+  return nextEnv;
+};
 
 const requireArg = (value: string | undefined, label: string): string => {
   if (typeof value === "string") {
@@ -44,9 +71,21 @@ const requireArg = (value: string | undefined, label: string): string => {
 };
 
 async function main() {
-  const [cmd, ...args] = positionals;
+  const rawArgs = process.argv.slice(2);
+  const normalizedArgs = normalizeLegacyArgs(rawArgs);
+  const helpRequested =
+    normalizedArgs.includes("--help") || normalizedArgs.includes("-h");
 
-  if (values.help || !cmd) {
+  const { config, restArgs } = await loadKanbanConfig({
+    argv: normalizedArgs,
+    env: applyLegacyEnv(process.env),
+  });
+
+  const [cmd, ...args] = restArgs;
+  const boardFile = config.boardFile;
+  const tasksDir = config.tasksDir;
+
+  if (helpRequested || !cmd) {
     console.error(
       `Usage: kanban [--kanban path] [--tasks path] <subcommand> [args...]\n` +
         `Subcommands: count, getColumn, getByColumn, find, find-by-title, update_status, move_up, move_down, pull, push, sync, regenerate, indexForSearch, search`,
@@ -57,28 +96,28 @@ async function main() {
   switch (cmd) {
     case "count": {
       const column = args[0];
-      const board = await loadBoard(KANBAN, TASKS);
+      const board = await loadBoard(boardFile, tasksDir);
       const n = countTasks(board, column);
       printJSONL({ count: n });
       break;
     }
     case "getColumn": {
       const column = requireArg(args[0], "column name");
-      const board = await loadBoard(KANBAN, TASKS);
+      const board = await loadBoard(boardFile, tasksDir);
       const colData = getColumn(board, column);
       printJSONL(colData);
       break;
     }
     case "getByColumn": {
       const column = requireArg(args[0], "column name");
-      const board = await loadBoard(KANBAN, TASKS);
+      const board = await loadBoard(boardFile, tasksDir);
       const tasks = getTasksByColumn(board, column);
       printJSONL(tasks);
       break;
     }
     case "find": {
       const id = requireArg(args[0], "task id");
-      const board = await loadBoard(KANBAN, TASKS);
+      const board = await loadBoard(boardFile, tasksDir);
       const t = findTaskById(board, id);
       if (t) printJSONL(t);
       break;
@@ -89,7 +128,7 @@ async function main() {
         joined.length > 0 ? joined : undefined,
         "task title",
       );
-      const board = await loadBoard(KANBAN, TASKS);
+      const board = await loadBoard(boardFile, tasksDir);
       const t = findTaskByTitle(board, title);
       if (t) printJSONL(t);
       break;
@@ -98,52 +137,52 @@ async function main() {
       const [rawId, rawStatus] = args;
       const id = requireArg(rawId, "task id");
       const newStatus = requireArg(rawStatus, "new status");
-      const board = await loadBoard(KANBAN, TASKS);
-      const updated = await updateStatus(board, id, newStatus, KANBAN);
+      const board = await loadBoard(boardFile, tasksDir);
+      const updated = await updateStatus(board, id, newStatus, boardFile);
       printJSONL(updated);
       break;
     }
     case "move_up": {
       const [rawId] = args;
       const id = requireArg(rawId, "task id");
-      const board = await loadBoard(KANBAN, TASKS);
-      const res = await moveTask(board, id, -1, KANBAN);
+      const board = await loadBoard(boardFile, tasksDir);
+      const res = await moveTask(board, id, -1, boardFile);
       printJSONL(res);
       break;
     }
     case "move_down": {
       const [rawId] = args;
       const id = requireArg(rawId, "task id");
-      const board = await loadBoard(KANBAN, TASKS);
-      const res = await moveTask(board, id, +1, KANBAN);
+      const board = await loadBoard(boardFile, tasksDir);
+      const res = await moveTask(board, id, +1, boardFile);
       printJSONL(res);
       break;
     }
     case "pull": {
-      const board = await loadBoard(KANBAN, TASKS);
-      const res = await pullFromTasks(board, TASKS, KANBAN);
+      const board = await loadBoard(boardFile, tasksDir);
+      const res = await pullFromTasks(board, tasksDir, boardFile);
       printJSONL(res);
       break;
     }
     case "push": {
-      const board = await loadBoard(KANBAN, TASKS);
-      const res = await pushToTasks(board, TASKS);
+      const board = await loadBoard(boardFile, tasksDir);
+      const res = await pushToTasks(board, tasksDir);
       printJSONL(res);
       break;
     }
     case "sync": {
-      const board = await loadBoard(KANBAN, TASKS);
-      const res = await syncBoardAndTasks(board, TASKS, KANBAN);
+      const board = await loadBoard(boardFile, tasksDir);
+      const res = await syncBoardAndTasks(board, tasksDir, boardFile);
       printJSONL(res);
       break;
     }
     case "regenerate": {
-      const res = await regenerateBoard(TASKS, KANBAN);
+      const res = await regenerateBoard(tasksDir, boardFile);
       printJSONL(res);
       break;
     }
     case "indexForSearch": {
-      const res = await indexForSearch(TASKS);
+      const res = await indexForSearch(tasksDir);
       printJSONL(res);
       break;
     }
@@ -153,7 +192,7 @@ async function main() {
         joined.length > 0 ? joined : undefined,
         "search term",
       );
-      const board = await loadBoard(KANBAN, TASKS);
+      const board = await loadBoard(boardFile, tasksDir);
       const res = await searchTasks(board, term);
       printJSONL(res);
       break;

--- a/packages/kanban/src/tests/cli-config.test.ts
+++ b/packages/kanban/src/tests/cli-config.test.ts
@@ -1,0 +1,68 @@
+import path from "node:path";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { spawn } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+import test from "ava";
+
+import { makeTask, withTempDir, writeTaskFile } from "../test-utils/helpers.js";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const PACKAGE_ROOT = path.resolve(__dirname, "..", "..");
+const CLI_ENTRY = path.join(PACKAGE_ROOT, "dist", "index.js");
+
+const runCli = async (
+  args: ReadonlyArray<string>,
+  options: Readonly<{ env?: NodeJS.ProcessEnv }> = {},
+): Promise<void> =>
+  new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [CLI_ENTRY, ...args], {
+      cwd: PACKAGE_ROOT,
+      env: { ...process.env, ...options.env },
+      stdio: "inherit",
+    });
+    child.once("error", reject);
+    child.once("close", (code) => {
+      if (code === 0) {
+        resolve();
+        return;
+      }
+      reject(new Error(`CLI exited with code ${code ?? "null"}`));
+    });
+  });
+
+test("CLI regeneration respects board path from kanban config", async (t) => {
+  const tempDir = await withTempDir(t);
+  const configDir = path.join(tempDir, "config");
+  await mkdir(configDir, { recursive: true });
+
+  const tasksDir = path.join(configDir, "tasks");
+  await mkdir(tasksDir, { recursive: true });
+
+  const boardDir = path.join(configDir, "output");
+  await mkdir(boardDir, { recursive: true });
+  const boardPath = path.join(boardDir, "board-from-config.md");
+
+  const configPath = path.join(configDir, "kanban.config.json");
+  const config = {
+    tasksDir: "./tasks",
+    boardFile: "./output/board-from-config.md",
+  } as const;
+  await writeFile(configPath, JSON.stringify(config), "utf8");
+
+  const task = makeTask({
+    uuid: "cli-config",
+    title: "CLI Config",
+    status: "doing",
+  });
+  await writeTaskFile(tasksDir, task, { content: "Task body" });
+
+  await t.throwsAsync(() => readFile(boardPath, "utf8"));
+
+  await runCli(["regenerate"], {
+    env: { KANBAN_CONFIG: configPath },
+  });
+
+  const boardContent = await readFile(boardPath, "utf8");
+  t.true(boardContent.includes("CLI Config"));
+});


### PR DESCRIPTION
## Summary
- update the kanban CLI to resolve board and task paths through `loadKanbanConfig` while keeping legacy flags and env vars working
- pass the resolved paths into every subcommand entry point
- add an AVA regression test that spawns the CLI with a temp config plus a changelog note

## Testing
- pnpm --filter @promethean/kanban build
- pnpm --filter @promethean/kanban test *(fails: Identifier 'nodeMajorVersion' has already been declared)*

------
https://chatgpt.com/codex/tasks/task_e_68dd6dcf381483249b17d90a2cfbb4e2