### PR TITLE
feat: add MCP server for GitHub PR conflict tools

### DIFF
--- a/changelog.d/2025.10.02.02.06.55.md
+++ b/changelog.d/2025.10.02.02.06.55.md
@@ -1,0 +1,1 @@
+- add @promethean/mcp-github-conflicts package implementing github conflict mcp server tools

--- a/packages/mcp-github-conflicts/ava.config.mjs
+++ b/packages/mcp-github-conflicts/ava.config.mjs
@@ -1,0 +1,1 @@
+export { default } from "../../config/ava.config.mjs";

--- a/packages/mcp-github-conflicts/package.json
+++ b/packages/mcp-github-conflicts/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "@promethean/mcp-github-conflicts",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "dist/index.cjs",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    },
+    "./dist/*": "./dist/*",
+    "./*": "./dist/*"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc -b",
+    "clean": "rimraf dist",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "test": "pnpm run build && ava --config ../../config/ava.config.mjs",
+    "lint": "pnpm exec eslint .",
+    "coverage": "pnpm run build && c8 ava --config ../../config/ava.config.mjs",
+    "format": "pnpm exec prettier --write ."
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.17.5",
+    "zod": "^3.25.76"
+  },
+  "devDependencies": {
+    "ava": "^6.4.1",
+    "nock": "^14.0.0",
+    "rimraf": "^6.0.1",
+    "typescript": "^5.4.5"
+  },
+  "license": "GPL-3.0-only"
+}

--- a/packages/mcp-github-conflicts/project.json
+++ b/packages/mcp-github-conflicts/project.json
@@ -1,0 +1,41 @@
+{
+  "name": "@promethean/mcp-github-conflicts",
+  "root": "packages/mcp-github-conflicts",
+  "sourceRoot": "packages/mcp-github-conflicts/src",
+  "targets": {
+    "build": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "tsc -b",
+        "cwd": "packages/mcp-github-conflicts"
+      },
+      "outputs": ["{projectRoot}/dist"]
+    },
+    "typecheck": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "tsc -p tsconfig.json --noEmit",
+        "cwd": "packages/mcp-github-conflicts"
+      }
+    },
+    "test": {
+      "executor": "nx:run-commands",
+      "dependsOn": ["build"],
+      "options": {
+        "command": "ava --config ../../config/ava.config.mjs",
+        "cwd": "{projectRoot}",
+        "env": {
+          "AVA_PROJECT_ROOT": "."
+        }
+      }
+    },
+    "lint": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "eslint .",
+        "cwd": "packages/mcp-github-conflicts"
+      }
+    }
+  },
+  "tags": ["scope:packages"]
+}

