### PR TITLE
feat(enso-protocol): implement mcp client transports

### DIFF
--- a/packages/enso-protocol/README.md
+++ b/packages/enso-protocol/README.md
@@ -6,8 +6,9 @@ A reference implementation of the Promethean ENSO context protocol described in
 
 ## Modules
 
-- `adapter.ts` – Minimal MCP-compatible transport adapter with hookable
-  list/call handlers.
+- `adapter.ts` – Transport-aware MCP client that establishes JSON-RPC sessions
+  over HTTP streaming, Server-Sent Events, or stdio processes and exposes
+  discovery plus tool invocation helpers.
 - `cache.ts`, `store.ts` – Content-addressed cache primitives and persistent
   asset storage with deterministic SHA-256 CIDs.
 - `client.ts` – In-memory ENSO client façade that enforces capability-based

--- a/packages/enso-protocol/src/adapter.ts
+++ b/packages/enso-protocol/src/adapter.ts
@@ -1,3 +1,8 @@
+import { spawn } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import { once } from "node:events";
+import type { ChildProcessWithoutNullStreams } from "node:child_process";
+
 export type McpTransport =
   | { kind: "http-stream"; url: string }
   | { kind: "http-sse"; url: string }
@@ -9,35 +14,93 @@ export interface McpMount {
   metadata?: Record<string, unknown>;
 }
 
-export interface McpClientHandlers {
-  listTools?: () => Promise<unknown[]> | unknown[];
-  callTool?: (request: {
-    name: string;
-    args: unknown;
-    ttlMs: number;
-  }) => Promise<McpToolInvocationResult> | McpToolInvocationResult;
-}
-
 export interface McpToolInvocationResult {
   ok: boolean;
   result?: unknown;
   error?: string;
 }
 
