### PR TITLE
feat: track pts for browser voice frames

### DIFF
--- a/changelog.d/2024.11.24.12.30.00.md
+++ b/changelog.d/2024.11.24.12.30.00.md
@@ -1,0 +1,2 @@
+- Export the default 20 ms voice frame duration for tests and expose a getter for the resolved value.
+- Document the Safari-triggered RTC protocol fallback for voice frame timing.

--- a/changelog.d/2025.10.02.19.02.22.md
+++ b/changelog.d/2025.10.02.19.02.22.md
@@ -1,0 +1,2 @@
+- ensure enso browser gateway voice frames carry seq + pts metadata and emit eof on close
+- add unit coverage for pts monotonicity in forwarded frames

--- a/docs/duck-webrtc.md
+++ b/docs/duck-webrtc.md
@@ -32,10 +32,13 @@ A simple two-way browser interface for talking to **Duck** without Discord, buil
 - WebRTC channels:
   - `voice` (browser → gateway → ENSO).
   - `events` (gateway → browser).
-  - `audio` (gateway → browser, optional ENSO audio).
+- `audio` (gateway → browser, optional ENSO audio).
 - Forwards mic frames as `voice.frame` events to ENSO.
 - Mirrors ENSO `content.post` events to browser.
 - Configurable ICE servers via `ICE_SERVERS` env var.
+- `RTCDataChannel.protocol` is not guaranteed across browsers; if the `voice`
+  channel does not negotiate a `frameDurationMs`, the gateway falls back to
+  20 ms frames.
 
 ## Setup
 ```bash

--- a/docs/duck-webrtc.md
+++ b/docs/duck-webrtc.md
@@ -36,9 +36,10 @@ A simple two-way browser interface for talking to **Duck** without Discord, buil
 - Forwards mic frames as `voice.frame` events to ENSO.
 - Mirrors ENSO `content.post` events to browser.
 - Configurable ICE servers via `ICE_SERVERS` env var.
-- `RTCDataChannel.protocol` is not guaranteed across browsers; if the `voice`
-  channel does not negotiate a `frameDurationMs`, the gateway falls back to
-  20 ms frames.
+- `RTCDataChannel.protocol` is not guaranteed across browsers; Safari, for
+  example, can surface an empty string. If the `voice` channel does not
+  negotiate a `frameDurationMs`, the gateway falls back to 20 ms frames to keep
+  sequenced timestamps aligned with the expected 50fps audio cadence.
 
 ## Setup
 ```bash

--- a/packages/enso-browser-gateway/src/server.mjs
+++ b/packages/enso-browser-gateway/src/server.mjs
@@ -1,73 +1,89 @@
-import http from 'node:http';
-import crypto from 'node:crypto';
-import url from 'node:url';
-import { WebSocketServer } from 'ws';
-import wrtc from 'wrtc';
-import { EnsoClient, connectWebSocket } from '@promethean/enso-protocol';
+import http from "node:http";
+import crypto from "node:crypto";
+import url from "node:url";
+import { WebSocketServer } from "ws";
+import wrtc from "wrtc";
+import { EnsoClient, connectWebSocket } from "@promethean/enso-protocol";
+import {
+  createVoiceForwarder,
+  resolveFrameDurationMs,
+} from "./voice-forwarder.mjs";
 
 const PORT = process.env.PORT ? Number(process.env.PORT) : 8787;
-const ENSO_URL = process.env.ENSO_WS_URL || 'ws://localhost:7766';
+const ENSO_URL = process.env.ENSO_WS_URL || "ws://localhost:7766";
 const ICE_SERVERS = parseIceServers(process.env.ICE_SERVERS); // JSON string of RTCIceServer[]
 const AUTH_TOKEN = process.env.DUCK_TOKEN || null;
 
 const server = http.createServer((req, res) => {
   res.writeHead(200);
-  res.end('enso-browser-gateway');
+  res.end("enso-browser-gateway");
 });
 
