### PR TITLE
Add apply_patch MCP tool for universal diffs

### DIFF
--- a/changelog.d/2025.10.02.01.47.32.md
+++ b/changelog.d/2025.10.02.01.47.32.md
@@ -1,0 +1,1 @@
+- add an MCP `apply_patch` tool backed by `git apply` with dry-run support

--- a/packages/mcp/src/tests/apply-patch.test.ts
+++ b/packages/mcp/src/tests/apply-patch.test.ts
@@ -1,0 +1,92 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+import test from "ava";
+
+import { applyPatchTool } from "../tools/apply-patch.js";
+
+const execFileAsync = promisify(execFile);
+
+const baseCtx = {
+  env: {} as Readonly<Record<string, string | undefined>>,
+  fetch,
+  now: () => new Date(),
+} as const;
+
+const buildCtx = (root: string) => ({
+  ...baseCtx,
+  env: { ...baseCtx.env, MCP_ROOT_PATH: root } as typeof baseCtx.env,
+});
+
+test.serial("applies universal diff patches within MCP root", async (t) => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "mcp-apply-patch-"));
+  t.teardown(async () => {
+    await fs.rm(tmp, { recursive: true, force: true });
+  });
+
+  await execFileAsync("git", ["init"], { cwd: tmp });
+  const target = path.join(tmp, "example.txt");
+  await fs.writeFile(target, "hello\n", "utf8");
+
+  const diff = [
+    "diff --git a/example.txt b/example.txt",
+    "--- a/example.txt",
+    "+++ b/example.txt",
+    "@@ -1 +1,2 @@",
+    " hello",
+    "+world",
+    "",
+  ].join("\n");
+
+  const tool = applyPatchTool(buildCtx(tmp));
+  const result = (await tool.invoke({ diff })) as {
+    ok: boolean;
+    stdout: string;
+    stderr: string;
+    check: boolean;
+  };
+
+  t.true(result.ok);
+  t.false(result.check);
+
+  const content = await fs.readFile(target, "utf8");
+  t.true(content.includes("world"));
+});
+
+test.serial("supports dry-run validation", async (t) => {
+  const tmp = await fs.mkdtemp(
+    path.join(os.tmpdir(), "mcp-apply-patch-check-"),
+  );
+  t.teardown(async () => {
+    await fs.rm(tmp, { recursive: true, force: true });
+  });
+
+  await execFileAsync("git", ["init"], { cwd: tmp });
+  const target = path.join(tmp, "check.txt");
+  await fs.writeFile(target, "alpha\n", "utf8");
+
+  const diff = [
+    "diff --git a/check.txt b/check.txt",
+    "--- a/check.txt",
+    "+++ b/check.txt",
+    "@@ -1 +1,2 @@",
+    " alpha",
+    "+beta",
+    "",
+  ].join("\n");
+
+  const tool = applyPatchTool(buildCtx(tmp));
+  const validation = (await tool.invoke({ diff, check: true })) as {
+    ok: boolean;
+    check: boolean;
+  };
+
+  t.true(validation.ok);
+  t.true(validation.check);
+
+  const content = await fs.readFile(target, "utf8");
+  t.is(content, "alpha\n");
+});

