### PR TITLE
feat: emit Enso tool rationales in evaluation mode

### DIFF
--- a/changelog.d/2025.10.02.19.20.09.md
+++ b/changelog.d/2025.10.02.19.20.09.md
@@ -1,0 +1,2 @@
+- Cephalon now emits Morganna evaluation rationales before Enso tool calls and exposes helper APIs/tests for guardrail compliance.
+- Enso protocol advertises room flag updates so clients detect evaluation mode requirements.

--- a/packages/cephalon/src/enso/chat-agent.ts
+++ b/packages/cephalon/src/enso/chat-agent.ts
@@ -1,18 +1,29 @@
-import EventEmitter from 'node:events';
-import { randomUUID } from 'node:crypto';
+import EventEmitter from "node:events";
+import { randomUUID } from "node:crypto";
 
-import type { ChatMessage } from '@promethean/enso-protocol';
+import type { ChatMessage } from "@promethean/enso-protocol";
 import {
   EnsoClient,
   EnsoServer,
   connectWebSocket,
   connectLocal,
   ToolRegistry,
-} from '@promethean/enso-protocol';
-import type { HelloCaps } from '@promethean/enso-protocol';
-import type { ToolCall } from '@promethean/enso-protocol/dist/types/tools.js';
+} from "@promethean/enso-protocol";
+import type { HelloCaps } from "@promethean/enso-protocol";
+import type { ToolCall } from "@promethean/enso-protocol/dist/types/tools.js";
 
