### PR TITLE
Add caps.update capability revision event

### DIFF
--- a/changelog.d/2025.10.02.18.48.42.md
+++ b/changelog.d/2025.10.02.18.48.42.md
@@ -1,0 +1,1 @@
+- Added server-emitted `caps.update` capability revisions with client handling, documentation updates, and AVA coverage for mid-session grants and revocations.

--- a/docs/design/enso-protocol/02-transport-and-framing.md
+++ b/docs/design/enso-protocol/02-transport-and-framing.md
@@ -54,6 +54,7 @@ persist or replay short histories.
 | Chat | `chat.msg` | Lightweight text events for clients that do not need the richer `content.*` surface. | [Rooms, Sessions, and Capability Handshake](03-rooms-and-capabilities.md) |
 | Content | `content.post`, `content.message`, `content.retract`, `content.burn` | Rich, multi-part chat delivery, receipts, and deletions. | [Assets, Derivations, and Messaging](09-assets-and-derivations.md) & [Privacy Profiles and Retention Policy](11-privacy-and-retention.md) |
 | Presence | `presence.join`, `presence.part` | Room roster updates and advisory lifecycle signals. | [Rooms, Sessions, and Capability Handshake](03-rooms-and-capabilities.md) |
+| Capabilities | `caps.update` | Authoritative capability revisions with server acknowledgements. | [Rooms, Sessions, and Capability Handshake](03-rooms-and-capabilities.md) |
 | State | `state.patch` | CRDT-friendly room state diffs (e.g., degraded stream indicators). | [Flow Control and Reliability](04-flow-control-and-reliability.md) |
 | Tooling | `tool.advertise`, `tool.call`, `tool.result`, `tool.partial` | Capability discovery, invocation, incremental progress, and completion. | [Tools, Voice, and Stream Semantics](05-tools-and-streams.md) & [Model Context Protocol Interop](08-mcp-integration.md) |
 | Voice | `voice.meta` | Metadata accompanying `voice.frame` streams (language, speaker, hints). | [Tools, Voice, and Stream Semantics](05-tools-and-streams.md) |

--- a/docs/design/enso-protocol/03-rooms-and-capabilities.md
+++ b/docs/design/enso-protocol/03-rooms-and-capabilities.md
@@ -61,3 +61,36 @@ include:
 
 Clients should treat presence events as advisory; the gateway is the source of
 truth for who may send or receive traffic.
+
+## Capability Revisions
+
+Capability grants evolve with room policy and operator actions. Gateways MUST
+acknowledge any change with a canonical `caps.update` event so clients can
+adjust their tool surfaces deterministically.
+
+```json
+{
+  "kind": "event",
+  "type": "caps.update",
+  "payload": {
+    "session": "s1",
+    "caps": ["can.send.text"],
+    "revoked": ["can.asset.put"],
+    "revision": 2,
+    "reason": "policy:asset-freeze",
+    "acknowledgedAt": "2024-04-01T12:00:00Z"
+  }
+}
+```
+
+The payload conveys the complete, authoritative capability list along with
+explicit `granted`/`revoked` deltas for audit trails. `revision` increments on
+every change so receivers can discard stale updates, and `acknowledgedAt`
+timestamps when the server committed the revision. Clients that initiate a
+change MAY supply a `requestId`; servers echo it in the update so callers can
+correlate acknowledgements.
+
+`caps.update` SHOULD be broadcast to observers and ALWAYS delivered to the
+affected session before further enforcement decisions. Clients apply the new
+set prior to invoking tools; revocations immediately disable local affordances
+while grants unlock the corresponding actions.

--- a/packages/enso-protocol/src/server.ts
+++ b/packages/enso-protocol/src/server.ts
@@ -27,6 +27,7 @@ type SessionRecord = {
   readonly cache?: HelloCaps["cache"];
   readonly connectedAt: string;
   readonly auditLog: Envelope[];
+  capRevision: number;
 };
 
 /** Result of a successful handshake. */