--- a/packages/mcp-github-conflicts/src/github.ts
+++ b/packages/mcp-github-conflicts/src/github.ts
@@ -1,0 +1,337 @@
+import type { ReadonlyDeep } from "type-fest";
+
+export type JsonObject = ReadonlyDeep<Record<string, unknown>>;
+
+export type RepoCoordinates = {
+  readonly owner: string;
+  readonly name: string;
+};
+
+export type PullRequestCoordinates = {
+  readonly repo: RepoCoordinates;
+  readonly number: number;
+};
+
+export type MergeableState =
+  | "CONFLICTING"
+  | "MERGEABLE"
+  | "UNKNOWN"
+  | "UNMERGEABLE"
+  | "DRAFT"
+  | "BEHIND"
+  | "BLOCKED";
+
+export type MergeStateStatus =
+  | "BEHIND"
+  | "BLOCKED"
+  | "CLEAN"
+  | "DIRTY"
+  | "DRAFT"
+  | "HAS_HOOKS"
+  | "UNKNOWN";
+
+export type PullRequestStatus = {
+  readonly id: string;
+  readonly number: number;
+  readonly url: string;
+  readonly headRefName: string;
+  readonly headRefOid: string;
+  readonly baseRefName: string;
+  readonly mergeable: MergeableState;
+  readonly mergeStateStatus: MergeStateStatus;
+};
+
+export type PullRequestFetcher = (
+  coordinates: Readonly<PullRequestCoordinates>,
+) => Promise<PullRequestStatus>;
+
+export type Delay = (milliseconds: number) => Promise<void>;
+
+export type PullRequestPollOptions = {
+  readonly waitForKnown?: boolean;
+  readonly attempts?: number;
+  readonly delayMs?: number;
+  readonly delay?: Delay;
+};
+
+const defaultHeaders = (token: string): Readonly<Record<string, string>> =>
+  ({
+    Authorization: `Bearer ${token}`,
+    Accept: "application/vnd.github+json",
+    "X-GitHub-Api-Version": "2022-11-28",
+  }) as const;
+
+const isJsonObject = (value: unknown): value is JsonObject =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const toPlainJson = <T extends JsonObject>(value: T): T =>
+  JSON.parse(JSON.stringify(value)) as T;
+
+const deepFreeze = <T>(value: T): ReadonlyDeep<T> => {
+  if (Array.isArray(value)) {
+    return value.map((item) => deepFreeze(item)) as unknown as ReadonlyDeep<T>;
+  }
+
+  if (isJsonObject(value)) {
+    const frozenEntries = Object.entries(value).reduce<Record<string, unknown>>(
+      (accumulator, [key, entry]) => ({
+        ...accumulator,
+        [key]: deepFreeze(entry),
+      }),
+      {},
+    );
+
+    return Object.freeze(frozenEntries) as ReadonlyDeep<T>;
+  }
+
+  return value as ReadonlyDeep<T>;
+};
+
+type JsonRequestInit = Readonly<{
+  method?: string;
+  body?: string;
+  headers?: Readonly<Record<string, string>>;
+}>;
+
+export const defaultDelay: Delay = (milliseconds: number) =>
+  new Promise((resolve) => {
+    setTimeout(resolve, milliseconds);
+  });
+
+export class GitHubRequestError extends Error {
+  public readonly status: number;
+
+  public constructor(message: string, status: number) {
+    super(message);
+    this.name = "GitHubRequestError";
+    this.status = status;
+  }
+}
+
+export const createRestJsonClient =
+  (token: string, fetchImpl: typeof fetch) =>
+  async <T>(url: string, init: JsonRequestInit = {}): Promise<T> => {
+    const response = await fetchImpl(url, {
+      ...init,
+      headers: {
+        ...defaultHeaders(token),
+        "Content-Type": "application/json",
+        ...(init.headers ?? {}),
+      },
+    });
+
+    const raw = await response.text();
+    const data: JsonObject =
+      raw.trim().length === 0
+        ? deepFreeze({})
+        : deepFreeze(toPlainJson(JSON.parse(raw) as Record<string, unknown>));
+    const message =
+      typeof data.message === "string" ? data.message : response.statusText;
+
+    if (!response.ok) {
+      throw new GitHubRequestError(message, response.status);
+    }
+
+    return toPlainJson(data) as T;
+  };
+
+export const createGraphQLClient =
+  (token: string, fetchImpl: typeof fetch) =>
+  async <T>(query: string, variables: JsonObject = {}): Promise<T> => {
+    const response = await fetchImpl("https://api.github.com/graphql", {
+      method: "POST",
+      headers: {
+        ...defaultHeaders(token),
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ query, variables }),
+    });
+
+    const rawPayload = await response.text();
+    const payload: JsonObject = deepFreeze(
+      toPlainJson(JSON.parse(rawPayload) as Record<string, unknown>),
+    );
+    const errors = Array.isArray(payload.errors)
+      ? payload.errors.filter((candidate): candidate is JsonObject =>
+          isJsonObject(candidate),
+        )
+      : [];
+    const firstError = errors[0];
+    const messageValue = firstError?.message;
+
+    if (!response.ok) {
+      throw new GitHubRequestError(
+        typeof messageValue === "string" ? messageValue : response.statusText,
+        response.status,
+      );
+    }
+
+    if (errors.length > 0) {
+      throw new Error(JSON.stringify(errors));
+    }
+
+    const data = payload.data as T | undefined;
+
+    if (!data) {
+      throw new Error("GitHub response missing data");
+    }
+
+    return toPlainJson(data);
+  };
+
+const pullRequestQuery = `
+  query ($owner:String!, $name:String!, $number:Int!) {
+    repository(owner:$owner, name:$name) {
+      pullRequest(number:$number) {
+        id
+        number
+        url
+        headRefName
+        headRefOid
+        baseRefName
+        mergeable
+        mergeStateStatus
+      }
+    }
+  }
+`;
+
+export const createPullRequestFetcher =
+  (
+    gqlClient: <T>(query: string, variables?: JsonObject) => Promise<T>,
+  ): PullRequestFetcher =>
+  async (coordinates) => {
+    const data = await gqlClient<{
+      readonly repository?: {
+        readonly pullRequest?: PullRequestStatus;
+      };
+    }>(pullRequestQuery, {
+      owner: coordinates.repo.owner,
+      name: coordinates.repo.name,
+      number: coordinates.number,
+    });
+
+    const pullRequest = data.repository?.pullRequest;
+
+    if (!pullRequest) {
+      throw new Error("Pull request not found");
+    }
+
+    return pullRequest;
+  };
+
+export const pollPullRequestStatus = async (
+  fetcher: PullRequestFetcher,
+  coordinates: PullRequestCoordinates,
+  options: Readonly<PullRequestPollOptions> = {},
+): Promise<PullRequestStatus> => {
+  const configuration: Readonly<{
+    readonly waitForKnown: boolean;
+    readonly attempts: number;
+    readonly delayMs: number;
+    readonly delay: Delay;
+  }> = {
+    waitForKnown: options.waitForKnown ?? true,
+    attempts: options.attempts ?? 10,
+    delayMs: options.delayMs ?? 1200,
+    delay: options.delay ?? defaultDelay,
+  };
+
+  const iterate = async (
+    attempt: number,
+    current: PullRequestStatus,
+  ): Promise<PullRequestStatus> => {
+    if (
+      !configuration.waitForKnown ||
+      current.mergeable !== "UNKNOWN" ||
+      attempt >= configuration.attempts
+    ) {
+      return current;
+    }
+
+    await configuration.delay(configuration.delayMs);
+    const next = await fetcher(coordinates);
+    return iterate(attempt + 1, next);
+  };
+
+  const initial = await fetcher(coordinates);
+  return iterate(0, initial);
+};
+
+export const updatePullRequestBranch =
+  (restClient: <T>(url: string, init?: JsonRequestInit) => Promise<T>) =>
+  async (
+    coordinates: Readonly<PullRequestCoordinates>,
+    expectedHeadOid?: string,
+  ): Promise<JsonObject> => {
+    const body = expectedHeadOid ? { expected_head_sha: expectedHeadOid } : {};
+
+    const url = `https://api.github.com/repos/${coordinates.repo.owner}/${coordinates.repo.name}/pulls/${coordinates.number}/update-branch`;
+
+    return restClient<JsonObject>(url, {
+      method: "PUT",
+      body: JSON.stringify(body),
+    });
+  };
+
+export type AutoMergeMethod = "SQUASH" | "MERGE" | "REBASE";
+
+export const enablePullRequestAutoMerge =
+  (gqlClient: <T>(query: string, variables?: JsonObject) => Promise<T>) =>
+  async (
+    pullRequestId: string,
+    expectedHeadOid: string,
+    method: AutoMergeMethod,
+  ): Promise<void> => {
+    await gqlClient(pullRequestEnableMutation, {
+      pr: pullRequestId,
+      method,
+      expected: expectedHeadOid,
+    });
+  };
+
+const pullRequestEnableMutation = `
+  mutation($pr:ID!, $method:PullRequestMergeMethod!, $expected:String!){
+    enablePullRequestAutoMerge(input:{pullRequestId:$pr, mergeMethod:$method, expectedHeadOid:$expected}){
+      clientMutationId
+    }
+  }
+`;
+
+export const enqueuePullRequest =
+  (gqlClient: <T>(query: string, variables?: JsonObject) => Promise<T>) =>
+  async (pullRequestId: string): Promise<JsonObject> =>
+    gqlClient<JsonObject>(pullRequestEnqueueMutation, { id: pullRequestId });
+
+const pullRequestEnqueueMutation = `
+  mutation($id:ID!){
+    enqueuePullRequest(input:{pullRequestId:$id}){
+      mergeQueueEntry{
+        id
+        position
+      }
+    }
+  }
+`;
+
+export type MergeTriple = {
+  readonly path: string;
+  readonly base: string;
+  readonly ours: string;
+  readonly theirs: string;
+};
+
+export type Resolution = {
+  readonly path: string;
+  readonly content: string;
+};
+
+export type FetchMergeTriples = (
+  coordinates: Readonly<PullRequestCoordinates>,
+) => Promise<readonly MergeTriple[]>;
+
+export type ApplyResolution = (
+  coordinates: Readonly<PullRequestCoordinates>,
+  resolutions: readonly Resolution[],
+  expectedHeadOid: string,
+) => Promise<string>;

