### PR TITLE
feat: add async process manager tools to MCP

### DIFF
--- a/changelog.d/2024.03.19.00.00.00.md
+++ b/changelog.d/2024.03.19.00.00.00.md
@@ -1,0 +1,1 @@
+- Encapsulated the MCP process runner with bounded log buffers, canonical handles, and stronger stop semantics with new AVA coverage.

--- a/changelog.d/2025.10.01.20.09.10.md
+++ b/changelog.d/2025.10.01.20.09.10.md
@@ -1,0 +1,1 @@
+- Added dedicated MCP HTTP endpoints for process management, file tools, and GitHub APIs while keeping the legacy /mcp toolset.

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -25,6 +25,15 @@ import {
   filesWriteFileLines,
 } from "./tools/files.js";
 import { filesSearch } from "./tools/search.js";
+import {
+  processEnqueueTask,
+  processGetQueue,
+  processGetStderr,
+  processGetStdout,
+  processGetTaskRunnerConfig,
+  processStopTask,
+  processUpdateTaskRunnerConfig,
+} from "./tools/process-manager.js";
 import type { ToolFactory } from "./core/types.js";
 import {
   resolveHttpEndpoints,
@@ -41,6 +50,13 @@ const toolCatalog = new Map<string, ToolFactory>([
   ["files.write-content", filesWriteFileContent],
   ["files.write-lines", filesWriteFileLines],
   ["files.search", filesSearch],
+  ["process.getTaskRunnerConfig", processGetTaskRunnerConfig],
+  ["process.updateTaskRunnerConfig", processUpdateTaskRunnerConfig],
+  ["process.enqueueTask", processEnqueueTask],
+  ["process.stop", processStopTask],
+  ["process.getQueue", processGetQueue],
+  ["process.getStdout", processGetStdout],
+  ["process.getStderr", processGetStderr],
   ["tdd.scaffoldTest", tddScaffoldTest],
   ["tdd.changedFiles", tddChangedFiles],
   ["tdd.runTests", tddRunTests],

--- a/packages/mcp/src/tools/process-manager.ts
+++ b/packages/mcp/src/tools/process-manager.ts
@@ -6,15 +6,31 @@ import { z } from "zod";
 
 import type { ToolFactory } from "../core/types.js";
 
+const DEFAULT_MAX_RUNNING = 1;
+const DEFAULT_TERMINATE_GRACE_MS = 5_000;
+const DEFAULT_TERMINATE_FORCE_MS = 2_000;
+const DEFAULT_LINE_BUFFER_SIZE = 10_000;
+const DEFAULT_CHAR_BUFFER_SIZE = 16_384;
+
 type TaskStatus = "waiting" | "running" | "completed";
+
+type OutputBuffer = {
+  readonly lines: string[];
+  firstLine: number;
+  totalLines: number;
+  remainder: string;
+  tail: string;
+};
 
 type Task = {
   readonly id: string;
   readonly command: string;
   readonly args: readonly string[];
   readonly createdAt: Date;
-  name?: string;
+  readonly stdout: OutputBuffer;
+  readonly stderr: OutputBuffer;
   status: TaskStatus;
+  name?: string;
   cwd?: string;
   env?: Record<string, string>;
   pid: number | null;
@@ -25,12 +41,6 @@ type Task = {
   timeoutMs?: number;
   timeoutHandle?: NodeJS.Timeout;
   process?: ReturnType<typeof spawn>;
-  stdoutText: string;
-  stderrText: string;
-  stdoutLines: string[];
-  stderrLines: string[];
-  stdoutRemainder: string;
-  stderrRemainder: string;
 };
 
 type TaskSummary = Readonly<{
@@ -40,481 +50,550 @@ type TaskSummary = Readonly<{
   args: readonly string[];
   status: TaskStatus;
   pid: number | null;
+  cwd?: string;
   createdAt: string;
   startedAt?: string;
   completedAt?: string;
   exitCode?: number | null;
   signal?: NodeJS.Signals | null;
+  durationMs?: number;
 }>;
 
 type RunnerConfig = Readonly<{
   path: string;
   maxRunning: number;
   timeout?: number;
+  terminateGraceMs: number;
+  terminateForceMs: number;
+  lineBufferSize: number;
+  charBufferSize: number;
 }>;
 
-let taskCounter = 0;
-let config: RunnerConfig = {
-  path: process.cwd(),
-  maxRunning: 1,
+type RunnerState = {
+  readonly tasks: Map<string, Task>;
+  readonly waitingQueue: string[];
+  readonly runningTasks: Set<string>;
+  readonly completedTasks: string[];
+  config: RunnerConfig;
+  taskCounter: number;
 };
-const tasks = new Map<string, Task>();
-const waitingQueue: string[] = [];
-const runningTasks = new Set<string>();
-const completedTasks: string[] = [];
 
-const buildSummary = (task: Task): TaskSummary => ({
-  id: task.id,
-  name: task.name,
-  command: task.command,
-  args: task.args,
-  status: task.status,
-  pid: task.pid,
-  createdAt: task.createdAt.toISOString(),
-  startedAt: task.startedAt?.toISOString(),
-  completedAt: task.completedAt?.toISOString(),
-  exitCode: task.exitCode,
-  signal: task.signal ?? undefined,
+type ResolveHandle = string | number;
+
+const trimTail = (value: string, limit: number) =>
+  value.length <= limit ? value : value.slice(value.length - limit);
+
+const createOutputBuffer = (): OutputBuffer => ({
+  lines: [],
+  firstLine: 1,
+  totalLines: 0,
+  remainder: "",
+  tail: "",
 });
 
-const getConfig = () => ({ ...config });
-
-const updateConfig = (key: string, value: string | number | undefined) => {
-  if (key === "path") {
-    if (typeof value !== "string" || !value) {
-      throw new Error("path must be a non-empty string");
+const flushRemainder = (buffer: OutputBuffer, lineLimit: number) => {
+  if (buffer.remainder) {
+    buffer.lines.push(buffer.remainder);
+    buffer.totalLines += 1;
+    buffer.remainder = "";
+    if (buffer.lines.length > lineLimit) {
+      const overshoot = buffer.lines.length - lineLimit;
+      buffer.lines.splice(0, overshoot);
+      buffer.firstLine += overshoot;
     }
-    config = { ...config, path: path.resolve(value) };
-    return config;
   }
-  if (key === "maxRunning") {
-    const parsed = Number(value);
-    if (!Number.isInteger(parsed) || parsed <= 0) {
-      throw new Error("maxRunning must be a positive integer");
-    }
-    config = { ...config, maxRunning: parsed };
-    maybeRunNext();
-    return config;
-  }
-  if (key === "timeout") {
-    if (value === undefined || value === null) {
-      const { timeout, ...rest } = config;
-      config = rest as RunnerConfig;
-      return config;
-    }
-    const parsed = Number(value);
-    if (!Number.isFinite(parsed) || parsed <= 0) {
-      throw new Error("timeout must be a positive number of milliseconds");
-    }
-    config = { ...config, timeout: parsed };
-    return config;
-  }
-  throw new Error(`Unknown config key: ${key}`);
 };
 
-const appendOutput = (task: Task, kind: "stdout" | "stderr", chunk: Buffer) => {
+const appendOutput = (
+  buffer: OutputBuffer,
+  chunk: Buffer,
+  { lineLimit, charLimit }: { lineLimit: number; charLimit: number },
+) => {
   const text = chunk.toString("utf8");
-  if (kind === "stdout") {
-    task.stdoutText += text;
-    const combined = task.stdoutRemainder + text;
-    const parts = combined.split(/\r?\n/);
-    task.stdoutRemainder = parts.pop() ?? "";
-    task.stdoutLines.push(...parts);
-    return;
-  }
-  task.stderrText += text;
-  const combined = task.stderrRemainder + text;
+  const combined = buffer.remainder + text;
   const parts = combined.split(/\r?\n/);
-  task.stderrRemainder = parts.pop() ?? "";
-  task.stderrLines.push(...parts);
+  buffer.remainder = parts.pop() ?? "";
+  for (const line of parts) {
+    buffer.lines.push(line);
+    buffer.totalLines += 1;
+  }
+  if (buffer.lines.length > lineLimit) {
+    const overshoot = buffer.lines.length - lineLimit;
+    buffer.lines.splice(0, overshoot);
+    buffer.firstLine += overshoot;
+  }
+  buffer.tail = trimTail(buffer.tail + text, charLimit);
 };
 
-const flushRemainders = (task: Task) => {
-  if (task.stdoutRemainder) {
-    task.stdoutLines.push(task.stdoutRemainder);
-    task.stdoutRemainder = "";
-  }
-  if (task.stderrRemainder) {
-    task.stderrLines.push(task.stderrRemainder);
-    task.stderrRemainder = "";
-  }
+const outputTail = (buffer: OutputBuffer, charLimit: number) => {
+  const pendingTail = buffer.tail + buffer.remainder;
+  return trimTail(pendingTail, charLimit);
 };
 
-const finalizeTask = (
-  task: Task,
-  exitCode: number | null,
-  signal: NodeJS.Signals | null,
-) => {
-  flushRemainders(task);
-  if (task.timeoutHandle) {
-    task.timeoutHandle.unref();
-    clearTimeout(task.timeoutHandle);
-    task.timeoutHandle = undefined;
-  }
-  task.exitCode = exitCode;
-  task.signal = signal;
-  task.completedAt = new Date();
-  task.status = "completed";
-  task.process = undefined;
-  runningTasks.delete(task.id);
-  if (!completedTasks.includes(task.id)) {
-    completedTasks.push(task.id);
-  }
-};
-
-const maybeRunNext = () => {
-  while (runningTasks.size < config.maxRunning && waitingQueue.length > 0) {
-    const nextId = waitingQueue.shift();
-    if (!nextId) continue;
-    const task = tasks.get(nextId);
-    if (!task) continue;
-    if (task.status !== "waiting") continue;
-    startTask(task);
-  }
-};
-
-const startTask = (task: Task) => {
-  const child = spawn(task.command, task.args, {
-    cwd: task.cwd ?? config.path,
-    env: { ...process.env, ...(task.env ?? {}) },
-    stdio: ["ignore", "pipe", "pipe"],
-  });
-  task.process = child;
-  task.status = "running";
-  task.startedAt = new Date();
-  task.pid = child.pid ?? null;
-  runningTasks.add(task.id);
-
-  child.stdout?.on("data", (chunk: Buffer) =>
-    appendOutput(task, "stdout", chunk),
-  );
-  child.stderr?.on("data", (chunk: Buffer) =>
-    appendOutput(task, "stderr", chunk),
-  );
-
-  child.once("error", (err) => {
-    appendOutput(task, "stderr", Buffer.from(String(err)));
-    finalizeTask(task, null, null);
-    maybeRunNext();
-  });
-
-  child.once("exit", (code, signal) => {
-    finalizeTask(task, code, signal);
-    maybeRunNext();
-  });
-
-  const timeout = task.timeoutMs ?? config.timeout;
-  if (timeout && Number.isFinite(timeout)) {
-    const handle = setTimeout(() => {
-      if (task.process) {
-        task.process.kill("SIGTERM");
-      }
-    }, timeout);
-    handle.unref();
-    task.timeoutHandle = handle;
-  }
-};
-
-const createTask = (input: {
-  command: string;
-  args: readonly string[];
-  name?: string;
-  cwd?: string;
-  env?: Record<string, string>;
-  timeoutMs?: number;
-}): Task => {
-  const id = `task-${++taskCounter}`;
-  const task: Task = {
-    id,
-    command: input.command,
-    args: input.args,
-    createdAt: new Date(),
-    name: input.name,
-    status: "waiting",
-    cwd: input.cwd,
-    env: input.env,
-    pid: null,
-    timeoutMs: input.timeoutMs,
-    stdoutText: "",
-    stderrText: "",
-    stdoutLines: [],
-    stderrLines: [],
-    stdoutRemainder: "",
-    stderrRemainder: "",
-  };
-  tasks.set(id, task);
-  waitingQueue.push(id);
-  return task;
-};
-
-const resolveTask = (handle: string | number): Task => {
-  if (typeof handle === "number") {
-    for (const task of tasks.values()) {
-      if (task.pid === handle) return task;
-    }
-    throw new Error(`No task with pid ${handle}`);
-  }
-  const byId = tasks.get(handle);
-  if (byId) return byId;
-  for (const task of tasks.values()) {
-    if (task.name === handle) return task;
-  }
-  throw new Error(`No task with handle ${handle}`);
-};
-
-const linesFor = (task: Task, kind: "stdout" | "stderr") => {
-  const base = kind === "stdout" ? task.stdoutLines : task.stderrLines;
-  const remainder =
-    kind === "stdout" ? task.stdoutRemainder : task.stderrRemainder;
-  return remainder ? [...base, remainder] : [...base];
-};
-
-const getLogs = (
-  task: Task,
-  kind: "stdout" | "stderr",
-  input: {
-    startLine?: number;
-    count?: number;
-    pageNumber?: number;
-    length?: number;
-  },
-) => {
-  const lines = linesFor(task, kind);
-  if (lines.length === 0) {
-    return {
-      start: 0,
-      end: 0,
-      pagenumber: input.pageNumber ?? null,
-      lastPage: true,
-      logs: "",
-    } as const;
-  }
-  if (typeof input.startLine === "number") {
-    const startIndex = Math.max(0, input.startLine - 1);
-    const count = input.count ?? lines.length;
-    const slice = lines.slice(startIndex, startIndex + count);
-    const endLine = slice.length ? startIndex + slice.length : startIndex;
-    return {
-      start: startIndex + 1,
-      end: endLine,
-      pagenumber: null,
-      lastPage: endLine >= lines.length,
-      logs: slice.join("\n"),
-    } as const;
-  }
-  const pageNumber = input.pageNumber ?? 1;
-  const length = input.length ?? lines.length;
-  const startIndex = (pageNumber - 1) * length;
-  const slice = lines.slice(startIndex, startIndex + length);
-  const endLine = slice.length ? startIndex + slice.length : startIndex;
+const buildSummary = (task: Task): TaskSummary => {
+  const durationMs = task.startedAt
+    ? (task.completedAt?.getTime() ?? Date.now()) - task.startedAt.getTime()
+    : undefined;
   return {
-    start: startIndex + 1,
-    end: endLine,
-    pagenumber: pageNumber,
-    lastPage: endLine >= lines.length,
-    logs: slice.join("\n"),
-  } as const;
+    id: task.id,
+    name: task.name,
+    command: task.command,
+    args: task.args,
+    status: task.status,
+    pid: task.pid,
+    cwd: task.cwd,
+    createdAt: task.createdAt.toISOString(),
+    startedAt: task.startedAt?.toISOString(),
+    completedAt: task.completedAt?.toISOString(),
+    exitCode: task.exitCode,
+    signal: task.signal ?? undefined,
+    durationMs,
+  };
 };
 
-const TERMINATE_GRACE_PERIOD_MS = 5_000;
-const TERMINATE_FORCE_TIMEOUT_MS = 2_000;
+const createRunner = (initial?: Partial<RunnerConfig>) => {
+  const state: RunnerState = {
+    tasks: new Map(),
+    waitingQueue: [],
+    runningTasks: new Set(),
+    completedTasks: [],
+    config: {
+      path: path.resolve(process.cwd()),
+      maxRunning: DEFAULT_MAX_RUNNING,
+      terminateGraceMs: DEFAULT_TERMINATE_GRACE_MS,
+      terminateForceMs: DEFAULT_TERMINATE_FORCE_MS,
+      lineBufferSize: DEFAULT_LINE_BUFFER_SIZE,
+      charBufferSize: DEFAULT_CHAR_BUFFER_SIZE,
+      ...initial,
+    },
+    taskCounter: 0,
+  };
 
-const stopTask = async (
-  handle: string | number,
-  tail: number,
-  signal?: NodeJS.Signals,
-) => {
-  const task = resolveTask(handle);
-  if (task.status === "waiting") {
-    const index = waitingQueue.indexOf(task.id);
-    if (index >= 0) waitingQueue.splice(index, 1);
-    task.status = "completed";
+  const getConfig = (): RunnerConfig => ({ ...state.config });
+
+  const finalizeTask = (
+    task: Task,
+    exitCode: number | null,
+    signal: NodeJS.Signals | null,
+  ) => {
+    flushRemainder(task.stdout, state.config.lineBufferSize);
+    flushRemainder(task.stderr, state.config.lineBufferSize);
+    if (task.timeoutHandle) {
+      task.timeoutHandle.unref();
+      clearTimeout(task.timeoutHandle);
+      task.timeoutHandle = undefined;
+    }
+    task.exitCode = exitCode;
+    task.signal = signal;
     task.completedAt = new Date();
-    if (!completedTasks.includes(task.id)) completedTasks.push(task.id);
-    return { tail: "" } as const;
-  }
-  if (task.status === "completed" || !task.process) {
-    const combined = `${task.stdoutText}${task.stderrText}`;
-    const tailText = combined.slice(-tail);
-    return { tail: tailText } as const;
-  }
-  const proc = task.process;
-  proc.kill(signal ?? "SIGTERM");
-  const exitPromise = once(proc, "exit");
+    task.status = "completed";
+    task.process = undefined;
+    state.runningTasks.delete(task.id);
+    if (!state.completedTasks.includes(task.id)) {
+      state.completedTasks.push(task.id);
+    }
+  };
 
-  const guard = new Promise<never>((_resolve, reject) => {
-    const terminateTimer = setTimeout(() => {
-      if (!proc.killed) {
-        proc.kill("SIGKILL");
-      }
-      const forceTimer = setTimeout(() => {
-        reject(
-          new Error(
-            `Process ${proc.pid ?? "<unknown>"} failed to exit after SIGKILL`,
-          ),
-        );
-      }, TERMINATE_FORCE_TIMEOUT_MS);
-      forceTimer.unref();
-      void exitPromise.finally(() => {
-        clearTimeout(forceTimer);
-      });
-    }, TERMINATE_GRACE_PERIOD_MS);
-    terminateTimer.unref();
-    void exitPromise.finally(() => {
-      clearTimeout(terminateTimer);
+  const startTask = (task: Task) => {
+    const child = spawn(task.command, task.args, {
+      cwd: task.cwd ?? state.config.path,
+      env: { ...process.env, ...(task.env ?? {}) },
+      stdio: ["ignore", "pipe", "pipe"],
     });
+    task.process = child;
+    task.status = "running";
+    task.startedAt = new Date();
+    task.pid = child.pid ?? null;
+    state.runningTasks.add(task.id);
+
+    const bufferConfig = {
+      lineLimit: state.config.lineBufferSize,
+      charLimit: state.config.charBufferSize,
+    };
+
+    if (child.stdout) {
+      (async () => {
+        for await (const chunk of child.stdout!) {
+          appendOutput(task.stdout, chunk as Buffer, bufferConfig);
+        }
+      })().catch(() => {
+        /* ignore stream iteration errors */
+      });
+    }
+    if (child.stderr) {
+      (async () => {
+        for await (const chunk of child.stderr!) {
+          appendOutput(task.stderr, chunk as Buffer, bufferConfig);
+        }
+      })().catch(() => {
+        /* ignore stream iteration errors */
+      });
+    }
+
+    child.once("error", (err) => {
+      appendOutput(task.stderr, Buffer.from(String(err)), bufferConfig);
+      finalizeTask(task, null, null);
+      maybeRunNext();
+    });
+
+    child.once("close", (code, signal) => {
+      finalizeTask(task, code, signal);
+      maybeRunNext();
+    });
+
+    const timeout = task.timeoutMs ?? state.config.timeout;
+    if (timeout && Number.isFinite(timeout)) {
+      const handle = setTimeout(() => {
+        if (task.process) {
+          try {
+            task.process.kill("SIGTERM");
+          } catch {
+            /* ignore */
+          }
+        }
+      }, timeout);
+      handle.unref();
+      task.timeoutHandle = handle;
+    }
+  };
+
+  const maybeRunNext = () => {
+    while (
+      state.runningTasks.size < state.config.maxRunning &&
+      state.waitingQueue.length > 0
+    ) {
+      const nextId = state.waitingQueue.shift();
+      if (!nextId) continue;
+      const task = state.tasks.get(nextId);
+      if (!task || task.status !== "waiting") continue;
+      startTask(task);
+    }
+  };
+
+  const createTask = (input: {
+    command: string;
+    args: readonly string[];
+    name?: string;
+    cwd?: string;
+    env?: Record<string, string>;
+    timeoutMs?: number;
+  }): Task => {
+    const id = `task-${++state.taskCounter}`;
+    const task: Task = {
+      id,
+      command: input.command,
+      args: input.args,
+      createdAt: new Date(),
+      stdout: createOutputBuffer(),
+      stderr: createOutputBuffer(),
+      status: "waiting",
+      name: input.name,
+      cwd: input.cwd,
+      env: input.env,
+      pid: null,
+      timeoutMs: input.timeoutMs,
+    };
+    state.tasks.set(id, task);
+    state.waitingQueue.push(id);
+    return task;
+  };
+
+  const updateConfig = (key: keyof RunnerConfig, value: unknown) => {
+    if (key === "path") {
+      if (typeof value !== "string" || value.length === 0) {
+        throw new Error("path must be a non-empty string");
+      }
+      state.config = { ...state.config, path: path.resolve(value) };
+      return getConfig();
+    }
+    if (key === "maxRunning") {
+      const parsed = Number(value);
+      if (!Number.isInteger(parsed) || parsed <= 0) {
+        throw new Error("maxRunning must be a positive integer");
+      }
+      state.config = { ...state.config, maxRunning: parsed };
+      maybeRunNext();
+      return getConfig();
+    }
+    if (key === "timeout") {
+      if (value === undefined || value === null) {
+        const { timeout: _timeout, ...rest } = state.config;
+        state.config = rest as RunnerConfig;
+        return getConfig();
+      }
+      const parsed = Number(value);
+      if (!Number.isFinite(parsed) || parsed <= 0) {
+        throw new Error("timeout must be a positive number of milliseconds");
+      }
+      state.config = { ...state.config, timeout: parsed };
+      return getConfig();
+    }
+    if (key === "terminateGraceMs" || key === "terminateForceMs") {
+      const parsed = Number(value);
+      if (!Number.isFinite(parsed) || parsed < 0) {
+        throw new Error(`${key} must be a non-negative number of milliseconds`);
+      }
+      state.config = { ...state.config, [key]: parsed } as RunnerConfig;
+      return getConfig();
+    }
+    if (key === "lineBufferSize" || key === "charBufferSize") {
+      const parsed = Number(value);
+      if (!Number.isInteger(parsed) || parsed <= 0) {
+        throw new Error(`${key} must be a positive integer`);
+      }
+      state.config = { ...state.config, [key]: parsed } as RunnerConfig;
+      return getConfig();
+    }
+    throw new Error(`Unknown config key: ${String(key)}`);
+  };
+
+  const resolveTask = (handle: ResolveHandle): Task => {
+    if (typeof handle === "number") {
+      for (const task of state.tasks.values()) {
+        if (task.pid === handle) return task;
+      }
+      throw new Error(`No task with pid ${handle}`);
+    }
+    const byId = state.tasks.get(handle);
+    if (byId) return byId;
+    for (const task of state.tasks.values()) {
+      if (task.name === handle) return task;
+    }
+    throw new Error(`No task with handle ${handle}`);
+  };
+
+  const calculateLogs = (
+    buffer: OutputBuffer,
+    input:
+      | { startLine: number; count: number }
+      | { pagenumber: number; length: number },
+  ) => {
+    const availableLines = buffer.lines;
+    if (availableLines.length === 0) {
+      return {
+        start: 0,
+        end: 0,
+        pagenumber: "pagenumber" in input ? input.pagenumber : null,
+        lastPage: true,
+        logs: "",
+        truncated: buffer.totalLines > 0,
+      } as const;
+    }
+    const firstAvailable = buffer.firstLine;
+    const lastAvailable = firstAvailable + availableLines.length - 1;
+
+    if ("startLine" in input) {
+      const requestedStart = Math.max(input.startLine, firstAvailable);
+      if (requestedStart > lastAvailable) {
+        return {
+          start: lastAvailable + 1,
+          end: lastAvailable,
+          pagenumber: null,
+          lastPage: true,
+          logs: "",
+          truncated: true,
+        } as const;
+      }
+      const startIndex = requestedStart - firstAvailable;
+      const slice = availableLines.slice(startIndex, startIndex + input.count);
+      const endLine = slice.length
+        ? requestedStart + slice.length - 1
+        : requestedStart - 1;
+      return {
+        start: requestedStart,
+        end: endLine,
+        pagenumber: null,
+        lastPage: endLine >= lastAvailable,
+        logs: slice.join("\n"),
+        truncated: requestedStart !== input.startLine || buffer.firstLine > 1,
+      } as const;
+    }
+
+    const pageNumber = input.pagenumber;
+    const length = input.length;
+    const startIndex = (pageNumber - 1) * length;
+    const slice = availableLines.slice(startIndex, startIndex + length);
+    const actualStart = firstAvailable + startIndex;
+    const endLine = slice.length
+      ? actualStart + slice.length - 1
+      : actualStart - 1;
+    const lastPage = endLine >= lastAvailable;
+    return {
+      start: actualStart,
+      end: endLine,
+      pagenumber: pageNumber,
+      lastPage,
+      logs: slice.join("\n"),
+      truncated: buffer.firstLine > 1,
+    } as const;
+  };
+
+  const tailForTask = (task: Task, tail: number) => {
+    if (tail <= 0) return "";
+    const combined =
+      outputTail(task.stdout, state.config.charBufferSize) +
+      outputTail(task.stderr, state.config.charBufferSize);
+    return trimTail(combined, tail);
+  };
+
+  const stopTask = async (
+    handle: ResolveHandle,
+    tail: number,
+    signal?: NodeJS.Signals,
+  ) => {
+    const task = resolveTask(handle);
+    if (task.status === "waiting") {
+      const index = state.waitingQueue.indexOf(task.id);
+      if (index >= 0) state.waitingQueue.splice(index, 1);
+      task.status = "completed";
+      task.completedAt = new Date();
+      if (!state.completedTasks.includes(task.id)) {
+        state.completedTasks.push(task.id);
+      }
+      return { tail: "" } as const;
+    }
+    if (task.status === "completed" || !task.process) {
+      return { tail: tailForTask(task, tail) } as const;
+    }
+    const proc = task.process;
+    try {
+      if (signal) {
+        proc.kill(signal);
+      } else {
+        proc.kill("SIGTERM");
+      }
+    } catch {
+      proc.kill();
+    }
+
+    const closePromise = once(proc, "close");
+
+    const guard = new Promise<never>((_resolve, reject) => {
+      const graceTimer = setTimeout(() => {
+        if (process.platform !== "win32" && !proc.killed) {
+          try {
+            proc.kill("SIGKILL");
+          } catch {
+            /* ignore */
+          }
+        }
+        const forceTimer = setTimeout(() => {
+          reject(
+            new Error(
+              `Process ${
+                proc.pid ?? "<unknown>"
+              } failed to exit after escalation`,
+            ),
+          );
+        }, state.config.terminateForceMs);
+        forceTimer.unref();
+        void closePromise.finally(() => {
+          clearTimeout(forceTimer);
+        });
+      }, state.config.terminateGraceMs);
+      graceTimer.unref();
+      void closePromise.finally(() => {
+        clearTimeout(graceTimer);
+      });
+    });
+
+    await Promise.race([closePromise, guard]);
+    await closePromise;
+
+    return { tail: tailForTask(task, tail) } as const;
+  };
+
+  const getQueue = () => ({
+    waiting: state.waitingQueue
+      .map((id) => state.tasks.get(id))
+      .filter((task): task is Task => Boolean(task))
+      .map(buildSummary),
+    running: Array.from(state.runningTasks)
+      .map((id) => state.tasks.get(id))
+      .filter((task): task is Task => Boolean(task))
+      .map(buildSummary),
+    completed: state.completedTasks
+      .map((id) => state.tasks.get(id))
+      .filter((task): task is Task => Boolean(task))
+      .map(buildSummary),
   });
 
-  await Promise.race([exitPromise, guard]);
-  await exitPromise;
+  const reset = () => {
+    for (const task of state.tasks.values()) {
+      if (task.process && task.status === "running") {
+        try {
+          task.process.kill("SIGTERM");
+        } catch {
+          /* ignore */
+        }
+      }
+      if (task.timeoutHandle) {
+        task.timeoutHandle.unref();
+        clearTimeout(task.timeoutHandle);
+      }
+    }
+    state.tasks.clear();
+    state.waitingQueue.length = 0;
+    state.runningTasks.clear();
+    state.completedTasks.length = 0;
+    state.taskCounter = 0;
+    const { timeout } = state.config;
+    state.config = {
+      path: path.resolve(process.cwd()),
+      maxRunning: DEFAULT_MAX_RUNNING,
+      terminateGraceMs: DEFAULT_TERMINATE_GRACE_MS,
+      terminateForceMs: DEFAULT_TERMINATE_FORCE_MS,
+      lineBufferSize: DEFAULT_LINE_BUFFER_SIZE,
+      charBufferSize: DEFAULT_CHAR_BUFFER_SIZE,
+      ...(timeout ? { timeout } : {}),
+    };
+  };
 
-  const combined = `${task.stdoutText}${task.stderrText}`;
-  const tailText = combined.slice(-tail);
-  return { tail: tailText } as const;
+  return {
+    getConfig,
+    updateConfig,
+    createTask,
+    maybeRunNext,
+    stopTask,
+    getQueue,
+    resolveTask,
+    calculateLogs,
+    tailForTask,
+    reset,
+  };
 };
+
+const runner = createRunner();
+
+const runnerConfigSchema = z.enum([
+  "path",
+  "maxRunning",
+  "timeout",
+  "terminateGraceMs",
+  "terminateForceMs",
+  "lineBufferSize",
+  "charBufferSize",
+] as const satisfies readonly (keyof RunnerConfig)[]);
+
+const ALLOWED_SIGNALS = [
+  "SIGTERM",
+  "SIGINT",
+  "SIGKILL",
+  "SIGHUP",
+  "SIGQUIT",
+] as const satisfies readonly NodeJS.Signals[];
 
 const EnqueueSchema = z.object({
-  command: z.string(),
+  command: z.string().min(1),
   args: z.array(z.string()).default([]),
   opts: z
     .object({
-      name: z.string().optional(),
-      cwd: z.string().optional(),
+      name: z.string().min(1).optional(),
+      cwd: z.string().min(1).optional(),
       env: z.record(z.string()).optional(),
-      timeoutDuration: z.number().positive().optional(),
+      timeoutMs: z.number().positive().optional(),
     })
-    .optional(),
-  name: z.string().optional(),
-  cwd: z.string().optional(),
-  env: z.record(z.string()).optional(),
-  timeout: z.boolean().optional(),
-  timeoutDuration: z.number().positive().optional(),
-});
-
-export const processGetTaskRunnerConfig: ToolFactory = () => ({
-  spec: {
-    name: "process.getTaskRunnerConfig",
-    description: "Return the current task runner configuration.",
-  },
-  invoke: async () => ({ config: getConfig() }),
-});
-
-export const processUpdateTaskRunnerConfig: ToolFactory = () => {
-  const Schema = z.object({
-    key: z.enum(["path", "maxRunning", "timeout"]),
-    value: z.union([z.string(), z.number()]).optional(),
-  });
-  return {
-    spec: {
-      name: "process.updateTaskRunnerConfig",
-      description: "Update a single key in the task runner configuration.",
-      inputSchema: {
-        key: Schema.shape.key,
-        value: Schema.shape.value,
-      },
-    },
-    invoke: async (raw: unknown) => {
-      const { key, value } = Schema.parse(raw);
-      const cfg = updateConfig(key, value);
-      return { config: cfg };
-    },
-  };
-};
-
-export const processEnqueueTask: ToolFactory = () => ({
-  spec: {
-    name: "process.enqueueTask",
-    description:
-      "Enqueue a command for execution respecting concurrency limits.",
-    inputSchema: {
-      command: z.string(),
-      args: z.array(z.string()).optional(),
-      opts: z
-        .object({
-          name: z.string().optional(),
-          cwd: z.string().optional(),
-          env: z.record(z.string()).optional(),
-          timeoutDuration: z.number().optional(),
-        })
-        .optional(),
-      name: z.string().optional(),
-      cwd: z.string().optional(),
-      env: z.record(z.string()).optional(),
-      timeout: z.boolean().optional(),
-      timeoutDuration: z.number().optional(),
-    },
-  },
-  invoke: async (raw: unknown) => {
-    const parsed = EnqueueSchema.parse(raw);
-    const taskName = parsed.name ?? parsed.opts?.name;
-    const cwd = parsed.cwd ?? parsed.opts?.cwd;
-    const env = parsed.env ?? parsed.opts?.env;
-    const timeoutDuration =
-      parsed.timeoutDuration ?? parsed.opts?.timeoutDuration;
-    const timeoutMs = parsed.timeout
-      ? timeoutDuration ?? config.timeout
-      : timeoutDuration;
-    const task = createTask({
-      command: parsed.command,
-      args: parsed.args,
-      name: taskName,
-      cwd,
-      env,
-      timeoutMs: timeoutMs,
-    });
-    maybeRunNext();
-    return { name: task.name, pid: task.pid };
-  },
-});
-
-export const processStopTask: ToolFactory = () => {
-  const Schema = z.object({
-    handle: z.union([z.string(), z.number()]),
-    tail: z.number().int().min(0).default(0),
-    signal: z.string().optional(),
-  });
-  return {
-    spec: {
-      name: "process.stop",
-      description:
-        "Stop a running task via pid or name and return trailing output.",
-      inputSchema: {
-        handle: Schema.shape.handle,
-        tail: Schema.shape.tail,
-        signal: Schema.shape.signal,
-      },
-    },
-    invoke: async (raw: unknown) => {
-      const { handle, tail, signal } = Schema.parse(raw);
-      const result = await stopTask(
-        handle,
-        tail,
-        signal as NodeJS.Signals | undefined,
-      );
-      return result;
-    },
-  };
-};
-
-export const processGetQueue: ToolFactory = () => ({
-  spec: {
-    name: "process.getQueue",
-    description: "Return waiting, running, and completed task summaries.",
-  },
-  invoke: async () => ({
-    waiting: waitingQueue
-      .map((id) => tasks.get(id))
-      .filter((task): task is Task => Boolean(task))
-      .map(buildSummary),
-    running: Array.from(runningTasks)
-      .map((id) => tasks.get(id))
-      .filter((task): task is Task => Boolean(task))
-      .map(buildSummary),
-    completed: completedTasks
-      .map((id) => tasks.get(id))
-      .filter((task): task is Task => Boolean(task))
-      .map(buildSummary),
-  }),
+    .default({}),
 });
 
 const LogSchema = z.union([
@@ -529,6 +608,87 @@ const LogSchema = z.union([
     count: z.number().int().min(1),
   }),
 ]);
+
+export const processGetTaskRunnerConfig: ToolFactory = () => ({
+  spec: {
+    name: "process.getTaskRunnerConfig",
+    description: "Return the current task runner configuration.",
+  },
+  invoke: async () => ({ config: runner.getConfig() }),
+});
+
+export const processUpdateTaskRunnerConfig: ToolFactory = () => {
+  const Schema = z.object({
+    key: runnerConfigSchema,
+    value: z.union([z.string(), z.number()]).optional(),
+  });
+  return {
+    spec: {
+      name: "process.updateTaskRunnerConfig",
+      description: "Update a single key in the task runner configuration.",
+      inputSchema: {
+        key: Schema.shape.key,
+        value: Schema.shape.value,
+      },
+    },
+    invoke: async (raw: unknown) => {
+      const { key, value } = Schema.parse(raw);
+      const config = runner.updateConfig(key, value);
+      return { config };
+    },
+  };
+};
+
+export const processEnqueueTask: ToolFactory = () => ({
+  spec: {
+    name: "process.enqueueTask",
+    description:
+      "Enqueue a command for execution respecting concurrency limits.",
+    inputSchema: {
+      command: z.string(),
+      args: z.array(z.string()).optional(),
+      opts: EnqueueSchema.shape.opts.optional(),
+    },
+  },
+  invoke: async (raw: unknown) => {
+    const parsed = EnqueueSchema.parse(raw);
+    const task = runner.createTask({
+      command: parsed.command,
+      args: parsed.args,
+      name: parsed.opts.name,
+      cwd: parsed.opts.cwd,
+      env: parsed.opts.env,
+      timeoutMs: parsed.opts.timeoutMs,
+    });
+    runner.maybeRunNext();
+    return { id: task.id, name: task.name, pid: task.pid };
+  },
+});
+
+export const processStopTask: ToolFactory = () => {
+  const Schema = z.object({
+    handle: z.union([z.string(), z.number()]),
+    tail: z.number().int().min(0).default(0),
+    signal: z.enum(ALLOWED_SIGNALS).optional(),
+  });
+  return {
+    spec: {
+      name: "process.stop",
+      description:
+        "Stop a running task via id, pid, or name and return trailing output.",
+      inputSchema: {
+        handle: Schema.shape.handle,
+        tail: Schema.shape.tail,
+        signal: Schema.shape.signal,
+      },
+    },
+    invoke: async (raw: unknown) => {
+      const { handle, tail, signal } = Schema.parse(raw);
+      const result = await runner.stopTask(handle, tail, signal);
+      return result;
+    },
+  };
+};
 
 const buildLogSpec = (name: string) => ({
   name,
@@ -546,15 +706,15 @@ export const processGetStdout: ToolFactory = () => ({
   spec: buildLogSpec("process.getStdout"),
   invoke: async (raw: unknown) => {
     const parsed = LogSchema.parse(raw);
-    const task = resolveTask(parsed.handle);
+    const task = runner.resolveTask(parsed.handle);
     if ("startLine" in parsed) {
-      return getLogs(task, "stdout", {
+      return runner.calculateLogs(task.stdout, {
         startLine: parsed.startLine,
         count: parsed.count,
       });
     }
-    return getLogs(task, "stdout", {
-      pageNumber: parsed.pagenumber,
+    return runner.calculateLogs(task.stdout, {
+      pagenumber: parsed.pagenumber,
       length: parsed.length,
     });
   },
@@ -564,33 +724,30 @@ export const processGetStderr: ToolFactory = () => ({
   spec: buildLogSpec("process.getStderr"),
   invoke: async (raw: unknown) => {
     const parsed = LogSchema.parse(raw);
-    const task = resolveTask(parsed.handle);
+    const task = runner.resolveTask(parsed.handle);
     if ("startLine" in parsed) {
-      return getLogs(task, "stderr", {
+      return runner.calculateLogs(task.stderr, {
         startLine: parsed.startLine,
         count: parsed.count,
       });
     }
-    return getLogs(task, "stderr", {
-      pageNumber: parsed.pagenumber,
+    return runner.calculateLogs(task.stderr, {
+      pagenumber: parsed.pagenumber,
       length: parsed.length,
     });
   },
 });
 
+export const processGetQueue: ToolFactory = () => ({
+  spec: {
+    name: "process.getQueue",
+    description: "Return waiting, running, and completed task summaries.",
+  },
+  invoke: async () => runner.getQueue(),
+});
+
 export const __resetProcessManagerForTests = () => {
-  for (const task of tasks.values()) {
-    if (task.process && task.status === "running") {
-      task.process.kill("SIGTERM");
-    }
-  }
-  tasks.clear();
-  waitingQueue.length = 0;
-  runningTasks.clear();
-  completedTasks.length = 0;
-  taskCounter = 0;
-  config = {
-    path: process.cwd(),
-    maxRunning: 1,
-  };
+  runner.reset();
 };
+
+export type { RunnerConfig };

--- a/packages/mcp/src/tools/process-manager.ts
+++ b/packages/mcp/src/tools/process-manager.ts
@@ -1,0 +1,566 @@
+import { spawn } from "node:child_process";
+import { once } from "node:events";
+import path from "node:path";
+
+import { z } from "zod";
+
+import type { ToolFactory } from "../core/types.js";
+
+type TaskStatus = "waiting" | "running" | "completed";
+
+type Task = {
+  readonly id: string;
+  readonly command: string;
+  readonly args: readonly string[];
+  readonly createdAt: Date;
+  name?: string;
+  status: TaskStatus;
+  cwd?: string;
+  env?: Record<string, string>;
+  pid: number | null;
+  startedAt?: Date;
+  completedAt?: Date;
+  exitCode?: number | null;
+  signal?: NodeJS.Signals | null;
+  timeoutMs?: number;
+  timeoutHandle?: NodeJS.Timeout;
+  process?: ReturnType<typeof spawn>;
+  stdoutText: string;
+  stderrText: string;
+  stdoutLines: string[];
+  stderrLines: string[];
+  stdoutRemainder: string;
+  stderrRemainder: string;
+};
+
+type TaskSummary = Readonly<{
+  id: string;
+  name?: string;
+  command: string;
+  args: readonly string[];
+  status: TaskStatus;
+  pid: number | null;
+  createdAt: string;
+  startedAt?: string;
+  completedAt?: string;
+  exitCode?: number | null;
+  signal?: NodeJS.Signals | null;
+}>;
+
+type RunnerConfig = Readonly<{
+  path: string;
+  maxRunning: number;
+  timeout?: number;
+}>;
+
+let taskCounter = 0;
+let config: RunnerConfig = {
+  path: process.cwd(),
+  maxRunning: 1,
+};
+const tasks = new Map<string, Task>();
+const waitingQueue: string[] = [];
+const runningTasks = new Set<string>();
+const completedTasks: string[] = [];
+
+const buildSummary = (task: Task): TaskSummary => ({
+  id: task.id,
+  name: task.name,
+  command: task.command,
+  args: task.args,
+  status: task.status,
+  pid: task.pid,
+  createdAt: task.createdAt.toISOString(),
+  startedAt: task.startedAt?.toISOString(),
+  completedAt: task.completedAt?.toISOString(),
+  exitCode: task.exitCode,
+  signal: task.signal ?? undefined,
+});
+
+const getConfig = () => ({ ...config });
+
+const updateConfig = (key: string, value: string | number | undefined) => {
+  if (key === "path") {
+    if (typeof value !== "string" || !value) {
+      throw new Error("path must be a non-empty string");
+    }
+    config = { ...config, path: path.resolve(value) };
+    return config;
+  }
+  if (key === "maxRunning") {
+    const parsed = Number(value);
+    if (!Number.isInteger(parsed) || parsed <= 0) {
+      throw new Error("maxRunning must be a positive integer");
+    }
+    config = { ...config, maxRunning: parsed };
+    maybeRunNext();
+    return config;
+  }
+  if (key === "timeout") {
+    if (value === undefined || value === null) {
+      const { timeout, ...rest } = config;
+      config = rest as RunnerConfig;
+      return config;
+    }
+    const parsed = Number(value);
+    if (!Number.isFinite(parsed) || parsed <= 0) {
+      throw new Error("timeout must be a positive number of milliseconds");
+    }
+    config = { ...config, timeout: parsed };
+    return config;
+  }
+  throw new Error(`Unknown config key: ${key}`);
+};
+
+const appendOutput = (task: Task, kind: "stdout" | "stderr", chunk: Buffer) => {
+  const text = chunk.toString("utf8");
+  if (kind === "stdout") {
+    task.stdoutText += text;
+    const combined = task.stdoutRemainder + text;
+    const parts = combined.split(/\r?\n/);
+    task.stdoutRemainder = parts.pop() ?? "";
+    task.stdoutLines.push(...parts);
+    return;
+  }
+  task.stderrText += text;
+  const combined = task.stderrRemainder + text;
+  const parts = combined.split(/\r?\n/);
+  task.stderrRemainder = parts.pop() ?? "";
+  task.stderrLines.push(...parts);
+};
+
+const flushRemainders = (task: Task) => {
+  if (task.stdoutRemainder) {
+    task.stdoutLines.push(task.stdoutRemainder);
+    task.stdoutRemainder = "";
+  }
+  if (task.stderrRemainder) {
+    task.stderrLines.push(task.stderrRemainder);
+    task.stderrRemainder = "";
+  }
+};
+
+const finalizeTask = (
+  task: Task,
+  exitCode: number | null,
+  signal: NodeJS.Signals | null,
+) => {
+  flushRemainders(task);
+  if (task.timeoutHandle) {
+    task.timeoutHandle.unref();
+    clearTimeout(task.timeoutHandle);
+    task.timeoutHandle = undefined;
+  }
+  task.exitCode = exitCode;
+  task.signal = signal;
+  task.completedAt = new Date();
+  task.status = "completed";
+  task.process = undefined;
+  runningTasks.delete(task.id);
+  if (!completedTasks.includes(task.id)) {
+    completedTasks.push(task.id);
+  }
+};
+
+const maybeRunNext = () => {
+  while (runningTasks.size < config.maxRunning && waitingQueue.length > 0) {
+    const nextId = waitingQueue.shift();
+    if (!nextId) continue;
+    const task = tasks.get(nextId);
+    if (!task) continue;
+    if (task.status !== "waiting") continue;
+    startTask(task);
+  }
+};
+
+const startTask = (task: Task) => {
+  const child = spawn(task.command, task.args, {
+    cwd: task.cwd ?? config.path,
+    env: { ...process.env, ...(task.env ?? {}) },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  task.process = child;
+  task.status = "running";
+  task.startedAt = new Date();
+  task.pid = child.pid ?? null;
+  runningTasks.add(task.id);
+
+  child.stdout?.on("data", (chunk: Buffer) =>
+    appendOutput(task, "stdout", chunk),
+  );
+  child.stderr?.on("data", (chunk: Buffer) =>
+    appendOutput(task, "stderr", chunk),
+  );
+
+  child.once("error", (err) => {
+    appendOutput(task, "stderr", Buffer.from(String(err)));
+    finalizeTask(task, null, null);
+    maybeRunNext();
+  });
+
+  child.once("exit", (code, signal) => {
+    finalizeTask(task, code, signal);
+    maybeRunNext();
+  });
+
+  const timeout = task.timeoutMs ?? config.timeout;
+  if (timeout && Number.isFinite(timeout)) {
+    const handle = setTimeout(() => {
+      if (task.process) {
+        task.process.kill("SIGTERM");
+      }
+    }, timeout);
+    handle.unref();
+    task.timeoutHandle = handle;
+  }
+};
+
+const createTask = (input: {
+  command: string;
+  args: readonly string[];
+  name?: string;
+  cwd?: string;
+  env?: Record<string, string>;
+  timeoutMs?: number;
+}): Task => {
+  const id = `task-${++taskCounter}`;
+  const task: Task = {
+    id,
+    command: input.command,
+    args: input.args,
+    createdAt: new Date(),
+    name: input.name,
+    status: "waiting",
+    cwd: input.cwd,
+    env: input.env,
+    pid: null,
+    timeoutMs: input.timeoutMs,
+    stdoutText: "",
+    stderrText: "",
+    stdoutLines: [],
+    stderrLines: [],
+    stdoutRemainder: "",
+    stderrRemainder: "",
+  };
+  tasks.set(id, task);
+  waitingQueue.push(id);
+  return task;
+};
+
+const resolveTask = (handle: string | number): Task => {
+  if (typeof handle === "number") {
+    for (const task of tasks.values()) {
+      if (task.pid === handle) return task;
+    }
+    throw new Error(`No task with pid ${handle}`);
+  }
+  const byId = tasks.get(handle);
+  if (byId) return byId;
+  for (const task of tasks.values()) {
+    if (task.name === handle) return task;
+  }
+  throw new Error(`No task with handle ${handle}`);
+};
+
+const linesFor = (task: Task, kind: "stdout" | "stderr") => {
+  const base = kind === "stdout" ? task.stdoutLines : task.stderrLines;
+  const remainder =
+    kind === "stdout" ? task.stdoutRemainder : task.stderrRemainder;
+  return remainder ? [...base, remainder] : [...base];
+};
+
+const getLogs = (
+  task: Task,
+  kind: "stdout" | "stderr",
+  input: {
+    startLine?: number;
+    count?: number;
+    pageNumber?: number;
+    length?: number;
+  },
+) => {
+  const lines = linesFor(task, kind);
+  if (lines.length === 0) {
+    return {
+      start: 0,
+      end: 0,
+      pagenumber: input.pageNumber ?? null,
+      lastPage: true,
+      logs: "",
+    } as const;
+  }
+  if (typeof input.startLine === "number") {
+    const startIndex = Math.max(0, input.startLine - 1);
+    const count = input.count ?? lines.length;
+    const slice = lines.slice(startIndex, startIndex + count);
+    const endLine = slice.length ? startIndex + slice.length : startIndex;
+    return {
+      start: startIndex + 1,
+      end: endLine,
+      pagenumber: null,
+      lastPage: endLine >= lines.length,
+      logs: slice.join("\n"),
+    } as const;
+  }
+  const pageNumber = input.pageNumber ?? 1;
+  const length = input.length ?? lines.length;
+  const startIndex = (pageNumber - 1) * length;
+  const slice = lines.slice(startIndex, startIndex + length);
+  const endLine = slice.length ? startIndex + slice.length : startIndex;
+  return {
+    start: startIndex + 1,
+    end: endLine,
+    pagenumber: pageNumber,
+    lastPage: endLine >= lines.length,
+    logs: slice.join("\n"),
+  } as const;
+};
+
+const stopTask = async (
+  handle: string | number,
+  tail: number,
+  signal?: NodeJS.Signals,
+) => {
+  const task = resolveTask(handle);
+  if (task.status === "waiting") {
+    const index = waitingQueue.indexOf(task.id);
+    if (index >= 0) waitingQueue.splice(index, 1);
+    task.status = "completed";
+    task.completedAt = new Date();
+    if (!completedTasks.includes(task.id)) completedTasks.push(task.id);
+    return { tail: "" } as const;
+  }
+  if (task.status === "completed" || !task.process) {
+    const combined = `${task.stdoutText}${task.stderrText}`;
+    const tailText = combined.slice(-tail);
+    return { tail: tailText } as const;
+  }
+  const proc = task.process;
+  proc.kill(signal ?? "SIGTERM");
+  await once(proc, "exit");
+  const combined = `${task.stdoutText}${task.stderrText}`;
+  const tailText = combined.slice(-tail);
+  return { tail: tailText } as const;
+};
+
+const EnqueueSchema = z.object({
+  command: z.string(),
+  args: z.array(z.string()).default([]),
+  opts: z
+    .object({
+      name: z.string().optional(),
+      cwd: z.string().optional(),
+      env: z.record(z.string()).optional(),
+      timeoutDuration: z.number().positive().optional(),
+    })
+    .optional(),
+  name: z.string().optional(),
+  cwd: z.string().optional(),
+  env: z.record(z.string()).optional(),
+  timeout: z.boolean().optional(),
+  timeoutDuration: z.number().positive().optional(),
+});
+
+export const processGetTaskRunnerConfig: ToolFactory = () => ({
+  spec: {
+    name: "process.getTaskRunnerConfig",
+    description: "Return the current task runner configuration.",
+  },
+  invoke: async () => ({ config: getConfig() }),
+});
+
+export const processUpdateTaskRunnerConfig: ToolFactory = () => {
+  const Schema = z.object({
+    key: z.enum(["path", "maxRunning", "timeout"]),
+    value: z.union([z.string(), z.number()]).optional(),
+  });
+  return {
+    spec: {
+      name: "process.updateTaskRunnerConfig",
+      description: "Update a single key in the task runner configuration.",
+      inputSchema: {
+        key: Schema.shape.key,
+        value: Schema.shape.value,
+      },
+    },
+    invoke: async (raw: unknown) => {
+      const { key, value } = Schema.parse(raw);
+      const cfg = updateConfig(key, value);
+      return { config: cfg };
+    },
+  };
+};
+
+export const processEnqueueTask: ToolFactory = () => ({
+  spec: {
+    name: "process.enqueueTask",
+    description:
+      "Enqueue a command for execution respecting concurrency limits.",
+    inputSchema: {
+      command: z.string(),
+      args: z.array(z.string()).optional(),
+      opts: z
+        .object({
+          name: z.string().optional(),
+          cwd: z.string().optional(),
+          env: z.record(z.string()).optional(),
+          timeoutDuration: z.number().optional(),
+        })
+        .optional(),
+      name: z.string().optional(),
+      cwd: z.string().optional(),
+      env: z.record(z.string()).optional(),
+      timeout: z.boolean().optional(),
+      timeoutDuration: z.number().optional(),
+    },
+  },
+  invoke: async (raw: unknown) => {
+    const parsed = EnqueueSchema.parse(raw);
+    const taskName = parsed.name ?? parsed.opts?.name;
+    const cwd = parsed.cwd ?? parsed.opts?.cwd;
+    const env = parsed.env ?? parsed.opts?.env;
+    const timeoutDuration =
+      parsed.timeoutDuration ?? parsed.opts?.timeoutDuration;
+    const timeoutMs = parsed.timeout
+      ? timeoutDuration ?? config.timeout
+      : timeoutDuration;
+    const task = createTask({
+      command: parsed.command,
+      args: parsed.args,
+      name: taskName,
+      cwd,
+      env,
+      timeoutMs: timeoutMs,
+    });
+    maybeRunNext();
+    return { name: task.name, pid: task.pid };
+  },
+});
+
+export const processStopTask: ToolFactory = () => {
+  const Schema = z.object({
+    handle: z.union([z.string(), z.number()]),
+    tail: z.number().int().min(0).default(0),
+    signal: z.string().optional(),
+  });
+  return {
+    spec: {
+      name: "process.stop",
+      description:
+        "Stop a running task via pid or name and return trailing output.",
+      inputSchema: {
+        handle: Schema.shape.handle,
+        tail: Schema.shape.tail,
+        signal: Schema.shape.signal,
+      },
+    },
+    invoke: async (raw: unknown) => {
+      const { handle, tail, signal } = Schema.parse(raw);
+      const result = await stopTask(
+        handle,
+        tail,
+        signal as NodeJS.Signals | undefined,
+      );
+      return result;
+    },
+  };
+};
+
+export const processGetQueue: ToolFactory = () => ({
+  spec: {
+    name: "process.getQueue",
+    description: "Return waiting, running, and completed task summaries.",
+  },
+  invoke: async () => ({
+    waiting: waitingQueue
+      .map((id) => tasks.get(id))
+      .filter((task): task is Task => Boolean(task))
+      .map(buildSummary),
+    running: Array.from(runningTasks)
+      .map((id) => tasks.get(id))
+      .filter((task): task is Task => Boolean(task))
+      .map(buildSummary),
+    completed: completedTasks
+      .map((id) => tasks.get(id))
+      .filter((task): task is Task => Boolean(task))
+      .map(buildSummary),
+  }),
+});
+
+const LogSchema = z.union([
+  z.object({
+    handle: z.union([z.string(), z.number()]),
+    pagenumber: z.number().int().min(1),
+    length: z.number().int().min(1),
+  }),
+  z.object({
+    handle: z.union([z.string(), z.number()]),
+    startLine: z.number().int().min(1),
+    count: z.number().int().min(1),
+  }),
+]);
+
+const buildLogSpec = (name: string) => ({
+  name,
+  description: "Retrieve task output with pagination or explicit line ranges.",
+  inputSchema: {
+    handle: z.union([z.string(), z.number()]),
+    pagenumber: z.number().optional(),
+    length: z.number().optional(),
+    startLine: z.number().optional(),
+    count: z.number().optional(),
+  },
+});
+
+export const processGetStdout: ToolFactory = () => ({
+  spec: buildLogSpec("process.getStdout"),
+  invoke: async (raw: unknown) => {
+    const parsed = LogSchema.parse(raw);
+    const task = resolveTask(parsed.handle);
+    if ("startLine" in parsed) {
+      return getLogs(task, "stdout", {
+        startLine: parsed.startLine,
+        count: parsed.count,
+      });
+    }
+    return getLogs(task, "stdout", {
+      pageNumber: parsed.pagenumber,
+      length: parsed.length,
+    });
+  },
+});
+
+export const processGetStderr: ToolFactory = () => ({
+  spec: buildLogSpec("process.getStderr"),
+  invoke: async (raw: unknown) => {
+    const parsed = LogSchema.parse(raw);
+    const task = resolveTask(parsed.handle);
+    if ("startLine" in parsed) {
+      return getLogs(task, "stderr", {
+        startLine: parsed.startLine,
+        count: parsed.count,
+      });
+    }
+    return getLogs(task, "stderr", {
+      pageNumber: parsed.pagenumber,
+      length: parsed.length,
+    });
+  },
+});
+
+export const __resetProcessManagerForTests = () => {
+  for (const task of tasks.values()) {
+    if (task.process && task.status === "running") {
+      task.process.kill("SIGTERM");
+    }
+  }
+  tasks.clear();
+  waitingQueue.length = 0;
+  runningTasks.clear();
+  completedTasks.length = 0;
+  taskCounter = 0;
+  config = {
+    path: process.cwd(),
+    maxRunning: 1,
+  };
+};

--- a/packages/mcp/test/process-manager.test.ts
+++ b/packages/mcp/test/process-manager.test.ts
@@ -1,0 +1,117 @@
+import test from "ava";
+
+import {
+  __resetProcessManagerForTests,
+  processEnqueueTask,
+  processGetQueue,
+  processGetStdout,
+  processGetTaskRunnerConfig,
+  processStopTask,
+  processUpdateTaskRunnerConfig,
+} from "../src/tools/process-manager.js";
+
+test.beforeEach(() => {
+  __resetProcessManagerForTests();
+});
+
+const ctx = {
+  env: {},
+  fetch,
+  now: () => new Date(),
+} as const;
+
+test.serial("returns and updates task runner config", async (t) => {
+  const getCfg = processGetTaskRunnerConfig(ctx);
+  const updateCfg = processUpdateTaskRunnerConfig(ctx);
+  const initial = await getCfg.invoke(undefined);
+  t.truthy(initial.config.path);
+  t.is(initial.config.maxRunning, 1);
+
+  await updateCfg.invoke({ key: "maxRunning", value: 2 });
+  await updateCfg.invoke({ key: "path", value: process.cwd() });
+  const after = await getCfg.invoke(undefined);
+  t.is(after.config.maxRunning, 2);
+  t.is(after.config.path, process.cwd());
+});
+
+test.serial("enqueues tasks and captures stdout", async (t) => {
+  const enqueue = processEnqueueTask(ctx);
+  const queue = processGetQueue(ctx);
+  const stdout = processGetStdout(ctx);
+  const updateCfg = processUpdateTaskRunnerConfig(ctx);
+  await updateCfg.invoke({ key: "path", value: process.cwd() });
+  await updateCfg.invoke({ key: "maxRunning", value: 1 });
+
+  await enqueue.invoke({
+    command: process.execPath,
+    args: ["-e", 'console.log("first");'],
+    name: "first",
+  });
+  await enqueue.invoke({
+    command: process.execPath,
+    args: ["-e", 'console.log("second");'],
+    name: "second",
+  });
+
+  let completed = 0;
+  for (let i = 0; i < 20; i += 1) {
+    const state = await queue.invoke(undefined);
+    completed = state.completed.length;
+    if (completed === 2) break;
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+
+  const finalState = await queue.invoke(undefined);
+  t.is(finalState.completed.length, 2);
+  t.deepEqual(
+    finalState.completed.map((task) => task.name),
+    ["first", "second"],
+  );
+
+  const logs = await stdout.invoke({ handle: "first", startLine: 1, count: 5 });
+  t.true(logs.logs.includes("first"));
+  t.true(logs.lastPage);
+});
+
+test.serial("stops running task and returns tail", async (t) => {
+  const enqueue = processEnqueueTask(ctx);
+  const stop = processStopTask(ctx);
+  const queue = processGetQueue(ctx);
+  const updateCfg = processUpdateTaskRunnerConfig(ctx);
+  await updateCfg.invoke({ key: "path", value: process.cwd() });
+  await updateCfg.invoke({ key: "maxRunning", value: 1 });
+
+  await enqueue.invoke({
+    command: process.execPath,
+    args: [
+      "-e",
+      'console.log("start"); setInterval(() => console.log("tick"), 20); setTimeout(() => {}, 1000);',
+    ],
+    name: "ticker",
+  });
+
+  let pid: number | null = null;
+  for (let i = 0; i < 20; i += 1) {
+    const state = await queue.invoke(undefined);
+    const running = state.running.find((task) => task.name === "ticker");
+    if (running?.pid) {
+      pid = running.pid;
+      break;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  t.truthy(pid);
+
+  const result = await stop.invoke({ handle: "ticker", tail: 20 });
+  t.true(result.tail.length <= 20);
+  t.true(result.tail.includes("tick") || result.tail.includes("start"));
+
+  for (let i = 0; i < 20; i += 1) {
+    const state = await queue.invoke(undefined);
+    if (state.running.length === 0 && state.waiting.length === 0) break;
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+
+  const finalState = await queue.invoke(undefined);
+  t.is(finalState.running.length, 0);
+});

--- a/packages/mcp/test/process-manager.test.ts
+++ b/packages/mcp/test/process-manager.test.ts
@@ -45,12 +45,12 @@ test.serial("enqueues tasks and captures stdout", async (t) => {
   await enqueue.invoke({
     command: process.execPath,
     args: ["-e", 'console.log("first");'],
-    name: "first",
+    opts: { name: "first" },
   });
   await enqueue.invoke({
     command: process.execPath,
     args: ["-e", 'console.log("second");'],
-    name: "second",
+    opts: { name: "second" },
   });
 
   let completed = 0;
@@ -87,7 +87,7 @@ test.serial("stops running task and returns tail", async (t) => {
       "-e",
       'console.log("start"); setInterval(() => console.log("tick"), 20); setTimeout(() => {}, 1000);',
     ],
-    name: "ticker",
+    opts: { name: "ticker" },
   });
 
   let pid: number | null = null;
@@ -115,3 +115,95 @@ test.serial("stops running task and returns tail", async (t) => {
   const finalState = await queue.invoke(undefined);
   t.is(finalState.running.length, 0);
 });
+
+test.serial("paginates stderr with bounded buffers", async (t) => {
+  const enqueue = processEnqueueTask(ctx);
+  const queue = processGetQueue(ctx);
+  const stderr = processGetStderr(ctx);
+  const updateCfg = processUpdateTaskRunnerConfig(ctx);
+
+  await updateCfg.invoke({ key: "path", value: process.cwd() });
+  await updateCfg.invoke({ key: "maxRunning", value: 1 });
+  await updateCfg.invoke({ key: "lineBufferSize", value: 5 });
+
+  const { id } = (await enqueue.invoke({
+    command: process.execPath,
+    args: [
+      "-e",
+      "for (let i = 0; i < 20; i += 1) { console.error(`err-${i}`); }",
+    ],
+    opts: { name: "stderr" },
+  })) as { id: string };
+
+  for (let i = 0; i < 40; i += 1) {
+    const state = await queue.invoke(undefined);
+    if (state.completed.some((task) => task.id === id)) break;
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+
+  const page = await stderr.invoke({
+    handle: id,
+    pagenumber: 1,
+    length: 3,
+  });
+  t.is(page.start, 16);
+  t.is(page.end, 18);
+  t.true(page.truncated);
+  t.true(page.logs.includes("err-16"));
+
+  const range = await stderr.invoke({
+    handle: id,
+    startLine: 1,
+    count: 2,
+  });
+  t.is(range.start, 16);
+  t.is(range.end, 17);
+  t.true(range.truncated);
+  t.true(range.logs.includes("err-17"));
+});
+
+test.serial(
+  "stop escalates to SIGKILL when process ignores SIGTERM",
+  async (t) => {
+    const enqueue = processEnqueueTask(ctx);
+    const stop = processStopTask(ctx);
+    const queue = processGetQueue(ctx);
+    const updateCfg = processUpdateTaskRunnerConfig(ctx);
+
+    await updateCfg.invoke({ key: "path", value: process.cwd() });
+    await updateCfg.invoke({ key: "maxRunning", value: 1 });
+    await updateCfg.invoke({ key: "terminateGraceMs", value: 50 });
+    await updateCfg.invoke({ key: "terminateForceMs", value: 100 });
+
+    const { id } = (await enqueue.invoke({
+      command: process.execPath,
+      args: [
+        "-e",
+        [
+          'process.on("SIGTERM", () => { /* ignore */ });',
+          "setInterval(() => {}, 1000);",
+        ].join("\n"),
+      ],
+      opts: { name: "stubborn" },
+    })) as { id: string };
+
+    for (let i = 0; i < 40; i += 1) {
+      const state = await queue.invoke(undefined);
+      if (state.running.some((task) => task.id === id)) break;
+      await new Promise((resolve) => setTimeout(resolve, 25));
+    }
+
+    await stop.invoke({ handle: id, tail: 0 });
+
+    let completed;
+    for (let i = 0; i < 80; i += 1) {
+      const state = await queue.invoke(undefined);
+      completed = state.completed.find((task) => task.id === id);
+      if (completed) break;
+      await new Promise((resolve) => setTimeout(resolve, 25));
+    }
+
+    t.truthy(completed);
+    t.is(completed?.signal, "SIGKILL");
+  },
+);

--- a/promethean.mcp.json
+++ b/promethean.mcp.json
@@ -19,5 +19,31 @@
     "tdd.coverage",
     "tdd.propertyCheck",
     "tdd.mutationScore"
-  ]
+  ],
+  "endpoints": {
+    "process": {
+      "tools": [
+        "process.getTaskRunnerConfig",
+        "process.updateTaskRunnerConfig",
+        "process.enqueueTask",
+        "process.stop",
+        "process.getQueue",
+        "process.getStdout",
+        "process.getStderr"
+      ]
+    },
+    "files": {
+      "tools": [
+        "files.list-directory",
+        "files.tree-directory",
+        "files.view-file",
+        "files.write-content",
+        "files.write-lines",
+        "files.search"
+      ]
+    },
+    "github": {
+      "tools": ["github.request", "github.graphql", "github.rate-limit"]
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- add a process manager tool suite for configuring runners, enqueuing commands, streaming logs, and stopping tasks
- register the new tools with the MCP server and cover the queue/control flows with AVA tests

## Testing
- pnpm --filter @promethean/mcp test *(fails: Identifier 'nodeMajorVersion' has already been declared while loading shared AVA config)*
- pnpm exec eslint packages/mcp/src/tools/process-manager.ts packages/mcp/test/process-manager.test.ts *(fails: repository-wide functional rules report numerous existing violations)*

------
https://chatgpt.com/codex/tasks/task_e_68dd7d63e71483249fac88628081453a