@@ -50,6 +51,15 @@ type HandshakeOptions = {
   readonly privacyProfile?: PrivacyProfile;
   readonly wantsE2E?: boolean;
   readonly evaluationMode?: boolean;
+};
+
+type CapabilityUpdate = {
+  readonly caps?: readonly string[];
+  readonly grant?: readonly string[];
+  readonly revoke?: readonly string[];
+  readonly reason?: string;
+  readonly requestId?: string;
+  readonly broadcast?: boolean;
 };
 
 function mkEnvelope<T>(type: string, payload: T): Envelope<T> {
@@ -129,6 +139,7 @@ export class EnsoServer extends EventEmitter {
       cache: hello.cache,
       connectedAt: new Date().toISOString(),
       auditLog: [],
+      capRevision: 0,
     };
     this.sessions.set(session.id, record);
     this.guardrails.setEvaluationMode(
@@ -193,6 +204,58 @@ export class EnsoServer extends EventEmitter {
     this.recordAudit(sessionId, part);
     this.emit("message", { id: sessionId }, part);
     this.sessions.delete(sessionId);
+  }
+
+  /**
+   * Apply capability changes to a session and broadcast the authoritative set.
+   */
+  updateCapabilities(
+    sessionId: string,
+    update: CapabilityUpdate = {},
+  ): Envelope | undefined {
+    const record = this.sessions.get(sessionId);
+    if (!record) {
+      return undefined;
+    }
+    const current = new Set(record.capabilities);
+    let nextSet: Set<string>;
+    if (update.caps) {
+      nextSet = new Set(update.caps);
+    } else {
+      nextSet = new Set(current);
+      update.grant?.forEach((cap) => nextSet.add(cap));
+      update.revoke?.forEach((cap) => nextSet.delete(cap));
+    }
+    const nextCaps = Array.from(nextSet);
+    const granted = nextCaps.filter((cap) => !current.has(cap));
+    const revoked = [...current].filter((cap) => !nextSet.has(cap));
+    if (granted.length === 0 && revoked.length === 0) {
+      return undefined;
+    }
+    record.capabilities.splice(0, record.capabilities.length, ...nextCaps);
+    record.capRevision += 1;
+    const payload = {
+      session: sessionId,
+      caps: nextCaps,
+      revision: record.capRevision,
+      acknowledgedAt: new Date().toISOString(),
+      ...(granted.length > 0 ? { granted } : {}),
+      ...(revoked.length > 0 ? { revoked } : {}),
+      ...(update.reason ? { reason: update.reason } : {}),
+      ...(update.requestId ? { requestId: update.requestId } : {}),
+    };
+    const envelope = mkEnvelope("caps.update", payload);
+    this.recordAudit(sessionId, envelope);
+    this.emit("message", { id: sessionId }, envelope);
+    if (update.broadcast !== false) {
+      for (const [otherId] of this.sessions) {
+        if (otherId === sessionId) {
+          continue;
+        }
+        this.emit("message", { id: otherId }, envelope);
+      }
+    }
+    return envelope;
   }
 
   /** Dispatch an inbound envelope through the registered router. */

--- a/packages/enso-protocol/src/types/events.ts
+++ b/packages/enso-protocol/src/types/events.ts
@@ -51,6 +51,17 @@ export type PresencePartPayload = {
   readonly reason?: string;
 };
 
+export type CapsUpdatePayload = {
+  readonly session: string;
+  readonly caps: readonly string[];
+  readonly revision: number;
+  readonly granted?: readonly string[];
+  readonly revoked?: readonly string[];
+  readonly reason?: string;
+  readonly requestId?: string;
+  readonly acknowledgedAt?: string;
+};
+
 export type StatePatchPayload = {
   readonly room?: string;
   readonly diff?: unknown;
@@ -177,6 +188,7 @@ export type EventPayloadMap = {
   readonly "content.burn": ContentBurnPayload;
   readonly "presence.join": PresenceJoinPayload;
   readonly "presence.part": PresencePartPayload;
+  readonly "caps.update": CapsUpdatePayload;
   readonly "state.patch": StatePatchPayload;
   readonly "tool.advertise": ToolAdvertisement;
   readonly "tool.call": ToolCall;
@@ -235,6 +247,7 @@ export type ContentRetractEvent = EventOf<"content.retract">;
 export type ContentBurnEvent = EventOf<"content.burn">;
 export type PresenceJoinEvent = EventOf<"presence.join">;
 export type PresencePartEvent = EventOf<"presence.part">;
+export type CapsUpdateEvent = EventOf<"caps.update">;
 export type StatePatchEvent = EventOf<"state.patch">;
 export type ToolAdvertiseEvent = EventOf<"tool.advertise">;
 export type ToolCallEvent = EventOf<"tool.call">;


### PR DESCRIPTION
## Summary
- document the canonical `caps.update` capability revision event and acknowledgement semantics
- extend the ENSO protocol types, server, and client to emit and apply capability updates with revision tracking
- add AVA coverage for mid-session capability revocation and restoration plus a changelog entry

## Testing
- pnpm exec eslint packages/enso-protocol/src/client.ts packages/enso-protocol/src/server.ts packages/enso-protocol/src/tests/transport.spec.ts packages/enso-protocol/src/types/events.ts *(fails: missing `jiti` dependency in the eslint environment)*
- pnpm --filter @promethean/enso-protocol test *(fails: repository lacks installed `ava`/`node` type definitions in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dec50db4408324a14897a110927dff