--- a/packages/mcp-github-conflicts/src/index.ts
+++ b/packages/mcp-github-conflicts/src/index.ts
@@ -1,0 +1,2 @@
+export * from "./github.js";
+export { createConflictServer, server } from "./server.js";

--- a/packages/mcp-github-conflicts/src/server.ts
+++ b/packages/mcp-github-conflicts/src/server.ts
@@ -1,0 +1,201 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { ReadonlyDeep } from "type-fest";
+import { z } from "zod";
+
+import {
+  createGraphQLClient,
+  createPullRequestFetcher,
+  createRestJsonClient,
+  enablePullRequestAutoMerge,
+  enqueuePullRequest,
+  pollPullRequestStatus,
+  updatePullRequestBranch,
+  type AutoMergeMethod,
+  type PullRequestCoordinates,
+} from "./github.js";
+
+export type ConflictServerDependencies = {
+  readonly fetchImpl?: typeof fetch;
+};
+
+const coordinatesFrom = (
+  repo: Readonly<{ readonly owner: string; readonly name: string }>,
+  number: number,
+): PullRequestCoordinates => ({
+  repo: { owner: repo.owner, name: repo.name },
+  number,
+});
+
+type RegisterContext = ReadonlyDeep<{
+  server: McpServer;
+  fetchImpl: typeof fetch;
+}>;
+
+type ToolResponse = {
+  content: Array<{ type: "text"; text: string }>;
+};
+
+const toToolResponse = (value: unknown): ToolResponse => ({
+  content: [
+    {
+      type: "text",
+      text: typeof value === "string" ? value : JSON.stringify(value),
+    },
+  ],
+});
+
+const statusSchema = z.object({
+  token: z.string(),
+  repo: z.object({ owner: z.string(), name: z.string() }),
+  number: z.number().int(),
+  waitForKnown: z.boolean().default(true),
+  attempts: z.number().int().default(10),
+  delayMs: z.number().int().default(1200),
+});
+
+type StatusArgs = ReadonlyDeep<z.infer<typeof statusSchema>>;
+
+const registerStatusTool = (context: RegisterContext) => {
+  const { server, fetchImpl } = context;
+  server.registerTool(
+    "pr.status",
+    {
+      description:
+        "Get PR mergeability and state; polls until not UNKNOWN if requested.",
+      inputSchema: statusSchema.shape,
+    },
+    async ({
+      token,
+      repo,
+      number,
+      waitForKnown,
+      attempts,
+      delayMs,
+    }: StatusArgs) => {
+      const gqlClient = createGraphQLClient(token, fetchImpl);
+      const fetcher = createPullRequestFetcher(gqlClient);
+      const status = await pollPullRequestStatus(
+        fetcher,
+        coordinatesFrom(repo, number),
+        {
+          waitForKnown,
+          attempts,
+          delayMs,
+        },
+      );
+      return toToolResponse(status);
+    },
+  );
+};
+
+const updateSchema = z.object({
+  token: z.string(),
+  repo: z.object({ owner: z.string(), name: z.string() }),
+  number: z.number().int(),
+  expectedHeadOid: z.string().optional(),
+});
+
+type UpdateArgs = ReadonlyDeep<z.infer<typeof updateSchema>>;
+
+const registerUpdateBranchTool = (context: RegisterContext) => {
+  const { server, fetchImpl } = context;
+  server.registerTool(
+    "pr.updateBranch",
+    {
+      description:
+        "Server-side merge base→head (like the Update branch button).",
+      inputSchema: updateSchema.shape,
+    },
+    async ({ token, repo, number, expectedHeadOid }: UpdateArgs) => {
+      const rest = createRestJsonClient(token, fetchImpl);
+      const update = updatePullRequestBranch(rest);
+      const result = await update(
+        coordinatesFrom(repo, number),
+        expectedHeadOid,
+      );
+      return toToolResponse(result);
+    },
+  );
+};
+
+const autoMergeSchema = z.object({
+  token: z.string(),
+  repo: z.object({ owner: z.string(), name: z.string() }),
+  number: z.number().int(),
+  expectedHeadOid: z.string(),
+  method: z.enum(["SQUASH", "MERGE", "REBASE"]).default("SQUASH"),
+});
+
+type AutoMergeArgs = ReadonlyDeep<z.infer<typeof autoMergeSchema>>;
+
+const registerAutoMergeTool = (context: RegisterContext) => {
+  const { server, fetchImpl } = context;
+  server.registerTool(
+    "pr.enableAutoMerge",
+    {
+      description: "Enable auto-merge for a clean PR.",
+      inputSchema: autoMergeSchema.shape,
+    },
+    async ({ token, repo, number, expectedHeadOid, method }: AutoMergeArgs) => {
+      const gqlClient = createGraphQLClient(token, fetchImpl);
+      const fetcher = createPullRequestFetcher(gqlClient);
+      const pullRequest = await fetcher(coordinatesFrom(repo, number));
+      const enable = enablePullRequestAutoMerge(gqlClient);
+      await enable(pullRequest.id, expectedHeadOid, method as AutoMergeMethod);
+      return toToolResponse({ ok: true });
+    },
+  );
+};
+
+const enqueueSchema = z.object({
+  token: z.string(),
+  repo: z.object({ owner: z.string(), name: z.string() }),
+  number: z.number().int(),
+});
+
+type EnqueueArgs = ReadonlyDeep<z.infer<typeof enqueueSchema>>;
+
+const registerEnqueueTool = (context: RegisterContext) => {
+  const { server, fetchImpl } = context;
+  server.registerTool(
+    "pr.enqueue",
+    {
+      description: "Add PR to merge queue.",
+      inputSchema: enqueueSchema.shape,
+    },
+    async ({ token, repo, number }: EnqueueArgs) => {
+      const gqlClient = createGraphQLClient(token, fetchImpl);
+      const fetcher = createPullRequestFetcher(gqlClient);
+      const pullRequest = await fetcher(coordinatesFrom(repo, number));
+      const enqueue = enqueuePullRequest(gqlClient);
+      const result = await enqueue(pullRequest.id);
+      return toToolResponse(result);
+    },
+  );
+};
+
+type ImmutableServer = ReadonlyDeep<McpServer>;
+
+export const createConflictServer = (
+  dependencies: ConflictServerDependencies = {},
+): ImmutableServer => {
+  const fetchImpl = dependencies.fetchImpl ?? fetch;
+
+  const server = new McpServer({
+    name: "promethean-gh-conflicts",
+    version: "0.1.0",
+  });
+
+  const context: RegisterContext = { server, fetchImpl };
+
+  registerStatusTool(context);
+  registerUpdateBranchTool(context);
+  registerAutoMergeTool(context);
+  registerEnqueueTool(context);
+
+  // TODO: pr.fetchMergeTriples & pr.applyResolution — implement via Git data API or a short-lived clone, then use createCommitOnBranch.
+
+  return server as ImmutableServer;
+};
+
+export const server = createConflictServer();

