### PR TITLE
Fix Kanban comment parsing to keep inline comments

### DIFF
--- a/changelog.d/2025.10.02.21.33.39.md
+++ b/changelog.d/2025.10.02.21.33.39.md
@@ -1,0 +1,1 @@
+- Fix Kanban parser to retain card text when other HTML comments appear before the id marker.

--- a/packages/markdown/src/kanban.ts
+++ b/packages/markdown/src/kanban.ts
@@ -143,7 +143,7 @@ const cloneCard = (card: Card): Card => ({
 const ensureId = (value: string | undefined): string => value ?? randomUUID();
 
 const parseCardLine = (body: string, isDone: boolean): { readonly card: Card; readonly hasInlineId: boolean } => {
-    const commentMatch = body.match(/([\s\S]*?)<!--\s*id:\s*([A-Za-z0-9._:-]+)\s*-->\s*$/u);
+    const commentMatch = body.match(/([\s\S]*)<!--\s*id:\s*([A-Za-z0-9._:-]+)\s*-->\s*$/u);
     const withoutComment = commentMatch ? commentMatch[1] ?? '' : body;
     const inlineId = commentMatch?.[2];
     const attrsMatch = withoutComment.match(/\{[^}]+\}\s*$/u);

--- a/packages/markdown/src/tests/kanban.test.ts
+++ b/packages/markdown/src/tests/kanban.test.ts
@@ -19,3 +19,15 @@ test('card attribute serialization escapes quotes and backslashes', async (t) =>
     const cards = reloaded.listCards('Todo');
     t.deepEqual(cards[0].attrs, attrs);
 });
+
+test('parsing cards keeps inline comments before id comment', async (t) => {
+    const markdown = ['## Todo', '- [ ] Example <!-- note --> details <!-- id: card-1 -->'].join('\n');
+    const board = await MarkdownBoard.load(markdown);
+    const cards = board.listCards('Todo');
+    t.is(cards.length, 1);
+    const card = cards[0]!;
+    t.is(card.id, 'card-1');
+    t.is(card.text, 'Example <!-- note --> details');
+    const roundTrip = await board.toMarkdown();
+    t.true(roundTrip.includes('Example <!-- note --> details <!-- id: card-1 -->'));
+});


### PR DESCRIPTION
## Summary
- update the Kanban parser to treat the id marker as trailing so earlier inline HTML comments stay in the card text
- add a regression test covering the scenario and document the change in the changelog

## Testing
- pnpm --filter @promethean/markdown test

------
https://chatgpt.com/codex/tasks/task_e_68deed44357483248e930f0ada73dcab