### PR TITLE
feat(mcp): decode github base64 payloads automatically

### DIFF
--- a/changelog.d/2025.10.03.04.09.00.md
+++ b/changelog.d/2025.10.03.04.09.00.md
@@ -1,0 +1,1 @@
+- Ensure GitHub MCP tools automatically decode base64 payloads in responses and remove manual base64 handling from callers.

--- a/packages/mcp/src/tests/github-request.test.ts
+++ b/packages/mcp/src/tests/github-request.test.ts
@@ -1,0 +1,54 @@
+import test from "ava";
+
+import { githubRequestTool } from "../tools/github/request.js";
+
+test("github_request decodes base64 encoded content payloads", async (t) => {
+  const rawContent = Buffer.from("console.log('hi');", "utf8")
+    .toString("base64")
+    .replace(/(.{8})/g, "$1\n");
+  const response = new Response(
+    JSON.stringify({
+      name: "index.ts",
+      path: "src/index.ts",
+      encoding: "base64",
+      content: rawContent,
+    }),
+    {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    },
+  );
+
+  const tool = githubRequestTool({
+    env: {
+      GITHUB_BASE_URL: "https://api.github.test",
+      GITHUB_API_VERSION: "2022-11-28",
+      GITHUB_TOKEN: "secret",
+    },
+    fetch: (async () => response.clone()) as typeof fetch,
+    now: () => new Date(),
+  });
+
+  const result = (await tool.invoke({
+    method: "GET",
+    path: "/repos/promethean/mcp/contents/src/index.ts",
+  })) as {
+    status: number;
+    data: {
+      content: string;
+      rawContent: string;
+      encoding: string;
+      rawEncoding: string;
+    };
+  };
+
+  t.is(result.status, 200);
+  t.deepEqual(result.data, {
+    name: "index.ts",
+    path: "src/index.ts",
+    content: "console.log('hi');",
+    rawContent,
+    encoding: "utf-8",
+    rawEncoding: "base64",
+  });
+});

--- a/packages/mcp/src/tools/github/base64.ts
+++ b/packages/mcp/src/tools/github/base64.ts
@@ -1,0 +1,85 @@
+const BASE64_ENCODING = "base64";
+const UTF8_ENCODING = "utf-8";
+const whitespacePattern = /\s+/g;
+const base64Pattern =
+  /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/;
+
+type GithubPayload =
+  | ReadonlyArray<GithubPayload>
+  | Readonly<Record<string, unknown>>
+  | string
+  | number
+  | boolean
+  | null
+  | undefined;
+
+type GithubBase64Node = Readonly<{
+  readonly encoding: string;
+  readonly content: string;
+}>;
+
+const stripWhitespace = (value: string): string =>
+  value.replace(whitespacePattern, "");
+
+const normalizeBase64String = (value: string): string =>
+  Buffer.from(value, "base64").toString("base64").replace(/=+$/, "");
+
+const isValidBase64 = (value: string): boolean =>
+  base64Pattern.test(value) &&
+  normalizeBase64String(value) === value.replace(/=+$/, "");
+
+const isRecord = (value: unknown): value is Readonly<Record<string, unknown>> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const isGithubBase64Node = (
+  value: Readonly<Record<string, unknown>>,
+): value is GithubBase64Node =>
+  typeof value.encoding === "string" &&
+  value.encoding.toLowerCase() === BASE64_ENCODING &&
+  typeof value.content === "string";
+
+const decodeBase64Content = (
+  value: GithubBase64Node,
+): Readonly<Record<string, unknown>> => {
+  const normalized = stripWhitespace(value.content);
+  if (!isValidBase64(normalized)) {
+    return value;
+  }
+  const buffer = Buffer.from(normalized, "base64");
+  return {
+    ...value,
+    encoding: UTF8_ENCODING,
+    rawEncoding: value.encoding,
+    rawContent: value.content,
+    content: buffer.toString("utf8"),
+  } as const;
+};
+
+const transformNode = (value: GithubPayload): GithubPayload => {
+  if (Array.isArray(value)) {
+    const items = value as ReadonlyArray<GithubPayload>;
+    return items.map((item) => transformNode(item)) as readonly GithubPayload[];
+  }
+  if (isRecord(value)) {
+    const entries = Object.entries(value) as ReadonlyArray<
+      readonly [string, GithubPayload]
+    >;
+    const transformedEntries = entries.map(
+      ([key, entry]) => [key, transformNode(entry)] as const,
+    );
+    const transformed = Object.fromEntries(transformedEntries) as Readonly<
+      Record<string, unknown>
+    >;
+    if (isGithubBase64Node(transformed)) {
+      return decodeBase64Content(transformed);
+    }
+    return transformed;
+  }
+  return value;
+};
+
+export const normalizeGithubPayload = <T>(value: T): T =>
+  transformNode(value as GithubPayload) as T;
+
+export const isBase64String = (value: string): boolean =>
+  isValidBase64(stripWhitespace(value));

