### PR TITLE
Clarify report-forge input comments

### DIFF
--- a/changelog.d/2025.10.02.21.36.28.md
+++ b/changelog.d/2025.10.02.21.36.28.md
@@ -1,0 +1,1 @@
+- Clarified report-forge input comments to describe the repository slug and issue list expectations.

--- a/packages/report-forge/src/lib/types.ts
+++ b/packages/report-forge/src/lib/types.ts
@@ -11,7 +11,9 @@ export type Issue = {
 };
 
 export type ReportInput = {
-  repo: string; // e.g. 'riatzukiza/promethean'
+  /** GitHub repository slug in `owner/name` format. */
+  repo: string;
+  /** Issues to summarize, usually sourced from the GitHub REST API. */
   issues: readonly Issue[];
 };
 


### PR DESCRIPTION
## Summary
- clarify the report input type comments to explain the expected owner/name slug and issue source
- add a changelog entry capturing the comment clarification

## Testing
- pnpm --filter @promethean/report-forge test

------
https://chatgpt.com/codex/tasks/task_e_68deed47173c83249ee0787b338f2c57