### PR TITLE
feat: add Nx package generator MCP tool

### DIFF
--- a/changelog.d/2025.10.02.03.40.00.mcp-nx-generator.md
+++ b/changelog.d/2025.10.02.03.40.00.mcp-nx-generator.md
@@ -1,0 +1,1 @@
+- Added an MCP tool that runs the Nx package generator with preset aliases and dry-run support.

--- a/docs/agile/tasks/create-nx-package-mcp-tool.md
+++ b/docs/agile/tasks/create-nx-package-mcp-tool.md
@@ -1,0 +1,69 @@
+---
+uuid: 8b52c0aa-1f68-4db1-bd4e-612c7c9f853c
+title: Create MCP tool for Nx package scaffolding
+status: in-review
+priority: P3
+labels: []
+created_at: '2025-10-02T03:30:00.000Z'
+---
+## 🛠️ Description
+
+Add an MCP tool that runs the workspace Nx package generator so agents can scaffold new packages consistently with repository presets.
+
+---
+
+## 🎯 Goals
+
+- Allow MCP clients to create new packages by calling the existing Nx generator.
+- Support preset selection that maps to repository package templates.
+- Provide dry-run support so agents can preview the scaffold when needed.
+
+---
+
+## 📦 Requirements
+
+- [x] Implement an MCP tool that executes the Nx package generator with name and preset inputs.
+- [x] Accept human-friendly preset aliases (library, service, frontend) that map to generator presets.
+- [x] Return stdout/stderr and exit information so agents can audit generator runs.
+- [x] Cover the new tool with unit tests.
+- [x] Document the tool in package change notes.
+
+---
+
+## 📋 Subtasks
+
+- [x] Define schema validation and preset normalization for the tool input.
+- [x] Implement command execution via pnpm exec nx.
+- [x] Add AVA tests for argument construction and alias mapping.
+- [x] Register the tool with the MCP server registry.
+- [x] Add changelog entry summarizing the tool.
+
+---
+
+## 🔗 Related Epics
+
+#framework-core
+
+---
+
+## ⛓️ Blocked By
+
+Nothing
+
+## ⛓️ Blocks
+
+Nothing
+
+---
+
+## 🔍 Relevant Links
+
+- [[kanban]]
+- tools/generators/package/README.md
+- packages/mcp/src/tools/pnpm.ts
+
+## Notes
+- Story Points: 3
+
+#in-progress
+

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -41,6 +41,7 @@ import {
   pnpmRemove,
   pnpmRunScript,
 } from "./tools/pnpm.js";