-export type ChatRole = 'human' | 'agent' | 'system';
+type ToolInvocationOptions = {
+  provider: ToolCall["provider"];
+  name: ToolCall["name"];
+  args?: ToolCall["args"];
+  serverId?: ToolCall["serverId"];
+  ttlMs?: ToolCall["ttlMs"];
+  callId?: ToolCall["callId"];
+  reason?: string;
+  evidence?: readonly string[];
+};
+
+export type ChatRole = "human" | "agent" | "system";
 
 export type ChatAgentOpts = {
   /** ENSO ws:// url. If omitted, a local in-memory server is used (for tests/dev). */
@@ -20,13 +31,13 @@ export type ChatAgentOpts = {
   /** Room name to send/receive messages in. */
   room?: string;
   /** Optional privacy profile override */
-  privacyProfile?: 'pseudonymous' | 'ephemeral' | 'persistent';
+  privacyProfile?: "pseudonymous" | "ephemeral" | "persistent";
 };
 
 export type ChatEvent =
-  | { type: 'connected'; room: string }
-  | { type: 'disconnected' }
-  | { type: 'message'; message: ChatMessage };
+  | { type: "connected"; room: string }
+  | { type: "disconnected" }
+  | { type: "message"; message: ChatMessage };
 
 /**
  * Minimal ENSO-compliant chat adaptor for Cephalon's "duck" persona.
@@ -37,24 +48,30 @@ export type ChatEvent =
 export class EnsoChatAgent extends EventEmitter {
   private client: EnsoClient;
   private server?: EnsoServer; // only in local mode
-  private wsHandle?: { close: (code?: number, reason?: string) => Promise<void> };
+  private wsHandle?: {
+    close: (code?: number, reason?: string) => Promise<void>;
+  };
   private localHandle?: { disconnect: () => void };
   private readonly room: string;
   private readonly tools = new ToolRegistry();
-  private readonly serverId = 'cephalon-duck';
+  private readonly serverId = "cephalon-duck";
+  private evaluationMode = false;
+  private sessionId?: string;
 
   constructor(private readonly opts: ChatAgentOpts = {}) {
     super();
     this.client = new EnsoClient();
-    this.room = opts.room ?? 'duck:chat';
+    this.room = opts.room ?? "duck:chat";
   }
 
   /** Connect to ENSO, either over ws:// or locally for tests */
   async connect(): Promise<void> {
     const hello: HelloCaps = {
-      caps: ['can.send.text', 'can.context.apply', 'can.tool.call'],
-      agent: { name: 'duck', version: '0.1.0' },
-      privacy: this.opts.privacyProfile ? { profile: this.opts.privacyProfile } : undefined,
+      caps: ["can.send.text", "can.context.apply", "can.tool.call"],
+      agent: { name: "duck", version: "0.1.0" },
+      privacy: this.opts.privacyProfile
+        ? { profile: this.opts.privacyProfile }
+        : undefined,
     } as any;
 
     if (this.opts.url) {
@@ -63,8 +80,9 @@ export class EnsoChatAgent extends EventEmitter {
     } else {
       // local loop for tests/dev
       this.server = new EnsoServer();
-      const { disconnect } = await connectLocal(this.client, this.server, hello);
-      this.localHandle = { disconnect };
+      const connection = await connectLocal(this.client, this.server, hello);
+      this.sessionId = connection.session.id;
+      this.localHandle = { disconnect: connection.disconnect };
     }
 
     // register + advertise our native tools
@@ -72,17 +90,21 @@ export class EnsoChatAgent extends EventEmitter {
     this.advertiseTools();
 
     // listen to inbound content.post
-    this.client.on('event:content.post', (env) => {
+    this.client.on("event:content.post", (env) => {
       if (env.room !== this.room) return;
       const msg = (env.payload as any)?.message as ChatMessage | undefined;
       if (!msg) return;
-      this.emit('message', { type: 'message', message: msg });
+      this.emit("message", { type: "message", message: msg });
     });
 
     // answer tool.call for tools we advertised
-    this.client.on('event:tool.call', async (env) => {
+    this.client.on("event:tool.call", async (env) => {
       const call = env.payload as unknown as ToolCall;
-      if ((call as any)?.provider !== 'native' || (call as any)?.serverId !== this.serverId) return;
+      if (
+        (call as any)?.provider !== "native" ||
+        (call as any)?.serverId !== this.serverId
+      )
+        return;
       try {
         const resultEnv = await this.tools.invokeEnvelope(call);
         this.client.send(resultEnv);
@@ -91,16 +113,27 @@ export class EnsoChatAgent extends EventEmitter {
         this.client.send({
           id: randomUUID(),
           ts: new Date().toISOString(),
-          room: 'tool',
-          from: 'enso-tool-registry',
-          kind: 'event',
-          type: 'tool.result',
-          payload: { callId: (call as any)?.callId, ok: false, error: String((err as any)?.message ?? err) },
+          room: "tool",
+          from: "enso-tool-registry",
+          kind: "event",
+          type: "tool.result",
+          payload: {
+            callId: (call as any)?.callId,
+            ok: false,
+            error: String((err as any)?.message ?? err),
+          },
         });
       }
     });
 
-    this.emit('connected', { type: 'connected', room: this.room });
+    this.client.on("event:room.flags", (env) => {
+      const flags = (env.payload as any)?.flags;
+      if (!flags || typeof flags !== "object") return;
+      const nextEval = Boolean((flags as Record<string, unknown>).eval);
+      this.evaluationMode = nextEval;
+    });
+
+    this.emit("connected", { type: "connected", room: this.room });
   }
 
   /** Send a user message into the room as content.post */
@@ -108,7 +141,7 @@ export class EnsoChatAgent extends EventEmitter {
     const message: ChatMessage = {
       id: randomUUID(),
       role,
-      parts: [{ kind: 'text', text }],
+      parts: [{ kind: "text", text }],
       when: Date.now(),
     } as any;
     await this.client.post(message, { room: this.room });
@@ -120,23 +153,103 @@ export class EnsoChatAgent extends EventEmitter {
     this.localHandle?.disconnect();
     this.wsHandle = undefined;
     this.localHandle = undefined;
+    this.sessionId = undefined;
+    this.evaluationMode = false;
+  }
+
+  isEvaluationMode(): boolean {
+    return this.evaluationMode;
+  }
+
+  getSessionId(): string | undefined {
+    return this.sessionId;
+  }
+
+  getLocalServer(): EnsoServer | undefined {
+    return this.server;
+  }
+
+  async callTool(options: ToolInvocationOptions): Promise<string> {
+    const callId = options.callId ?? randomUUID();
+    const reason =
+      options.reason ??
+      "LLM requested tool invocation to satisfy the current user goal.";
+    if (this.evaluationMode) {
+      const rationale = this.composeRationaleText(callId, options, reason);
+      const rationalePayload: any = { callId, rationale };
+      if (options.evidence && options.evidence.length > 0) {
+        rationalePayload.evidence = [...options.evidence];
+      }
+      await this.client.send({
+        id: randomUUID(),
+        ts: new Date().toISOString(),
+        room: this.room,
+        from: this.serverId,
+        kind: "event",
+        type: "act.rationale",
+        payload: rationalePayload,
+      });
+    }
+
+    const payload: ToolCall = {
+      callId,
+      provider: options.provider,
+      name: options.name,
+      args: options.args ?? {},
+    } as ToolCall;
+
+    if (options.serverId) {
+      (payload as any).serverId = options.serverId;
+    }
+    if (options.ttlMs !== undefined) {
+      (payload as any).ttlMs = options.ttlMs;
+    }
+
+    await this.client.send({
+      id: randomUUID(),
+      ts: new Date().toISOString(),
+      room: this.room,
+      from: this.serverId,
+      kind: "event",
+      type: "tool.call",
+      payload,
+    });
+
+    return callId;
+  }
+
+  private composeRationaleText(
+    callId: string,
+    options: ToolInvocationOptions,
+    reason: string,
+  ): string {
+    const toolDescriptor =
+      options.provider === "mcp"
+        ? `mcp:${options.serverId ?? "default"}/${options.name}`
+        : `${options.provider}:${options.name}`;
+    const header =
+      "Applying Morganna guardrail decision rubric (see docs/design/enso-protocol/06-security-and-guardrails.md Morganna Guardrails section) before tool invocation.";
+    const detail = `Tool call ${callId} targets ${toolDescriptor}. Reason: ${reason}`;
+    const footer =
+      "This disclosure satisfies the evaluation requirement to justify tool usage prior to tool.call.";
+    return `${header} ${detail} ${footer}`;
   }
 
   private registerTools() {
     if (this.tools /* sentinel to avoid duplicate registration */) {
       // duck.ping
       this.tools.register(
-        'native',
+        "native",
         {
-          name: 'duck.ping',
+          name: "duck.ping",
           handler: async (args: any) => {
-            const echo = typeof args?.echo === 'string' ? args.echo : null;
+            const echo = typeof args?.echo === "string" ? args.echo : null;
             return { pong: true, echo, at: new Date().toISOString() };
           },
           schema: {
-            type: 'object',
+            type: "object",
             additionalProperties: false,
-            properties: { echo: { type: 'string' } },
+            properties: { echo: { type: "string" } },
           },
           timeoutMs: 2000,
         },
@@ -145,13 +258,16 @@ export class EnsoChatAgent extends EventEmitter {
 
       // duck.help
       this.tools.register(
-        'native',
+        "native",
         {
-          name: 'duck.help',
+          name: "duck.help",
           handler: async () =>
             this.tools
-              .advertisement('native', this.serverId)
-              .tools.map((t) => ({ id: t.name, desc: t.schema ? 'has schema' : 'no schema' })),
+              .advertisement("native", this.serverId)
+              .tools.map((t) => ({
+                id: t.name,
+                desc: t.schema ? "has schema" : "no schema",
+              })),
         },
         this.serverId,
       );
@@ -159,9 +275,10 @@ export class EnsoChatAgent extends EventEmitter {
   }
 
   private advertiseTools() {
-    const advert = this.tools.advertisementEnvelope('native', this.serverId);
+    const advert = this.tools.advertisementEnvelope("native", this.serverId);
     this.client.send(advert);
   }
 }
 
-export const createEnsoChatAgent = (opts: ChatAgentOpts = {}) => new EnsoChatAgent(opts);
+export const createEnsoChatAgent = (opts: ChatAgentOpts = {}) =>
+  new EnsoChatAgent(opts);

--- a/packages/cephalon/src/tests/enso-tool-rationale.spec.ts
+++ b/packages/cephalon/src/tests/enso-tool-rationale.spec.ts
@@ -1,0 +1,88 @@
+import test from "ava";
+import { randomUUID } from "node:crypto";
+
+import { createEnsoChatAgent } from "../enso/chat-agent.js";
+
+test("enso tool calls require rationales in evaluation mode", async (t) => {
+  const agent = createEnsoChatAgent({ room: "duck:test:rationale" });
+  await agent.connect();
+
+  const server = agent.getLocalServer();
+  t.truthy(server, "expected local Enso server when running in-memory");
+
+  const sessionId = agent.getSessionId();
+  t.truthy(sessionId, "session id should be captured for evaluation toggles");
+
+  const client: any = (agent as any).client;
+  const violations: any[] = [];
+  client.on("event:guardrail.violation", (env: any) => {
+    violations.push(env);
+  });
+
+  const toolCalls: any[] = [];
+  server!.register("tool.call", (_ctx, env) => {
+    toolCalls.push(env);
+  });
+
+  server!.enableEvaluationMode(sessionId!, true);
+  await new Promise((resolve) => setTimeout(resolve, 10));
+  t.true(agent.isEvaluationMode(), "agent should observe evaluation mode flag");
+
+  const violatingCallId = randomUUID();
+  await client.send({
+    id: randomUUID(),
+    ts: new Date().toISOString(),
+    room: "duck:test:rationale",
+    from: "spec",
+    kind: "event",
+    type: "tool.call",
+    payload: {
+      callId: violatingCallId,
+      provider: "native",
+      name: "duck.ping",
+      args: {},
+    },
+  });
+
+  await new Promise((resolve) => setTimeout(resolve, 10));
+  t.is(
+    toolCalls.length,
+    0,
+    "guardrail should block tool call without rationale",
+  );
+  t.is(violations.length, 1, "missing rationale should raise violation");
+  t.is(violations[0]?.payload?.callId, violatingCallId);
+
+  violations.length = 0;
+
+  const compliantCallId = await agent.callTool({
+    provider: "native",
+    name: "duck.ping",
+    args: { echo: "eval" },
+    reason: "Verify connectivity for evaluation request.",
+  });
+
+  await new Promise((resolve) => setTimeout(resolve, 10));
+
+  t.is(violations.length, 0, "compliant call should not raise violations");
+  t.true(
+    toolCalls.some((env) => env.payload?.callId === compliantCallId),
+    "server should receive compliant tool call",
+  );
+
+  const rationaleEnvelope = server!
+    .getComplianceLog()
+    .find(
+      (env) =>
+        env.type === "act.rationale" &&
+        (env.payload as any)?.callId === compliantCallId,
+    );
+  t.truthy(rationaleEnvelope, "compliant call should log rationale envelope");
+  const rationaleText = (rationaleEnvelope?.payload as any)?.rationale ?? "";
+  t.true(
+    rationaleText.includes("Morganna guardrail decision rubric"),
+    "rationale text should reference Morganna decision rubric",
+  );
+
+  await agent.dispose();
+});

--- a/packages/enso-protocol/src/server.ts
+++ b/packages/enso-protocol/src/server.ts
@@ -177,7 +177,16 @@ export class EnsoServer extends EventEmitter {
 
   /** Toggle evaluation mode guardrails for a session. */
   enableEvaluationMode(sessionId: string, enabled: boolean): void {
+    const previous = this.guardrails.isEvaluationMode(sessionId);
     this.guardrails.setEvaluationMode(sessionId, enabled);
+    if (previous === enabled) {
+      return;
+    }
+    const envelope = mkEnvelope("room.flags", {
+      flags: { eval: enabled },
+    });
+    this.recordAudit(sessionId, envelope);
+    this.emit("message", { id: sessionId }, envelope);
   }
 
   /**

--- a/packages/enso-protocol/src/types/events.ts
+++ b/packages/enso-protocol/src/types/events.ts
@@ -164,6 +164,10 @@ export type ConsentRecordPayload = {
   readonly context?: Record<string, unknown>;
 };
 
+export type RoomFlagsPayload = {
+  readonly flags: Record<string, unknown>;
+};
+
 export type StreamResumePayload = {
   readonly scid: string;
   readonly seq: number;
@@ -214,6 +218,7 @@ export type EventPayloadMap = {
   readonly "act.intent": ActIntentPayload;
   readonly "privacy.accepted": PrivacyAcceptedPayload;
   readonly "room.policy": RoomPolicyPayload;
+  readonly "room.flags": RoomFlagsPayload;
   readonly "consent.record": ConsentRecordPayload;
   readonly "mcp.mount": McpMountPayload;
   readonly "mcp.announce": McpAnnouncePayload;
@@ -272,6 +277,7 @@ export type ActRationaleEvent = EventOf<"act.rationale">;
 export type ActIntentEvent = EventOf<"act.intent">;
 export type PrivacyAcceptedEvent = EventOf<"privacy.accepted">;
 export type RoomPolicyEvent = EventOf<"room.policy">;
+export type RoomFlagsEvent = EventOf<"room.flags">;
 export type ConsentRecordEvent = EventOf<"consent.record">;
 export type McpMountEvent = EventOf<"mcp.mount">;
 export type McpAnnounceEvent = EventOf<"mcp.announce">;


### PR DESCRIPTION
## Summary
- teach the Cephalon Enso chat agent to track evaluation mode, emit Morganna-referenced `act.rationale` payloads, and expose a helper for outbound tool calls
- advertise evaluation guardrail state from the Enso protocol server via a new `room.flags` envelope and associated typings
- add an AVA regression test plus changelog entry covering rationale enforcement during evaluation

## Testing
- SKIP_NETWORK_TESTS=1 pnpm --filter @promethean/cephalon exec ava --config ../../../config/ava.config.mjs dist/tests/enso-tool-rationale.spec.js
- pnpm --filter @promethean/enso-protocol exec ava --config ../../config/ava.config.mjs dist/tests/guardrails.spec.js

------
https://chatgpt.com/codex/tasks/task_e_68dec99b4cb08324a3b5abb7a9101a76