### PR TITLE
feat: guard enso handshake for browser gateway

### DIFF
--- a/changelog.d/2025.10.02.19.16.04.md
+++ b/changelog.d/2025.10.02.19.16.04.md
@@ -1,0 +1,1 @@
+- enforce ENSO handshake readiness and error reporting in the browser gateway, with accompanying tests and documentation.

--- a/packages/enso-browser-gateway/README.md
+++ b/packages/enso-browser-gateway/README.md
@@ -1,0 +1,20 @@
+# @promethean/enso-browser-gateway
+
+This gateway bridges browser WebRTC peers with an ENSO runtime over WebSockets.
+
+## Handshake behaviour
+
+On every browser connection the gateway opens an ENSO WebSocket session using
+the `ENSO-1` protocol descriptor. The gateway waits for the ENSO handshake to
+complete before delivering text or tool payloads to the browser data channels.
+
+If the ENSO handshake fails or exceeds the readiness timeout, the gateway sends
+an error envelope to the browser client before closing the WebSocket:
+
+```json
+{"type":"error","reason":"<error message>"}
+```
+
+The browser can rely on receiving this message before the socket closes when
+handshake problems occur, allowing deterministic UI feedback for slow or failed
+sessions.

--- a/packages/enso-browser-gateway/src/handshake.mjs
+++ b/packages/enso-browser-gateway/src/handshake.mjs
@@ -1,0 +1,123 @@
+const DEFAULT_TIMEOUT_MS = 10000;
+const DEFAULT_CLOSE_CODE = 1011;
+const DEFAULT_CLOSE_REASON = "enso handshake failed";
+
+function safeStringify(value) {
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
+
+function normalizeError(error) {
+  if (error instanceof Error) return error;
+  if (error && typeof error === "object") {
+    const message = error.message ?? safeStringify(error);
+    return new Error(typeof message === "string" ? message : String(message));
+  }
+  return new Error(String(error));
+}
+
+function stringifyReason(error) {
+  return error?.message ? String(error.message) : String(error);
+}
+
+export function waitForReadyWithTimeout(
+  readyPromise,
+  timeoutMs = DEFAULT_TIMEOUT_MS,
+) {
+  if (!readyPromise || typeof readyPromise.then !== "function") {
+    return Promise.reject(
+      new Error("Expected a promise for handshake readiness."),
+    );
+  }
+  if (timeoutMs <= 0 || !Number.isFinite(timeoutMs)) {
+    return readyPromise;
+  }
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    const timer = setTimeout(() => {
+      settled = true;
+      reject(new Error(`ENSO handshake timed out after ${timeoutMs}ms`));
+    }, timeoutMs);
+    readyPromise
+      .then((value) => {
+        if (settled) return;
+        clearTimeout(timer);
+        resolve(value);
+      })
+      .catch((error) => {
+        if (settled) return;
+        clearTimeout(timer);
+        reject(error);
+      });
+  });
+}
+
+export function createHandshakeGuard(handle, ws, options = {}) {
+  const {
+    timeoutMs = DEFAULT_TIMEOUT_MS,
+    closeCode = DEFAULT_CLOSE_CODE,
+    closeReason = DEFAULT_CLOSE_REASON,
+    logger,
+  } = options;
+
+  let resolved = false;
+  let failure = null;
+
+  const closeHandle = () => {
+    if (handle && typeof handle.close === "function") {
+      Promise.resolve()
+        .then(() => handle.close())
+        .catch(() => {});
+    }
+  };
+
+  const notifyFailure = (error) => {
+    const reason = stringifyReason(error);
+    logger?.error?.("ENSO handshake failed", error);
+    if (ws && ws.readyState === ws?.OPEN) {
+      try {
+        ws.send(JSON.stringify({ type: "error", reason }));
+      } catch (sendError) {
+        logger?.warn?.(
+          "Failed to notify browser of handshake failure",
+          sendError,
+        );
+      }
+    }
+    try {
+      ws?.close?.(closeCode, closeReason);
+    } catch (closeError) {
+      logger?.warn?.(
+        "Failed to close browser socket after handshake failure",
+        closeError,
+      );
+    }
+    closeHandle();
+  };
+
+  const monitoredPromise = waitForReadyWithTimeout(handle?.ready, timeoutMs)
+    .then(() => {
+      resolved = true;
+    })
+    .catch((error) => {
+      failure = normalizeError(error);
+      notifyFailure(failure);
+      throw failure;
+    });
+
+  monitoredPromise.catch(() => {});
+
+  return {
+    wait: async () => {
+      if (failure) {
+        throw failure;
+      }
+      await monitoredPromise;
+    },
+    isReady: () => resolved,
+    error: () => failure,
+  };
+}