--- a/packages/mcp/src/tools/apply-patch.ts
+++ b/packages/mcp/src/tools/apply-patch.ts
@@ -1,0 +1,131 @@
+import { spawn } from "node:child_process";
+import { buffer } from "node:stream/consumers";
+import { resolve as resolvePath } from "node:path";
+
+import { z } from "zod";
+
+import { getMcpRoot } from "../files.js";
+import type { ToolFactory } from "../core/types.js";
+
+const isUniversalDiff = (value: string): boolean =>
+  /^(?:Index: |diff --git|---\s)/m.test(value);
+
+type GitApplyResult = Readonly<{
+  stdout: string;
+  stderr: string;
+}>;
+
+type GitApplyOptions = Readonly<{
+  cwd: string;
+  check: boolean;
+}>;
+
+class GitApplyError extends Error {
+  readonly code: number | null;
+  readonly stdout: string;
+  readonly stderr: string;
+
+  constructor(
+    message: string,
+    code: number | null,
+    stdout: string,
+    stderr: string,
+  ) {
+    super(message);
+    this.name = "GitApplyError";
+    this.code = code;
+    this.stdout = stdout;
+    this.stderr = stderr;
+  }
+}
+
+const runGitApply = async (
+  diff: string,
+  options: GitApplyOptions,
+): Promise<GitApplyResult> => {
+  const args = [
+    "apply",
+    "--whitespace=nowarn",
+    ...(options.check ? ["--check"] : []),
+  ] as const;
+
+  const child = spawn("git", args, {
+    cwd: options.cwd,
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+
+  const exitCodePromise = new Promise<number | null>((resolve, reject) => {
+    child.once("error", reject);
+    child.once("close", resolve);
+  });
+
+  const stdoutPromise = buffer(child.stdout).then((buf) =>
+    buf.toString("utf8"),
+  );
+  const stderrPromise = buffer(child.stderr).then((buf) =>
+    buf.toString("utf8"),
+  );
+
+  child.stdin.end(diff, "utf8");
+
+  const [code, stdout, stderr] = await Promise.all([
+    exitCodePromise,
+    stdoutPromise,
+    stderrPromise,
+  ]);
+
+  if (code === 0) {
+    return { stdout, stderr };
+  }
+
+  throw new GitApplyError("git apply failed", code, stdout, stderr);
+};
+
+export const applyPatchTool: ToolFactory = (ctx) => {
+  const shape = {
+    diff: z.string().min(1, "diff is required"),
+    check: z.boolean().default(false),
+  } as const;
+  const Schema = z.object(shape);
+
+  const spec = {
+    name: "apply_patch",
+    description:
+      "Apply a universal diff patch to the MCP sandbox using git apply.",
+    inputSchema: shape,
+  } as const;
+
+  const invoke = async (raw: unknown) => {
+    const argsParsed = Schema.parse(raw);
+    const { diff, check } = argsParsed;
+
+    if (!isUniversalDiff(diff)) {
+      throw new Error("Input does not look like a universal diff");
+    }
+
+    const cwd = ctx.env.MCP_ROOT_PATH
+      ? resolvePath(ctx.env.MCP_ROOT_PATH)
+      : getMcpRoot();
+    const onSuccess = (result: GitApplyResult) => ({
+      ok: true as const,
+      stdout: result.stdout.trim(),
+      stderr: result.stderr.trim(),
+      check,
+    });
+    const onFailure = (error: unknown): never => {
+      if (error instanceof GitApplyError) {
+        const tail = [error.stdout.trim(), error.stderr.trim()]
+          .filter((part) => part.length > 0)
+          .join("\n");
+        const details = tail.length > 0 ? `: ${tail}` : "";
+        throw new Error(
+          `git apply exited with code ${error.code ?? "unknown"}${details}`,
+        );
+      }
+      throw error as Error;
+    };
+    return runGitApply(diff, { cwd, check }).then(onSuccess, onFailure);
+  };
+
+  return { spec, invoke };
+};

--- a/promethean.mcp.json
+++ b/promethean.mcp.json
@@ -10,6 +10,7 @@
     "files.write-content",
     "files.write-lines",
     "files.search",
+    "apply_patch",
     "tdd.scaffoldTest",
     "tdd.changedFiles",
     "tdd.runTests",
@@ -39,7 +40,8 @@
         "files.view-file",
         "files.write-content",
         "files.write-lines",
-        "files.search"
+        "files.search",
+        "apply_patch"
       ]
     },
     "github": {


### PR DESCRIPTION
## Summary
- add an `apply_patch` MCP tool that runs universal diffs through `git apply`, including dry-run support
- register the new tool with the MCP server and expose it through the default configuration
- cover the tool with AVA tests and document the change in the changelog

## Testing
- pnpm exec eslint packages/mcp/src/tools/apply-patch.ts packages/mcp/src/tests/apply-patch.test.ts
- pnpm exec eslint packages/mcp/src/index.ts
- pnpm --filter @promethean/mcp test

------
https://chatgpt.com/codex/tasks/task_e_68ddd724b73c832486e8c7d8ed5a8133