--- a/packages/mcp-github-conflicts/src/tests/github.test.ts
+++ b/packages/mcp-github-conflicts/src/tests/github.test.ts
@@ -1,0 +1,146 @@
+import test from "ava";
+import nock from "nock";
+
+import {
+  createGraphQLClient,
+  createPullRequestFetcher,
+  createRestJsonClient,
+  pollPullRequestStatus,
+  updatePullRequestBranch,
+  type PullRequestCoordinates,
+  type PullRequestStatus,
+} from "../github.js";
+
+const coordinates: PullRequestCoordinates = {
+  repo: { owner: "riatzukiza", name: "promethean" },
+  number: 42,
+};
+
+test.before(() => {
+  nock.disableNetConnect();
+});
+
+test.after(() => {
+  nock.enableNetConnect();
+});
+
+test.afterEach(() => {
+  nock.cleanAll();
+});
+
+const createSequenceFetcher = (
+  sequence: readonly PullRequestStatus[],
+): (() => Promise<PullRequestStatus>) => {
+  const iterator = sequence[Symbol.iterator]();
+  const fallback = sequence.at(-1);
+
+  if (!fallback) {
+    throw new Error("sequence must contain at least one entry");
+  }
+
+  return async (): Promise<PullRequestStatus> => {
+    const next = iterator.next();
+    if (next.done) {
+      return fallback;
+    }
+    return next.value ?? fallback;
+  };
+};
+
+test("pollPullRequestStatus resolves UNKNOWN states", async (t) => {
+  const statuses: readonly PullRequestStatus[] = [
+    {
+      id: "pr1",
+      number: 42,
+      url: "https://example.test/pr/42",
+      headRefName: "feature",
+      headRefOid: "abc",
+      baseRefName: "main",
+      mergeable: "UNKNOWN",
+      mergeStateStatus: "UNKNOWN",
+    },
+    {
+      id: "pr1",
+      number: 42,
+      url: "https://example.test/pr/42",
+      headRefName: "feature",
+      headRefOid: "abc",
+      baseRefName: "main",
+      mergeable: "MERGEABLE",
+      mergeStateStatus: "CLEAN",
+    },
+  ];
+
+  const fetcher = createSequenceFetcher(statuses);
+
+  const result = await pollPullRequestStatus(fetcher, coordinates, {
+    attempts: 5,
+    delayMs: 0,
+    delay: async () => undefined,
+  });
+
+  t.is(result.mergeable, "MERGEABLE");
+});
+
+test("updatePullRequestBranch forwards expected head sha", async (t) => {
+  const scope = nock("https://api.github.com", {
+    reqheaders: {
+      authorization: "Bearer token",
+      accept: "application/vnd.github+json",
+      "content-type": "application/json",
+    },
+  })
+    .put("/repos/riatzukiza/promethean/pulls/42/update-branch", {
+      expected_head_sha: "deadbeef",
+    })
+    .reply(200, { message: "updated" });
+
+  const restClient = createRestJsonClient("token", fetch);
+  const update = updatePullRequestBranch(restClient);
+  const response = await update(coordinates, "deadbeef");
+
+  t.deepEqual(response, { message: "updated" });
+  t.true(scope.isDone());
+});
+
+test("createPullRequestFetcher retrieves pull request metadata", async (t) => {
+  const scope = nock("https://api.github.com", {
+    reqheaders: {
+      authorization: "Bearer token",
+      accept: "application/vnd.github+json",
+      "content-type": "application/json",
+    },
+  })
+    .post("/graphql", (body: Readonly<Record<string, unknown>>) => {
+      t.deepEqual(body.variables, {
+        owner: "riatzukiza",
+        name: "promethean",
+        number: 42,
+      });
+      return true;
+    })
+    .reply(200, {
+      data: {
+        repository: {
+          pullRequest: {
+            id: "pr1",
+            number: 42,
+            url: "https://example.test/pr/42",
+            headRefName: "feature",
+            headRefOid: "abc",
+            baseRefName: "main",
+            mergeable: "MERGEABLE",
+            mergeStateStatus: "CLEAN",
+          },
+        },
+      },
+    });
+
+  const gqlClient = createGraphQLClient("token", fetch);
+  const fetcher = createPullRequestFetcher(gqlClient);
+  const status = await fetcher(coordinates);
+
+  t.is(status.id, "pr1");
+  t.is(status.mergeable, "MERGEABLE");
+  t.true(scope.isDone());
+});

