### PR TITLE
docs: annotate enso package roadmap with status and next steps

### DIFF
--- a/docs/design/enso-protocol/13-package-roadmap.md
+++ b/docs/design/enso-protocol/13-package-roadmap.md
@@ -5,24 +5,18 @@ for ENSO-1.
 
 ## Package Priorities
 
-1. **`enso-protocol`** – publish schemas, codecs, and guards shared by all
-   participants.
-2. **`enso-gateway`** – implement WebSocket transport, room registry, policy
-   broadcast, and routing handlers.
-3. **`enso-client`** – deliver the TypeScript SDK with assets, contexts, cache,
-   and voice helpers.
-4. **`enso-asset`** – content-addressed blob store with chunk ingestion and
-   hash verification.
-5. **`enso-cache`** – cache registry with LRU/TTL policy, manifests, and
-   deterministic CID helpers.
-6. **`enso-transcode`** – deterministic derivation runners for PDF, OCR, audio,
-   and video workloads.
-7. **`enso-context`** – context registry, rule evaluation, and LLM view
-   computation.
-8. **`enso-mcp`** – bridge for MCP mounts and tool execution.
-9. **`enso-rituals`** – AVA guardrails verifying Morganna rules, deterministic
-   CIDs, and privacy behaviours.
-10. **`enso-cli`** – developer demo for quick manual testing.
+| Package | Responsibilities | Status | Next Steps |
+| --- | --- | --- | --- |
+| **`enso-protocol`** | Publish schemas, codecs, and guards shared by all participants. | ✅ Implemented | Continue evolving schemas as new events emerge. |
+| **`enso-gateway`** | Implement WebSocket transport, room registry, policy broadcast, and routing handlers. | ⏳ Pending | Bootstrap the server and handler wiring from the [Gateway Handler Checklist](#gateway-handler-checklist). |
+| **`enso-client`** | Deliver the TypeScript SDK with assets, contexts, cache, and voice helpers. | ⏳ Pending | Flesh out the SDK using the [Client Skeleton](./07-sdk-and-implementation.md#client-skeleton). |
+| **`enso-asset`** | Content-addressed blob store with chunk ingestion and hash verification. | ⏳ Pending | Stand up the store following the [Asset Upload Lifecycle](./09-assets-and-derivations.md#asset-upload-lifecycle). |
+| **`enso-cache`** | Cache registry with LRU/TTL policy, manifests, and deterministic CID helpers. | ⏳ Pending | Implement cache coordination per [Caching and Content Addressing](./10-caching.md). |
+| **`enso-transcode`** | Deterministic derivation runners for PDF, OCR, audio, and video workloads. | ⏳ Pending | Prototype derivation workers aligned with [Derivation Requests](./09-assets-and-derivations.md#derivation-requests). |
+| **`enso-context`** | Context registry, rule evaluation, and LLM view computation. | ⏳ Pending | Build the registry and view builder described in [Context Management and Data Curation](./12-context-management.md). |
+| **`enso-mcp`** | Bridge for MCP mounts and tool execution. | ⏳ Pending | Implement the bridge according to [Model Context Protocol Interop](./08-mcp-integration.md). |
+| **`enso-rituals`** | AVA guardrails verifying Morganna rules, deterministic CIDs, and privacy behaviours. | ⏳ Pending | Codify guardrails from [Rituals (Guardrail Tests)](#rituals-guardrail-tests). |
+| **`enso-cli`** | Developer demo for quick manual testing. | ⏳ Pending | Flesh out the CLI interactions outlined in [Demo CLI Behaviour](#demo-cli-behaviour). |
 
 ## Gateway Handler Checklist
 


### PR DESCRIPTION
## Summary
- convert the ENSO package priority list into a status table
- mark `enso-protocol` as implemented while noting pending packages with next actions
- cross-link roadmap notes to the relevant protocol design chapters

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68dddad785a08324bebfb31009fdf73a