### PR TITLE
Address legacy compile defaults and expose markdown sync helpers

### DIFF
--- a/changelog.d/2025.10.01.23.04.27.md
+++ b/changelog.d/2025.10.01.23.04.27.md
@@ -1,0 +1,2 @@
+- Preserve default compile context limits when legacy callers omit optional parameters.
+- Export markdown sync applyUpdates helper for downstream tests.

--- a/packages/persistence/src/contextStore.ts
+++ b/packages/persistence/src/contextStore.ts
@@ -181,10 +181,14 @@ export class ContextStore {
     ): Promise<Message[]> {
         const options = resolveCompileOptions(textsOrOptions, legacyArgs);
 
-        const resolvedTexts: readonly string[] = options.texts ?? DEFAULT_COMPILE_OPTIONS.texts;
+        const definedOptions = Object.fromEntries(
+            Object.entries(options).filter(([, value]) => value !== undefined),
+        ) as Partial<CompileContextOptions>;
+
+        const resolvedTexts: readonly string[] = definedOptions.texts ?? DEFAULT_COMPILE_OPTIONS.texts;
         const resolved: Required<CompileContextOptions> = {
             ...DEFAULT_COMPILE_OPTIONS,
-            ...options,
+            ...definedOptions,
             texts: [...resolvedTexts],
         };
 


### PR DESCRIPTION
## Summary
- ignore undefined compile context overrides so legacy calls keep their default limits
- export markdown sync helpers (including normalizeBoardInstance) needed by downstream consumers
- document the fixes in the changelog

## Testing
- pnpm --filter @promethean/tests exec ava --config ../../config/ava.config.mjs dist/markdown.sync.helpers.test.js

------
https://chatgpt.com/codex/tasks/task_e_68ddb24423f88324a73186df38c3ebcc