### PR TITLE
docs: sync enso protocol checklist references

### DIFF
--- a/changelog.d/2025.10.02.02.24.28.md
+++ b/changelog.d/2025.10.02.02.24.28.md
@@ -1,0 +1,1 @@
+- Updated the Enso protocol overview checklist to point at the implemented transport, presence, voice, tool, guardrail, and CLI modules for future iteration planning.

--- a/docs/design/enso-protocol/01-overview.md
+++ b/docs/design/enso-protocol/01-overview.md
@@ -53,9 +53,9 @@ surface areas with immutable data handling.
 
 ## Minimal Feature Checklist (v0.1)
 
-- [ ] WebSocket transport with framed envelopes and ping/pong
-- [ ] Presence events (`presence.join`, `presence.part`) and `chat.msg`
-- [ ] `voice.frame` streaming with pause/resume and sequence tracking
-- [ ] `tool.advertise`, `tool.call`, and `tool.result` covering at least one tool
-- [ ] Evaluation mode (`room.flags.eval`) requiring `act.rationale`
-- [ ] CLI demo linking microphone input to transcript and reply playback
+- [x] WebSocket transport with framed envelopes and ping/pong — implemented in [transport.ts](../../../packages/enso-protocol/src/transport.ts) with coverage in [voice-transport.spec.ts](../../../packages/enso-protocol/src/tests/voice-transport.spec.ts).
+- [x] Presence events (`presence.join`, `presence.part`) and `chat.msg` — emitted in [server.ts](../../../packages/enso-protocol/src/server.ts) and exercised by [transport.spec.ts](../../../packages/enso-protocol/src/tests/transport.spec.ts).
+- [x] `voice.frame` streaming with pause/resume and sequence tracking — handled by [client.ts](../../../packages/enso-protocol/src/client.ts) and [flow.ts](../../../packages/enso-protocol/src/flow.ts), verified in [voice-transport.spec.ts](../../../packages/enso-protocol/src/tests/voice-transport.spec.ts).
+- [x] `tool.advertise`, `tool.call`, and `tool.result` covering at least one tool — provided by [tools.ts](../../../packages/enso-protocol/src/tools.ts) with guardrail integration in [server.ts](../../../packages/enso-protocol/src/server.ts) and tested via [tools.spec.ts](../../../packages/enso-protocol/src/tests/tools.spec.ts).
+- [x] Evaluation mode (`room.flags.eval`) requiring `act.rationale` — enforced by [guardrails.ts](../../../packages/enso-protocol/src/guardrails.ts) through the server handshake in [server.ts](../../../packages/enso-protocol/src/server.ts) with scenarios in [guardrails.spec.ts](../../../packages/enso-protocol/src/tests/guardrails.spec.ts).
+- [x] CLI demo linking microphone input to transcript and reply playback — implemented in [cli.ts](../../../packages/enso-protocol/src/cli.ts) with scripted coverage in [cli.spec.ts](../../../packages/enso-protocol/src/tests/cli.spec.ts).


### PR DESCRIPTION
## Summary
- mark the Enso protocol overview checklist items that are already implemented
- link each checklist entry to the corresponding modules and automated tests
- log the documentation refresh in the changelog feed

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68dddad4ee3c8324bbe1a3940e579fd3