### PR TITLE
test: cover github.apply_patch failures

### DIFF
--- a/changelog.d/2025.10.03.04.56.47.md
+++ b/changelog.d/2025.10.03.04.56.47.md
@@ -1,0 +1,1 @@
+- add apply_patch failure coverage and export input schema for consumers


### PR DESCRIPTION
## Summary
- add a github.apply_patch MCP tool that commits unified diffs to GitHub branches using the createCommitOnBranch mutation
- register the tool in the MCP registry and document it alongside existing GitHub helpers
- cover the new tool with tests for file additions and edits via mocked GitHub responses
- export the compiled github.apply_patch input schema and cover deletions-only and failure scenarios

## Testing
- pnpm --filter @promethean/mcp test

------
https://chatgpt.com/codex/tasks/task_e_68df54deeab8832481bc9a6fad0f4df9