--- a/packages/mcp-github-conflicts/tsconfig.json
+++ b/packages/mcp-github-conflicts/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../config/tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "composite": true
+  },
+  "include": ["src/**/*"],
+  "references": []
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2711,6 +2711,28 @@ importers:
         specifier: 5.9.2
         version: 5.9.2
 
+  packages/mcp-github-conflicts:
+    dependencies:
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.17.5
+        version: 1.17.5
+      zod:
+        specifier: ^3.25.76
+        version: 3.25.76
+    devDependencies:
+      ava:
+        specifier: ^6.4.1
+        version: 6.4.1(encoding@0.1.13)
+      nock:
+        specifier: ^14.0.0
+        version: 14.0.10
+      rimraf:
+        specifier: ^6.0.1
+        version: 6.0.1
+      typescript:
+        specifier: ^5.4.5
+        version: 5.9.2
+
   packages/migrations:
     dependencies:
       '@promethean/embedding':
@@ -5393,6 +5415,10 @@ packages:
   '@mongodb-js/saslprep@1.3.0':
     resolution: {integrity: sha512-zlayKCsIjYb7/IdfqxorK5+xUMyi4vOKcFy10wKJYc63NSdKI8mNME+uJqfatkPmOSMMUiojrL58IePKBm3gvQ==}
 
