### PR TITLE
Fix Nx lint targets to ignore forwarded flags

### DIFF
--- a/changelog.d/2025.10.01.18.32.58.md
+++ b/changelog.d/2025.10.01.18.32.58.md
@@ -1,0 +1,1 @@
+- fix Nx lint targets to ignore forwarded flags and add configs for packages missing project.json

--- a/nx.json
+++ b/nx.json
@@ -23,6 +23,11 @@
     },
     "test": {
       "dependsOn": ["build"]
+    },
+    "lint": {
+      "options": {
+        "forwardAllArgs": false
+      }
     }
   },
   "projects": {

--- a/packages/broker/project.json
+++ b/packages/broker/project.json
@@ -1,0 +1,37 @@
+{
+  "name": "@promethean/broker",
+  "root": "packages/broker",
+  "targets": {
+    "build": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm run build",
+        "cwd": "packages/broker"
+      },
+      "outputs": ["{projectRoot}/dist"]
+    },
+    "typecheck": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm run typecheck",
+        "cwd": "packages/broker"
+      }
+    },
+    "test": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm run test",
+        "cwd": "packages/broker"
+      }
+    },
+    "lint": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm run lint",
+        "cwd": "packages/broker",
+        "forwardAllArgs": false
+      }
+    }
+  },
+  "tags": ["scope:packages"]
+}

--- a/packages/discord/project.json
+++ b/packages/discord/project.json
@@ -1,0 +1,38 @@
+{
+  "name": "@promethean/discord",
+  "root": "packages/discord",
+  "targets": {
+    "build": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm run build",
+        "cwd": "packages/discord"
+      },
+      "outputs": ["{projectRoot}/dist"]
+    },
+    "typecheck": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm run typecheck",
+        "cwd": "packages/discord"
+      }
+    },
+    "test": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm run test",
+        "cwd": "packages/discord"
+      }
+    },
+    "lint": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm run lint",
+        "cwd": "packages/discord",
+        "forwardAllArgs": false
+      }
+    }
+  },
+  "tags": ["scope:packages"],
+  "sourceRoot": "packages/discord/src"
+}

--- a/packages/docops-frontend/project.json
+++ b/packages/docops-frontend/project.json
@@ -1,0 +1,38 @@
+{
+  "name": "@promethean/docops-frontend",
+  "root": "packages/docops-frontend",
+  "targets": {
+    "build": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm run build",
+        "cwd": "packages/docops-frontend"
+      },
+      "outputs": ["{projectRoot}/dist"]
+    },
+    "typecheck": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm run typecheck",
+        "cwd": "packages/docops-frontend"
+      }
+    },
+    "test": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm run test",
+        "cwd": "packages/docops-frontend"
+      }
+    },
+    "lint": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm run lint",
+        "cwd": "packages/docops-frontend",
+        "forwardAllArgs": false
+      }
+    }
+  },
+  "tags": ["scope:packages"],
+  "sourceRoot": "packages/docops-frontend/src"
+}

--- a/packages/eidolon-field/project.json
+++ b/packages/eidolon-field/project.json
@@ -1,0 +1,22 @@
+{
+  "name": "eidolon-field",
+  "root": "packages/eidolon-field",
+  "targets": {
+    "test": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm run test",
+        "cwd": "packages/eidolon-field"
+      }
+    },
+    "lint": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm run lint",
+        "cwd": "packages/eidolon-field",
+        "forwardAllArgs": false
+      }
+    }
+  },
+  "tags": ["scope:packages"]
+}

--- a/packages/enso-protocol/project.json
+++ b/packages/enso-protocol/project.json
@@ -1,0 +1,31 @@
+{
+  "name": "@promethean/enso-protocol",
+  "root": "packages/enso-protocol",
+  "targets": {
+    "build": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm run build",
+        "cwd": "packages/enso-protocol"
+      },
+      "outputs": ["{projectRoot}/dist"]
+    },
+    "test": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm run test",
+        "cwd": "packages/enso-protocol"
+      }
+    },
+    "lint": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm exec eslint .",
+        "cwd": "packages/enso-protocol",
+        "forwardAllArgs": false
+      }
+    }
+  },
+  "tags": ["scope:packages"],
+  "sourceRoot": "packages/enso-protocol/src"
+}

