### PR TITLE
Add pnpm workspace MCP tools

### DIFF
--- a/changelog.d/2025.03.09.00.00.00.md
+++ b/changelog.d/2025.03.09.00.00.00.md
@@ -1,0 +1,1 @@
+- Added pnpm workspace management MCP tools (install/add/remove/runScript) with filter-aware command execution and coverage tests.

--- a/docs/agile/tasks/setup-mcp-pnpm-ops.md
+++ b/docs/agile/tasks/setup-mcp-pnpm-ops.md
@@ -1,0 +1,60 @@
+---
+uuid: 9b3f1c89-9a76-4f18-92a4-38275b1bc1f0
+title: Setup MCP server for pnpm workspace management
+status: in-progress
+priority: P2
+labels:
+  - #framework-core
+created_at: '2025-03-09T00:00:00.000Z'
+---
+#In-Progress
+
+## 🛠️ Description
+
+- Provide an MCP server that can install, add, and remove pnpm dependencies at the workspace root or scoped to a package filter, plus expose pnpm script execution.
+
+## Description
+- **What changed?** New requirement to automate pnpm dependency and script operations via MCP so agents can manage workspace packages.
+- **Where is the impact?** Applies to dev tooling; new server likely lives under `packages/` and touches workspace config.
+- **Why now?** Enables remote automation and scripted dependency updates for MCP clients.
+- **Supporting context** User request in current session.
+
+## Goals
+- MCP server exposes tools for `pnpm install`, `pnpm add`, `pnpm remove`, and script execution with optional `--filter` package targeting.
+- Document usage and constraints so future agents can extend capabilities safely.
+
+## Requirements
+- [ ] pnpm operations succeed for workspace root and filtered packages.
+- [ ] Tests or smoke checks cover command invocation helpers.
+- [ ] Documentation updated with usage details.
+- [ ] PR merged: (link once created)
+- [ ] Additional constraints or non-functional requirements are addressed: support GPL-3.0-only licensing and follow repo lint/build gates.
+
+## Subtasks
+1. Review existing MCP tooling packages and decide placement for new server.
+2. Implement pnpm command runner with workspace vs filter support.
+3. Register MCP tools/resources and provide docs/tests.
+
+Estimate: 5
+
+---
+
+## 🔗 Related Epics
+
+- [[kanban]]
+
+---
+
+## ⛓️ Blocked By
+
+- None
+
+## ⛓️ Blocks
+
+- None
+
+---
+
+## 🔍 Relevant Links
+
+- User request (current session)

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -54,3 +54,7 @@ This is a scaffold extracted to consolidate multiple MCP servers into one packag
 
 ## Tools
 - files.search — grep-like content search returning path/line/snippet triples.
+- pnpm.install — run `pnpm install` with optional `--filter` targeting specific packages.
+- pnpm.add — add dependencies, supporting workspace or filtered package scopes.
+- pnpm.remove — remove dependencies from the workspace or filtered packages.
+- pnpm.runScript — execute `pnpm run <script>` with optional extra args and filters.

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -34,6 +34,12 @@ import {
   processStopTask,
   processUpdateTaskRunnerConfig,
 } from "./tools/process-manager.js";