--- a/packages/enso-browser-gateway/src/handshake.test.mjs
+++ b/packages/enso-browser-gateway/src/handshake.test.mjs
@@ -1,0 +1,84 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createHandshakeGuard } from "./handshake.mjs";
+
+function createMockHandle(ready) {
+  let closeCount = 0;
+  return {
+    ready,
+    close: () => {
+      closeCount += 1;
+      return Promise.resolve();
+    },
+    get closeCount() {
+      return closeCount;
+    },
+  };
+}
+
+function createMockWebSocket() {
+  const sent = [];
+  const closes = [];
+  const ws = {
+    OPEN: 1,
+    readyState: 1,
+    send: (data) => {
+      sent.push(data);
+    },
+    close: (code, reason) => {
+      closes.push({ code, reason });
+      ws.readyState = 3;
+    },
+  };
+  return {
+    ws,
+    sent,
+    closes,
+  };
+}
+
+test("handshake guard resolves once the handshake completes", async () => {
+  const ready = new Promise((resolve) => setTimeout(resolve, 5));
+  const handle = createMockHandle(ready);
+  const { ws } = createMockWebSocket();
+  const guard = createHandshakeGuard(handle, ws, { timeoutMs: 50 });
+
+  await guard.wait();
+  assert.equal(guard.isReady(), true);
+  assert.equal(guard.error(), null);
+});
+
+test("handshake guard reports failures to the browser client", async () => {
+  const ready = Promise.resolve().then(() => {
+    throw new Error("nope");
+  });
+  const handle = createMockHandle(ready);
+  const socket = createMockWebSocket();
+  const guard = createHandshakeGuard(handle, socket.ws, { timeoutMs: 50 });
+
+  await assert.rejects(guard.wait(), /nope/);
+  assert.equal(socket.sent.length, 1);
+  assert.deepEqual(JSON.parse(socket.sent[0]), {
+    type: "error",
+    reason: "nope",
+  });
+  assert.equal(socket.closes.length, 1);
+  assert.equal(socket.closes[0].code, 1011);
+  assert.equal(handle.closeCount, 1);
+});
+
+test("handshake guard times out and emits an error payload", async () => {
+  const ready = new Promise(() => {});
+  const handle = createMockHandle(ready);
+  const socket = createMockWebSocket();
+  const guard = createHandshakeGuard(handle, socket.ws, { timeoutMs: 20 });
+
+  await assert.rejects(guard.wait(), /timed out/);
+  assert.equal(socket.sent.length, 1);
+  const payload = JSON.parse(socket.sent[0]);
+  assert.equal(payload.type, "error");
+  assert.match(payload.reason, /timed out/);
+  assert.equal(socket.closes.length, 1);
+  assert.equal(socket.closes[0].code, 1011);
+  assert.equal(handle.closeCount, 1);
+});

