### PR TITLE
feat(mcp): add workflow log tools

### DIFF
--- a/changelog.d/2024.04.12.19.58.00.md
+++ b/changelog.d/2024.04.12.19.58.00.md
@@ -1,0 +1,1 @@
+- Updated GitHub workflow log tools to return decoded text content instead of base64 archives.

--- a/changelog.d/2025.10.03.06.05.53.md
+++ b/changelog.d/2025.10.03.06.05.53.md
@@ -1,0 +1,2 @@
+- Added GitHub Actions workflow run and job log retrieval tools to the MCP server with archive decoding support.
+- Documented and tested the workflow log tools, including structured extraction of ZIP archives.

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -39,6 +39,7 @@
     "@promethean/discord": "workspace:*",
     "fast-check": "^3.23.2",
     "fastify": "5.0.0",
+    "fflate": "^0.8.2",
     "jsedn": "0.4.1",
     "minimatch": "^9.0.5",
     "uuid": "9.0.1",

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -25,6 +25,10 @@ import { githubGraphqlTool } from "./tools/github/graphql.js";
 import { githubRateLimitTool } from "./tools/github/rate-limit.js";
 import { githubContentsWrite } from "./tools/github/contents.js";
 import {
+  githubWorkflowGetJobLogs,
+  githubWorkflowGetRunLogs,
+} from "./tools/github/workflows.js";
+import {
   githubReviewCheckoutBranch,
   githubReviewCommit,
   githubReviewCreateBranch,
@@ -95,6 +99,8 @@ const toolCatalog = new Map<string, ToolFactory>([
   ["github.graphql", githubGraphqlTool],
   ["github.rate-limit", githubRateLimitTool],
   ["github.contents.write", githubContentsWrite],
+  ["github.workflow.getRunLogs", githubWorkflowGetRunLogs],
+  ["github.workflow.getJobLogs", githubWorkflowGetJobLogs],
   ["github.review.openPullRequest", githubReviewOpenPullRequest],
   ["github.review.getComments", githubReviewGetComments],
   ["github.review.getReviewComments", githubReviewGetReviewComments],

--- a/packages/mcp/src/tests/github-workflow.test.ts
+++ b/packages/mcp/src/tests/github-workflow.test.ts
@@ -15,7 +15,6 @@ const buildResponse = (body: ReadonlyDeep<Uint8Array>): Response =>
 
 type WorkflowLogResult = Readonly<{
   readonly archiveSize: number;
-  readonly archiveBase64: string;
   readonly fileCount: number;
   readonly files: ReadonlyArray<{
     readonly path: string;
@@ -28,7 +27,6 @@ type WorkflowLogResult = Readonly<{
 // eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
 const runRunLogsTest = async ({
   is,
-  true: assertTrue,
   deepEqual,
 }: ReadonlyDeep<ExecutionContext>) => {
   const archive = zipSync({
@@ -63,7 +61,6 @@ const runRunLogsTest = async ({
     runId: 42,
   })) as WorkflowLogResult;
   is(result.archiveSize, archive.byteLength);
-  assertTrue(result.archiveBase64.length > 0);
   is(result.fileCount, 1);
   deepEqual(result.files, [
     {

--- a/packages/mcp/src/tests/github-workflow.test.ts
+++ b/packages/mcp/src/tests/github-workflow.test.ts
@@ -1,0 +1,125 @@
+import test, { type ExecutionContext } from "ava";
+import type { ReadonlyDeep } from "type-fest";
+import { strToU8, zipSync } from "fflate";
+
+import {
+  githubWorkflowGetJobLogs,
+  githubWorkflowGetRunLogs,
+} from "../tools/github/workflows.js";
+
+const buildResponse = (body: ReadonlyDeep<Uint8Array>): Response =>
+  new Response(body, {
+    status: 200,
+    headers: { "content-type": "application/zip" },
+  });
+
+type WorkflowLogResult = Readonly<{
+  readonly archiveSize: number;
+  readonly archiveBase64: string;
+  readonly fileCount: number;
+  readonly files: ReadonlyArray<{
+    readonly path: string;
+    readonly size: number;
+    readonly lineCount: number;
+    readonly content: string;
+  }>;
+}>;
+
+// eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
+const runRunLogsTest = async ({
+  is,
+  true: assertTrue,
+  deepEqual,
+}: ReadonlyDeep<ExecutionContext>) => {
+  const archive = zipSync({
+    "logs/1_initialize.txt": strToU8("hello\nworld"),
+  });
+  const fetchStub = (async (
+    input: ReadonlyDeep<Parameters<typeof fetch>[0]>,
+    init?: ReadonlyDeep<Parameters<typeof fetch>[1]>,
+  ) => {
+    const url = typeof input === "string" ? input : String(input);
+    is(
+      url,
+      "https://api.github.test/repos/promethean/mcp/actions/runs/42/logs",
+    );
+    const headers = (init?.headers ?? {}) as Readonly<Record<string, string>>;
+    is(headers["Authorization"], "Bearer secret");
+    return buildResponse(archive).clone();
+  }) satisfies typeof fetch;
+  const tool = githubWorkflowGetRunLogs({
+    env: {
+      GITHUB_BASE_URL: "https://api.github.test",
+      GITHUB_API_VERSION: "2022-11-28",
+      GITHUB_TOKEN: "secret",
+    },
+    fetch: fetchStub,
+    now: () => new Date(),
+  });
+
+  const result = (await tool.invoke({
+    owner: "promethean",
+    repo: "mcp",
+    runId: 42,
+  })) as WorkflowLogResult;
+  is(result.archiveSize, archive.byteLength);
+  assertTrue(result.archiveBase64.length > 0);
+  is(result.fileCount, 1);
+  deepEqual(result.files, [
+    {
+      path: "logs/1_initialize.txt",
+      size: 11,
+      lineCount: 2,
+      content: "hello\nworld",
+    },
+  ]);
+};
+
+// eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
+const runJobLogsTest = async ({
+  is,
+  deepEqual,
+}: ReadonlyDeep<ExecutionContext>) => {
+  const archive = zipSync({
+    "logs/2_run-tests.txt": strToU8("ok\n"),
+  });
+  const fetchStub = (async (
+    input: ReadonlyDeep<Parameters<typeof fetch>[0]>,
+  ) => {
+    const url = typeof input === "string" ? input : String(input);
+    is(
+      url,
+      "https://api.github.test/repos/promethean/mcp/actions/jobs/987654/logs",
+    );
+    return buildResponse(archive).clone();
+  }) satisfies typeof fetch;
+  const tool = githubWorkflowGetJobLogs({
+    env: {
+      GITHUB_BASE_URL: "https://api.github.test",
+    },
+    fetch: fetchStub,
+    now: () => new Date(),
+  });
+
+  const result = (await tool.invoke({
+    owner: "promethean",
+    repo: "mcp",
+    jobId: "987654",
+  })) as {
+    fileCount: number;
+    files: ReadonlyArray<{ path: string; content: string }>;
+  };
+
+  is(result.fileCount, 1);
+  deepEqual(result.files, [
+    {
+      path: "logs/2_run-tests.txt",
+      size: 3,
+      lineCount: 2,
+      content: "ok\n",
+    },
+  ]);
+};
+
+test("github.workflow.getRunLogs returns extracted run logs", runRunLogsTest);
+test("github.workflow.getJobLogs returns extracted job logs", runJobLogsTest);

--- a/packages/mcp/src/tools/github/workflows.ts
+++ b/packages/mcp/src/tools/github/workflows.ts
@@ -26,7 +26,6 @@ type GithubLogFile = Readonly<{
 
 type GithubLogArchive = Readonly<{
   readonly archiveSize: number;
-  readonly archiveBase64: string;
   readonly fileCount: number;
   readonly files: readonly GithubLogFile[];
 }>;
@@ -111,7 +110,6 @@ const fetchLogArchive = async (
   const files = await decodeLogArchive(buffer);
   return {
     archiveSize: buffer.byteLength,
-    archiveBase64: Buffer.from(buffer).toString("base64"),
     fileCount: files.length,
     files,
   } as const;

--- a/packages/mcp/src/tools/github/workflows.ts
+++ b/packages/mcp/src/tools/github/workflows.ts
@@ -1,0 +1,182 @@
+import { strFromU8, unzipSync } from "fflate";
+import { z } from "zod";
+import type { ReadonlyDeep } from "type-fest";
+
+import type { ToolContext, ToolFactory } from "../../core/types.js";
+
+const DEFAULT_API_VERSION = "2022-11-28";
+const DEFAULT_BASE_URL = "https://api.github.com";
+
+const IdSchema = z.union([
+  z.number().int().nonnegative(),
+  z
+    .string()
+    .trim()
+    .regex(/^[0-9]+$/, "must be a numeric identifier"),
+]);
+
+type Identifier = z.infer<typeof IdSchema>;
+
+type GithubLogFile = Readonly<{
+  readonly path: string;
+  readonly size: number;
+  readonly lineCount: number;
+  readonly content: string;
+}>;
+
+type GithubLogArchive = Readonly<{
+  readonly archiveSize: number;
+  readonly archiveBase64: string;
+  readonly fileCount: number;
+  readonly files: readonly GithubLogFile[];
+}>;
+
+type GithubRequestDeps = ReadonlyDeep<{
+  readonly fetch: ToolContext["fetch"];
+  readonly headers: Readonly<Record<string, string>>;
+  readonly url: string;
+}>;
+
+const buildGithubHeaders = (
+  env: ToolContext["env"],
+): Readonly<Record<string, string>> => {
+  const token = env.GITHUB_TOKEN;
+  const apiVersion = env.GITHUB_API_VERSION ?? DEFAULT_API_VERSION;
+  const baseHeaders = {
+    Accept: "application/vnd.github+json",
+    "X-GitHub-Api-Version": apiVersion,
+  } as const;
+  return token
+    ? { ...baseHeaders, Authorization: `Bearer ${token}` }
+    : baseHeaders;
+};
+
+const toIdString = (value: Identifier): string =>
+  typeof value === "number" ? value.toString(10) : value;
+
+const toGithubUrl = (base: string, path: string): string =>
+  new URL(path, base).toString();
+
+const countLines = (content: string): number => {
+  if (content.length === 0) {
+    return 0;
+  }
+  const normalized = content.replace(/\r\n/g, "\n");
+  return normalized.split("\n").length;
+};
+
+const decodeLogArchive = async (
+  archive: ReadonlyDeep<Uint8Array>,
+): Promise<readonly GithubLogFile[]> =>
+  Promise.resolve(archive)
+    .then((buffer) => unzipSync(buffer))
+    .then((files) =>
+      Object.entries(files).map(([path, bytes]) => {
+        const content = strFromU8(bytes);
+        return {
+          path,
+          size: bytes.byteLength,
+          lineCount: countLines(content),
+          content,
+        } as const;
+      }),
+    )
+    .catch((error) => {
+      throw new Error(
+        "[github.workflow] Failed to unzip workflow logs archive",
+        { cause: error },
+      );
+    });
+
+const fetchLogArchive = async (
+  deps: GithubRequestDeps,
+): Promise<GithubLogArchive> => {
+  const response = await deps.fetch(deps.url, {
+    method: "GET",
+    headers: deps.headers,
+  });
+
+  if (!response.ok) {
+    const body = await response
+      .text()
+      .catch(() => "<unable to read response body>");
+    throw new Error(
+      `[github.workflow] Failed to download workflow logs (${
+        response.status
+      }): ${body.slice(0, 500)}`,
+    );
+  }
+
+  const buffer = new Uint8Array(await response.arrayBuffer());
+  const files = await decodeLogArchive(buffer);
+  return {
+    archiveSize: buffer.byteLength,
+    archiveBase64: Buffer.from(buffer).toString("base64"),
+    fileCount: files.length,
+    files,
+  } as const;
+};
+
+export const githubWorkflowGetRunLogs: ToolFactory = (ctx) => {
+  const shape = {
+    owner: z.string().trim().min(1),
+    repo: z.string().trim().min(1),
+    runId: IdSchema,
+  } as const;
+  const Schema = z.object(shape);
+
+  return {
+    spec: {
+      name: "github.workflow.getRunLogs",
+      description:
+        "Download and extract the log files for a GitHub Actions workflow run.",
+      inputSchema: shape,
+    },
+    invoke: async (raw: unknown) => {
+      const args = Schema.parse(raw);
+      const base = ctx.env.GITHUB_BASE_URL ?? DEFAULT_BASE_URL;
+      const runId = toIdString(args.runId);
+      const url = toGithubUrl(
+        base,
+        `/repos/${args.owner}/${args.repo}/actions/runs/${runId}/logs`,
+      );
+      return fetchLogArchive({
+        fetch: ctx.fetch,
+        headers: buildGithubHeaders(ctx.env),
+        url,
+      });
+    },
+  } as const;
+};
+
+export const githubWorkflowGetJobLogs: ToolFactory = (ctx) => {
+  const shape = {
+    owner: z.string().trim().min(1),
+    repo: z.string().trim().min(1),
+    jobId: IdSchema,
+  } as const;
+  const Schema = z.object(shape);
+
+  return {
+    spec: {
+      name: "github.workflow.getJobLogs",
+      description:
+        "Download and extract the log files for a GitHub Actions workflow job.",
+      inputSchema: shape,
+    },
+    invoke: async (raw: unknown) => {
+      const args = Schema.parse(raw);
+      const base = ctx.env.GITHUB_BASE_URL ?? DEFAULT_BASE_URL;
+      const jobId = toIdString(args.jobId);
+      const url = toGithubUrl(
+        base,
+        `/repos/${args.owner}/${args.repo}/actions/jobs/${jobId}/logs`,
+      );
+      return fetchLogArchive({
+        fetch: ctx.fetch,
+        headers: buildGithubHeaders(ctx.env),
+        url,
+      });
+    },
+  } as const;
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2736,6 +2736,9 @@ importers:
       fastify:
         specifier: 5.0.0
         version: 5.0.0
+      fflate:
+        specifier: ^0.8.2
+        version: 0.8.2
       jsedn:
         specifier: 0.4.1
         version: 0.4.1
@@ -8414,6 +8417,9 @@ packages:
   fetch-blob@3.2.0:
     resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
     engines: {node: ^12.20 || >= 14.13}
+
+  fflate@0.8.2:
+    resolution: {integrity: sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==}
 
   figures@3.2.0:
     resolution: {integrity: sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==}
@@ -14656,7 +14662,7 @@ snapshots:
 
   axios@1.11.0:
     dependencies:
-      follow-redirects: 1.15.11(debug@4.3.7)
+      follow-redirects: 1.15.11(debug@4.4.3)
       form-data: 4.0.4
       proxy-from-env: 1.1.0
     transitivePeerDependencies:
@@ -16720,6 +16726,8 @@ snapshots:
       node-domexception: 1.0.0
       web-streams-polyfill: 3.3.3
 
+  fflate@0.8.2: {}
+
   figures@3.2.0:
     dependencies:
       escape-string-regexp: 1.0.5
@@ -17179,7 +17187,7 @@ snapshots:
   http-proxy@1.18.1:
     dependencies:
       eventemitter3: 4.0.7
-      follow-redirects: 1.15.11(debug@4.3.7)
+      follow-redirects: 1.15.11(debug@4.4.3)
       requires-port: 1.0.0
     transitivePeerDependencies:
       - debug


### PR DESCRIPTION
## Summary
- add GitHub workflow run and job log tools that download archives and return decoded file contents
- cover the new tools with unit tests that verify URL construction and log extraction logic
- add the fflate dependency for ZIP handling and document the feature in the changelog

## Testing
- pnpm --filter @promethean/mcp test
- pnpm exec eslint packages/mcp/src/tools/github/workflows.ts
- pnpm exec eslint packages/mcp/src/tests/github-workflow.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68df62443e288324bbee23b974d50e05