### PR TITLE
Refactor PCM16 helpers into shared duck-audio package

### DIFF
--- a/changelog.d/2025.02.15.12.00.00.md
+++ b/changelog.d/2025.02.15.12.00.00.md
@@ -1,0 +1,1 @@
+- Extracted shared PCM16 downmix utilities into `@promethean/duck-audio` and adopted them in Cephalon and Duck Web to keep clamp and decimation behavior aligned.

--- a/packages/cephalon/package.json
+++ b/packages/cephalon/package.json
@@ -59,7 +59,8 @@
     "wav": "^1.0.2",
     "wav-decoder": "^1.3.0",
     "ws": "^8.17.0",
-    "@promethean/security": "workspace:*"
+    "@promethean/security": "workspace:*",
+    "@promethean/duck-audio": "workspace:*"
   },
   "devDependencies": {
     "@promethean/broker": "workspace:*",

--- a/packages/cephalon/src/enso/transcriber-enso.ts
+++ b/packages/cephalon/src/enso/transcriber-enso.ts
@@ -15,6 +15,15 @@ import {
   type Envelope,
   type ChatMessage,
 } from "@promethean/enso-protocol";
+import {
+  PCM16_BYTES_PER_FRAME,
+  PCM16_FRAME_DURATION_MS,
+  PCM48_STEREO_CHANNELS,
+  PCM48_TO_16_DECIMATION,
+  SAMPLES_PER_DECIMATED_OUTPUT,
+  averageStereoFrame,
+  clampPcm16,
+} from "@promethean/duck-audio";
 
 /**
  * Downmix 48k stereo PCM16LE to 16k mono PCM16LE using simple box filter decimation (3:1).
@@ -37,7 +46,9 @@ export class ToPcm16kMono extends Transform {
     // Interpret as int16 samples
     const inSamplesTotal = this.carry.length + (chunk.length >>> 1);
     // Each stereo frame = 2 samples; 3 frames -> 6 samples -> 1 output sample
-    const usableSamples = Math.floor(inSamplesTotal / 6) * 6;
+    const usableSamples =
+      Math.floor(inSamplesTotal / SAMPLES_PER_DECIMATED_OUTPUT) *
+      SAMPLES_PER_DECIMATED_OUTPUT;
     // Merge carry + incoming into a single Int16Array view without extra copies when possible
     const incoming = new Int16Array(
       chunk.buffer,
@@ -53,26 +64,19 @@ export class ToPcm16kMono extends Transform {
       merged.set(incoming, this.carry.length);
     }
 
-    const outCount = Math.floor(usableSamples / 6);
+    const outCount = Math.floor(usableSamples / SAMPLES_PER_DECIMATED_OUTPUT);
     const out = new Int16Array(outCount);
     let oi = 0;
-    for (let i = 0; i < usableSamples; i += 6) {
-      // Three consecutive stereo frames: (L0,R0),(L1,R1),(L2,R2)
-      const l0 = merged[i] ?? 0;
-      const r0 = merged[i + 1] ?? 0;
-      const l1 = merged[i + 2] ?? 0;
-      const r1 = merged[i + 3] ?? 0;
-      const l2 = merged[i + 4] ?? 0;
-      const r2 = merged[i + 5] ?? 0;
-      // Downmix each to mono then average across 3 samples for crude LPF before decimation
-      const m0 = (l0 + r0) / 2;
-      const m1 = (l1 + r1) / 2;
-      const m2 = (l2 + r2) / 2;
-      let v = (m0 + m1 + m2) / 3;
-      // clamp to int16
-      if (v > 32767) v = 32767;
-      if (v < -32768) v = -32768;
-      out[oi++] = v | 0;
+    for (let i = 0; i < usableSamples; i += SAMPLES_PER_DECIMATED_OUTPUT) {
+      let monoAccumulator = 0;
+      for (let frame = 0; frame < PCM48_TO_16_DECIMATION; frame += 1) {
+        const base = i + frame * PCM48_STEREO_CHANNELS;
+        const left = merged[base] ?? 0;
+        const right = merged[base + 1] ?? 0;
+        monoAccumulator += averageStereoFrame(left, right);
+      }
+      const averaged = monoAccumulator / PCM48_TO_16_DECIMATION;
+      out[oi++] = clampPcm16(averaged);
     }
     // Save remainder into carry
     const rem = merged.length - usableSamples;
@@ -167,8 +171,8 @@ export class EnsoTranscriber extends Transcriber {
       stream: transformed,
       streamId,
       codec: "pcm16le/16000/1",
-      frameDurationMs: 20,
-      bytesPerFrame: 640,
+      frameDurationMs: PCM16_FRAME_DURATION_MS,
+      bytesPerFrame: PCM16_BYTES_PER_FRAME,
       emitEof: true,
     });
 

--- a/packages/cephalon/src/tests/enso/transcriber-enso.test.ts
+++ b/packages/cephalon/src/tests/enso/transcriber-enso.test.ts
@@ -1,5 +1,11 @@
 import test from "ava";
 
+import {
+  PCM16_MAX,
+  PCM16_MIN,
+  SAMPLES_PER_DECIMATED_OUTPUT,
+} from "@promethean/duck-audio";
+
 import { ToPcm16kMono } from "../../enso/transcriber-enso.js";
 
 function runThroughDownmix(samples: readonly number[]) {
@@ -24,9 +30,14 @@ function runThroughDownmix(samples: readonly number[]) {
 }
 
 test("ToPcm16kMono clamps extreme sample values without wrapping", async (t) => {
-  const negative = await runThroughDownmix(new Array(6).fill(-32768));
-  t.deepEqual([...negative], [-32768]);
+  const sampleCount = SAMPLES_PER_DECIMATED_OUTPUT;
+  const negative = await runThroughDownmix(
+    new Array(sampleCount).fill(PCM16_MIN),
+  );
+  t.deepEqual([...negative], [PCM16_MIN]);
 
-  const positive = await runThroughDownmix(new Array(6).fill(32767));
-  t.deepEqual([...positive], [32767]);
+  const positive = await runThroughDownmix(
+    new Array(sampleCount).fill(PCM16_MAX),
+  );
+  t.deepEqual([...positive], [PCM16_MAX]);
 });

--- a/packages/duck-audio/package.json
+++ b/packages/duck-audio/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@promethean/duck-audio",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "license": "GPL-3.0-only",
+  "main": "dist/index.js",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc --project tsconfig.json",
+    "clean": "rimraf dist tsconfig.tsbuildinfo"
+  }
+}

--- a/packages/duck-audio/project.json
+++ b/packages/duck-audio/project.json
@@ -1,0 +1,13 @@
+{
+  "name": "@promethean/duck-audio",
+  "sourceRoot": "packages/duck-audio/src",
+  "targets": {
+    "build": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm --filter @promethean/duck-audio run build"
+      }
+    }
+  },
+  "tags": []
+}

--- a/packages/duck-audio/src/index.ts
+++ b/packages/duck-audio/src/index.ts
@@ -1,0 +1,38 @@
+export const PCM16_MIN = -32768;
+export const PCM16_MAX = 32767;
+export const PCM16_SCALAR = 32767;
+
+export const PCM48_SAMPLE_RATE = 48_000;
+export const PCM16_SAMPLE_RATE = 16_000;
+export const PCM48_STEREO_CHANNELS = 2;
+export const PCM16_MONO_CHANNELS = 1;
+
+export const PCM48_TO_16_DECIMATION = PCM48_SAMPLE_RATE / PCM16_SAMPLE_RATE; // 3
+export const STEREO_FRAMES_PER_OUTPUT_SAMPLE = PCM48_TO_16_DECIMATION;
+export const SAMPLES_PER_DECIMATED_OUTPUT =
+  PCM48_STEREO_CHANNELS * PCM48_TO_16_DECIMATION; // 6 interleaved samples
+
+export const PCM16_FRAME_DURATION_MS = 20;
+export const PCM16_BYTES_PER_SAMPLE = 2;
+export const PCM16_BYTES_PER_FRAME =
+  (PCM16_SAMPLE_RATE * PCM16_FRAME_DURATION_MS * PCM16_BYTES_PER_SAMPLE) / 1000;
+
+export const clampPcm16 = (value: number): number => {
+  if (Number.isNaN(value)) return 0;
+  if (value <= PCM16_MIN) return PCM16_MIN;
+  if (value >= PCM16_MAX) return PCM16_MAX;
+  return value | 0;
+};
+
+export const averageStereoFrame = (left: number, right: number): number =>
+  (left + right) / PCM48_STEREO_CHANNELS;
+
+export const clampUnitFloat = (value: number): number => {
+  if (Number.isNaN(value)) return 0;
+  if (value <= -1) return -1;
+  if (value >= 1) return 1;
+  return value;
+};
+
+export const floatToPcm16 = (value: number): number =>
+  clampPcm16(clampUnitFloat(value) * PCM16_SCALAR);

--- a/packages/duck-audio/tsconfig.json
+++ b/packages/duck-audio/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../config/tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "composite": true,
+    "declaration": true
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/duck-web/package.json
+++ b/packages/duck-web/package.json
@@ -13,5 +13,8 @@
   "devDependencies": {
     "typescript": "^5.4.0",
     "vite": "^5.4.0"
+  },
+  "dependencies": {
+    "@promethean/duck-audio": "workspace:*"
   }
 }

--- a/packages/duck-web/src/wc/duck-chat.ts
+++ b/packages/duck-web/src/wc/duck-chat.ts
@@ -1,11 +1,22 @@
+import {
+  PCM48_STEREO_CHANNELS,
+  PCM48_TO_16_DECIMATION,
+  averageStereoFrame,
+  floatToPcm16,
+} from "@promethean/duck-audio";
+
 const identity = <T>(x: T) => x;
 
-const $ = (sel: string, root: ParentNode = document) => root.querySelector(sel) as HTMLElement | null;
+const $ = (sel: string, root: ParentNode = document) =>
+  root.querySelector(sel) as HTMLElement | null;
 const nowIso = () => new Date().toISOString();
 
 // --- Audio utilities -------------------------------------------------------
-const downsampleTo16kMono = async (source: MediaStream): Promise<ReadableStream<Uint8Array>> => {
-  const audioCtx = new (window.AudioContext || (window as any).webkitAudioContext)({ sampleRate: 48000 });
+const downsampleTo16kMono = async (
+  source: MediaStream,
+): Promise<ReadableStream<Uint8Array>> => {
+  const audioCtx = new (window.AudioContext ||
+    (window as any).webkitAudioContext)({ sampleRate: 48000 });
   const srcNode = audioCtx.createMediaStreamSource(source);
   const processor = audioCtx.createScriptProcessor(4096, 2, 1);
   srcNode.connect(processor);
@@ -18,17 +29,26 @@ const downsampleTo16kMono = async (source: MediaStream): Promise<ReadableStream<
         const r = e.inputBuffer.getChannelData(1) ?? l;
         // simple box decimation to 16k mono, 20ms frames => 320 samples/frame
         const samples: number[] = [];
-        for (let i = 0; i + 6 <= l.length; i += 6) {
-          const m0 = (l[i] + r[i]) / 2;
-          const m1 = (l[i + 2] + r[i + 2]) / 2;
-          const m2 = (l[i + 4] + r[i + 4]) / 2;
-          samples.push((m0 + m1 + m2) / 3);
+        const frameStride = PCM48_STEREO_CHANNELS;
+        const samplesPerOutput = PCM48_TO_16_DECIMATION * frameStride;
+        for (
+          let i = 0;
+          i + samplesPerOutput <= l.length;
+          i += samplesPerOutput
+        ) {
+          let monoAccumulator = 0;
+          for (let frame = 0; frame < PCM48_TO_16_DECIMATION; frame += 1) {
+            const base = i + frame * frameStride;
+            const left = l[base];
+            const right = r[base] ?? left;
+            monoAccumulator += averageStereoFrame(left, right);
+          }
+          samples.push(monoAccumulator / PCM48_TO_16_DECIMATION);
         }
-        // pack to PCM16 
+        // pack to PCM16
         const out = new Int16Array(samples.length);
         for (let i = 0; i < samples.length; i++) {
-          let v = Math.max(-1, Math.min(1, samples[i]));
-          out[i] = (v * 32767) | 0;
+          out[i] = floatToPcm16(samples[i]);
         }
         controller.enqueue(new Uint8Array(out.buffer));
       };
@@ -37,7 +57,7 @@ const downsampleTo16kMono = async (source: MediaStream): Promise<ReadableStream<
       processor.disconnect();
       srcNode.disconnect();
       audioCtx.close();
-    }
+    },
   });
 
   return reader;
@@ -45,13 +65,16 @@ const downsampleTo16kMono = async (source: MediaStream): Promise<ReadableStream<
 
 // Playback PCM16 mono 16k frames streamed over a RTCDataChannel labelled 'audio'
 const createPcmPlayer = () => {
-  const ctx = new (window.AudioContext || (window as any).webkitAudioContext)({ sampleRate: 16000 });
+  const ctx = new (window.AudioContext || (window as any).webkitAudioContext)({
+    sampleRate: 16000,
+  });
   let scheduled = ctx.currentTime;
   const scheduleFrame = (bytes: ArrayBuffer) => {
     const pcm = new Int16Array(bytes);
     const buf = ctx.createBuffer(1, pcm.length, 16000);
     const ch = buf.getChannelData(0);
-    for (let i = 0; i < pcm.length; i++) ch[i] = Math.max(-1, Math.min(1, pcm[i] / 32768));
+    for (let i = 0; i < pcm.length; i++)
+      ch[i] = Math.max(-1, Math.min(1, pcm[i] / 32768));
     const src = ctx.createBufferSource();
     src.buffer = buf;
     src.connect(ctx.destination);
@@ -64,7 +87,9 @@ const createPcmPlayer = () => {
 
 // --- WebRTC signaling over WebSocket --------------------------------------
 const connectSignaling = (url: string, token?: string) => {
-  const ws = new WebSocket(token ? `${url}?token=${encodeURIComponent(token)}` : url);
+  const ws = new WebSocket(
+    token ? `${url}?token=${encodeURIComponent(token)}` : url,
+  );
   const listeners = new Map<string, (msg: any) => void>();
   ws.onmessage = (ev) => {
     const msg = JSON.parse(String(ev.data));
@@ -72,8 +97,12 @@ const connectSignaling = (url: string, token?: string) => {
     if (fn) fn(msg);
   };
   return {
-    send: (type: string, data: any) => ws.readyState === 1 && ws.send(JSON.stringify({ type, ...data })),
-    on: (type: string, fn: (msg: any) => void) => { listeners.set(type, fn); return () => listeners.delete(type); },
+    send: (type: string, data: any) =>
+      ws.readyState === 1 && ws.send(JSON.stringify({ type, ...data })),
+    on: (type: string, fn: (msg: any) => void) => {
+      listeners.set(type, fn);
+      return () => listeners.delete(type);
+    },
     close: () => ws.close(),
   };
 };
@@ -108,15 +137,21 @@ export class DuckChat extends HTMLElement {
         <div class="log" id="log"></div>
       </section>`;
 
-    this.#log = $('#log', this) as HTMLElement;
-    $('#send', this)?.addEventListener('click', () => this.#sendText());
-    $('#mic', this)?.addEventListener('click', () => this.#toggleMic());
+    this.#log = $("#log", this) as HTMLElement;
+    $("#send", this)?.addEventListener("click", () => this.#sendText());
+    $("#mic", this)?.addEventListener("click", () => this.#toggleMic());
 
     // bootstrap connection immediately
-    const sigUrl = ($('#sig', this) as HTMLInputElement);
-    const token = ($('#token', this) as HTMLInputElement);
-    sigUrl.value ||= (location.protocol === 'https:' ? 'wss' : 'ws') + '://' + location.host.replace(/:\d+$/, ':8787') + '/ws';
-    this.#connect(sigUrl.value, token.value || undefined).catch((e) => this.#logLine('error: ' + e.message));
+    const sigUrl = $("#sig", this) as HTMLInputElement;
+    const token = $("#token", this) as HTMLInputElement;
+    sigUrl.value ||=
+      (location.protocol === "https:" ? "wss" : "ws") +
+      "://" +
+      location.host.replace(/:\d+$/, ":8787") +
+      "/ws";
+    this.#connect(sigUrl.value, token.value || undefined).catch((e) =>
+      this.#logLine("error: " + e.message),
+    );
   }
 
   disconnectedCallback() {
@@ -131,25 +166,27 @@ export class DuckChat extends HTMLElement {
       encodedInsertableStreams: false,
       iceServers: getIceServers(),
     });
-    this.#voice = this.#pc.createDataChannel('voice');
-    this.#voice.binaryType = 'arraybuffer';
+    this.#voice = this.#pc.createDataChannel("voice");
+    this.#voice.binaryType = "arraybuffer";
 
     // Handle server-created channels: 'events' (text) and 'audio' (pcm frames)
     this.#pc.ondatachannel = (ev) => {
-      if (ev.channel.label === 'events') {
+      if (ev.channel.label === "events") {
         ev.channel.onmessage = (mev) => {
           try {
             const msg = JSON.parse(String(mev.data));
-            if (msg.type === 'content.post' && msg.message) {
-              this.#logLine('duck: ' + msg.message.text);
-              const speak = ($('#speak', this) as HTMLInputElement)?.checked;
+            if (msg.type === "content.post" && msg.message) {
+              this.#logLine("duck: " + msg.message.text);
+              const speak = ($("#speak", this) as HTMLInputElement)?.checked;
               if (speak) this.#speak(msg.message.text);
             }
-          } catch (_) { /* noop */ }
+          } catch (_) {
+            /* noop */
+          }
         };