-/**
- * Lightweight client wrapper used by tests and the reference implementation.
- * Consumers can provide custom handlers to integrate with a real MCP bridge
- * while keeping the protocol dependency-free.
- */
+export class McpError extends Error {
+  constructor(
+    readonly kind: "transport" | "remote",
+    message: string,
+    readonly details?: unknown,
+    options?: ErrorOptions,
+  ) {
+    super(message, options);
+    this.name = "McpError";
+  }
+}
+
+type JsonRpcId = string | number;
+
+type JsonRpcRequest = {
+  readonly jsonrpc: "2.0";
+  readonly id: JsonRpcId;
+  readonly method: string;
+  readonly params?: unknown;
+};
+
+type JsonRpcSuccess = {
+  readonly jsonrpc: "2.0";
+  readonly id: JsonRpcId;
+  readonly result: unknown;
+};
+
+type JsonRpcFailure = {
+  readonly jsonrpc: "2.0";
+  readonly id: JsonRpcId;
+  readonly error: {
+    readonly code: number;
+    readonly message: string;
+    readonly data?: unknown;
+  };
+};
+
+type JsonRpcResponse = JsonRpcSuccess | JsonRpcFailure;
+
+export interface McpClientOptions {
+  fetch?: typeof fetch;
+  spawn?: typeof spawn;
+}
+
+interface JsonRpcTransport {
+  request(payload: JsonRpcRequest): Promise<JsonRpcResponse>;
+  close(): Promise<void>;
+}
+
 export class McpClient {
+  private readonly transport: JsonRpcTransport;
+
   constructor(
     readonly mount: McpMount,
-    private readonly handlers: McpClientHandlers = {},
-  ) {}
+    options: McpClientOptions = {},
+  ) {
+    this.transport = createTransport(mount.transport, options);
+  }
 
   async listTools(): Promise<unknown[]> {
-    if (this.handlers.listTools) {
-      return await this.handlers.listTools();
+    const result = await this.send("tools/list");
+    if (
+      result &&
+      typeof result === "object" &&
+      "tools" in result &&
+      Array.isArray((result as { tools?: unknown[] }).tools)
+    ) {
+      return (result as { tools: unknown[] }).tools;
+    }
+    return [];
+  }
+
+  async listResources(): Promise<unknown[]> {
+    const result = await this.send("resources/list");
+    if (
+      result &&
+      typeof result === "object" &&
+      "resources" in result &&
+      Array.isArray((result as { resources?: unknown[] }).resources)
+    ) {
+      return (result as { resources: unknown[] }).resources;
     }
     return [];
   }
@@ -47,13 +110,336 @@ export class McpClient {
     args: unknown;
     ttlMs: number;
   }): Promise<McpToolInvocationResult> {
-    if (this.handlers.callTool) {
-      const response = await this.handlers.callTool(request);
-      return response;
+    try {
+      const result = await this.send("tools/call", {
+        name: request.name,
+        arguments: request.args,
+        ttlMs: request.ttlMs,
+      });
+      return { ok: true, result };
+    } catch (error: unknown) {
+      if (error instanceof McpError) {
+        return {
+          ok: false,
+          error: `${error.kind}: ${error.message}`,
+          result:
+            error.kind === "remote" &&
+            error.details &&
+            typeof error.details === "object"
+              ? error.details
+              : undefined,
+        };
+      }
+      return {
+        ok: false,
+        error: `unknown: ${(error as Error)?.message ?? "tool call failed"}`,
+      };
+    }
+  }
+
+  async close(): Promise<void> {
+    await this.transport.close();
+  }
+
+  private async send(method: string, params?: unknown): Promise<unknown> {
+    const request: JsonRpcRequest = {
+      jsonrpc: "2.0",
+      id: randomUUID(),
+      method,
+      params,
+    };
+    try {
+      const response = await this.transport.request(request);
+      if ("error" in response) {
+        throw new McpError("remote", response.error.message, {
+          code: response.error.code,
+          data: response.error.data,
+        });
+      }
+      return response.result;
+    } catch (error: unknown) {
+      if (error instanceof McpError) {
+        throw error;
+      }
+      throw new McpError(
+        "transport",
+        `Failed to send ${method} to MCP server`,
+        undefined,
+        { cause: error },
+      );
+    }
+  }
+}
+
+function createTransport(
+  transport: McpTransport,
+  options: McpClientOptions,
+): JsonRpcTransport {
+  switch (transport.kind) {
+    case "http-stream":
+      return new HttpJsonRpcTransport(
+        transport.url,
+        "http-stream",
+        options.fetch ?? fetch,
+      );
+    case "http-sse":
+      return new HttpJsonRpcTransport(
+        transport.url,
+        "http-sse",
+        options.fetch ?? fetch,
+      );
+    case "stdio":
+      return new StdioJsonRpcTransport(
+        transport.command,
+        transport.args ?? [],
+        options.spawn ?? spawn,
+      );
+    default:
+      throw new McpError(
+        "transport",
+        `Unsupported transport kind ${(transport as { kind: string }).kind}`,
+      );
+  }
+}
+
+class HttpJsonRpcTransport implements JsonRpcTransport {
+  constructor(
+    private readonly url: string,
+    private readonly mode: "http-stream" | "http-sse",
+    private readonly doFetch: typeof fetch,
+  ) {}
+
+  async request(payload: JsonRpcRequest): Promise<JsonRpcResponse> {
+    const headers: Record<string, string> = {
+      "content-type": "application/json",
+    };
+    if (this.mode === "http-sse") {
+      headers.accept = "text/event-stream";
+    }
+    try {
+      const response = await this.doFetch(this.url, {
+        method: "POST",
+        headers,
+        body: JSON.stringify(payload),
+      });
+      if (!response.ok) {
+        throw new McpError(
+          "transport",
+          `HTTP ${response.status} ${response.statusText}`,
+        );
+      }
+      const contentType = response.headers.get("content-type") ?? "";
+      const bodyText = await response.text();
+      const data =
+        contentType.includes("text/event-stream") || this.mode === "http-sse"
+          ? parseSseBody(bodyText)
+          : parseJsonBody(bodyText);
+      return asJsonRpcResponse(data);
+    } catch (error: unknown) {
+      if (error instanceof McpError) {
+        throw error;
+      }
+      throw new McpError(
+        "transport",
+        `Failed to reach MCP server at ${this.url}`,
+        undefined,
+        { cause: error },
+      );
+    }
+  }
+
+  async close(): Promise<void> {
+    // Stateless HTTP transport has nothing to close.
+  }
+}
+
+class StdioJsonRpcTransport implements JsonRpcTransport {
+  private readonly child: ChildProcessWithoutNullStreams;
+  private readonly pending = new Map<
+    string,
+    {
+      resolve: (value: JsonRpcResponse) => void;
+      reject: (reason: unknown) => void;
+    }
+  >();
+  private buffer = "";
+  private closed = false;
+
+  constructor(
+    command: string,
+    args: readonly string[] = [],
+    spawnImpl: typeof spawn = spawn,
+  ) {
+    this.child = spawnImpl(command, [...args], {
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    this.child.stdout.setEncoding?.("utf8");
+    this.child.stdout.on("data", (chunk) => this.onData(chunk));
+    this.child.on("error", (error) =>
+      this.rejectAll(
+        new McpError("transport", error.message, undefined, { cause: error }),
+      ),
+    );
+    this.child.on("exit", (code, signal) => {
+      if (this.closed) return;
+      const reason =
+        code === null
+          ? `Process exited via signal ${signal ?? "unknown"}`
+          : `Process exited with code ${code}`;
+      this.rejectAll(new McpError("transport", reason));
+    });
+  }
+
+  async request(payload: JsonRpcRequest): Promise<JsonRpcResponse> {
+    if (!this.child.stdin.writable) {
+      throw new McpError("transport", "MCP stdio transport is not writable");
+    }
+    const id = String(payload.id);
+    return await new Promise<JsonRpcResponse>((resolve, reject) => {
+      this.pending.set(id, { resolve, reject });
+      const data = JSON.stringify(payload) + "\n";
+      this.child.stdin.write(data, (error) => {
+        if (error) {
+          this.pending.delete(id);
+          reject(
+            new McpError("transport", error.message, undefined, {
+              cause: error,
+            }),
+          );
+        }
+      });
+    });
+  }
+
+  async close(): Promise<void> {
+    this.closed = true;
+    for (const [id, entry] of this.pending.entries()) {
+      entry.reject(new McpError("transport", "Transport closed"));
+      this.pending.delete(id);
+    }
+    this.child.stdin.end();
+    if (this.child.exitCode === null) {
+      this.child.kill();
+      await once(this.child, "exit").catch(() => undefined);
+    }
+  }
+
+  private onData(chunk: string | Buffer): void {
+    this.buffer += chunk.toString();
+    while (true) {
+      const newline = this.buffer.indexOf("\n");
+      if (newline === -1) {
+        break;
+      }
+      const raw = this.buffer.slice(0, newline).trim();
+      this.buffer = this.buffer.slice(newline + 1);
+      if (!raw) {
+        continue;
+      }
+      let payload: unknown;
+      try {
+        payload = JSON.parse(raw);
+      } catch (error) {
+        this.rejectAll(
+          new McpError(
+            "transport",
+            "Received invalid JSON from MCP process",
+            undefined,
+            {
+              cause: error,
+            },
+          ),
+        );
+        continue;
+      }
+      const response = asJsonRpcResponse(payload);
+      const id = String(response.id);
+      const handler = this.pending.get(id);
+      if (handler) {
+        this.pending.delete(id);
+        handler.resolve(response);
+      }
+    }
+  }
+
+  private rejectAll(error: McpError): void {
+    for (const [id, handler] of this.pending.entries()) {
+      handler.reject(error);
+      this.pending.delete(id);
+    }
+  }
+}
+
+function parseJsonBody(body: string): unknown {
+  if (!body.trim()) {
+    throw new McpError("transport", "Empty response body");
+  }
+  try {
+    return JSON.parse(body);
+  } catch (error) {
+    throw new McpError("transport", "Invalid JSON body", undefined, {
+      cause: error,
+    });
+  }
+}
+
+function parseSseBody(body: string): unknown {
+  const lines = body.split(/\r?\n/);
+  const dataLines: string[] = [];
+  for (const line of lines) {
+    if (line.startsWith("data:")) {
+      dataLines.push(line.slice(5).trim());
+    }
+  }
+  if (dataLines.length === 0) {
+    throw new McpError("transport", "No data frames in SSE response");
+  }
+  const payload = dataLines.join("\n").trim();
+  if (!payload) {
+    throw new McpError("transport", "Empty SSE data frame");
+  }
+  try {
+    return JSON.parse(payload);
+  } catch (error) {
+    throw new McpError("transport", "Invalid SSE payload", undefined, {
+      cause: error,
+    });
+  }
+}
+
+function asJsonRpcResponse(payload: unknown): JsonRpcResponse {
+  if (!payload || typeof payload !== "object") {
+    throw new McpError("transport", "Invalid JSON-RPC response payload");
+  }
+  const record = payload as Record<string, unknown>;
+  if (record.jsonrpc !== "2.0" || record.id === undefined) {
+    throw new McpError("transport", "Malformed JSON-RPC response");
+  }
+  if ("error" in record) {
+    const error = record.error as {
+      code: number;
+      message: string;
+      data?: unknown;
+    };
+    if (
+      !error ||
+      typeof error.message !== "string" ||
+      typeof error.code !== "number"
+    ) {
+      throw new McpError("transport", "Malformed JSON-RPC error response");
     }
     return {
-      ok: false,
-      error: `No handler registered for tool invocation ${request.name}`,
+      jsonrpc: "2.0",
+      id: record.id as JsonRpcId,
+      error,
     };
   }
+  if (!("result" in record)) {
+    throw new McpError("transport", "Missing result in JSON-RPC response");
+  }
+  return {
+    jsonrpc: "2.0",
+    id: record.id as JsonRpcId,
+    result: record.result,
+  };
 }

--- a/packages/enso-protocol/src/tests/mcp-client.spec.ts
+++ b/packages/enso-protocol/src/tests/mcp-client.spec.ts
@@ -1,0 +1,307 @@
+import test from "ava";
+import { EventEmitter } from "node:events";
+import { PassThrough } from "node:stream";
+import type { ChildProcessWithoutNullStreams } from "node:child_process";
+
+const { Response, Headers } = globalThis;
+
+test.serial("http stream transport lists tools and calls tools", async (t) => {
+  const originalFetch = globalThis.fetch;
+  const requests: string[] = [];
+  const responses = [
+    new Response(
+      JSON.stringify({
+        jsonrpc: "2.0",
+        id: "1",
+        result: { tools: [{ name: "demo", description: "Demo tool" }] },
+      }),
+      {
+        status: 200,
+        headers: new Headers({ "content-type": "application/json" }),
+      },
+    ),
+    new Response(
+      JSON.stringify({
+        jsonrpc: "2.0",
+        id: "2",
+        result: { content: [{ type: "text", text: "ok" }] },
+      }),
+      {
+        status: 200,
+        headers: new Headers({ "content-type": "application/json" }),
+      },
+    ),
+  ];
+  globalThis.fetch = async (_input: RequestInfo | URL, init?: RequestInit) => {
+    requests.push((init?.body as string) ?? "");
+    return (
+      responses.shift() ??
+      new Response("{}", {
+        status: 500,
+        headers: new Headers({ "content-type": "application/json" }),
+      })
+    );
+  };
+
+  try {
+    const { McpClient } = await import("../adapter.js");
+    const client = new McpClient({
+      serverId: "demo",
+      transport: { kind: "http-stream", url: "https://mcp.example" },
+    });
+
+    t.deepEqual(await client.listTools(), [
+      { name: "demo", description: "Demo tool" },
+    ]);
+    const result = await client.callTool({
+      name: "demo",
+      args: { value: 1 },
+      ttlMs: 5000,
+    });
+    t.true(result.ok);
+    t.deepEqual(result.result, { content: [{ type: "text", text: "ok" }] });
+
+    t.is(requests.length, 2);
+    const [listPayload, callPayload] = requests.map((body) => JSON.parse(body));
+    t.is(listPayload.method, "tools/list");
+    t.is(callPayload.method, "tools/call");
+
+    await client.close();
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test.serial("http sse transport parses event stream", async (t) => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async () =>
+    new Response(
+      'data: {"jsonrpc":"2.0","id":"1","result":{"resources":[{"name":"notes"}]}}\n\n',
+      {
+        status: 200,
+        headers: new Headers({ "content-type": "text/event-stream" }),
+      },
+    );
+
+  try {
+    const { McpClient } = await import("../adapter.js");
+    const client = new McpClient({
+      serverId: "demo",
+      transport: { kind: "http-sse", url: "https://mcp.example" },
+    });
+
+    t.deepEqual(await client.listResources(), [{ name: "notes" }]);
+    await client.close();
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test.serial("transport failures raise structured errors", async (t) => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async () => {
+    throw new TypeError("connect ECONNREFUSED");
+  };
+
+  try {
+    const { McpClient, McpError } = await import("../adapter.js");
+    const client = new McpClient({
+      serverId: "offline",
+      transport: { kind: "http-stream", url: "https://offline" },
+    });
+
+    await t.throwsAsync(() => client.listTools(), {
+      instanceOf: McpError,
+      message: /Failed to reach MCP server/,
+    });
+    const result = await client.callTool({ name: "demo", args: {}, ttlMs: 10 });
+    t.false(result.ok);
+    t.regex(result.error ?? "", /transport:/);
+
+    await client.close();
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test.serial("http transport surfaces remote json-rpc errors", async (t) => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async () =>
+    new Response(
+      JSON.stringify({
+        jsonrpc: "2.0",
+        id: "1",
+        error: { code: -32000, message: "boom", data: { reason: "invalid" } },
+      }),
+      {
+        status: 200,
+        headers: new Headers({ "content-type": "application/json" }),
+      },
+    );
+
+  try {
+    const { McpClient, McpError } = await import("../adapter.js");
+    const client = new McpClient({
+      serverId: "remote",
+      transport: { kind: "http-stream", url: "https://mcp.example" },
+    });
+
+    await t.throwsAsync(() => client.listTools(), {
+      instanceOf: McpError,
+      message: /boom/,
+    });
+
+    const result = await client.callTool({
+      name: "demo",
+      args: {},
+      ttlMs: 100,
+    });
+    t.false(result.ok);
+    t.regex(result.error ?? "", /remote: boom/);
+    t.deepEqual(result.result, { code: -32000, data: { reason: "invalid" } });
+
+    await client.close();
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test.serial("http transport raises on non-ok status", async (t) => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async () =>
+    new Response("server error", {
+      status: 503,
+      statusText: "Service Unavailable",
+      headers: new Headers({ "content-type": "text/plain" }),
+    });
+
+  try {
+    const { McpClient, McpError } = await import("../adapter.js");
+    const client = new McpClient({
+      serverId: "remote",
+      transport: { kind: "http-stream", url: "https://mcp.example" },
+    });
+
+    await t.throwsAsync(() => client.listResources(), {
+      instanceOf: McpError,
+      message: /HTTP 503/,
+    });
+    await client.close();
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test.serial("http transport rejects empty payloads", async (t) => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async () =>
+    new Response("", {
+      status: 200,
+      headers: new Headers({ "content-type": "application/json" }),
+    });
+
+  try {
+    const { McpClient, McpError } = await import("../adapter.js");
+    const client = new McpClient({
+      serverId: "remote",
+      transport: { kind: "http-stream", url: "https://mcp.example" },
+    });
+
+    await t.throwsAsync(() => client.listTools(), {
+      instanceOf: McpError,
+      message: /Empty response body/,
+    });
+    await client.close();
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test.serial("sse transport validates data frames", async (t) => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async () =>
+    new Response(": keep-alive\n\n", {
+      status: 200,
+      headers: new Headers({ "content-type": "text/event-stream" }),
+    });
+
+  try {
+    const { McpClient, McpError } = await import("../adapter.js");
+    const client = new McpClient({
+      serverId: "demo",
+      transport: { kind: "http-sse", url: "https://mcp.example" },
+    });
+
+    await t.throwsAsync(() => client.listResources(), {
+      instanceOf: McpError,
+      message: /No data frames/,
+    });
+    await client.close();
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test.serial("stdio transport exchanges newline-delimited json", async (t) => {
+  const requests: string[] = [];
+  const spawnStub = ((..._args: unknown[]): ChildProcessWithoutNullStreams => {
+    const stdout = new PassThrough();
+    const stdin = new PassThrough();
+    const stderr = new PassThrough();
+    const emitter = new EventEmitter();
+    const child = emitter as unknown as ChildProcessWithoutNullStreams & {
+      kill: () => boolean;
+    };
+    Object.assign(child, { stdout, stdin, stderr });
+    Object.defineProperty(child, "exitCode", {
+      value: null,
+      writable: true,
+      configurable: true,
+    });
+    child.kill = () => {
+      queueMicrotask(() => emitter.emit("exit", 0, null));
+      return true;
+    };
+    stdin.on("data", (chunk) => {
+      const text = chunk.toString();
+      requests.push(text);
+      const request = JSON.parse(text);
+      if (request.method === "tools/list") {
+        stdout.write(
+          JSON.stringify({
+            jsonrpc: "2.0",
+            id: request.id,
+            result: { tools: [{ name: "stdio" }] },
+          }) + "\n",
+        );
+      } else {
+        stdout.write(
+          JSON.stringify({
+            jsonrpc: "2.0",
+            id: request.id,
+            result: { ok: true },
+          }) + "\n",
+        );
+      }
+    });
+    return child;
+  }) as unknown as typeof import("node:child_process").spawn;
+
+  const { McpClient } = await import("../adapter.js");
+  const client = new McpClient(
+    {
+      serverId: "local",
+      transport: { kind: "stdio", command: "fake" },
+    },
+    { spawn: spawnStub },
+  );
+
+  t.deepEqual(await client.listTools(), [{ name: "stdio" }]);
+  const result = await client.callTool({ name: "stdio", args: {}, ttlMs: 100 });
+  t.true(result.ok);
+
+  t.true(requests.some((line) => line.includes('"tools/list"')));
+  t.true(requests.some((line) => line.includes('"tools/call"')));
+
+  await client.close();
+});

--- a/packages/enso-protocol/src/tests/modules.spec.ts
+++ b/packages/enso-protocol/src/tests/modules.spec.ts
@@ -1,5 +1,4 @@
 import test from "ava";
-import { McpClient } from "../adapter.js";
 import { CacheRegistry } from "../cache.js";
 import { EnsoClient } from "../client.js";
 import { derivedCid, derive } from "../derive.js";
@@ -24,38 +23,6 @@ const CLIENT_CAPS = [
   "can.context.write",
   "can.context.apply",
 ] as const;
-
-test("adapter default handlers", async (t) => {
-  const client = new McpClient({
-    serverId: "demo",
-    transport: { kind: "stdio", command: "noop" },
-  });
-  t.deepEqual(await client.listTools(), []);
-  const result = await client.callTool({ name: "noop", args: {}, ttlMs: 10 });
-  t.false(result.ok);
-  t.regex(result.error ?? "", /No handler/);
-});
-
-test("adapter custom handlers", async (t) => {
-  const client = new McpClient(
-    {
-      serverId: "mcp",
-      transport: { kind: "http-stream", url: "https://mcp.example" },
-    },
-    {
-      listTools: () => [{ name: "demo" }],
-      callTool: async ({ name }) => ({ ok: true, result: name }),
-    },
-  );
-  t.deepEqual(await client.listTools(), [{ name: "demo" }]);
-  const response = await client.callTool({
-    name: "demo",
-    args: { q: 1 },
-    ttlMs: 1000,
-  });
-  t.true(response.ok);
-  t.is(response.result, "demo");
-});
 
 test("cache registry operations", (t) => {
   const cache = new CacheRegistry();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14090,7 +14090,7 @@ snapshots:
 
   axios@1.11.0:
     dependencies:
-      follow-redirects: 1.15.11(debug@4.3.7)
+      follow-redirects: 1.15.11(debug@4.4.3)
       form-data: 4.0.4
       proxy-from-env: 1.1.0
     transitivePeerDependencies:
@@ -16582,7 +16582,7 @@ snapshots:
   http-proxy@1.18.1:
     dependencies:
       eventemitter3: 4.0.7
-      follow-redirects: 1.15.11(debug@4.3.7)
+      follow-redirects: 1.15.11(debug@4.4.3)
       requires-port: 1.0.0
     transitivePeerDependencies:
       - debug


### PR DESCRIPTION
## Summary
- replace the MCP client stub with a transport-aware JSON-RPC implementation that handles HTTP streaming, SSE, and stdio processes with structured errors
- add dedicated AVA coverage for the MCP client happy paths and failure cases and update the README module description

## Testing
- pnpm --filter @promethean/enso-protocol test

------
https://chatgpt.com/codex/tasks/task_e_68dddada60ec8324985c28776623e187