### PR TITLE
feat(mcp): add discord MCP tools

### DIFF
--- a/changelog.d/2025.02.15.discord-mcp.md
+++ b/changelog.d/2025.02.15.discord-mcp.md
@@ -1,0 +1,1 @@
+- add HTTP MCP tools for sending and listing Discord channel messages, backed by DiscordRestProxy

--- a/changelog.d/2025.02.16.discord-mcp-config.md
+++ b/changelog.d/2025.02.16.discord-mcp-config.md
@@ -1,0 +1,2 @@
+## Added
+- Included discord message tools in the default MCP config and documented the new Discord capabilities.

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -30,7 +30,9 @@ You can now configure via **file** or **env** (env kept for back-compat):
     "files.view-file",
     "files.write-content",
     "files.write-lines",
-    "files.search"
+    "files.search",
+    "discord.send-message",
+    "discord.list-messages"
   ]
 }
 ```
@@ -54,3 +56,5 @@ This is a scaffold extracted to consolidate multiple MCP servers into one packag
 
 ## Tools
 - files.search — grep-like content search returning path/line/snippet triples.
+- discord.send-message — send a message to a Discord channel using the configured tenant + space URN.
+- discord.list-messages — fetch paginated messages from a Discord channel.

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -27,6 +27,7 @@
     "@fastify/static": "^7.0.4",
     "@modelcontextprotocol/sdk": "^1.17.5",
     "@stryker-mutator/core": "^8.7.1",
+    "@promethean/discord": "workspace:*",
     "fast-check": "^3.23.2",
     "fastify": "5.0.0",
     "minimatch": "^9.0.5",
@@ -36,6 +37,7 @@
   },
   "devDependencies": {
     "@types/node": "20.19.11",
+    "esmock": "^2.7.3",
     "rimraf": "6.0.1",
     "tsx": "4.19.2",
     "typescript": "5.9.2"

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -39,6 +39,7 @@ import {
   resolveHttpEndpoints,
   resolveStdioTools,
 } from "./core/resolve-config.js";
+import { discordSendMessage, discordListMessages } from "./tools/discord.js";
 
 const toolCatalog = new Map<string, ToolFactory>([
   ["github.request", githubRequestTool],
@@ -66,6 +67,8 @@ const toolCatalog = new Map<string, ToolFactory>([
   ["tdd.coverage", tddCoverage],
   ["tdd.propertyCheck", tddPropertyCheck],
   ["tdd.mutationScore", tddMutationScore],
+  ["discord.send-message", discordSendMessage],
+  ["discord.list-messages", discordListMessages],
 ]);
 
 const env = process.env;

--- a/packages/mcp/src/tests/discord-tools.test.ts
+++ b/packages/mcp/src/tests/discord-tools.test.ts
@@ -1,0 +1,181 @@
+import test from "ava";
+import esmock from "esmock";
+
+import type { ToolContext } from "../core/types.js";
+
+type SendCall = {
+  readonly provider: string;
+  readonly tenant: string;
+  readonly method: string;
+  readonly route: string;
+  readonly body: unknown;
+  readonly fetch: typeof fetch;
+};
+
+type SendArgs = Readonly<
+  [string, string, string, string, unknown, typeof fetch]
+>;
+
+const channelIdFrom = (spaceUrn: string) => {
+  const parts = spaceUrn.split(":");
+  return parts[parts.length - 1] ?? spaceUrn;
+};
+
+const record = <T>(ref: { current: ReadonlyArray<T> }, value: T) => {
+  ref.current = [...ref.current, value];
+};
+
+const buildRoute = (method: "GET" | "POST", channelId: string) =>
+  ({ method, route: `/channels/${channelId}/messages` }) as const;
+
+function createProxyStub() {
+  const sendCalls = { current: [] as ReadonlyArray<SendCall> };
+  const listCalls = {
+    current: [] as ReadonlyArray<{
+      readonly spaceUrn: string;
+      readonly params: Record<string, unknown>;
+    }>,
+  };
+  const postUrns = { current: [] as ReadonlyArray<string> };
+
+  return {
+    get sendCalls(): ReadonlyArray<SendCall> {
+      return sendCalls.current;
+    },
+    get listCalls(): ReadonlyArray<{
+      readonly spaceUrn: string;
+      readonly params: Record<string, unknown>;
+    }> {
+      return listCalls.current;
+    },
+    get postUrns(): ReadonlyArray<string> {
+      return postUrns.current;
+    },
+    routeForPostMessage(spaceUrn: string) {
+      record(postUrns, spaceUrn);
+      return buildRoute("POST", channelIdFrom(spaceUrn));
+    },
+    routeForListMessages(
+      spaceUrn: string,
+      params?: Readonly<Record<string, unknown>>,
+    ) {
+      record(listCalls, { spaceUrn, params: params ?? {} });
+      return buildRoute("GET", channelIdFrom(spaceUrn));
+    },
+    async send(...args: SendArgs) {
+      const [provider, tenant, method, route, body, fetchFn] = args;
+      record(sendCalls, {
+        provider,
+        tenant,
+        method,
+        route,
+        body,
+        fetch: fetchFn,
+      });
+      return {
+        ok: true,
+        status: 200,
+        body: { id: "message-1" },
+        bucket: `${method}:${route}`,
+        retry_after_ms: 1500,
+      } as const;
+    },
+  } as const;
+}
+
+test("discord.send-message routes payloads via proxy", async (t) => {
+  const modulePath = new URL("../tools/discord.js", import.meta.url).pathname;
+  const proxy = createProxyStub();
+  const mod = await esmock<typeof import("../tools/discord.js")>(modulePath, {
+    "@promethean/discord": {
+      DiscordRestProxy: class {
+        constructor() {
+          return proxy;
+        }
+      },
+    },
+  });
+
+  const ctx: ToolContext = {
+    env: {},
+    fetch: (async () => new Response()) as typeof fetch,
+    now: () => new Date(),
+  };
+
+  const tool = mod.discordSendMessage(ctx);
+  const result = await tool.invoke({
+    tenant: "promethean",
+    spaceUrn: "urn:discord:space:promethean:123",
+    message: { content: "hello" },
+  });
+
+  t.is(proxy.sendCalls.length, 1);
+  t.deepEqual(proxy.postUrns, ["urn:discord:space:promethean:123"]);
+  const call = proxy.sendCalls[0]!;
+  t.deepEqual(call, {
+    provider: "discord",
+    tenant: "promethean",
+    method: "POST",
+    route: "/channels/123/messages",
+    body: { content: "hello" },
+    fetch: ctx.fetch,
+  });
+  t.deepEqual(result, {
+    ok: true,
+    status: 200,
+    body: { id: "message-1" },
+    bucket: "POST:/channels/123/messages",
+    retryAfterMs: 1500,
+  });
+});
+
+test("discord.list-messages supports env fallbacks and params", async (t) => {
+  const modulePath = new URL("../tools/discord.js", import.meta.url).pathname;
+  const proxy = createProxyStub();
+  const mod = await esmock<typeof import("../tools/discord.js")>(modulePath, {
+    "@promethean/discord": {
+      DiscordRestProxy: class {
+        constructor() {
+          return proxy;
+        }
+      },
+    },
+  });
+
+  const ctx: ToolContext = {
+    env: {
+      DISCORD_TENANT: "duck-guild",
+      DISCORD_SPACE_URN: "urn:discord:space:duck:456",
+      DISCORD_PROVIDER: "discord-cloud",
+    },
+    fetch: (async () => new Response()) as typeof fetch,
+    now: () => new Date(),
+  };
+
+  const tool = mod.discordListMessages(ctx);
+  const result = await tool.invoke({ limit: 25, before: "789" });
+
+  t.is(proxy.listCalls.length, 1);
+  const listCall = proxy.listCalls[0]!;
+  t.is(listCall.spaceUrn, "urn:discord:space:duck:456");
+  t.deepEqual(listCall.params, { limit: 25, before: "789" });
+
+  t.is(proxy.sendCalls.length, 1);
+  const sendCall = proxy.sendCalls[0]!;
+  t.deepEqual(sendCall, {
+    provider: "discord-cloud",
+    tenant: "duck-guild",
+    method: "GET",
+    route: "/channels/456/messages",
+    body: undefined,
+    fetch: ctx.fetch,
+  });
+
+  t.deepEqual(result, {
+    ok: true,
+    status: 200,
+    body: { id: "message-1" },
+    bucket: "GET:/channels/456/messages",
+    retryAfterMs: 1500,
+  });
+});

--- a/packages/mcp/src/tools/discord.ts
+++ b/packages/mcp/src/tools/discord.ts
@@ -1,0 +1,224 @@
+import { z } from "zod";
+import { DiscordRestProxy } from "@promethean/discord";
+
+import type { Tool, ToolContext, ToolFactory } from "../core/types.js";
+
+const RestResponseSchema = z
+  .object({
+    ok: z.boolean(),
+    status: z.number(),
+    body: z.unknown().optional(),
+    bucket: z.string().optional(),
+    retry_after_ms: z.number().optional(),
+  })
+  .readonly();
+
+type RouteDescriptor = Readonly<{ method: string; route: string }>;
+type ListParams = Readonly<{
+  readonly limit?: number;
+  readonly before?: string;
+  readonly after?: string;
+  readonly around?: string;
+}>;
+
+type SendArgs = Readonly<
+  [string, string, string, string, unknown, typeof fetch]
+>;
+
+type ProxyLike = Readonly<{
+  routeForPostMessage: (spaceUrn: string) => RouteDescriptor;
+  routeForListMessages: (
+    spaceUrn: string,
+    params?: ListParams,
+  ) => RouteDescriptor;
+  send: (...args: SendArgs) => Promise<unknown>;
+}>;
+
+type ProxyFactory = () => ProxyLike;
+
+const defaultProxyFactory: ProxyFactory = () =>
+  new (DiscordRestProxy as unknown as new () => DiscordRestProxy)() as unknown as ProxyLike;
+
+const resolveProvider = (
+  explicit: string | undefined,
+  env: Readonly<Record<string, string | undefined>>,
+): string => explicit ?? env.DISCORD_PROVIDER ?? "discord";
+
+const requireValue = (value: string | undefined, message: string): string =>
+  z.string({ required_error: message }).min(1, message).parse(value);
+
+const resolveTenant = (
+  explicit: string | undefined,
+  env: Readonly<Record<string, string | undefined>>,
+): string => {
+  const tenant =
+    explicit ??
+    env.DISCORD_TENANT ??
+    env.DISCORD_GUILD ??
+    env.DISCORD_SPACE_TENANT;
+  return requireValue(
+    tenant,
+    "discord tools require a tenant; pass `tenant` or set DISCORD_TENANT / DISCORD_GUILD",
+  );
+};
+
+const resolveSpaceUrn = (
+  explicit: string | undefined,
+  env: Readonly<Record<string, string | undefined>>,
+): string => {
+  const urn = explicit ?? env.DISCORD_SPACE_URN ?? env.DISCORD_CHANNEL_URN;
+  return requireValue(
+    urn,
+    "discord tools require a spaceUrn; pass `spaceUrn` or set DISCORD_SPACE_URN",
+  );
+};
+
+const mapResult = (
+  input: unknown,
+): Readonly<{
+  ok: boolean;
+  status: number;
+  body?: unknown;
+  bucket?: string;
+  retryAfterMs: number | null;
+}> => {
+  const safe = RestResponseSchema.parse(input);
+  return {
+    ok: safe.ok,
+    status: safe.status,
+    ...(typeof safe.body !== "undefined" ? { body: safe.body } : {}),
+    ...(safe.bucket ? { bucket: safe.bucket } : {}),
+    retryAfterMs:
+      typeof safe.retry_after_ms === "number" ? safe.retry_after_ms : null,
+  };
+};
+
+const MessagePayload = z
+  .object({
+    content: z.string().max(2000).optional(),
+    embeds: z.array(z.unknown()).optional(),
+    allowed_mentions: z.unknown().optional(),
+    tts: z.boolean().optional(),
+    components: z.array(z.unknown()).optional(),
+    attachments: z.array(z.unknown()).optional(),
+  })
+  .refine(
+    (value) => Boolean(value.content) || Boolean(value.embeds?.length),
+    "message content or embeds are required",
+  );
+
+const createSendMessageTool = (
+  ctx: ToolContext,
+  proxyFactory: ProxyFactory,
+): Tool => {
+  const shape = {
+    provider: z.string().optional(),
+    tenant: z.string().optional(),
+    spaceUrn: z.string().optional(),
+    message: MessagePayload,
+  } as const;
+  const Schema = z.object(shape);
+
+  const spec = {
+    name: "discord.send-message",
+    description:
+      "Send a message to a Discord channel. Provide content or embeds and the Discord space URN.",
+    inputSchema: shape,
+  };
+
+  const proxy = proxyFactory();
+
+  const invoke = async (raw: unknown) => {
+    const args = Schema.parse(raw);
+    const provider = resolveProvider(args.provider, ctx.env);
+    const tenant = resolveTenant(args.tenant, ctx.env);
+    const spaceUrn = resolveSpaceUrn(args.spaceUrn, ctx.env);
+    const { method, route } = proxy.routeForPostMessage(spaceUrn);
+    const res = await proxy.send(
+      provider,
+      tenant,
+      method,
+      route,
+      args.message,
+      ctx.fetch,
+    );
+    return mapResult(res);
+  };
+
+  return { spec, invoke };
+};
+
+const ListSchemaShape = {
+  provider: z.string().optional(),
+  tenant: z.string().optional(),
+  spaceUrn: z.string().optional(),
+  limit: z.number().int().min(1).max(100).optional(),
+  before: z.string().optional(),
+  after: z.string().optional(),
+  around: z.string().optional(),
+} as const;
+
+const ListSchema = z.object(ListSchemaShape);
+
+const createListMessagesTool = (
+  ctx: ToolContext,
+  proxyFactory: ProxyFactory,
+): Tool => {
+  const spec = {
+    name: "discord.list-messages",
+    description:
+      "List recent messages from a Discord channel with optional pagination parameters.",
+    inputSchema: ListSchemaShape,
+  };
+
+  const proxy = proxyFactory();
+
+  const invoke = async (raw: unknown) => {
+    const args = ListSchema.parse(raw);
+    const provider = resolveProvider(args.provider, ctx.env);
+    const tenant = resolveTenant(args.tenant, ctx.env);
+    const spaceUrn = resolveSpaceUrn(args.spaceUrn, ctx.env);
+    const params: ListParams = {
+      ...(typeof args.limit === "number" ? { limit: args.limit } : {}),
+      ...(args.before ? { before: args.before } : {}),
+      ...(args.after ? { after: args.after } : {}),
+      ...(args.around ? { around: args.around } : {}),
+    };
+
+    const { method, route } = proxy.routeForListMessages(spaceUrn, params);
+    const res = await proxy.send(
+      provider,
+      tenant,
+      method,
+      route,
+      undefined,
+      ctx.fetch,
+    );
+    return mapResult(res);
+  };
+
+  return { spec, invoke };
+};
+
+export const createDiscordSendMessageTool = (
+  proxyFactory: ProxyFactory = defaultProxyFactory,
+): ToolFactory => {
+  return (ctx) => createSendMessageTool(ctx, proxyFactory);
+};
+
+export const createDiscordListMessagesTool = (
+  proxyFactory: ProxyFactory = defaultProxyFactory,
+): ToolFactory => {
+  return (ctx) => createListMessagesTool(ctx, proxyFactory);
+};
+
+export const discordSendMessage: ToolFactory = createDiscordSendMessageTool();
+export const discordListMessages: ToolFactory = createDiscordListMessagesTool();
+
+export const discordTools = (
+  ctx: ToolContext,
+  proxyFactory: ProxyFactory = defaultProxyFactory,
+): Readonly<{ sendMessage: Tool; listMessages: Tool }> => ({
+  sendMessage: createSendMessageTool(ctx, proxyFactory),
+  listMessages: createListMessagesTool(ctx, proxyFactory),
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2676,6 +2676,9 @@ importers:
       '@modelcontextprotocol/sdk':
         specifier: ^1.17.5
         version: 1.17.5
+      '@promethean/discord':
+        specifier: workspace:*
+        version: link:../discord
       '@stryker-mutator/core':
         specifier: ^8.7.1
         version: 8.7.1
@@ -2701,6 +2704,9 @@ importers:
       '@types/node':
         specifier: 20.19.11
         version: 20.19.11
+      esmock:
+        specifier: ^2.7.3
+        version: 2.7.3
       rimraf:
         specifier: 6.0.1
         version: 6.0.1
@@ -14090,7 +14096,7 @@ snapshots:
 
   axios@1.11.0:
     dependencies:
-      follow-redirects: 1.15.11(debug@4.3.7)
+      follow-redirects: 1.15.11(debug@4.4.3)
       form-data: 4.0.4
       proxy-from-env: 1.1.0
     transitivePeerDependencies:
@@ -16582,7 +16588,7 @@ snapshots:
   http-proxy@1.18.1:
     dependencies:
       eventemitter3: 4.0.7
-      follow-redirects: 1.15.11(debug@4.3.7)
+      follow-redirects: 1.15.11(debug@4.4.3)
       requires-port: 1.0.0
     transitivePeerDependencies:
       - debug

--- a/promethean.mcp.json
+++ b/promethean.mcp.json
@@ -18,7 +18,9 @@
     "tdd.stopWatch",
     "tdd.coverage",
     "tdd.propertyCheck",
-    "tdd.mutationScore"
+    "tdd.mutationScore",
+    "discord.send-message",
+    "discord.list-messages"
   ],
   "endpoints": {
     "process": {
@@ -44,6 +46,9 @@
     },
     "github": {
       "tools": ["github.request", "github.graphql", "github.rate-limit"]
+    },
+    "discord": {
+      "tools": ["discord.send-message", "discord.list-messages"]
     }
   }
 }


### PR DESCRIPTION
## Summary
- add a discord MCP tool module exposing send-message and list-messages factories
- register the new tools with the MCP server entry point and document the change
- add AVA coverage exercising both tools via an esmocked DiscordRestProxy

## Testing
- pnpm --filter @promethean/mcp test

------
https://chatgpt.com/codex/tasks/task_e_68ddde8f294c8324a0d271e22b9a9a0e