-      } else if (ev.channel.label === 'audio') {
+      } else if (ev.channel.label === "audio") {
         this.#player ||= createPcmPlayer();
-        ev.channel.binaryType = 'arraybuffer';
+        ev.channel.binaryType = "arraybuffer";
         ev.channel.onmessage = (mev) => {
           const bytes = mev.data as ArrayBuffer;
           this.#player!.scheduleFrame(bytes);
@@ -158,32 +195,35 @@ export class DuckChat extends HTMLElement {
     };
 
     // signaling
-    this.#sig.on('ready', async () => {
+    this.#sig.on("ready", async () => {
       const offer = await this.#pc!.createOffer();
       await this.#pc!.setLocalDescription(offer);
-      this.#sig!.send('offer', { sdp: offer.sdp });
+      this.#sig!.send("offer", { sdp: offer.sdp });
     });
-    this.#sig.on('answer', async ({ sdp }) => {
-      await this.#pc!.setRemoteDescription({ type: 'answer', sdp });
-      this.#logLine('webrtc connected');
+    this.#sig.on("answer", async ({ sdp }) => {
+      await this.#pc!.setRemoteDescription({ type: "answer", sdp });
+      this.#logLine("webrtc connected");
     });
-    this.#sig.on('ice', async ({ candidate }) => {
+    this.#sig.on("ice", async ({ candidate }) => {
       if (candidate) await this.#pc!.addIceCandidate(candidate);
     });
     this.#pc.onicecandidate = (ev) => {