--- a/packages/enso-browser-gateway/src/server.mjs
+++ b/packages/enso-browser-gateway/src/server.mjs
@@ -1,73 +1,101 @@
-import http from 'node:http';
-import crypto from 'node:crypto';
-import url from 'node:url';
-import { WebSocketServer } from 'ws';
-import wrtc from 'wrtc';
-import { EnsoClient, connectWebSocket } from '@promethean/enso-protocol';
+import http from "node:http";
+import crypto from "node:crypto";
+import url from "node:url";
+import { WebSocketServer } from "ws";
+import wrtc from "wrtc";
+import { EnsoClient, connectWebSocket } from "@promethean/enso-protocol";
+import { createHandshakeGuard } from "./handshake.mjs";
 
 const PORT = process.env.PORT ? Number(process.env.PORT) : 8787;
-const ENSO_URL = process.env.ENSO_WS_URL || 'ws://localhost:7766';
+const ENSO_URL = process.env.ENSO_WS_URL || "ws://localhost:7766";
 const ICE_SERVERS = parseIceServers(process.env.ICE_SERVERS); // JSON string of RTCIceServer[]
 const AUTH_TOKEN = process.env.DUCK_TOKEN || null;
 
 const server = http.createServer((req, res) => {
   res.writeHead(200);
-  res.end('enso-browser-gateway');
+  res.end("enso-browser-gateway");
 });
 
-const wss = new WebSocketServer({ server, path: '/ws' });
+const wss = new WebSocketServer({ server, path: "/ws" });
 