+  '@mswjs/interceptors@0.39.7':
+    resolution: {integrity: sha512-sURvQbbKsq5f8INV54YJgJEdk8oxBanqkTiXXd33rKmofFCwZLhLRszPduMZ9TA9b8/1CHc/IJmOlBHJk2Q5AQ==}
+    engines: {node: '>=18'}
+
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
 
@@ -5521,6 +5547,15 @@ packages:
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
+
+  '@open-draft/deferred-promise@2.2.0':
+    resolution: {integrity: sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==}
+
+  '@open-draft/logger@0.3.0':
+    resolution: {integrity: sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ==}
+
+  '@open-draft/until@2.1.0':
+    resolution: {integrity: sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==}
 
   '@opentelemetry/api@1.9.0':
     resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
@@ -8678,6 +8713,9 @@ packages:
     resolution: {integrity: sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==}
     engines: {node: '>= 0.4'}
 
+  is-node-process@1.2.0:
+    resolution: {integrity: sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==}
+
   is-number-object@1.1.1:
     resolution: {integrity: sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==}
     engines: {node: '>= 0.4'}
@@ -9619,6 +9657,10 @@ packages:
   nise@5.1.9:
     resolution: {integrity: sha512-qOnoujW4SV6e40dYxJOb3uvuoPHtmLzIk4TFo+j0jPJoC+5Z9xja5qH5JZobEPsa8+YYphMrOSwnrshEhG2qww==}
 
