### PR TITLE
Fix duplicate node major version constant in AVA config

### DIFF
--- a/changelog.d/2025.10.01.18.27.16.md
+++ b/changelog.d/2025.10.01.18.27.16.md
@@ -1,0 +1,1 @@
+- Fix shared AVA config to avoid redeclaring the Node major version helper and guard optional flags behind explicit type checks.

--- a/config/ava.config.mjs
+++ b/config/ava.config.mjs
@@ -236,10 +236,6 @@ if (!hasCompiledTests && !hasDirectJsTests) {
 
 const nodeArguments = ["--enable-source-maps"];
 const moduleMockFlag = "--experimental-test-module-mocks";
-const nodeMajorVersion = Number.parseInt(
-  process.versions.node.split(".")[0],
-  10,
-);
 
 function determineNodeMajorVersion() {
   const version = process.versions?.node;
@@ -268,6 +264,7 @@ if (
 // also gate on the runtime major version to avoid passing invalid execArgv
 // values to older environments.
 if (
+  typeof nodeMajorVersion === "number" &&
   nodeMajorVersion >= 22 &&
   process.allowedNodeEnvironmentFlags?.has(moduleMockFlag) &&
   !nodeArguments.includes(moduleMockFlag)


### PR DESCRIPTION
## Summary
- remove the redundant nodeMajorVersion declaration in the shared AVA config and guard module mock flag detection with an explicit type check
- record the AVA config fix in the changelog

## Testing
- pnpm exec eslint config/ava.config.mjs

------
https://chatgpt.com/codex/tasks/task_e_68dd71216ff08324862f41bddfd83305