--- a/packages/fsm/project.json
+++ b/packages/fsm/project.json
@@ -1,0 +1,38 @@
+{
+  "name": "@promethean/fsm",
+  "root": "packages/fsm",
+  "targets": {
+    "build": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm run build",
+        "cwd": "packages/fsm"
+      },
+      "outputs": ["{projectRoot}/dist"]
+    },
+    "typecheck": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm run typecheck",
+        "cwd": "packages/fsm"
+      }
+    },
+    "test": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm run test",
+        "cwd": "packages/fsm"
+      }
+    },
+    "lint": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm run lint",
+        "cwd": "packages/fsm",
+        "forwardAllArgs": false
+      }
+    }
+  },
+  "tags": ["scope:packages"],
+  "sourceRoot": "packages/fsm/src"
+}

--- a/packages/health-dashboard-frontend/project.json
+++ b/packages/health-dashboard-frontend/project.json
@@ -1,0 +1,24 @@
+{
+  "name": "@promethean/health-dashboard-frontend",
+  "root": "packages/health-dashboard-frontend",
+  "targets": {
+    "build": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm run build",
+        "cwd": "packages/health-dashboard-frontend"
+      },
+      "outputs": ["{projectRoot}/dist"]
+    },
+    "lint": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm exec eslint .",
+        "cwd": "packages/health-dashboard-frontend",
+        "forwardAllArgs": false
+      }
+    }
+  },
+  "tags": ["scope:packages"],
+  "sourceRoot": "packages/health-dashboard-frontend/src"
+}

--- a/packages/health/project.json
+++ b/packages/health/project.json
@@ -1,0 +1,22 @@
+{
+  "name": "health-service",
+  "root": "packages/health",
+  "targets": {
+    "test": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm run test",
+        "cwd": "packages/health"
+      }
+    },
+    "lint": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm run lint",
+        "cwd": "packages/health",
+        "forwardAllArgs": false
+      }
+    }
+  },
+  "tags": ["scope:packages"]
+}

--- a/packages/heartbeat/project.json
+++ b/packages/heartbeat/project.json
@@ -1,0 +1,22 @@
+{
+  "name": "heartbeat-service",
+  "root": "packages/heartbeat",
+  "targets": {
+    "test": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm run test",
+        "cwd": "packages/heartbeat"
+      }
+    },
+    "lint": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm run lint",
+        "cwd": "packages/heartbeat",
+        "forwardAllArgs": false
+      }
+    }
+  },
+  "tags": ["scope:packages"]
+}

--- a/packages/indexer-core/project.json
+++ b/packages/indexer-core/project.json
@@ -1,0 +1,38 @@
+{
+  "name": "@promethean/indexer-core",
+  "root": "packages/indexer-core",
+  "targets": {
+    "build": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm run build",
+        "cwd": "packages/indexer-core"
+      },
+      "outputs": ["{projectRoot}/dist"]
+    },
+    "typecheck": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm run typecheck",
+        "cwd": "packages/indexer-core"
+      }
+    },
+    "test": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm run test",
+        "cwd": "packages/indexer-core"
+      }
+    },
+    "lint": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm run lint",
+        "cwd": "packages/indexer-core",
+        "forwardAllArgs": false
+      }
+    }
+  },
+  "tags": ["scope:packages"],
+  "sourceRoot": "packages/indexer-core/src"
+}

--- a/packages/indexer-service/project.json
+++ b/packages/indexer-service/project.json
@@ -1,0 +1,38 @@
+{
+  "name": "@promethean/indexer-service",
+  "root": "packages/indexer-service",
+  "targets": {
+    "build": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm run build",
+        "cwd": "packages/indexer-service"
+      },
+      "outputs": ["{projectRoot}/dist"]
+    },
+    "typecheck": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm run typecheck",
+        "cwd": "packages/indexer-service"
+      }
+    },
+    "test": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm run test",
+        "cwd": "packages/indexer-service"
+      }
+    },
+    "lint": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm run lint",
+        "cwd": "packages/indexer-service",
+        "forwardAllArgs": false
+      }
+    }
+  },
+  "tags": ["scope:packages"],
+  "sourceRoot": "packages/indexer-service/src"
+}

--- a/packages/legacy/project.json
+++ b/packages/legacy/project.json
@@ -1,0 +1,22 @@
+{
+  "name": "@promethean/legacy",
+  "root": "packages/legacy",
+  "targets": {
+    "test": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm run test",
+        "cwd": "packages/legacy"
+      }
+    },
+    "lint": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm exec eslint .",
+        "cwd": "packages/legacy",
+        "forwardAllArgs": false
+      }
+    }
+  },
+  "tags": ["scope:packages"]
+}