+import { nxGeneratePackage } from "./tools/nx.js";
 import type { ToolFactory } from "./core/types.js";
 import {
   resolveHttpEndpoints,
@@ -69,6 +70,7 @@ const toolCatalog = new Map<string, ToolFactory>([
   ["pnpm.add", pnpmAdd],
   ["pnpm.remove", pnpmRemove],
   ["pnpm.runScript", pnpmRunScript],
+  ["nx.generatePackage", nxGeneratePackage],
   ["tdd.scaffoldTest", tddScaffoldTest],
   ["tdd.changedFiles", tddChangedFiles],
   ["tdd.runTests", tddRunTests],

--- a/packages/mcp/src/tests/nx.test.ts
+++ b/packages/mcp/src/tests/nx.test.ts
@@ -1,0 +1,99 @@
+import test from "ava";
+
+import type { ToolContext } from "../core/types.js";
+import {
+  __test__,
+  buildNxGenerateArgs,
+  resolvePreset,
+  type NxGenerateResult,
+} from "../tools/nx.js";
+
+const noopFetch: typeof fetch = async (..._args) => {
+  throw new Error("fetch not implemented");
+};
+
+const baseCtx: ToolContext = {
+  env: {},
+  fetch: noopFetch,
+  now: () => new Date(0),
+};
+
+const makeResult = (args: readonly string[]): NxGenerateResult => ({
+  command: "pnpm",
+  args,
+  cwd: "/workspace",
+  exitCode: 0,
+  stdout: "",
+  stderr: "",
+});
+
+test("resolvePreset maps aliases and defaults", (t) => {
+  t.is(resolvePreset(undefined), "ts-lib");
+  t.is(resolvePreset("library"), "ts-lib");
+  t.is(resolvePreset("service"), "fastify-service");
+  t.is(resolvePreset("frontend"), "web-frontend");
+});
+
+test("resolvePreset throws on unknown presets", (t) => {
+  t.throws(() => resolvePreset("unknown"), {
+    message: /Unknown preset/,
+  });
+});
+
+test("buildNxGenerateArgs includes dry run flag", (t) => {
+  t.deepEqual(
+    buildNxGenerateArgs({ name: "demo", preset: "ts-lib", dryRun: false }),
+    [
+      "exec",
+      "nx",
+      "generate",
+      "tools:package",
+      "--name",
+      "demo",
+      "--preset",
+      "ts-lib",
+      "--no-interactive",
+    ],
+  );
+
+  t.deepEqual(
+    buildNxGenerateArgs({ name: "demo", preset: "ts-lib", dryRun: true }),
+    [
+      "exec",
+      "nx",
+      "generate",
+      "tools:package",
+      "--name",
+      "demo",
+      "--preset",
+      "ts-lib",
+      "--no-interactive",
+      "--dry-run",
+    ],
+  );
+});
+
+test("nx.generatePackage tool normalizes inputs", async (t) => {
+  const executor = async (args: readonly string[]) => makeResult(args);
+
+  const tool = __test__.createTool(baseCtx, executor);
+  const result = (await tool.invoke({
+    name: " My Service ",
+    preset: "frontend",
+    dryRun: true,
+  })) as NxGenerateResult;
+
+  t.deepEqual(result.args, [
+    "exec",
+    "nx",
+    "generate",
+    "tools:package",
+    "--name",
+    "My Service",
+    "--preset",
+    "web-frontend",
+    "--no-interactive",
+    "--dry-run",
+  ]);
+  t.is(result.exitCode, 0);
+});

--- a/packages/mcp/src/tools/nx.ts
+++ b/packages/mcp/src/tools/nx.ts
@@ -1,0 +1,229 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+import { z } from "zod";
+
+import { getMcpRoot } from "../files.js";
+import type { ToolContext, ToolFactory } from "../core/types.js";
+
+const execFileAsync = promisify(execFile);
+
+const MAX_BUFFER = 16 * 1024 * 1024;
+const DEFAULT_TIMEOUT = 10 * 60 * 1000;
+const NON_WHITESPACE = /\S/;
+
+const PRESETS = ["ts-lib", "base", "web-frontend", "fastify-service"] as const;
+
+export type NxPreset = (typeof PRESETS)[number];
+
+const DEFAULT_PRESET: NxPreset = "ts-lib";
+const GENERATOR_ID = "tools:package";
+
+const PRESET_ALIASES = new Map<string, NxPreset>([
+  ["ts-lib", "ts-lib"],
+  ["tslib", "ts-lib"],
+  ["library", "ts-lib"],
+  ["lib", "ts-lib"],
+  ["base", "base"],
+  ["frontend", "web-frontend"],
+  ["web-frontend", "web-frontend"],
+  ["web", "web-frontend"],
+  ["ui", "web-frontend"],
+  ["fastify", "fastify-service"],
+  ["fastify-service", "fastify-service"],
+  ["service", "fastify-service"],
+]) as ReadonlyMap<string, NxPreset>;
+
+type NxExecError = Readonly<
+  NodeJS.ErrnoException & {
+    stdout?: string;
+    stderr?: string;
+    signal?: NodeJS.Signals;
+  }
+>;
+
+const isDefinedString = (
+  entry: readonly [string, string | undefined],
+): entry is readonly [string, string] => typeof entry[1] === "string";
+
+const sanitizeEnv = (
+  env: Readonly<Record<string, string | undefined>>,
+): Readonly<Record<string, string>> =>
+  Object.fromEntries(
+    Object.entries({ ...process.env, ...env }).filter(isDefinedString),
+  ) as Readonly<Record<string, string>>;
+
+const isExecError = (value: unknown): value is NxExecError =>
+  Boolean(
+    value &&
+      typeof value === "object" &&
+      "stdout" in value &&
+      "stderr" in value,
+  );
+
+export type NxGenerateResult = Readonly<{
+  command: string;
+  args: readonly string[];
+  cwd: string;
+  exitCode: number | null;
+  signal?: NodeJS.Signals | null;
+  stdout: string;
+  stderr: string;
+  error?: string;
+}>;
+
+type NxExecutor = (args: readonly string[]) => Promise<NxGenerateResult>;
+
+const toSuccessResult = (
+  command: string,
+  args: readonly string[],
+  cwd: string,
+): Pick<NxGenerateResult, "command" | "args" | "cwd" | "exitCode"> => ({
+  command,
+  args,
+  cwd,
+  exitCode: 0,
+});
+
+const mergeSuccess = (
+  base: Pick<NxGenerateResult, "command" | "args" | "cwd" | "exitCode">,
+  io: Readonly<{ stdout: string; stderr: string }>,
+): NxGenerateResult => ({
+  ...base,
+  stdout: io.stdout,
+  stderr: io.stderr,
+});
+
+const toErrorResult = (
+  command: string,
+  args: readonly string[],
+  cwd: string,
+  error: NxExecError,
+): NxGenerateResult => {
+  const exitCode = typeof error.code === "number" ? error.code : null;
+  return {
+    command,
+    args,
+    cwd,
+    exitCode,
+    signal: error.signal ?? null,
+    stdout: error.stdout ?? "",
+    stderr: error.stderr ?? "",
+    error: exitCode && exitCode !== 0 ? error.message : undefined,
+  };
+};
+
+const runNxCommand = (
+  ctx: ToolContext,
+  args: readonly string[],
+): Promise<NxGenerateResult> => {
+  const bin = ctx.env.PNPM_BIN ?? "pnpm";
+  const cwd = getMcpRoot();
+  const env = sanitizeEnv(ctx.env);
+  const base = toSuccessResult(bin, args, cwd);
+
+  const handleError = (
+    error: unknown,
+  ): NxGenerateResult | Promise<NxGenerateResult> => {
+    if (!isExecError(error)) {
+      return Promise.reject(error);
+    }
+    if (!(typeof error.code === "number" || error.code === null)) {
+      return Promise.reject(error);
+    }
+    return toErrorResult(bin, args, cwd, error);
+  };
+
+  return execFileAsync(bin, args, {
+    cwd,
+    env: { ...env },
+    encoding: "utf8",
+    maxBuffer: MAX_BUFFER,
+    timeout: DEFAULT_TIMEOUT,
+  })
+    .then((io) => mergeSuccess(base, io))
+    .catch(handleError);
+};
+
+const normalizePresetKey = (value: string): string =>
+  value.trim().toLowerCase();
+
+export const resolvePreset = (input?: string): NxPreset => {
+  if (!input) {
+    return DEFAULT_PRESET;
+  }
+  const preset = PRESET_ALIASES.get(normalizePresetKey(input));
+  if (!preset) {
+    const allowed = Array.from(
+      new Set([DEFAULT_PRESET, ...PRESET_ALIASES.values()]),
+    );
+    throw new Error(
+      `Unknown preset "${input}". Expected one of: ${Array.from(allowed).join(
+        ", ",
+      )}.`,
+    );
+  }
+  return preset;
+};
+
+export const buildNxGenerateArgs = (
+  options: Readonly<{ name: string; preset: NxPreset; dryRun: boolean }>,
+): readonly string[] => {
+  const baseArgs = [
+    "exec",
+    "nx",
+    "generate",
+    GENERATOR_ID,
+    "--name",
+    options.name,
+    "--preset",
+    options.preset,
+    "--no-interactive",
+  ] as const;
+
+  if (!options.dryRun) {
+    return baseArgs;
+  }
+
+  return [...baseArgs, "--dry-run"] as const;
+};
+
+const createTool = (
+  _ctx: ToolContext,
+  executor: NxExecutor,
+): ReturnType<ToolFactory> => {
+  const shape = {
+    name: z.string().min(1).regex(NON_WHITESPACE),
+    preset: z.string().min(1).regex(NON_WHITESPACE).optional(),
+    dryRun: z.boolean().default(false),
+  } as const;
+  const Schema = z.object(shape);
+
+  const spec = {
+    name: "nx.generatePackage",
+    description:
+      "Generate a new workspace package using the Nx tools:package generator.",
+    inputSchema: shape,
+  } as const;
+
+  const invoke = async (raw: unknown) => {
+    const parsed = Schema.parse(raw);
+    const name = parsed.name.trim();
+    const preset = resolvePreset(parsed.preset);
+    const dryRun = parsed.dryRun ?? false;
+    const args = buildNxGenerateArgs({ name, preset, dryRun });
+    return executor(args);
+  };
+
+  return { spec, invoke };
+};
+
+export const nxGeneratePackage: ToolFactory = (ctx) =>
+  createTool(ctx, (args) => runNxCommand(ctx, args));
+
+export const __test__ = {
+  createTool,
+  resolvePreset,
+  buildNxGenerateArgs,
+  runNxCommand,
+};


### PR DESCRIPTION
## Summary
- add an MCP tool that runs the Nx package generator with preset aliases and dry-run support
- register the new tool with the MCP server catalog and cover it with unit tests
- document the work in the agile task tracker and changelog entry

## Testing
- pnpm --filter @promethean/mcp test
- pnpm exec eslint packages/mcp/src/tools/nx.ts packages/mcp/src/index.ts packages/mcp/src/tests/nx.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68dde8dc0c9883248d2942033c2aaf13