-const wss = new WebSocketServer({ server, path: '/ws' });
+const wss = new WebSocketServer({ server, path: "/ws" });
 
-wss.on('connection', async (ws, req) => {
+wss.on("connection", async (ws, req) => {
   // optional bearer token via query ?token=...
   if (AUTH_TOKEN) {
-    const q = new url.URL(req.url, 'http://localhost').searchParams;
-    const tok = q.get('token');
-    if (tok !== AUTH_TOKEN) { ws.close(4403, 'forbidden'); return; }
+    const q = new url.URL(req.url, "http://localhost").searchParams;
+    const tok = q.get("token");
+    if (tok !== AUTH_TOKEN) {
+      ws.close(4403, "forbidden");
+      return;
+    }
   }
 
   // ENSO client per browser
   const client = new EnsoClient();
-  const hello = { caps: ['can.voice.stream', 'can.send.text'], agent: { name: 'duck-web', version: '0.0.2' } };
+  const hello = {
+    caps: ["can.voice.stream", "can.send.text"],
+    agent: { name: "duck-web", version: "0.0.2" },
+  };
   const handle = connectWebSocket(client, ENSO_URL, hello);
 
   const pc = new wrtc.RTCPeerConnection({ iceServers: ICE_SERVERS });
-  const events = pc.createDataChannel('events'); // outbound to browser
-  const audio = pc.createDataChannel('audio'); // optional: send pcm16 frames to browser
+  const events = pc.createDataChannel("events"); // outbound to browser
+  const audio = pc.createDataChannel("audio"); // optional: send pcm16 frames to browser
   let voice;
 
   // ICE back to browser
   pc.onicecandidate = (ev) => {
-    if (ev.candidate) ws.send(JSON.stringify({ type: 'ice', candidate: ev.candidate }));
+    if (ev.candidate)
+      ws.send(JSON.stringify({ type: "ice", candidate: ev.candidate }));
   };
 
   pc.ondatachannel = (ev) => {
-    if (ev.channel.label === 'voice') {
+    if (ev.channel.label === "voice") {
       voice = ev.channel;
-      let streamId = crypto.randomUUID();
-      let seq = 0;
+      const streamId = crypto.randomUUID();
       const room = `voice:${Date.now()}`;
-      client.voice.register(streamId, 0);
+      const forwarder = createVoiceForwarder({
+        client,
+        streamId,
+        room,
+        frameDurationMs: resolveFrameDurationMs(ev.channel),
+      });
 
       voice.onmessage = async (mev) => {
         const buf = Buffer.from(mev.data);
-        await client.voice.sendFrame({
-          kind: 'voice.frame',
-          codec: 'pcm16le/16000/1',
-          streamId,
-          seq: seq++,
-          data: new Uint8Array(buf),
-        }, { room });
+        await forwarder.handleChunk(buf);
+      };
+
+      voice.onclose = () => {
+        void forwarder.handleClose();
+      };
+      voice.onerror = () => {
+        void forwarder.handleClose();
       };
     }
   };
 
   // Mirror ENSO content.post text to browser
-  client.on('event:content.post', (env) => {
+  client.on("event:content.post", (env) => {
     const message = env?.payload?.message;
     if (!message) return;
-    const part = (message.parts || []).find((x) => x?.kind === 'text');
-    const text = part?.text || '';
-    events.send(JSON.stringify({ type: 'content.post', message: { text } }));
+    const part = (message.parts || []).find((x) => x?.kind === "text");
+    const text = part?.text || "";
+    events.send(JSON.stringify({ type: "content.post", message: { text } }));
   });
 
   // If/when ENSO emits audio frames for TTS, forward them to browser
@@ -78,30 +94,48 @@ wss.on('connection', async (ws, req) => {
   // });
 
   // Minimal signaling
-  ws.send(JSON.stringify({ type: 'ready' }));
-  ws.on('message', async (raw) => {
+  ws.send(JSON.stringify({ type: "ready" }));
+  ws.on("message", async (raw) => {
     const msg = JSON.parse(String(raw));
-    if (msg.type === 'offer') {
-      await pc.setRemoteDescription({ type: 'offer', sdp: msg.sdp });
+    if (msg.type === "offer") {
+      await pc.setRemoteDescription({ type: "offer", sdp: msg.sdp });
       const answer = await pc.createAnswer();
       await pc.setLocalDescription(answer);
-      ws.send(JSON.stringify({ type: 'answer', sdp: answer.sdp }));
-    } else if (msg.type === 'ice') {
+      ws.send(JSON.stringify({ type: "answer", sdp: answer.sdp }));
+    } else if (msg.type === "ice") {
       await pc.addIceCandidate(msg.candidate);
-    } else if (msg.type === 'text') {
+    } else if (msg.type === "text") {
       const room = `voice:${Date.now()}`;
-      await client.post({ id: crypto.randomUUID(), role: 'human', parts: [{ kind: 'text', text: msg.text }], when: Date.now() }, { room });
+      await client.post(
+        {
+          id: crypto.randomUUID(),
+          role: "human",
+          parts: [{ kind: "text", text: msg.text }],
+          when: Date.now(),
+        },
+        { room },
+      );
     }
   });
 
-  ws.on('close', async () => {
-    try { await handle.close(); } catch {}
-    try { pc.close(); } catch {}
+  ws.on("close", async () => {
+    try {
+      await handle.close();
+    } catch {}
+    try {
+      pc.close();
+    } catch {}
   });
 });
 
-server.listen(PORT, () => console.log('enso-browser-gateway listening on :' + PORT));
+server.listen(PORT, () =>
+  console.log("enso-browser-gateway listening on :" + PORT),
+);
 
 function parseIceServers(json) {
-  try { return json ? JSON.parse(json) : []; } catch { return []; }
+  try {
+    return json ? JSON.parse(json) : [];
+  } catch {
+    return [];
+  }
 }

--- a/packages/enso-browser-gateway/src/tests/voice-forwarder.spec.mjs
+++ b/packages/enso-browser-gateway/src/tests/voice-forwarder.spec.mjs
@@ -1,5 +1,8 @@
 import test from "ava";
-import { createVoiceForwarder } from "../voice-forwarder.mjs";
+import {
+  createVoiceForwarder,
+  DEFAULT_FRAME_DURATION_MS,
+} from "../voice-forwarder.mjs";
 
 test("forwarder adds seq and monotonic pts for each frame", async (t) => {
   const frames = [];
@@ -39,4 +42,6 @@ test("forwarder adds seq and monotonic pts for each frame", async (t) => {
   t.is(eof.seq, 2);
   t.is(eof.pts, 40);
   t.deepEqual(eof.data, new Uint8Array(0));
+
+  t.is(forwarder.getFrameDurationMs(), DEFAULT_FRAME_DURATION_MS);
 });

--- a/packages/enso-browser-gateway/src/tests/voice-forwarder.spec.mjs
+++ b/packages/enso-browser-gateway/src/tests/voice-forwarder.spec.mjs
@@ -1,0 +1,42 @@
+import test from "ava";
+import { createVoiceForwarder } from "../voice-forwarder.mjs";
+
+test("forwarder adds seq and monotonic pts for each frame", async (t) => {
+  const frames = [];
+  const client = {
+    voice: {
+      register: () => {},
+      sendFrame: async (frame) => {
+        frames.push(frame);
+      },
+    },
+  };
+
+  const forwarder = createVoiceForwarder({
+    client,
+    streamId: "stream-1",
+    room: "room-1",
+    frameDurationMs: 20,
+  });
+
+  await forwarder.handleChunk(Buffer.from([0, 1]));
+  await forwarder.handleChunk(Buffer.from([2, 3]));
+  await forwarder.handleClose();
+
+  t.is(frames.length, 3);
+
+  const [first, second, eof] = frames;
+  t.deepEqual(first.data, new Uint8Array([0, 1]));
+  t.is(first.seq, 0);
+  t.is(first.pts, 0);
+
+  t.deepEqual(second.data, new Uint8Array([2, 3]));
+  t.is(second.seq, 1);
+  t.is(second.pts, 20);
+  t.true(second.pts > first.pts);
+
+  t.is(eof.eof, true);
+  t.is(eof.seq, 2);
+  t.is(eof.pts, 40);
+  t.deepEqual(eof.data, new Uint8Array(0));
+});

--- a/packages/enso-browser-gateway/src/voice-forwarder.mjs
+++ b/packages/enso-browser-gateway/src/voice-forwarder.mjs
@@ -1,0 +1,64 @@
+export function resolveFrameDurationMs(channel) {
+  if (!channel?.protocol) return 20;
+  const match = /frame(?:Duration)?(?:Ms)?=(\d+)/i.exec(channel.protocol);
+  if (!match) return 20;
+  const value = Number.parseInt(match[1], 10);
+  return Number.isFinite(value) && value > 0 ? value : 20;
+}
+
+export function createVoiceForwarder({
+  client,
+  streamId,
+  room,
+  frameDurationMs = 20,
+  codec = "pcm16le/16000/1",
+}) {
+  client.voice.register(streamId, 0);
+  let seq = 0;
+  let pts = 0;
+  let closed = false;
+
+  async function send(frame) {
+    await client.voice.sendFrame(
+      {
+        kind: "voice.frame",
+        codec,
+        streamId,
+        ...frame,
+      },
+      { room },
+    );
+  }
+
+  return {
+    async handleChunk(chunk) {
+      if (closed) return;
+      const data = toUint8Array(chunk);
+      if (data === null) return;
+      const currentSeq = seq++;
+      const currentPts = pts;
+      pts += frameDurationMs;
+      await send({ seq: currentSeq, pts: currentPts, data });
+    },
+    async handleClose() {
+      if (closed) return;
+      closed = true;
+      const data = new Uint8Array(0);
+      await send({ seq: seq++, pts, data, eof: true });
+    },
+  };
+}
+
+function toUint8Array(chunk) {
+  if (chunk instanceof Uint8Array) {
+    const isBuffer = typeof Buffer !== "undefined" && Buffer.isBuffer?.(chunk);
+    if (isBuffer) {
+      return new Uint8Array(chunk.buffer, chunk.byteOffset, chunk.byteLength);
+    }
+    return chunk;
+  }
+  if (chunk instanceof ArrayBuffer) {
+    return new Uint8Array(chunk);
+  }
+  return null;
+}

--- a/packages/enso-browser-gateway/src/voice-forwarder.mjs
+++ b/packages/enso-browser-gateway/src/voice-forwarder.mjs
@@ -1,4 +1,4 @@
-const DEFAULT_FRAME_DURATION_MS = 20;
+export const DEFAULT_FRAME_DURATION_MS = 20;
 const MIN_FRAME_DURATION_MS = 5;
 const MAX_FRAME_DURATION_MS = 200;
 
@@ -45,6 +45,9 @@ export function createVoiceForwarder({
   }
 
   return {
+    getFrameDurationMs() {
+      return resolvedFrameDurationMs;
+    },
     async handleChunk(chunk) {
       if (closed) return;
       const data = toUint8Array(chunk);


### PR DESCRIPTION
## Summary
- factor voice forwarding into a helper that registers streams, tracks seq/pts, and emits EOF on channel close
- read an optional negotiated frame duration and attach monotonically increasing pts values when relaying frames
- add an AVA harness that asserts forwarded frames include seq/pts metadata and document the change

## Testing
- pnpm exec ava --config config/ava.config.mjs packages/enso-browser-gateway/src/tests/voice-forwarder.spec.mjs
- pnpm exec eslint packages/enso-browser-gateway/src --ext .mjs

------
https://chatgpt.com/codex/tasks/task_e_68dec8ebe33483248ca8701d7e7e5a50