+  nock@14.0.10:
+    resolution: {integrity: sha512-Q7HjkpyPeLa0ZVZC5qpxBt5EyLczFJ91MEewQiIi9taWuA0KB/MDJlUWtON+7dGouVdADTQsf9RA7TZk6D8VMw==}
+    engines: {node: '>=18.20.0 <20 || >=20.12.1'}
+
   node-abi@3.77.0:
     resolution: {integrity: sha512-DSmt0OEcLoK4i3NuscSbGjOf3bqiDEutejqENSplMSFA/gmB8mkED9G4pKWnPl7MDU4rSHebKPHeitpDfyH0cQ==}
     engines: {node: '>=10'}
@@ -9843,6 +9885,9 @@ packages:
   os-tmpdir@1.0.2:
     resolution: {integrity: sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==}
     engines: {node: '>=0.10.0'}
+
+  outvariant@1.4.3:
+    resolution: {integrity: sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==}
 
   own-keys@1.0.1:
     resolution: {integrity: sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==}
@@ -10241,6 +10286,10 @@ packages:
 
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
+
+  propagate@2.0.1:
+    resolution: {integrity: sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==}
+    engines: {node: '>= 8'}
 
   proper-lockfile@4.1.2:
     resolution: {integrity: sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==}
@@ -10851,6 +10900,9 @@ packages:
 
   streamx@2.22.1:
     resolution: {integrity: sha512-znKXEBxfatz2GBNK02kRnCXjV+AA4kjZIUxeWSr3UGirZMJfTE9uiwKHobnbgxWyL/JWro8tTq+vOqAK1/qbSA==}
