### PR TITLE
Gate ENSO clients on handshake readiness

### DIFF
--- a/packages/cephalon/src/enso/transcriber-enso.ts
+++ b/packages/cephalon/src/enso/transcriber-enso.ts
@@ -183,6 +183,16 @@ export class EnsoTranscriber extends Transcriber {
         await this.handshake;
       } catch {
         off();
+        const endTime = Date.now();
+        this.emit("transcriptEnd", {
+          startTime,
+          endTime,
+          speaker,
+          user: speaker.user as any,
+          userName: speaker.user.username,
+          transcript: "",
+          originalTranscript: "",
+        });
         if (typeof (capture as any)?.destroy === "function") {
           (capture as any).destroy();
         }

--- a/packages/cephalon/src/enso/transcriber-enso.ts
+++ b/packages/cephalon/src/enso/transcriber-enso.ts
@@ -108,6 +108,7 @@ export class EnsoTranscriber extends Transcriber {
   } | null = null;
   private readonly url: string;
   private readonly roomPrefix: string;
+  private readonly handshake: Promise<void>;
 
   constructor(opts: EnsoTranscriberOptions = {}) {
     // Provide a noop broker to avoid legacy broker wiring in base class
@@ -119,10 +120,15 @@ export class EnsoTranscriber extends Transcriber {
     this.client = new EnsoClient();
     // Connect immediately; throw if handshake fails
     const hello: HelloCaps = {
+      proto: "ENSO-1",
       caps: ["can.voice.stream", "can.send.text"],
       agent: { name: "cephalon-duck", version: "0.1.0" },
-    } as any;
+    };
     const handle = connectWebSocket(this.client, this.url, hello);
+    this.handshake = handle.ready.catch((error) => {
+      this.emit("error", error);
+      throw error;
+    });
     this.wsHandle = { close: handle.close };
   }
 
@@ -172,23 +178,38 @@ export class EnsoTranscriber extends Transcriber {
       emitEof: true,
     });
 
-    // Register stream for flow control bookkeeping
-    this.client.voice.register(streamId, 0);
-    void pumpAudioFrames(capture, (frame) =>
-      this.client.voice.sendFrame(frame, { room }),
-    ).catch((err) => {
-      // Non-fatal: emit an end with empty transcript if upstream fails
-      const endTime = Date.now();
-      this.emit("transcriptEnd", {
-        startTime,
-        endTime,
-        speaker,
-        user: speaker.user as any,
-        userName: speaker.user.username,
-        transcript: "",
-      });
-      console.error("ENSO voice pump error", err);
-    });
+    const startPump = async () => {
+      try {
+        await this.handshake;
+      } catch {
+        off();
+        if (typeof (capture as any)?.destroy === "function") {
+          (capture as any).destroy();
+        }
+        return;
+      }
+      // Register stream for flow control bookkeeping after handshake
+      this.client.voice.register(streamId, 0);
+      try {
+        await pumpAudioFrames(capture, (frame) =>
+          this.client.voice.sendFrame(frame, { room }),
+        );
+      } catch (err) {
+        // Non-fatal: emit an end with empty transcript if upstream fails
+        const endTime = Date.now();
+        this.emit("transcriptEnd", {
+          startTime,
+          endTime,
+          speaker,
+          user: speaker.user as any,
+          userName: speaker.user.username,
+          transcript: "",
+        });
+        console.error("ENSO voice pump error", err);
+      }
+    };
+
+    void startPump();
 
     return pcmStream;
   }

--- a/packages/cephalon/src/tests/enso-chat-agent.spec.ts
+++ b/packages/cephalon/src/tests/enso-chat-agent.spec.ts
@@ -1,21 +1,161 @@
-import test from 'ava';
-import { once } from 'node:events';
-import { createEnsoChatAgent } from '../enso/chat-agent.js';
+import test from "ava";
+import { once } from "node:events";
+import { randomUUID } from "node:crypto";
+import { Buffer } from "node:buffer";
+import { WebSocketServer } from "ws";
+import type WebSocket from "ws";
+
+import { createEnsoChatAgent } from "../enso/chat-agent.js";
+
+type Envelope<T = unknown> = {
+  id: string;
+  ts: string;
+  room: string;
+  from: string;
+  kind: "event" | "stream";
+  type: string;
+  payload: T;
+};
+
+type TransportFrame =
+  | { type: "hello"; payload: Record<string, unknown> }
+  | { type: "envelope"; payload: Envelope };
+
+const encodeFrame = (frame: TransportFrame) =>
+  JSON.stringify(frame, (_key, value) => {
+    if (value instanceof Uint8Array) {
+      return { __enso_binary__: Buffer.from(value).toString("base64") };
+    }
+    return value;
+  });
+
+const createEnvelope = <T>(input: {
+  kind: "event" | "stream";
+  type: string;
+  payload: T;
+  room?: string;
+  from?: string;
+}): Envelope<T> => ({
+  id: randomUUID(),
+  ts: new Date().toISOString(),
+  room: input.room ?? "server",
+  from: input.from ?? "enso-server",
+  kind: input.kind,
+  type: input.type,
+  payload: input.payload,
+});
 
 // smoke test: local loop, send & receive a chat message
 // uses connectLocal when no URL is provided
 