-      if (ev.candidate) this.#sig!.send('ice', { candidate: ev.candidate });
+      if (ev.candidate) this.#sig!.send("ice", { candidate: ev.candidate });
     };
   }
 
   async #toggleMic() {
-    const micBtn = $('#mic', this)!;
-    const on = micBtn.getAttribute('aria-pressed') === 'true';
+    const micBtn = $("#mic", this)!;
+    const on = micBtn.getAttribute("aria-pressed") === "true";
     if (on) {
-      micBtn.setAttribute('aria-pressed', 'false');
-      this.#logLine('mic stopped');
+      micBtn.setAttribute("aria-pressed", "false");
+      this.#logLine("mic stopped");
       return;
     }
-    const media = await navigator.mediaDevices.getUserMedia({ audio: { channelCount: 2, sampleRate: 48000 }, video: false });
+    const media = await navigator.mediaDevices.getUserMedia({
+      audio: { channelCount: 2, sampleRate: 48000 },
+      video: false,
+    });
     const pcm = await downsampleTo16kMono(media);
     const writer = this.#voice!.send.bind(this.#voice);
 
@@ -194,8 +234,8 @@ export class DuckChat extends HTMLElement {
       writer(value.buffer);
       pump();
     };
-    micBtn.setAttribute('aria-pressed', 'true');
-    this.#logLine('mic started');
+    micBtn.setAttribute("aria-pressed", "true");
+    this.#logLine("mic started");
     pump();
   }
 
