### PR TITLE
Preserve kanban slugs derived from filenames

### DIFF
--- a/changelog.d/2025.02.14.00.00.00.md
+++ b/changelog.d/2025.02.14.00.00.00.md
@@ -1,0 +1,2 @@
+## Changed
+- Preserve kanban task wiki links by preferring existing filenames when regenerating boards.

--- a/packages/kanban/src/lib/kanban.ts
+++ b/packages/kanban/src/lib/kanban.ts
@@ -109,6 +109,22 @@ const isFallbackSlug = (slug: string, uuid: string): boolean => {
 
 const fallbackFileBase = (uuid: string): string => `Task ${uuid.slice(0, 8)}`;
 
+const resolveTaskSlug = (task: Task, baseName: string): string => {
+  const sanitizedBase = sanitizeFileNameBase(baseName);
+  const explicitSlug =
+    typeof task.slug === "string" && task.slug.trim().length > 0
+      ? task.slug.trim()
+      : undefined;
+  const fallbackSource =
+    sanitizedBase.length > 0 ? sanitizedBase : task.title ?? sanitizedBase;
+  const slugSource = explicitSlug ?? fallbackSource;
+  const normalized = sanitizeFileNameBase(slugSource ?? "");
+  if (normalized.length > 0) {
+    return normalized;
+  }
+  return fallbackFileBase(task.uuid);
+};
+
 const deriveFileBaseFromTask = (task: Task): string => {
   const fromSlug =
     typeof task.slug === "string" ? sanitizeFileNameBase(task.slug) : "";
@@ -128,6 +144,23 @@ const ensureTaskFileBase = (task: Task): string => {
     task.slug = base;
   }
   return base;
+};
+
+const slugMatchesSourcePath = (task: Task): boolean => {
+  if (!task.sourcePath) {
+    return false;
+  }
+  const normalizedSlug =
+    typeof task.slug === "string" && task.slug.length > 0
+      ? sanitizeFileNameBase(task.slug)
+      : "";
+  if (normalizedSlug.length === 0) {
+    return false;
+  }
+  const normalizedSource = sanitizeFileNameBase(
+    path.basename(task.sourcePath, path.extname(task.sourcePath)),
+  );
+  return normalizedSource.length > 0 && normalizedSlug === normalizedSource;
 };
 
 const ensureUniqueFileBase = (
@@ -356,9 +389,7 @@ const readTasksFolder = async (dir: string): Promise<Task[]> => {
           const parsed = data as Task;
           const enriched = ensureLabelsPresent(parsed, parsed.content);
           const baseName = path.basename(file, path.extname(file));
-          const normalizedSlug = sanitizeFileNameBase(
-            enriched.slug ?? enriched.title ?? baseName,
-          );
+          const normalizedSlug = resolveTaskSlug(enriched, baseName);
           tasks.push({ ...enriched, slug: normalizedSlug, sourcePath: file });
         }
       } catch {}
@@ -370,9 +401,7 @@ const readTasksFolder = async (dir: string): Promise<Task[]> => {
         if (parsedTask) {
           const enriched = ensureLabelsPresent(parsedTask, body);
           const baseName = path.basename(file, path.extname(file));
-          const normalizedSlug = sanitizeFileNameBase(
-            enriched.slug ?? enriched.title ?? baseName,
-          );
+          const normalizedSlug = resolveTaskSlug(enriched, baseName);
           tasks.push({ ...enriched, slug: normalizedSlug, sourcePath: file });
         }
       } catch (error) {
@@ -523,22 +552,45 @@ const resolveTaskFilePath = async (
   return match?.sourcePath;
 };
 
+const assignStableSlugs = (columns: ColumnData[]): Map<string, string> => {
+  const ordered: { task: Task; locked: boolean; order: number }[] = [];
+  let order = 0;
+  for (const column of columns) {
+    for (const task of column.tasks) {
+      ordered.push({ task, locked: slugMatchesSourcePath(task), order });
+      order += 1;
+    }
+  }
+  ordered.sort((a, b) => {
+    if (a.locked === b.locked) {
+      return a.order - b.order;
+    }
+    return a.locked ? -1 : 1;
+  });
+  const used = new Map<string, string>();
+  const finalSlugs = new Map<string, string>();
+  for (const entry of ordered) {
+    const baseName = ensureTaskFileBase(entry.task);
+    const uniqueBase = ensureUniqueFileBase(baseName, used, entry.task.uuid);
+    finalSlugs.set(entry.task.uuid, uniqueBase);
+    used.set(uniqueBase, entry.task.uuid);
+  }
+  return finalSlugs;
+};
+
 const serializeBoard = (board: Board): string => {
   const lines: string[] = ["---", "kanban-plugin: board", "---", ""];
-  const seenNames = new Map<string, string>();
   const columns = mergeColumnsCaseInsensitive(board.columns);
+  const finalSlugs = assignStableSlugs(columns);
   for (const col of columns) {
     lines.push(`## ${col.name}`);
     lines.push("");
     for (const task of col.tasks) {
       const done = /done/i.test(col.name) ? "x" : " ";
-      const baseName = ensureTaskFileBase(task);
-      const uniqueBase = ensureUniqueFileBase(baseName, seenNames, task.uuid);
-      if (task.slug !== uniqueBase) {
-        task.slug = uniqueBase;
+      const linkTarget = finalSlugs.get(task.uuid) ?? ensureTaskFileBase(task);
+      if (task.slug !== linkTarget) {
+        task.slug = linkTarget;
       }
-      seenNames.set(uniqueBase, task.uuid);
-      const linkTarget = uniqueBase;
       const displayTitle =
         task.title.trim().length > 0 ? task.title.trim() : linkTarget;
       const wikiLink =
@@ -744,7 +796,7 @@ const fallbackTaskFromRaw = (filePath: string, raw: string): Task | null => {
         .map((entry) => entry.replace(/^['"]|['"]$/g, "").trim())
         .filter((entry) => entry.length > 0)
     : [];
-  const baseTask: Task = {
+  const partialTask: Task = {
     uuid,
     title,
     status,
@@ -753,7 +805,11 @@ const fallbackTaskFromRaw = (filePath: string, raw: string): Task | null => {
     created_at: getValue("created_at") ?? NOW_ISO(),
     estimates: {},
     content: bodyContent.trim(),
-    slug: sanitizeFileNameBase(title),
+  };
+  const slug = resolveTaskSlug(partialTask, baseName);
+  const baseTask: Task = {
+    ...partialTask,
+    slug,
     sourcePath: filePath,
   };
   return ensureLabelsPresent(baseTask, bodyContent);
@@ -918,7 +974,6 @@ const BLOCKS_HEADING = "## ⛓️ Blocks";
 
 const escapeRegExp = (value: string): string =>
   value.replace(/[\\/\-^$*+?.()|[\]{}]/g, "\\$&");
-
 
 const formatSectionBlock = (
   heading: string,

--- a/packages/kanban/src/tests/regenerate.test.ts
+++ b/packages/kanban/src/tests/regenerate.test.ts
@@ -53,3 +53,30 @@ test("Task file bodies are the same before and after the board regeneration", as
 
   t.deepEqual(Array.from(after.entries()), Array.from(before.entries()));
 });
+
+test("regenerateBoard links to the hyphenated basename when titles have spaces", async (t) => {
+  const tempDir = await withTempDir(t);
+  const boardPath = path.join(tempDir, "board.md");
+  const tasksDir = path.join(tempDir, "tasks");
+  await mkdir(tasksDir, { recursive: true });
+
+  const task = makeTask({
+    uuid: "regen-hyphen",
+    title: "Spaced Out Task",
+    status: "Todo",
+    slug: "spaced-out-task",
+  });
+  await writeTaskFile(tasksDir, task, { content: "Body" });
+
+  await regenerateBoard(tasksDir, boardPath);
+
+  const boardContent = await readFile(boardPath, "utf8");
+  t.true(
+    boardContent.includes("[[spaced-out-task|Spaced Out Task]]"),
+    "Board should link to the hyphenated basename",
+  );
+  t.false(
+    boardContent.includes("[[Spaced Out Task]]"),
+    "Board should not link directly to the spaced title",
+  );
+});


### PR DESCRIPTION
## Summary
- prefer task file basenames when loading tasks that do not declare a slug
- keep board serialization from renaming tasks whose slugs already match their source files while still de-duplicating
- add a regeneration regression test that verifies wiki links stay aligned with hyphenated filenames

## Testing
- pnpm exec eslint packages/kanban/src/lib/kanban.ts packages/kanban/src/tests/regenerate.test.ts (fails with existing lint warnings across the file)
- pnpm --filter @promethean/kanban test -- --match "regenerateBoard links to the hyphenated basename when titles have spaces" (fails because ava.config.mjs redeclares nodeMajorVersion)


------
https://chatgpt.com/codex/tasks/task_e_68dd6dd111a08324955f2320258a110a