--- a/packages/llm-chat-frontend/project.json
+++ b/packages/llm-chat-frontend/project.json
@@ -1,0 +1,24 @@
+{
+  "name": "@promethean/llm-chat-frontend",
+  "root": "packages/llm-chat-frontend",
+  "targets": {
+    "build": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm run build",
+        "cwd": "packages/llm-chat-frontend"
+      },
+      "outputs": ["{projectRoot}/dist"]
+    },
+    "lint": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm exec eslint .",
+        "cwd": "packages/llm-chat-frontend",
+        "forwardAllArgs": false
+      }
+    }
+  },
+  "tags": ["scope:packages"],
+  "sourceRoot": "packages/llm-chat-frontend/src"
+}

--- a/packages/markdown-graph-frontend/project.json
+++ b/packages/markdown-graph-frontend/project.json
@@ -1,0 +1,24 @@
+{
+  "name": "@promethean/markdown-graph-frontend",
+  "root": "packages/markdown-graph-frontend",
+  "targets": {
+    "build": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm run build",
+        "cwd": "packages/markdown-graph-frontend"
+      },
+      "outputs": ["{projectRoot}/dist"]
+    },
+    "lint": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm exec eslint .",
+        "cwd": "packages/markdown-graph-frontend",
+        "forwardAllArgs": false
+      }
+    }
+  },
+  "tags": ["scope:packages"],
+  "sourceRoot": "packages/markdown-graph-frontend/src"
+}

--- a/packages/monitoring/project.json
+++ b/packages/monitoring/project.json
@@ -1,0 +1,38 @@
+{
+  "name": "@promethean/monitoring",
+  "root": "packages/monitoring",
+  "targets": {
+    "build": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm run build",
+        "cwd": "packages/monitoring"
+      },
+      "outputs": ["{projectRoot}/dist"]
+    },
+    "typecheck": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm run typecheck",
+        "cwd": "packages/monitoring"
+      }
+    },
+    "test": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm run test",
+        "cwd": "packages/monitoring"
+      }
+    },
+    "lint": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm run lint",
+        "cwd": "packages/monitoring",
+        "forwardAllArgs": false
+      }
+    }
+  },
+  "tags": ["scope:packages"],
+  "sourceRoot": "packages/monitoring/src"
+}

--- a/packages/pm2-helpers/project.json
+++ b/packages/pm2-helpers/project.json
@@ -1,0 +1,38 @@
+{
+  "name": "@promethean/pm2-helpers",
+  "root": "packages/pm2-helpers",
+  "targets": {
+    "build": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm run build",
+        "cwd": "packages/pm2-helpers"
+      },
+      "outputs": ["{projectRoot}/dist"]
+    },
+    "typecheck": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm run typecheck",
+        "cwd": "packages/pm2-helpers"
+      }
+    },
+    "test": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm run test",
+        "cwd": "packages/pm2-helpers"
+      }
+    },
+    "lint": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm run lint",
+        "cwd": "packages/pm2-helpers",
+        "forwardAllArgs": false
+      }
+    }
+  },
+  "tags": ["scope:packages"],
+  "sourceRoot": "packages/pm2-helpers/src"
+}

--- a/packages/portfolio-frontend/project.json
+++ b/packages/portfolio-frontend/project.json
@@ -1,0 +1,24 @@
+{
+  "name": "@promethean/portfolio-frontend",
+  "root": "packages/portfolio-frontend",
+  "targets": {
+    "build": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm run build",
+        "cwd": "packages/portfolio-frontend"
+      },
+      "outputs": ["{projectRoot}/dist"]
+    },
+    "lint": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm exec eslint .",
+        "cwd": "packages/portfolio-frontend",
+        "forwardAllArgs": false
+      }
+    }
+  },
+  "tags": ["scope:packages"],
+  "sourceRoot": "packages/portfolio-frontend/src"
+}

--- a/packages/promethean-cli/project.json
+++ b/packages/promethean-cli/project.json
@@ -1,0 +1,24 @@
+{
+  "name": "@promethean/promethean-cli",
+  "root": "packages/promethean-cli",
+  "targets": {
+    "build": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm run build",
+        "cwd": "packages/promethean-cli"
+      },
+      "outputs": ["{projectRoot}/dist"]
+    },
+    "lint": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm exec eslint .",
+        "cwd": "packages/promethean-cli",
+        "forwardAllArgs": false
+      }
+    }
+  },
+  "tags": ["scope:packages"],
+  "sourceRoot": "packages/promethean-cli/src"
+}