@@ -204,21 +244,23 @@ export class DuckChat extends HTMLElement {
       const u = new SpeechSynthesisUtterance(text);
       this.#tts.cancel();
       this.#tts.speak(u);
-    } catch (_) { /* ignore */ }
+    } catch (_) {
+      /* ignore */
+    }
   }
 
   #sendText() {
-    const el = $('#text', this) as HTMLTextAreaElement;
+    const el = $("#text", this) as HTMLTextAreaElement;
     const text = el.value.trim();
     if (!text) return;
-    this.#sig?.send('text', { text });
-    this.#logLine('you: ' + text);
-    el.value = '';
+    this.#sig?.send("text", { text });
+    this.#logLine("you: " + text);
+    el.value = "";
   }
 
   #logLine(line: string) {
     const el = this.#log!;
-    const p = document.createElement('div');
+    const p = document.createElement("div");
     p.textContent = `[${nowIso()}] ${line}`;
     el.appendChild(p);
     el.scrollTop = el.scrollHeight;
@@ -227,7 +269,7 @@ export class DuckChat extends HTMLElement {
 
 function getIceServers(): RTCIceServer[] {
   try {
-    const raw = localStorage.getItem('duck.iceServers');
+    const raw = localStorage.getItem("duck.iceServers");
     if (!raw) return [];
     return JSON.parse(raw);
   } catch {
@@ -235,4 +277,4 @@ function getIceServers(): RTCIceServer[] {
   }
 }
 
-customElements.define('duck-chat', DuckChat);
+customElements.define("duck-chat", DuckChat);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -506,6 +506,9 @@ importers:
       '@promethean/agent-ecs':
         specifier: workspace:*
         version: link:../agent-ecs
+      '@promethean/duck-audio':
+        specifier: workspace:*
+        version: link:../duck-audio
       '@promethean/embedding':
         specifier: workspace:*
         version: link:../embedding
@@ -1546,7 +1549,13 @@ importers:
         specifier: ^8.5.9
         version: 8.18.1
 
+  packages/duck-audio: {}
+
   packages/duck-web:
+    dependencies:
+      '@promethean/duck-audio':
+        specifier: workspace:*
+        version: link:../duck-audio
     devDependencies:
       typescript:
         specifier: ^5.4.0
@@ -2758,7 +2767,7 @@ importers:
     devDependencies:
       ava:
         specifier: ^6.4.1
-        version: 6.4.1(encoding@0.1.13)
+        version: 6.4.1(encoding@0.1.13)(rollup@4.52.3)
       nock:
         specifier: ^14.0.0
         version: 14.0.10


### PR DESCRIPTION
## Summary
- add a new `@promethean/duck-audio` workspace package that exports shared PCM16 clamp and decimation helpers
- update Cephalon's ENSO downmixer and tests to use the shared constants
- align Duck Web's browser downsampler with the shared helper logic

## Testing
- pnpm --filter @promethean/duck-audio run build
- pnpm --filter @promethean/cephalon test
- pnpm --filter @promethean/duck-web run build

------
https://chatgpt.com/codex/tasks/task_e_68dee4b242bc8324aaa26eb3acf0a654