+
+  strict-event-emitter@0.5.1:
+    resolution: {integrity: sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==}
 
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
@@ -12685,6 +12737,15 @@ snapshots:
     dependencies:
       sparse-bitfield: 3.0.3
 
+  '@mswjs/interceptors@0.39.7':
+    dependencies:
+      '@open-draft/deferred-promise': 2.2.0
+      '@open-draft/logger': 0.3.0
+      '@open-draft/until': 2.1.0
+      is-node-process: 1.2.0
+      outvariant: 1.4.3
+      strict-event-emitter: 0.5.1
+
   '@napi-rs/wasm-runtime@0.2.12':
     dependencies:
       '@emnapi/core': 1.5.0
@@ -12831,6 +12892,15 @@ snapshots:
 
   '@nx/nx-win32-x64-msvc@20.0.0':
     optional: true
+
+  '@open-draft/deferred-promise@2.2.0': {}
+
+  '@open-draft/logger@0.3.0':
+    dependencies:
+      is-node-process: 1.2.0
+      outvariant: 1.4.3
+
+  '@open-draft/until@2.1.0': {}
 
   '@opentelemetry/api@1.9.0': {}
 
@@ -16781,6 +16851,8 @@ snapshots:
 
   is-negative-zero@2.0.3: {}
 
+  is-node-process@1.2.0: {}
+
   is-number-object@1.1.1:
     dependencies:
       call-bound: 1.0.4
@@ -16991,8 +17063,7 @@ snapshots:
 
   json-stable-stringify-without-jsonify@1.0.1: {}
 
-  json-stringify-safe@5.0.1:
-    optional: true
+  json-stringify-safe@5.0.1: {}
 
   json5@1.0.2:
     dependencies:
@@ -17940,6 +18011,12 @@ snapshots:
       just-extend: 6.2.0
       path-to-regexp: 6.3.0
 
+  nock@14.0.10:
+    dependencies:
+      '@mswjs/interceptors': 0.39.7
+      json-stringify-safe: 5.0.1
+      propagate: 2.0.1
+
   node-abi@3.77.0:
     dependencies:
       semver: 7.7.2
@@ -18269,6 +18346,8 @@ snapshots:
   os-browserify@0.3.0: {}
 
   os-tmpdir@1.0.2: {}
+
+  outvariant@1.4.3: {}
 
   own-keys@1.0.1:
     dependencies:
@@ -18699,6 +18778,8 @@ snapshots:
       loose-envify: 1.4.0
       object-assign: 4.1.1
       react-is: 16.13.1
+
+  propagate@2.0.1: {}
 
   proper-lockfile@4.1.2:
     dependencies:
@@ -19519,6 +19600,8 @@ snapshots:
       text-decoder: 1.2.3
     optionalDependencies:
       bare-events: 2.6.1
+
+  strict-event-emitter@0.5.1: {}
 
   string-width@4.2.3:
     dependencies:

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -115,6 +115,9 @@
     },
     {
       "path": "./packages/ws"
+    },
+    {
+      "path": "./packages/mcp-github-conflicts"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- add the @promethean/mcp-github-conflicts workspace package with GitHub REST/GraphQL helpers and tool registration
- expose typed MCP tools for status polling, branch updates, auto-merge, and merge queue operations
- cover the new helpers with AVA tests and wire the package into the monorepo build graph

## Testing
- `pnpm --filter @promethean/mcp-github-conflicts lint`
- `pnpm --filter @promethean/mcp-github-conflicts build`
- `pnpm --filter @promethean/mcp-github-conflicts test`


------
https://chatgpt.com/codex/tasks/task_e_68dddc52f5f88324b1f2e2b6ae50abf8