### PR TITLE
feat: add codex request changes tool

### DIFF
--- a/changelog.d/2025.10.02.21.59.06.md
+++ b/changelog.d/2025.10.02.21.59.06.md
@@ -1,0 +1,2 @@
+## Added
+- Added an MCP tool to request Codex changes by tagging @codex in pull request comments.

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -26,6 +26,7 @@ import {
   githubReviewGetActionStatus,
   githubReviewGetComments,
   githubReviewGetReviewComments,
+  githubReviewRequestChangesFromCodex,
   githubReviewOpenPullRequest,
   githubReviewPush,
   githubReviewRevertCommits,
@@ -87,6 +88,10 @@ const toolCatalog = new Map<string, ToolFactory>([
   ["github.review.getComments", githubReviewGetComments],
   ["github.review.getReviewComments", githubReviewGetReviewComments],
   ["github.review.submitComment", githubReviewSubmitComment],
+  [
+    "github.review.requestChangesFromCodex",
+    githubReviewRequestChangesFromCodex,
+  ],
   ["github.review.submitReview", githubReviewSubmitReview],
   ["github.review.getActionStatus", githubReviewGetActionStatus],
   ["github.review.commit", githubReviewCommit],


### PR DESCRIPTION
## Summary
- add an MCP tool that files pull request comments requesting Codex changes and guarantees the @codex mention
- register the new tool in the MCP catalog
- cover the new workflow with a regression test and changelog entry

## Testing
- `pnpm --filter @promethean/mcp test`


------
https://chatgpt.com/codex/tasks/task_e_68def3026ee8832489ef69a222424e32