--- a/packages/mcp/src/tools/github/request.ts
+++ b/packages/mcp/src/tools/github/request.ts
@@ -1,108 +1,217 @@
 import { z } from "zod";
-import type { ToolFactory } from "../../core/types.js";
+import type { ReadonlyDeep } from "type-fest";
+
+import type { ToolContext, ToolFactory } from "../../core/types.js";
+
+import { normalizeGithubPayload } from "./base64.js";
+
+const shape = {
+  method: z.enum(["GET", "POST", "PUT", "PATCH", "DELETE"]),
+  path: z.string(),
+  query: z.record(z.any()).optional(),
+  headers: z.record(z.string()).optional(),
+  body: z.any().optional(),
+  paginate: z.boolean().optional(),
+  perPage: z.number().int().positive().max(1000).optional(),
+  maxPages: z.number().int().positive().max(100).optional(),
+} as const;
+
+const Schema = z.object(shape);
+
+type GithubRequestArgs = ReadonlyDeep<z.infer<typeof Schema>>;
+
+type GithubResponse = Readonly<{
+  readonly status: number;
+  readonly headers: Readonly<Record<string, string>>;
+  readonly data: unknown;
+}>;
+
+const parseTextPayload = async (text: string): Promise<unknown> =>
+  text.length === 0
+    ? null
+    : await Promise.resolve()
+        .then(() => JSON.parse(text) as unknown)
+        .catch(() => text);
+
+const toHeadersRecord = (headers: Headers): Readonly<Record<string, string>> =>
+  Object.fromEntries(headers);
+
+const storeCacheBody = async ({
+  ctx,
+  key,
+  etag,
+  text,
+}: Readonly<{
+  readonly ctx: ToolContext;
+  readonly key: string;
+  readonly etag: string;
+  readonly text: string;
+}>): Promise<void> => {
+  if (!ctx.cache) {
+    return;
+  }
+  const encoded = new TextEncoder().encode(text);
+  await Promise.all([
+    ctx.cache.etagSet(key, etag),
+    ctx.cache.setBody(key, encoded),
+  ]);
+};
+
+const readCachedBody = async ({
+  ctx,
+  key,
+}: Readonly<{ readonly ctx: ToolContext; readonly key: string }>): Promise<
+  GithubResponse | undefined
+> => {
+  if (!ctx.cache) {
+    return undefined;
+  }
+  const body = await ctx.cache.getBody(key);
+  if (!body) {
+    return undefined;
+  }
+  const cached = JSON.parse(new TextDecoder().decode(body)) as unknown;
+  return {
+    status: 200,
+    headers: {},
+    data: normalizeGithubPayload(cached),
+  };
+};
+
+const buildHeaders = (
+  token: string | undefined,
+  apiVersion: string,
+  overrides: Readonly<Record<string, string>> | undefined,
+): Readonly<Record<string, string>> => ({
+  Accept: "application/vnd.github+json",
+  "X-GitHub-Api-Version": apiVersion,
+  ...(token ? { Authorization: `Bearer ${token}` } : {}),
+  ...(overrides ?? {}),
+});
+
+type FetchSingleOptions = ReadonlyDeep<{
+  readonly ctx: ToolContext;
+  readonly args: GithubRequestArgs;
+  readonly url: string;
+  readonly headers: Readonly<Record<string, string>>;
+  readonly cacheKey: string;
+}>;
+
+const fetchSingle = async (
+  options: FetchSingleOptions,
+): Promise<GithubResponse> => {
+  const { ctx, args, url, headers, cacheKey } = options;
+  const response = await ctx.fetch(url, {
+    method: args.method,
+    headers,
+    body: args.body ? JSON.stringify(args.body) : undefined,
+  } as RequestInit);
+
+  if (response.status === 304) {
+    const cached = await readCachedBody({ ctx, key: cacheKey });
+    return cached ?? { status: 304, headers: {}, data: null };
+  }
+
+  const text = await response.text();
+  if (response.ok && ctx.cache && args.method === "GET") {
+    const etag = response.headers.get("etag");
+    if (etag) {
+      await storeCacheBody({ ctx, key: cacheKey, etag, text });
+    }
+  }
+
+  const data = await parseTextPayload(text);
+  return {
+    status: response.status,
+    headers: toHeadersRecord(response.headers),
+    data: normalizeGithubPayload(data),
+  };
+};
+
+type FetchPageOptions = ReadonlyDeep<{
+  readonly ctx: ToolContext;
+  readonly url: string;
+  readonly headers: Readonly<Record<string, string>>;
+  readonly per: number;
+  readonly max: number;
+  readonly page: number;
+  readonly acc: ReadonlyArray<unknown>;
+}>;
+
+const fetchPageSequence = async (
+  options: FetchPageOptions,
+): Promise<unknown> => {
+  const { ctx, url, headers, per, max, page, acc } = options;
+  if (page > max) {
+    return acc;
+  }
+  const pageUrl = new URL(url);
+  pageUrl.searchParams.set("per_page", String(per));
+  pageUrl.searchParams.set("page", String(page));
+  const response = await ctx.fetch(pageUrl, {
+    method: "GET",
+    headers,
+  } as RequestInit);
+  const text = await response.text();
+  const parsed = await parseTextPayload(text);
+  const normalized = normalizeGithubPayload(parsed);
+  if (!Array.isArray(normalized) || response.status >= 400) {
+    return { page, status: response.status, data: normalized };
+  }
+  const nextAcc = acc.concat(normalized);
+  if (normalized.length < per) {
+    return nextAcc;
+  }
+  return fetchPageSequence({
+    ctx,
+    url,
+    headers,
+    per,
+    max,
+    page: page + 1,
+    acc: nextAcc,
+  });
+};
 
 export const githubRequestTool: ToolFactory = (ctx) => {
   const base = ctx.env.GITHUB_BASE_URL ?? "https://api.github.com";
   const apiVer = ctx.env.GITHUB_API_VERSION ?? "2022-11-28";
   const token = ctx.env.GITHUB_TOKEN;
 
-  // Define SHAPE for the SDK and SCHEMA for runtime parsing
-  const shape = {
-    method: z.enum(["GET", "POST", "PUT", "PATCH", "DELETE"]),
-    path: z.string(),
-    query: z.record(z.any()).optional(),
-    headers: z.record(z.string()).optional(),
-    body: z.any().optional(),
-    paginate: z.boolean().optional(),
-    perPage: z.number().int().positive().max(1000).optional(),
-    maxPages: z.number().int().positive().max(100).optional(),
-  } as const;
-  const Schema = z.object(shape);
-
   const spec = {
     name: "github_request",
     description: "Call GitHub REST API with optional ETag cache & pagination.",
-    inputSchema: shape, // <— ZodRawShape
+    inputSchema: shape,
   } as const;
 
   const invoke = async (raw: unknown) => {
     const args = Schema.parse(raw);
-    const url = new URL(args.path, base);
-    const q = args.query ?? {};
-    Object.entries(q).forEach(([k, v]) => url.searchParams.set(k, String(v)));
+    const baseUrl = new URL(args.path, base);
+    const entries = Object.entries(args.query ?? {}) as ReadonlyArray<
+      readonly [string, unknown]
+    >;
+    entries.forEach(([key, value]) => {
+      baseUrl.searchParams.set(key, String(value));
+    });
+    const url = baseUrl.toString();
+    const headers = buildHeaders(token, apiVer, args.headers);
+    const cacheKey = `rest:${url}`;
 
-    const headers: Record<string, string> = {
-      Accept: "application/vnd.github+json",
-      "X-GitHub-Api-Version": apiVer,
-      ...(token ? { Authorization: `Bearer ${token}` } : {}),
-      ...(args.headers ?? {}),
-    };
-
-    const cacheKey = `rest:${url.toString()}`;
-
-    const doFetch = async () => {
-      const res = await ctx.fetch(url, {
-        method: args.method,
+    if (args.paginate) {
+      const per = args.perPage ?? 100;
+      const max = args.maxPages ?? 1;
+      return fetchPageSequence({
+        ctx,
+        url,
         headers,
-        body: args.body ? JSON.stringify(args.body) : undefined,
-      } as RequestInit);
-
-      if (res.status === 304 && ctx.cache) {
-        const body = await ctx.cache.getBody(cacheKey);
-        if (!body) return { status: 304, headers: {}, data: null };
-        return {
-          status: 200,
-          headers: {},
-          data: JSON.parse(new TextDecoder().decode(body)),
-        };
-      }
-
-      const text = await res.text();
-      const etag = res.headers.get("etag") ?? undefined;
-      if (res.ok && ctx.cache && etag && args.method === "GET") {
-        await ctx.cache.etagSet(cacheKey, etag);
-        await ctx.cache.setBody(cacheKey, new TextEncoder().encode(text));
-      }
-
-      let data: unknown;
-      try {
-        data = text ? JSON.parse(text) : null;
-      } catch {
-        data = text;
-      }
-      return {
-        status: res.status,
-        headers: Object.fromEntries(res.headers),
-        data,
-      };
-    };
-
-    if (!args.paginate) return doFetch();
-
-    const per = args.perPage ?? 100;
-    const max = args.maxPages ?? 1;
-    url.searchParams.set("per_page", String(per));
-
-    const pages: unknown[] = [];
-    for (let page = 1; page <= max; page++) {
-      url.searchParams.set("page", String(page));
-      const res = await ctx.fetch(url, {
-        method: "GET",
-        headers,
-      } as RequestInit);
-      const text = await res.text();
-      let data: unknown;
-      try {
-        data = text ? JSON.parse(text) : null;
-      } catch {
-        data = text;
-      }
-      if (!Array.isArray(data) || res.status >= 400)
-        return { page, status: res.status, data };
-      pages.push(...data);
-      if ((data as unknown[]).length < per) break;
+        per,
+        max,
+        page: 1,
+        acc: [],
+      });
     }
-    return pages;
+
+    return fetchSingle({ ctx, args, url, headers, cacheKey });
   };
 
   return { spec, invoke };


### PR DESCRIPTION
## Summary
- add a shared GitHub base64 normalizer and apply it to the REST request and contents tools so clients receive decoded payloads
- extend the contents and request tests to cover automatic base64 handling and document the change in the changelog

## Testing
- pnpm --filter @promethean/mcp test
- pnpm exec eslint packages/mcp/src/tools/github/base64.ts packages/mcp/src/tools/github/contents.ts packages/mcp/src/tools/github/request.ts packages/mcp/src/tests/github-contents.test.ts packages/mcp/src/tests/github-request.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68df45e6ffb08324ba3250fa23a41850