+import {
+  pnpmAdd,
+  pnpmInstall,
+  pnpmRemove,
+  pnpmRunScript,
+} from "./tools/pnpm.js";
 import type { ToolFactory } from "./core/types.js";
 import {
   resolveHttpEndpoints,
@@ -57,6 +63,10 @@ const toolCatalog = new Map<string, ToolFactory>([
   ["process.getQueue", processGetQueue],
   ["process.getStdout", processGetStdout],
   ["process.getStderr", processGetStderr],
+  ["pnpm.install", pnpmInstall],
+  ["pnpm.add", pnpmAdd],
+  ["pnpm.remove", pnpmRemove],
+  ["pnpm.runScript", pnpmRunScript],
   ["tdd.scaffoldTest", tddScaffoldTest],
   ["tdd.changedFiles", tddChangedFiles],
   ["tdd.runTests", tddRunTests],

--- a/packages/mcp/src/tests/pnpm.test.ts
+++ b/packages/mcp/src/tests/pnpm.test.ts
@@ -1,0 +1,124 @@
+import test from "ava";
+
+import type { ToolContext } from "../core/types.js";
+import {
+  buildPnpmArgs,
+  normalizeFilters,
+  normalizeStringList,
+  type PnpmResult,
+  __test__,
+} from "../tools/pnpm.js";
+
+const noopFetch: typeof fetch = async (..._args) => {
+  throw new Error("fetch not implemented");
+};
+
+const baseCtx: ToolContext = {
+  env: {},
+  fetch: noopFetch,
+  now: () => new Date(0),
+};
+
+const makeResult = (args: readonly string[]): PnpmResult => ({
+  command: "pnpm",
+  args,
+  cwd: "/workspace",
+  exitCode: 0,
+  stdout: "",
+  stderr: "",
+});
+
+test("normalizeStringList trims values", (t) => {
+  t.deepEqual(normalizeStringList("pkg"), ["pkg"]);
+  t.deepEqual(normalizeStringList([" foo ", "bar"]), ["foo", "bar"]);
+});
+
+test("normalizeFilters dedupes filters", (t) => {
+  t.deepEqual(normalizeFilters(undefined), []);
+  t.deepEqual(normalizeFilters("pkg"), ["pkg"]);
+  t.deepEqual(normalizeFilters(["pkg", "pkg", " apps/* "]), ["pkg", "apps/*"]);
+});
+
+test("buildPnpmArgs prepends filters", (t) => {
+  t.deepEqual(buildPnpmArgs(["install"]), ["install"]);
+  t.deepEqual(buildPnpmArgs(["run", "lint"], { filter: "app" }), [
+    "--filter",
+    "app",
+    "run",
+    "lint",
+  ]);
+  t.deepEqual(
+    buildPnpmArgs(["add", "lodash"], { filter: ["pkg-a", "pkg-b"] }),
+    ["--filter", "pkg-a", "--filter", "pkg-b", "add", "lodash"],
+  );
+});
+
+test("pnpm.install tool forwards options", async (t) => {
+  const tool = __test__.createInstallTool(baseCtx, async (args) =>
+    makeResult(args),
+  );
+  const result = (await tool.invoke({
+    filter: "packages/*",
+    frozenLockfile: true,
+    offline: true,
+  })) as PnpmResult;
+  t.deepEqual(result.args, [
+    "--filter",
+    "packages/*",
+    "install",
+    "--frozen-lockfile",
+    "--offline",
+  ]);
+});
+
+test("pnpm.add tool builds dependency list", async (t) => {
+  const tool = __test__.createAddTool(baseCtx, async (args) =>
+    makeResult(args),
+  );
+  const result = (await tool.invoke({
+    dependencies: ["lodash", "fp-ts"],
+    dev: true,
+    exact: true,
+    filter: "pkg",
+  })) as PnpmResult;
+  t.deepEqual(result.args, [
+    "--filter",
+    "pkg",
+    "add",
+    "--save-dev",
+    "--save-exact",
+    "lodash",
+    "fp-ts",
+  ]);
+});
+
+test("pnpm.remove tool removes packages", async (t) => {
+  const tool = __test__.createRemoveTool(baseCtx, async (args) =>
+    makeResult(args),
+  );
+  const result = (await tool.invoke({
+    dependencies: "react",
+  })) as PnpmResult;
+  t.deepEqual(result.args, ["remove", "react"]);
+});
+
+test("pnpm.runScript tool passes script arguments", async (t) => {
+  const tool = __test__.createRunScriptTool(baseCtx, async (args) =>
+    makeResult(args),
+  );
+  const result = (await tool.invoke({
+    script: "build",
+    args: ["--prod"],
+    filter: ["pkg-a", "pkg-b"],
+  })) as PnpmResult;
+  t.deepEqual(result.args, [
+    "--filter",
+    "pkg-a",
+    "--filter",
+    "pkg-b",
+    "run",
+    "build",
+    "--",
+    "--prod",
+  ]);
+});

--- a/packages/mcp/src/tools/pnpm.ts
+++ b/packages/mcp/src/tools/pnpm.ts
@@ -1,0 +1,318 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+import { z } from "zod";
+
+import { getMcpRoot } from "../files.js";
+import type { Tool, ToolContext, ToolFactory } from "../core/types.js";
+
+const execFileAsync = promisify(execFile);
+
+const MAX_BUFFER = 16 * 1024 * 1024;
+const DEFAULT_TIMEOUT = 10 * 60 * 1000;
+
+const NON_WHITESPACE = /\S/;
+
+export type FilterInput = string | readonly string[] | undefined;
+
+export type PnpmResult = Readonly<{
+  command: string;
+  args: readonly string[];
+  cwd: string;
+  exitCode: number | null;
+  signal?: NodeJS.Signals | null;
+  stdout: string;
+  stderr: string;
+  error?: string;
+}>;
+
+type PnpmExecutor = (args: readonly string[]) => Promise<PnpmResult>;
+
+const isDefinedString = (
+  entry: readonly [string, string | undefined],
+): entry is readonly [string, string] => typeof entry[1] === "string";
+
+const sanitizeEnv = (
+  env: Readonly<Record<string, string | undefined>>,
+): NodeJS.ProcessEnv =>
+  Object.fromEntries(
+    Object.entries({ ...process.env, ...env }).filter(isDefinedString),
+  );
+
+const isExecError = (
+  value: unknown,
+): value is NodeJS.ErrnoException & {
+  stdout?: string;
+  stderr?: string;
+  signal?: NodeJS.Signals;
+} =>
+  Boolean(
+    value &&
+      typeof value === "object" &&
+      "stdout" in value &&
+      "stderr" in value,
+  );
+
+const toSuccessResult = (bin: string, args: readonly string[], cwd: string) =>
+  ({
+    command: bin,
+    args,
+    cwd,
+    exitCode: 0,
+  }) satisfies Pick<PnpmResult, "command" | "args" | "cwd" | "exitCode">;
+
+const mergeSuccess = (
+  base: Pick<PnpmResult, "command" | "args" | "cwd" | "exitCode">,
+  io: Readonly<{ stdout: string; stderr: string }>,
+): PnpmResult => ({
+  ...base,
+  stdout: io.stdout,
+  stderr: io.stderr,
+});
+
+const toErrorResult = (
+  bin: string,
+  args: readonly string[],
+  cwd: string,
+  error: NodeJS.ErrnoException & {
+    stdout?: string;
+    stderr?: string;
+    signal?: NodeJS.Signals;
+  },
+): PnpmResult => {
+  const exitCode = typeof error.code === "number" ? error.code : null;
+  return {
+    command: bin,
+    args,
+    cwd,
+    exitCode,
+    signal: error.signal ?? null,
+    stdout: error.stdout ?? "",
+    stderr: error.stderr ?? "",
+    error: exitCode && exitCode !== 0 ? error.message : undefined,
+  };
+};
+
+const runPnpmCommand = (
+  ctx: ToolContext,
+  args: readonly string[],
+): Promise<PnpmResult> => {
+  const bin = ctx.env.PNPM_BIN ?? "pnpm";
+  const cwd = getMcpRoot();
+  const env = sanitizeEnv(ctx.env);
+  const base = toSuccessResult(bin, args, cwd);
+  const handleError = (error: unknown): PnpmResult | Promise<PnpmResult> => {
+    if (!isExecError(error)) {
+      return Promise.reject(error);
+    }
+    if (!(typeof error.code === "number" || error.code === null)) {
+      return Promise.reject(error);
+    }
+    return toErrorResult(bin, args, cwd, error);
+  };
+
+  return execFileAsync(bin, args, {
+    cwd,
+    env,
+    encoding: "utf8",
+    maxBuffer: MAX_BUFFER,
+    timeout: DEFAULT_TIMEOUT,
+  })
+    .then((io) => mergeSuccess(base, io))
+    .catch(handleError);
+};
+
+const toStringArray = (value: string | readonly string[]): readonly string[] =>
+  (Array.isArray(value) ? value : [value]) as readonly string[];
+
+export const normalizeStringList = (
+  value: string | readonly string[],
+): readonly string[] =>
+  toStringArray(value).map((entry: string) => entry.trim());
+
+export const normalizeFilters = (filter?: FilterInput): readonly string[] => {
+  if (!filter) return [];
+  const values = normalizeStringList(filter).filter(
+    (entry) => entry.length > 0,
+  );
+  return Array.from(new Set(values));
+};
+
+export const buildPnpmArgs = (
+  command: readonly string[],
+  options: Readonly<{ filter?: FilterInput }> = {},
+): readonly string[] => [
+  ...normalizeFilters(options.filter).flatMap((value) => ["--filter", value]),
+  ...command,
+];
+
+const createExecutor = (ctx: ToolContext): PnpmExecutor => {
+  return (args) => runPnpmCommand(ctx, args);
+};
+
+const NonEmptyString = z.string().min(1).regex(NON_WHITESPACE);
+const StringList = z.union([NonEmptyString, z.array(NonEmptyString).min(1)]);
+const OptionalStringList = StringList.optional();
+
+const normalizeDependencies = (
+  value: string | readonly string[],
+): readonly string[] => {
+  const values = normalizeStringList(value).filter((entry) => entry.length > 0);
+  if (values.length === 0) {
+    throw new Error("At least one dependency is required.");
+  }
+  return values;
+};
+
+const installShape = {
+  filter: OptionalStringList,
+  frozenLockfile: z.boolean().optional(),
+  offline: z.boolean().optional(),
+  force: z.boolean().optional(),
+  ignoreScripts: z.boolean().optional(),
+} as const;
+
+const addShape = {
+  dependencies: StringList,
+  filter: OptionalStringList,
+  dev: z.boolean().optional(),
+  optional: z.boolean().optional(),
+  peer: z.boolean().optional(),
+  exact: z.boolean().optional(),
+} as const;
+
+const removeShape = {
+  dependencies: StringList,
+  filter: OptionalStringList,
+} as const;
+
+const runScriptShape = {
+  script: NonEmptyString,
+  args: z.array(z.string()).optional(),
+  filter: OptionalStringList,
+} as const;
+
+const createInstallTool = (
+  ctx: ToolContext,
+  exec: PnpmExecutor = createExecutor(ctx),
+): Tool => {
+  const Schema = z.object(installShape);
+  const spec = {
+    name: "pnpm.install",
+    description:
+      "Run pnpm install at the workspace root or limited to filtered packages.",
+    inputSchema: installShape,
+  } as const;
+
+  const invoke = async (raw: unknown) => {
+    const { filter, frozenLockfile, offline, force, ignoreScripts } =
+      Schema.parse(raw);
+    const command = [
+      "install",
+      ...(frozenLockfile ? ["--frozen-lockfile"] : []),
+      ...(offline ? ["--offline"] : []),
+      ...(force ? ["--force"] : []),
+      ...(ignoreScripts ? ["--ignore-scripts"] : []),
+    ];
+    const args = buildPnpmArgs(command, { filter });
+    return exec(args);
+  };
+
+  return { spec, invoke };
+};
+
+const createAddTool = (
+  ctx: ToolContext,
+  exec: PnpmExecutor = createExecutor(ctx),
+): Tool => {
+  const Schema = z.object(addShape);
+  const spec = {
+    name: "pnpm.add",
+    description:
+      "Add dependencies via pnpm, optionally scoped to specific workspace packages.",
+    inputSchema: addShape,
+  } as const;
+
+  const invoke = async (raw: unknown) => {
+    const { dependencies, filter, dev, optional, peer, exact } =
+      Schema.parse(raw);
+    const deps = normalizeDependencies(dependencies);
+    const flags = [
+      ...(dev ? ["--save-dev"] : []),
+      ...(optional ? ["--save-optional"] : []),
+      ...(peer ? ["--save-peer"] : []),
+      ...(exact ? ["--save-exact"] : []),
+    ];
+    const command = ["add", ...flags, ...deps];
+    const args = buildPnpmArgs(command, { filter });
+    return exec(args);
+  };
+
+  return { spec, invoke };
+};
+
+const createRemoveTool = (
+  ctx: ToolContext,
+  exec: PnpmExecutor = createExecutor(ctx),
+): Tool => {
+  const Schema = z.object(removeShape);
+  const spec = {
+    name: "pnpm.remove",
+    description:
+      "Remove dependencies via pnpm, optionally scoped to workspace filters.",
+    inputSchema: removeShape,
+  } as const;
+
+  const invoke = async (raw: unknown) => {
+    const { dependencies, filter } = Schema.parse(raw);
+    const deps = normalizeDependencies(dependencies);
+    const command = ["remove", ...deps];
+    const args = buildPnpmArgs(command, { filter });
+    return exec(args);
+  };
+
+  return { spec, invoke };
+};
+
+const createRunScriptTool = (
+  ctx: ToolContext,
+  exec: PnpmExecutor = createExecutor(ctx),
+): Tool => {
+  const Schema = z.object(runScriptShape);
+  const spec = {
+    name: "pnpm.runScript",
+    description:
+      "Execute a pnpm script, optionally filtered to specific workspace packages.",
+    inputSchema: runScriptShape,
+  } as const;
+
+  const invoke = async (raw: unknown) => {
+    const { script, args: extraArgs, filter } = Schema.parse(raw);
+    const extras: readonly string[] = extraArgs ?? [];
+    const sanitizedExtras = extras
+      .map((entry) => entry.trim())
+      .filter((entry) => entry.length > 0);
+    const argsSegment =
+      sanitizedExtras.length > 0 ? ["--", ...sanitizedExtras] : [];
+    const command = ["run", script, ...argsSegment];
+    const args = buildPnpmArgs(command, { filter });
+    return exec(args);
+  };
+
+  return { spec, invoke };
+};
+
+export const pnpmInstall: ToolFactory = (ctx) => createInstallTool(ctx);
+export const pnpmAdd: ToolFactory = (ctx) => createAddTool(ctx);
+export const pnpmRemove: ToolFactory = (ctx) => createRemoveTool(ctx);
+export const pnpmRunScript: ToolFactory = (ctx) => createRunScriptTool(ctx);
+
+export const __test__ = {
+  createInstallTool,
+  createAddTool,
+  createRemoveTool,
+  createRunScriptTool,
+  createExecutor,
+  runPnpmCommand,
+  normalizeDependencies,
+};

--- a/promethean.mcp.json
+++ b/promethean.mcp.json
@@ -18,7 +18,11 @@
     "tdd.stopWatch",
     "tdd.coverage",
     "tdd.propertyCheck",
-    "tdd.mutationScore"
+    "tdd.mutationScore",
+    "pnpm.install",
+    "pnpm.add",
+    "pnpm.remove",
+    "pnpm.runScript"
   ],
   "endpoints": {
     "process": {
@@ -44,6 +48,9 @@
     },
     "github": {
       "tools": ["github.request", "github.graphql", "github.rate-limit"]
+    },
+    "workspace": {
+      "tools": ["pnpm.install", "pnpm.add", "pnpm.remove", "pnpm.runScript"]
     }
   }
 }


### PR DESCRIPTION
## Summary
- add pnpm-focused MCP tool implementations to run install/add/remove/runScript with workspace filtering support
- register the new tools in the shared MCP catalog, expose them in the default config, and document their availability
- cover the helpers with AVA tests, add a changelog entry, and track the work in the agile task log

## Testing
- pnpm exec eslint packages/mcp/src/tools/pnpm.ts packages/mcp/src/index.ts packages/mcp/src/tests/pnpm.test.ts
- pnpm --filter @promethean/mcp test

------
https://chatgpt.com/codex/tasks/task_e_68ddd6aad1bc83249564fe65b0d7477c