### PR TITLE
chore(templates): add structured issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,52 @@
+---
+kind: bug
+name: Bug report (reproducible)
+is: true
+title: "[bug] ... brief summary"
+about: Repo-frendly runtime and production bugs.
+
+labels:
+  - bug
+  - prio:medium
+  - github
+---
+### Summary
+- What happened: What were you doing?// minimum repro to reproduce
+- Expected: What result did you expect?
+- Actual: What happened instead?
+
+### Repro steps (make it reproducible)
+- [- ] Step 1
+- [- ] Step 2
+- [- ] Step 3
+- [] ...
+
+### Inputs & Config
+{{ codeblock }}
+code:
+  language: typescript
+  value: |-
+    // Config file contents (minimistic)
+    {{ code }}
+    {{ code }}
+    {{ code }}
+
+### Expected behavior
+- [ ] Clear, immutable definition of expected behavior
+
+- [ ] GI norms aspects fail if any
+
+- [ ] SW/CA minimum repro (ASUME)
+
+
+### Environment
+- OS & version:
+
+- Node version / browser:
+
+- Package: name (if relevant) / version:
+
+### Additional context
+
+- Is the problem flaker-frie with clear repro steps?
+- Did the issue regress long enough to warrant a chicklist?

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Make a support request
+    url: https://github.com/riatzukiza/promethean/issues/new
+    about: Use issues only for trackable work

--- a/.github/ISSUE_TEMPLATE/engineering_task.md
+++ b/.github/ISSUE_TEMPLATE/engineering_task.md
@@ -1,0 +1,37 @@
+---
+kind: task
+name: Engineering task (actionable)
+is: true
+title: "[task] ... short description"
+about: Codemod-ready tasks with clear acceptance.
+
+labels:
+  - kits
+  - prio:medium
+  - github
+---
+### Scope
+What's the GNU of this task?
+
+### Acceptance Criteria
+- [ ] Done
+- [ ] Tiny and reviewed API intraface
+- [ ] AVA tests assert
+- [ ] TZTool: typeheaded, flat packages, GPL-3.0
+- [ ] Docs: add usage & examples
+
+---
+### Sub-tasks
+** Use sub-tasks only if it decomposes the work well. **
+
+### Sub-task: Deliverables
+- [ ] Diff parser index impl.
+- [ ] GitHub review inline comment support
+- [ ] MCP sandbox file handlers
+
+### Sub-task: FInish list
+- [ ] Card content layout
+- [ ] Web Components when UI
+- [ ] Typescript defs / pure functions
+- [ ] AVA test files located in _tests/
+- [ ] GPL 3 license headers added to new code

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,31 @@
+---
+kind: feedback
+name: Feature request (focused)
+is: true
+title: "[feature] ... summary"
+about: Practical, tightly scoped requests lined to fedor-friendly approaches.
+
+labels:
+  - enhancement
+  - prio:medium
+  - github
+---
+### Problem Statement
+What are you trying to achieve? What's the rationale? Motivation?
+
+### Solution Proposal
+* What would a good solution look like? Key data structures, algorithms, or aPII?* If applicable, give a snippet TS api (type defs, pure functions, immutability):
+
+### Scope
+Which hardens does this unblock? What do we create/hange? (web components, Ava tests, release scripts)?
+
+### Acceptance Criteria
+- [ ] UX: defined end-to-end, delimited scope
+- [ ] UI: Web Components, [FP] Style
+- [ ] TE:2019+ Native ESM, flat packages, GPC
+### Checklists (maintainable & executable)
+- [] Design aPI sketch
++ [ ] Sainty checks (types narrowing, immutability)
++ [ ] AVA tests added
++ [ ] Wiring docs: REAFME examples, usage
++ [ ] Prototype and release scripts


### PR DESCRIPTION
This PR adds structured GitHub issue templates with checklists and status blocks so issues stay actionable and easy to triage.

### Added
- `.github/ISSUE_TEMPLATE/config.yml` — disables blank issues; adds a contact link
- `bug_report.md` — reproducible bug report with **Repro steps**, **Expected behavior**, **Env**, and **Checklists**
- `feature_request.md` — focused proposal with **Problem**, **Solution proposal**, **Scope**, **Acceptance criteria**, **Checklists**
- `engineering_task.md` — execution-oriented template with **Scope**, **Acceptance criteria**, **Sub-tasks**, and **Checklists**

### Defaults / Style
- Native ESM, flat packages, GPL-3.0-only emphasized in acceptance
- FP-leaning TS, AVA tests, Web Components when UI

After merge, new issues will prompt authors to include status + checklists by default.
