### PR TITLE
Fix persistence typecheck regressions in persistence package

### DIFF
--- a/changelog.d/2025.02.14.22.30.00.md
+++ b/changelog.d/2025.02.14.22.30.00.md
@@ -1,0 +1,2 @@
+## Fixed
+- Resolve persistence dual store and context typing regressions to restore package typechecks.

--- a/packages/persistence/src/contextStore.ts
+++ b/packages/persistence/src/contextStore.ts
@@ -123,7 +123,6 @@ export class ContextStore {
         return Array.from(this.collections.values());
     }
 
-
     collectionCount(): number {
         return this.collections.size;
     }
@@ -180,11 +179,7 @@ export class ContextStore {
         textsOrOptions: readonly string[] | CompileContextOptions = [],
         ...legacyArgs: LegacyCompileArgs
     ): Promise<Message[]> {
-        const options: CompileContextOptions = Array.isArray(textsOrOptions)
-            ? { ...normaliseLegacyArgs(legacyArgs), texts: textsOrOptions }
-            : textsOrOptions;
-
-
+        const options = resolveCompileOptions(textsOrOptions, legacyArgs);
         const resolvedTexts: readonly string[] = options.texts ?? DEFAULT_COMPILE_OPTIONS.texts;
         const resolved: Required<CompileContextOptions> = {
             ...DEFAULT_COMPILE_OPTIONS,

--- a/packages/persistence/src/dualStore.ts
+++ b/packages/persistence/src/dualStore.ts
@@ -2,7 +2,7 @@ import { randomUUID } from 'node:crypto';
 
 import type { Collection as ChromaCollection, Metadata as ChromaMetadata, Where } from 'chromadb';
 import { RemoteEmbeddingFunction } from '@promethean/embedding';
-import type { Collection, Filter, OptionalUnlessRequiredId, Sort, WithId } from 'mongodb';
+import type { Collection, Filter, FilterOperators, OptionalUnlessRequiredId, Sort, WithId } from 'mongodb';
 import { AGENT_NAME } from '@promethean/legacy/env.js';
 
 import type { DualStoreEntry, AliasDoc, DualStoreMetadata, DualStoreTimestamp } from './types.js';
@@ -140,7 +140,6 @@ export class DualStoreManager<TextKey extends string = 'text', TimeKey extends s
         });
     }
 
-
     getMongoCollection(): Collection<DualStoreEntry<TextKey, TimeKey>> {
         return this.mongoCollection;
     }
@@ -159,12 +158,12 @@ export class DualStoreManager<TextKey extends string = 'text', TimeKey extends s
         const timestamp = toEpochMilliseconds(timestampCandidate);
         const metadata = withTimestampMetadata(entry.metadata, this.timeStampKey, timestamp);
 
-        const preparedEntry: DualStoreEntry<TextKey, TimeKey> = {
+        const preparedEntry = {
             ...entry,
             id,
             [this.timeStampKey]: timestamp,
             metadata,
-        };
+        } satisfies DualStoreEntry<TextKey, TimeKey>;
 
         const dualWriteEnabled = (process.env.DUAL_WRITE_ENABLED ?? 'true').toLowerCase() !== 'false';
         const isImage = metadata.type === 'image';
@@ -181,14 +180,9 @@ export class DualStoreManager<TextKey extends string = 'text', TimeKey extends s
             }
         }
 
-        const mongoDocument = {
-            id: preparedEntry.id,
-            [this.textKey]: preparedEntry[this.textKey],
-            [this.timeStampKey]: preparedEntry[this.timeStampKey],
-            metadata: preparedEntry.metadata,
-        } satisfies OptionalUnlessRequiredId<DualStoreEntry<TextKey, TimeKey>>;
-
-        await this.mongoCollection.insertOne(mongoDocument);
+        await this.mongoCollection.insertOne(
+            preparedEntry as OptionalUnlessRequiredId<DualStoreEntry<TextKey, TimeKey>>,
+        );
     }
 
     // TODO: remove in future – alias for backwards compatibility
@@ -197,9 +191,14 @@ export class DualStoreManager<TextKey extends string = 'text', TimeKey extends s
     }
 
     private createDefaultMongoFilter(): Filter<DualStoreEntry<TextKey, TimeKey>> {
+        const textCondition: FilterOperators<string> = {
+            $exists: true,
+            $regex: '\\S',
+        };
+
         return {
-            [this.textKey]: { $nin: [null, ''], $not: /^\s*$/ },
-        } satisfies Filter<DualStoreEntry<TextKey, TimeKey>>;
+            [this.textKey]: textCondition,
+        } as Filter<DualStoreEntry<TextKey, TimeKey>>;
     }
 
     private createDefaultSorter(): Sort {
@@ -236,7 +235,7 @@ export class DualStoreManager<TextKey extends string = 'text', TimeKey extends s
         };
 
         const queryResult = await this.chromaCollection.query<ChromaMetadata>(queryOptions);
-        const rows = queryResult.rows<ChromaMetadata>().flat();
+        const rows = queryResult.rows().flat();
 
         return rows
             .map((row) => {
@@ -247,15 +246,16 @@ export class DualStoreManager<TextKey extends string = 'text', TimeKey extends s
                 const metadata = cloneMetadata(row.metadata);
                 const timestampSource = pickTimestamp(metadata?.[this.timeStampKey], metadata?.timeStamp);
 
-                return {
+                const entry: DualStoreEntry<'text', 'timestamp'> = {
                     id: row.id,
                     text: row.document,
                     metadata,
                     timestamp: toEpochMilliseconds(timestampSource),
-                } satisfies DualStoreEntry<'text', 'timestamp'>;
-            })
-            .filter((entry): entry is DualStoreEntry<'text', 'timestamp'> => Boolean(entry))
-            .filter((entry, index, array) => array.findIndex((candidate) => candidate.text === entry.text) === index);
+                };
 
+                return entry;
+            })
+            .filter((entry): entry is DualStoreEntry<'text', 'timestamp'> => entry !== undefined)
+            .filter((entry, index, array) => array.findIndex((candidate) => candidate.text === entry.text) === index);
     }
 }


### PR DESCRIPTION
## Summary
- reuse the resolveCompileOptions helper when compiling persistence context to avoid union types escaping narrowing
- align dual store insert helpers and Mongo filters with the expected typings while removing the redundant Chroma row type argument
- document the persistence typecheck fix in the changelog

## Testing
- `pnpm --filter @promethean/persistence typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68ddbdecea088324a5ecc3b0b42b7ca8