### PR TITLE
test(web): guard ws protocols

### DIFF
--- a/apps/duck-web/src/net/ws.test.ts
+++ b/apps/duck-web/src/net/ws.test.ts
@@ -1,0 +1,32 @@
+import test from "ava";
+import { openWs, protocolsForBearer, type WsFactory } from "./ws";
+
+test("protocolsForBearer omits bearer subprotocol when token is missing", (t) => {
+  t.deepEqual(protocolsForBearer(undefined), ["duck.v1"]);
+  t.deepEqual(protocolsForBearer("   "), ["duck.v1"]);
+});
+
+test("protocolsForBearer trims bearer token and appends subprotocol", (t) => {
+  t.deepEqual(protocolsForBearer("  tok  "), ["duck.v1", "bearer.tok"]);
+});
+
+test("openWs forwards computed protocols to the WebSocket factory", (t) => {
+  const calls: Array<string[] | string | undefined> = [];
+  const mkWs: WsFactory = (_url, protocols) => {
+    calls.push(
+      Array.isArray(protocols)
+        ? [...protocols]
+        : protocols === undefined
+          ? undefined
+          : [protocols],
+    );
+    return {} as unknown as WebSocket;
+  };
+
+  const connect = openWs(mkWs);
+  connect("wss://duck.example");
+  connect("wss://duck.example", "  tok  ");
+
+  t.deepEqual(calls[0], ["duck.v1"]);
+  t.deepEqual(calls[1], ["duck.v1", "bearer.tok"]);
+});

--- a/apps/duck-web/src/net/ws.ts
+++ b/apps/duck-web/src/net/ws.ts
@@ -2,9 +2,14 @@ export type WsFactory = (
   url: string,
   protocols?: string | string[],
 ) => WebSocket;
+export const protocolsForBearer = (bearer?: string): string[] => {
+  const token = (bearer ?? "").trim();
+  return ["duck.v1", ...(token.length > 0 ? [`bearer.${token}`] : [])];
+};
+
 export const openWs =
   (mkWs: WsFactory = (u, p) => new WebSocket(u, p)) =>
   (url: string, bearer?: string) => {
-    const protocols = ["duck.v1", ...(bearer ? [`bearer.${bearer}`] : [])];
+    const protocols = protocolsForBearer(bearer);
     return mkWs(url, protocols);
   };

--- a/changelog.d/2025.10.02.22.38.16.md
+++ b/changelog.d/2025.10.02.22.38.16.md
@@ -1,0 +1,1 @@
+- Guarded empty bearer tokens when constructing WebSocket subprotocols and added coverage verifying the protocol list for `openWs`.


### PR DESCRIPTION
## Summary
- Open WebSocket with subprotocols (e.g. "duck.v1", "bearer.<token>") instead of query-string auth.
- Trim bearer tokens before building the subprotocol list, expose the helper for assertions, and guard empty inputs.
- Add Ava coverage that asserts the protocol selection with and without bearer tokens and log the change in the changelog fragment.

## Testing
- pnpm exec ava apps/duck-web/src/net/ws.test.ts *(fails: command "ava" not found in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68def7abec1083249220ceb40f501962