-wss.on('connection', async (ws, req) => {
+wss.on("connection", async (ws, req) => {
   // optional bearer token via query ?token=...
   if (AUTH_TOKEN) {
-    const q = new url.URL(req.url, 'http://localhost').searchParams;
-    const tok = q.get('token');
-    if (tok !== AUTH_TOKEN) { ws.close(4403, 'forbidden'); return; }
+    const q = new url.URL(req.url, "http://localhost").searchParams;
+    const tok = q.get("token");
+    if (tok !== AUTH_TOKEN) {
+      ws.close(4403, "forbidden");
+      return;
+    }
   }
 
   // ENSO client per browser
   const client = new EnsoClient();
-  const hello = { caps: ['can.voice.stream', 'can.send.text'], agent: { name: 'duck-web', version: '0.0.2' } };
+  const hello = {
+    proto: "ENSO-1",
+    caps: ["can.voice.stream", "can.send.text"],
+    agent: { name: "duck-web", version: "0.0.2" },
+  };
   const handle = connectWebSocket(client, ENSO_URL, hello);
+  const handshake = createHandshakeGuard(handle, ws, { logger: console });
+
+  const ensureHandshake = async () => {
+    try {
+      await handshake.wait();
+      return true;
+    } catch {
+      return false;
+    }
+  };
 
   const pc = new wrtc.RTCPeerConnection({ iceServers: ICE_SERVERS });
-  const events = pc.createDataChannel('events'); // outbound to browser
-  const audio = pc.createDataChannel('audio'); // optional: send pcm16 frames to browser
+  const events = pc.createDataChannel("events"); // outbound to browser
+  const audio = pc.createDataChannel("audio"); // optional: send pcm16 frames to browser
   let voice;
 
   // ICE back to browser
   pc.onicecandidate = (ev) => {
-    if (ev.candidate) ws.send(JSON.stringify({ type: 'ice', candidate: ev.candidate }));
+    if (ev.candidate)
+      ws.send(JSON.stringify({ type: "ice", candidate: ev.candidate }));
   };
 
   pc.ondatachannel = (ev) => {
-    if (ev.channel.label === 'voice') {
+    if (ev.channel.label === "voice") {
       voice = ev.channel;
       let streamId = crypto.randomUUID();
       let seq = 0;
       const room = `voice:${Date.now()}`;
-      client.voice.register(streamId, 0);
+      const registerVoice = async () => {
+        if (!(await ensureHandshake())) return;
+        client.voice.register(streamId, 0);
+      };
+      void registerVoice();
 
       voice.onmessage = async (mev) => {
         const buf = Buffer.from(mev.data);
-        await client.voice.sendFrame({
-          kind: 'voice.frame',
-          codec: 'pcm16le/16000/1',
-          streamId,
-          seq: seq++,
-          data: new Uint8Array(buf),
-        }, { room });
+        if (!(await ensureHandshake())) return;
+        await client.voice.sendFrame(
+          {
+            kind: "voice.frame",
+            codec: "pcm16le/16000/1",
+            streamId,
+            seq: seq++,
+            data: new Uint8Array(buf),
+          },
+          { room },
+        );
       };
     }
   };
 
   // Mirror ENSO content.post text to browser
-  client.on('event:content.post', (env) => {
+  client.on("event:content.post", async (env) => {
+    if (!(await ensureHandshake())) return;
     const message = env?.payload?.message;
     if (!message) return;
-    const part = (message.parts || []).find((x) => x?.kind === 'text');
-    const text = part?.text || '';
-    events.send(JSON.stringify({ type: 'content.post', message: { text } }));
+    const part = (message.parts || []).find((x) => x?.kind === "text");
+    const text = part?.text || "";
+    events.send(JSON.stringify({ type: "content.post", message: { text } }));
   });
 
   // If/when ENSO emits audio frames for TTS, forward them to browser
@@ -78,30 +106,49 @@ wss.on('connection', async (ws, req) => {
   // });
 
   // Minimal signaling
-  ws.send(JSON.stringify({ type: 'ready' }));
-  ws.on('message', async (raw) => {
+  ws.send(JSON.stringify({ type: "ready" }));
+  ws.on("message", async (raw) => {
     const msg = JSON.parse(String(raw));
-    if (msg.type === 'offer') {
-      await pc.setRemoteDescription({ type: 'offer', sdp: msg.sdp });
+    if (msg.type === "offer") {
+      await pc.setRemoteDescription({ type: "offer", sdp: msg.sdp });
       const answer = await pc.createAnswer();
       await pc.setLocalDescription(answer);
-      ws.send(JSON.stringify({ type: 'answer', sdp: answer.sdp }));
-    } else if (msg.type === 'ice') {
+      ws.send(JSON.stringify({ type: "answer", sdp: answer.sdp }));
+    } else if (msg.type === "ice") {
       await pc.addIceCandidate(msg.candidate);
-    } else if (msg.type === 'text') {
+    } else if (msg.type === "text") {
+      if (!(await ensureHandshake())) return;
       const room = `voice:${Date.now()}`;
-      await client.post({ id: crypto.randomUUID(), role: 'human', parts: [{ kind: 'text', text: msg.text }], when: Date.now() }, { room });
+      await client.post(
+        {
+          id: crypto.randomUUID(),
+          role: "human",
+          parts: [{ kind: "text", text: msg.text }],
+          when: Date.now(),
+        },
+        { room },
+      );
     }
   });
 
-  ws.on('close', async () => {
-    try { await handle.close(); } catch {}
-    try { pc.close(); } catch {}
+  ws.on("close", async () => {
+    try {
+      await handle.close();
+    } catch {}
+    try {
+      pc.close();
+    } catch {}
   });
 });
 
-server.listen(PORT, () => console.log('enso-browser-gateway listening on :' + PORT));
+server.listen(PORT, () =>
+  console.log("enso-browser-gateway listening on :" + PORT),
+);
 
 function parseIceServers(json) {
-  try { return json ? JSON.parse(json) : []; } catch { return []; }
+  try {
+    return json ? JSON.parse(json) : [];
+  } catch {
+    return [];
+  }
 }


### PR DESCRIPTION
## Summary
- add a handshake guard that enforces the ENSO-1 protocol, waits for readiness, and reports failures to the browser
- update the browser gateway to defer voice/text traffic until the ENSO handshake completes and surface failures over WebSocket
- document the error signalling semantics and add regression tests for slow and failed handshakes

## Testing
- node --test packages/enso-browser-gateway/src/handshake.test.mjs

------
https://chatgpt.com/codex/tasks/task_e_68dec9c309708324bd77ca618d1fcc1b