-test('EnsoChatAgent local echo', async (t) => {
-  const agent = createEnsoChatAgent({ room: 'duck:test' });
+test("EnsoChatAgent local echo", async (t) => {
+  const agent = createEnsoChatAgent({ room: "duck:test" });
   await agent.connect();
 
-  const p = once(agent as any, 'message');
-  await agent.sendText('human', 'ping');
-  const [evt] = (await Promise.race([p, new Promise((_, rej) => setTimeout(() => rej(new Error('timeout')), 2000))])) as any;
+  const p = once(agent as any, "message");
+  await agent.sendText("human", "ping");
+  const [evt] = (await Promise.race([
+    p,
+    new Promise((_, rej) => setTimeout(() => rej(new Error("timeout")), 2000)),
+  ])) as any;
 
-  t.truthy(evt?.type === 'message');
-  t.is(evt.message.parts[0].kind, 'text');
-  t.is(evt.message.parts[0].text, 'ping');
+  t.truthy(evt?.type === "message");
+  t.is(evt.message.parts[0].kind, "text");
+  t.is(evt.message.parts[0].text, "ping");
 
   await agent.dispose();
 });
+
+test.serial(
+  "EnsoChatAgent waits for privacy.accepted before sending envelopes",
+  async (t) => {
+    const server = new WebSocketServer({ port: 0 });
+
+    let address = server.address();
+    if (!address || typeof address === "string") {
+      await once(server, "listening");
+      address = server.address();
+    }
+
+    if (!address || typeof address === "string") {
+      t.fail("websocket server did not expose a usable port");
+      server.close();
+      return;
+    }
+
+    const frames: TransportFrame[] = [];
+    server.on("connection", (socket: WebSocket) => {
+      socket.on("message", (raw: Buffer | string) => {
+        const text = typeof raw === "string" ? raw : raw.toString();
+        frames.push(JSON.parse(text));
+      });
+    });
+
+    const agent = createEnsoChatAgent({
+      url: `ws://127.0.0.1:${address.port}`,
+    });
+
+    try {
+      const connectPromise = agent.connect();
+      const [socket] = (await once(server, "connection")) as [WebSocket];
+
+      await new Promise((resolve) => setImmediate(resolve));
+
+      t.deepEqual(
+        frames.map((frame) => frame.type),
+        ["hello"],
+      );
+      t.is(
+        frames.findIndex((frame) => frame.type === "envelope"),
+        -1,
+      );
+
+      const caps = ["can.send.text", "can.context.apply", "can.tool.call"];
+      const accepted = createEnvelope({
+        kind: "event",
+        type: "privacy.accepted",
+        payload: {
+          profile: "pseudonymous",
+          wantsE2E: false,
+          negotiatedCaps: caps,
+        },
+      });
+      const presence = createEnvelope({
+        kind: "event",
+        type: "presence.join",
+        payload: { session: "session-1", caps },
+      });
+
+      socket.send(encodeFrame({ type: "envelope", payload: accepted }));
+      socket.send(encodeFrame({ type: "envelope", payload: presence }));
+
+      await connectPromise;
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      await new Promise((resolve) => setImmediate(resolve));
+
+      const firstEnvelopeIndex = frames.findIndex(
+        (frame) => frame.type === "envelope",
+      );
+      t.true(firstEnvelopeIndex > 0);
+      t.is(
+        (frames[firstEnvelopeIndex] as any)?.payload?.type,
+        "tool.advertise",
+      );
+    } finally {
+      const handle = (agent as any).wsHandle;
+      if (handle && typeof handle.close === "function") {
+        const originalClose = handle.close.bind(handle);
+        handle.close = async (...args: unknown[]) => {
+          try {
+            await originalClose(...args);
+          } catch {
+            // ignore close errors during cleanup
+          }
+        };
+      }
+      await agent.dispose().catch(() => {});
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  },
+);


### PR DESCRIPTION
## Summary
- ensure the ENSO hello payload advertises proto "ENSO-1" and wait for the websocket handle to be ready before wiring chat tooling
- gate the transcriber handshake, persist the ready promise, and suppress audio streaming until privacy acceptance succeeds
- add an AVA test proving tool advertisement waits for `privacy.accepted` before transmitting envelopes

## Testing
- `pnpm --filter @promethean/cephalon build`
- `pnpm --filter @promethean/cephalon exec ava --config ../../config/ava.config.mjs dist/tests/enso-chat-agent.spec.js --node-arguments='--enable-source-maps' --match "EnsoChatAgent waits for privacy.accepted before sending envelopes"` *(fails: WebSocket closed before connection established)*
- `pnpm exec eslint packages/cephalon/src/enso/chat-agent.ts packages/cephalon/src/enso/transcriber-enso.ts packages/cephalon/src/tests/enso-chat-agent.spec.ts` *(fails: pre-existing lint violations)*

------
https://chatgpt.com/codex/tasks/task_e_68dec9c4a6348324a54de1c29684f5e6