--- a/packages/report-forge/project.json
+++ b/packages/report-forge/project.json
@@ -1,0 +1,31 @@
+{
+  "name": "@promethean/report-forge",
+  "root": "packages/report-forge",
+  "targets": {
+    "build": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm run build",
+        "cwd": "packages/report-forge"
+      },
+      "outputs": ["{projectRoot}/dist"]
+    },
+    "test": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm run test",
+        "cwd": "packages/report-forge"
+      }
+    },
+    "lint": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm run lint",
+        "cwd": "packages/report-forge",
+        "forwardAllArgs": false
+      }
+    }
+  },
+  "tags": ["scope:packages"],
+  "sourceRoot": "packages/report-forge/src"
+}

--- a/packages/shadow-conf/project.json
+++ b/packages/shadow-conf/project.json
@@ -1,0 +1,38 @@
+{
+  "name": "@promethean/shadow-conf",
+  "root": "packages/shadow-conf",
+  "targets": {
+    "build": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm run build",
+        "cwd": "packages/shadow-conf"
+      },
+      "outputs": ["{projectRoot}/dist"]
+    },
+    "typecheck": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm run typecheck",
+        "cwd": "packages/shadow-conf"
+      }
+    },
+    "test": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm run test",
+        "cwd": "packages/shadow-conf"
+      }
+    },
+    "lint": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm run lint",
+        "cwd": "packages/shadow-conf",
+        "forwardAllArgs": false
+      }
+    }
+  },
+  "tags": ["scope:packages"],
+  "sourceRoot": "packages/shadow-conf/src"
+}

--- a/packages/smart-chat-frontend/project.json
+++ b/packages/smart-chat-frontend/project.json
@@ -1,0 +1,24 @@
+{
+  "name": "@promethean/smart-chat-frontend",
+  "root": "packages/smart-chat-frontend",
+  "targets": {
+    "build": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm run build",
+        "cwd": "packages/smart-chat-frontend"
+      },
+      "outputs": ["{projectRoot}/dist"]
+    },
+    "lint": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm exec eslint .",
+        "cwd": "packages/smart-chat-frontend",
+        "forwardAllArgs": false
+      }
+    }
+  },
+  "tags": ["scope:packages"],
+  "sourceRoot": "packages/smart-chat-frontend/src"
+}

--- a/packages/smartgpt-dashboard-frontend/project.json
+++ b/packages/smartgpt-dashboard-frontend/project.json
@@ -1,0 +1,24 @@
+{
+  "name": "@promethean/smartgpt-dashboard-frontend",
+  "root": "packages/smartgpt-dashboard-frontend",
+  "targets": {
+    "build": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm run build",
+        "cwd": "packages/smartgpt-dashboard-frontend"
+      },
+      "outputs": ["{projectRoot}/dist"]
+    },
+    "lint": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm exec eslint .",
+        "cwd": "packages/smartgpt-dashboard-frontend",
+        "forwardAllArgs": false
+      }
+    }
+  },
+  "tags": ["scope:packages"],
+  "sourceRoot": "packages/smartgpt-dashboard-frontend/src"
+}

--- a/packages/ui-components/project.json
+++ b/packages/ui-components/project.json
@@ -1,0 +1,38 @@
+{
+  "name": "@promethean/ui-components",
+  "root": "packages/ui-components",
+  "targets": {
+    "build": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm run build",
+        "cwd": "packages/ui-components"
+      },
+      "outputs": ["{projectRoot}/dist"]
+    },
+    "typecheck": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm run typecheck",
+        "cwd": "packages/ui-components"
+      }
+    },
+    "test": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm run test",
+        "cwd": "packages/ui-components"
+      }
+    },
+    "lint": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm run lint",
+        "cwd": "packages/ui-components",
+        "forwardAllArgs": false
+      }
+    }
+  },
+  "tags": ["scope:packages"],
+  "sourceRoot": "packages/ui-components/src"
+}

--- a/packages/vision/project.json
+++ b/packages/vision/project.json
@@ -1,0 +1,22 @@
+{
+  "name": "vision-service",
+  "root": "packages/vision",
+  "targets": {
+    "test": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm run test",
+        "cwd": "packages/vision"
+      }
+    },
+    "lint": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm run lint",
+        "cwd": "packages/vision",
+        "forwardAllArgs": false
+      }
+    }
+  },
+  "tags": ["scope:packages"]
+}


### PR DESCRIPTION
## Summary
- stop Nx lint targets from forwarding CLI arguments to eslint so stray flags like `--paralell` are ignored
- add explicit `project.json` files for packages that were relying on inference so their lint targets call the package scripts without extra flags
- document the lint fix in the changelog

## Testing
- pnpm nx run @promethean/platform:lint --paralell
- pnpm nx run @promethean/docops-frontend:lint --paralell

------
https://chatgpt.com/codex/tasks/task_e_68dd70ca1100832490c139a17cddca34