### PR TITLE
Normalize DocOps relations chunk loader for missing data

### DIFF
--- a/changelog.d/2025.10.01.19.13.59.md
+++ b/changelog.d/2025.10.01.19.13.59.md
@@ -1,0 +1,2 @@
+## Added
+- Normalize missing chunk lookups in DocOps relations runner and cover with regression test for docs lacking chunk data.

--- a/packages/docops/src/04-relations.ts
+++ b/packages/docops/src/04-relations.ts
@@ -97,7 +97,10 @@ export async function runRelations(
     const order: string[] = [];
     const get = async (uuid: string): Promise<readonly Chunk[]> => {
       if (cache.has(uuid)) return cache.get(uuid)!;
-      const val = (await db.get(uuid).catch(() => [])) as readonly Chunk[];
+      const raw = await db.get(uuid).catch(() => undefined);
+      const val = Array.isArray(raw)
+        ? (raw as readonly Chunk[])
+        : ([] as readonly Chunk[]);
       cache.set(uuid, val);
       order.push(uuid);
       if (order.length > max) {

--- a/packages/docops/src/tests/relations.missing-chunks.test.ts
+++ b/packages/docops/src/tests/relations.missing-chunks.test.ts
@@ -1,0 +1,97 @@
+import * as path from "path";
+import * as fs from "fs/promises";
+
+import test from "ava";
+import matter from "gray-matter";
+
+import { runRelations } from "../04-relations.js";
+
+async function withTmp(fn: (dir: string) => Promise<void> | void) {
+  const dir = path.join(
+    process.cwd(),
+    "test-tmp",
+    `${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  );
+  await fs.mkdir(dir, { recursive: true });
+  try {
+    await fn(dir);
+  } finally {
+    await fs.rm(dir, { recursive: true, force: true });
+  }
+}
+
+function makeKV() {
+  const m = new Map<any, any>();
+  return {
+    async put(k: any, v: any) {
+      m.set(k, v);
+    },
+    async get(k: any) {
+      if (!m.has(k)) throw new Error("not found");
+      return m.get(k);
+    },
+    iterator() {
+      const it = m[Symbol.iterator]();
+      return {
+        async *[Symbol.asyncIterator]() {
+          for (const kv of it) yield kv as any;
+        },
+        async close() {},
+      };
+    },
+  } as const;
+}
+
+test.serial("runRelations skips missing chunk entries", async (t) => {
+  await withTmp(async (tmp) => {
+    const docsDir = path.join(tmp, "docs");
+    await fs.mkdir(docsDir, { recursive: true });
+
+    const docUuid = "doc-uuid";
+    const docPath = path.join(docsDir, "Doc.md");
+    const raw = matter.stringify("# Doc\nBody.", {
+      uuid: docUuid,
+      filename: "Doc",
+    });
+    await fs.writeFile(docPath, raw, "utf8");
+
+    const docsKV = makeKV();
+    await docsKV.put(docUuid, { path: docPath, title: "Doc" });
+
+    const chunksKV = {
+      async get() {
+        return undefined as unknown as readonly unknown[];
+      },
+    } as const;
+
+    const db = {
+      root: {
+        sublevel() {
+          return {
+            async get() {
+              return [];
+            },
+          };
+        },
+      },
+      docs: docsKV,
+      chunks: chunksKV,
+    } as any;
+
+    await t.notThrowsAsync(() =>
+      runRelations(
+        {
+          docsDir,
+          docThreshold: 0,
+          refThreshold: 0,
+        },
+        db,
+      ),
+    );
+
+    const fm = matter.read(docPath).data as Record<string, unknown>;
+    t.deepEqual(fm.related_to_uuid ?? [], []);
+    t.deepEqual(fm.related_to_title ?? [], []);
+    t.deepEqual(fm.references ?? [], []);
+  });
+});


### PR DESCRIPTION
## Summary
- normalize the DocOps relations chunk loader so missing or malformed entries return an empty array before caching
- add a regression test covering a document without chunk data to ensure runRelations completes cleanly
- document the change in the changelog

## Testing
- pnpm --filter @promethean/docops build
- pnpm --filter @promethean/docops test *(fails: ava.config.mjs throws `Identifier 'nodeMajorVersion' has already been declared` before tests run)*

------
https://chatgpt.com/codex/tasks/task_e_68dd7a9198ac8324b3755800577c7997