### PR TITLE
Address feedback for pcm16k worklet contract

### DIFF
--- a/apps/duck-web/public/pcm16k-worklet.js
+++ b/apps/duck-web/public/pcm16k-worklet.js
@@ -28,10 +28,7 @@ class PCM16kProcessor extends AudioWorkletProcessor {
       out[n] = end > start ? sum / (end - start) : 0;
     }
 
-    this.pos += outLen * r;
-    if (this.pos >= input.length) {
-      this.pos -= input.length;
-    }
+    this.pos = (this.pos + outLen * r) % input.length;
 
     this.port.postMessage(out);
     return true;

--- a/apps/duck-web/src/mic.ts
+++ b/apps/duck-web/src/mic.ts
@@ -7,9 +7,10 @@ type MicHandle = { stop: () => Promise<void>; ctx: AudioContext };
 /**
  * Wire the AudioWorklet-based microphone capture pipeline.
  *
- * The `pcm16k` worklet emits 16 kHz mono Float32 frames, which are converted to
- * signed 16-bit PCM samples before invoking the callback with a monotonic
- * timestamp from `performance.now()`.
+ * The `pcm16k` worklet emits 16 kHz mono Float32 frames (chunk size may vary,
+ * but frames are sequential with no gaps), which are converted to signed
+ * 16-bit PCM samples before invoking the callback with a monotonic timestamp
+ * from `performance.now()`.
  */
 export const startMic = async (onPcm: OnPcm): Promise<MicHandle> => {
   const ctx = new AudioContext({ sampleRate: 48000 });
@@ -26,6 +27,7 @@ export const startMic = async (onPcm: OnPcm): Promise<MicHandle> => {
     }
 
     const pcm = float32ToInt16(floatBuffer);
+    // TODO: consider queueing if onPcm is slow to avoid dropping frames.
     onPcm(pcm, performance.now());
   };
 


### PR DESCRIPTION
## Summary
- clamp the pcm16k worklet's fractional read position with modulo to avoid long-run drift
- document the 16 kHz mono Float32 -> PCM16 contract in the microphone glue and note future backpressure handling

## Testing
- pnpm exec eslint apps/duck-web/src/mic.ts apps/duck-web/public/pcm16k-worklet.js *(fails: file excluded from tsconfig project)*

------
https://chatgpt.com/codex/tasks/task_e_68def7ff7c208324b9dbcffee36ddd9c