### PR TITLE
fix: wire mcp.help to registry context and sanitize config paths

### DIFF
--- a/packages/mcp/config/mcp_servers.edn
+++ b/packages/mcp/config/mcp_servers.edn
@@ -1,21 +1,21 @@
 {:mcp-servers
  {:github
-  {:command "/home/err/devel/promethean/scripts/mcp/bin/github.sh"}
+ {:command "${HOME}/devel/promethean/scripts/mcp/bin/github.sh"}
 
   :github-chat
-  {:command "/home/err/devel/promethean/scripts/mcp/bin/github_chat.sh"}
+ {:command "${HOME}/devel/promethean/scripts/mcp/bin/github_chat.sh"}
 
   :sonarqube
-  {:command "/home/err/devel/promethean/scripts/mcp/bin/sonarqube.sh"}
+ {:command "${HOME}/devel/promethean/scripts/mcp/bin/sonarqube.sh"}
 
   :file-system
-  {:command "/home/err/devel/promethean/scripts/mcp/bin/filesystem.sh"}
+ {:command "${HOME}/devel/promethean/scripts/mcp/bin/filesystem.sh"}
 
   :obsidian
-  {:command "/home/err/devel/promethean/scripts/mcp/bin/obsidian.sh"}
+ {:command "${HOME}/devel/promethean/scripts/mcp/bin/obsidian.sh"}
 
   :duckduckgo
-  {:command "/home/err/devel/promethean/scripts/mcp/bin/duck.sh"}
+ {:command "${HOME}/devel/promethean/scripts/mcp/bin/duck.sh"}
 
   :npm-helper
   {:command "npx"
@@ -37,7 +37,7 @@
   {:command "npx"
    :args ["tritlo/lsp-mcp"
           "typescript"
-          "/home/err/.volta/bin/typescript-language-server"
+          "${HOME}/.volta/bin/typescript-language-server"
           "--stdio"]}
 
   :serena
@@ -49,21 +49,21 @@
    :args ["haiku-rag"
           "serve"
           "--stdio"
-          "--db" "/home/err/.local/share/haiku-rag"]}
+          "--db" "${HOME}/.local/share/haiku-rag"]}
   }
 
  :outputs
- [{:schema :codex.toml  :path "/home/err/.codex/config.toml"}
-  {:schema :vscode.json :path "/home/err/.config/User/mcp.json"
+ [{:schema :codex.toml  :path "${HOME}/.codex/config.toml"}
+  {:schema :vscode.json :path "${HOME}/.config/User/mcp.json"
    :opts {:include-inputs? true}}
-  {:schema :codex.json :path "/home/err/.codeium/windsurf/mcp_config.json"}
+  {:schema :codex.json :path "${HOME}/.codeium/windsurf/mcp_config.json"}
 
   ;; Oterm
-  {:schema :codex.json :path "/home/err/.local/share/oterm/config.json"}
+  {:schema :codex.json :path "${HOME}/.local/share/oterm/config.json"}
 
   ;; Emacs MCP package
   ;; doesn't work right.
   ;; we added a thing to parse emacs code with tree sitter to directly manipulate the
   ;; s-expressions instead of  handling strings.
   ;; we should use it.
-  {:schema :elisp       :path "/home/err/devel/promethean/.emacs/layers/llm/config.el"}]}
+  {:schema :elisp       :path "${HOME}/devel/promethean/.emacs/layers/llm/config.el"}]}

--- a/packages/mcp/src/core/registry.ts
+++ b/packages/mcp/src/core/registry.ts
@@ -4,10 +4,15 @@ export const buildRegistry = (
   factories: readonly ToolFactory[],
   ctx: ToolContext,
 ) => {
-  const tools: readonly Tool[] = factories.map((f) => f(ctx));
+  const list = (): readonly Tool[] => tools;
+  const ctxWithRegistry: ToolContext = {
+    ...ctx,
+    listTools: list,
+  };
+  const tools: readonly Tool[] = factories.map((f) => f(ctxWithRegistry));
   const byName = new Map(tools.map((t) => [t.spec.name, t]));
   return Object.freeze({
-    list: () => tools,
+    list,
     get: (name: string) => byName.get(name),
   });
 };

--- a/packages/mcp/src/core/types.ts
+++ b/packages/mcp/src/core/types.ts
@@ -1,16 +1,8 @@
 import type { ZodRawShape } from "zod";
 
-// Tool context carried into each factory - env, fetch, now, and optional cache hooks.
-export type ToolContext = Readonly<{
-  env: Readonly<Record<string, string | undefined>>;
-  fetch: typeof fetch;
-  now: () => Date;
-  cache?: Readonly<{
-    etagGet: (key: string) => Promise<string | undefined>;
-    etagSet: (key: string, etag: string) => Promise<void>;
-    getBody: (key: string) => Promise<Uint8Array | undefined>;
-    setBody: (key: string, body: Uint8Array) => Promise<void>;
-  }>;
+export type ToolExample = Readonly<{
+  args: Readonly<Record<string, unknown>>;
+  comment?: string;
 }>;
 
 // Piece of metadata about a tool. These feed straight into the agent ui:
@@ -26,7 +18,7 @@ export type ToolSpec = Readonly<{
   inputSchema?: ZodRawShape;
   outputSchema?: ZodRawShape;
   // New: agent-facing hints.
-  examples?: ReadonlyArray<{ args: unknown; comment?: string }>;
+  examples?: ReadonlyArray<ToolExample>;
   notes?: string;
 }>;
 
@@ -34,6 +26,20 @@ export type ToolSpec = Readonly<{
 export type Tool = Readonly<{
   spec: ToolSpec;
   invoke: (args: unknown) => Promise<unknown>;
+}>;
+
+// Tool context carried into each factory - env, fetch, now, and optional cache hooks.
+export type ToolContext = Readonly<{
+  env: Readonly<Record<string, string | undefined>>;
+  fetch: typeof fetch;
+  now: () => Date;
+  cache?: Readonly<{
+    etagGet: (key: string) => Promise<string | undefined>;
+    etagSet: (key: string, etag: string) => Promise<void>;
+    getBody: (key: string) => Promise<Uint8Array | undefined>;
+    setBody: (key: string, body: Uint8Array) => Promise<void>;
+  }>;
+  listTools?: () => readonly Tool[];
 }>;
 
 // Factory that creates a tool given the runtime context.

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -165,7 +165,9 @@ const mkCtx = () => ({
 
 // Ensure the help tool is available within any registry subset, unless explicitly omitted.
 const ensureHelp = (ids: readonly string[]): readonly string[] =>
-  toolCatalog.has("mcp.help") && !ids.includes("mcp.help") ? [...ids, "mcp.help"] : ids;
+  toolCatalog.has("mcp.help") && !ids.includes("mcp.help")
+    ? [...ids, "mcp.help"]
+    : ids;
 
 const selectFactories = (toolIds: readonly string[]): readonly ToolFactory[] =>
   toolIds
@@ -282,7 +284,6 @@ export const main = async (): Promise<void> => {
       httpConfig.endpoints.map((endpoint) => {
         const factories = selectFactories(ensureHelp(endpoint.tools));
         const registry = buildRegistry(factories, ctx);
-        (ctx as any).__registryList = () => registry.list();
         return {
           path: endpoint.path,
           kind: "registry" as const,
@@ -328,7 +329,6 @@ export const main = async (): Promise<void> => {
   const toolIds = ensureHelp(resolveStdioTools(cfg));
   const factories = selectFactories(toolIds);
   const registry = buildRegistry(factories, ctx);
-  (ctx as any).__registryList = () => registry.list();
   const server = createMcpServer(registry.list());
   const transport = stdioTransport();
   console.log("[mcp] transport = stdio");

--- a/packages/mcp/src/tools/help.ts
+++ b/packages/mcp/src/tools/help.ts
@@ -1,22 +1,32 @@
-import type { ToolFactory } from "../core/types.js";
+import type { ToolExample, ToolFactory, ToolSpec } from "../core/types.js";
+
+type HelpToolEntry = Readonly<{
+  name: string;
+  description: string;
+  inputSchema: ToolSpec["inputSchema"] | null;
+  outputSchema: ToolSpec["outputSchema"] | null;
+  examples: ReadonlyArray<ToolExample>;
+  notes: string;
+}>;
 
 export const help: ToolFactory = (ctx) => {
   const spec = {
     name: "mcp.help",
-    description: "List available tools with args, defaults, outputs, and examples.",
+    description:
+      "List available tools with args, defaults, outputs, and examples.",
     inputSchema: {},
-    outputSchema: { tools: {} } as any,
+    outputSchema: {},
   } as const;
 
   const invoke = async () => {
-    const list = (ctx as any).__registryList?.() ?? [];
-    const tools = list.map((t: any) => ({
-      name: t.spec.name,
-      description: t.spec.description,
-      inputSchema: t.spec.inputSchema ?? null,
-      outputSchema: t.spec.outputSchema ?? null,
-      examples: t.spec.examples ?? [],
-      notes: t.spec.notes ?? "",
+    const registry = ctx.listTools?.() ?? [];
+    const tools: readonly HelpToolEntry[] = registry.map((tool) => ({
+      name: tool.spec.name,
+      description: tool.spec.description,
+      inputSchema: tool.spec.inputSchema ?? null,
+      outputSchema: tool.spec.outputSchema ?? null,
+      examples: tool.spec.examples ?? [],
+      notes: tool.spec.notes ?? "",
     }));
     return { tools };
   };


### PR DESCRIPTION
## Summary
- expose the registry list through ToolContext so mcp.help can enumerate tools without unsafe casts
- remove the manual __registryList mutation in index.ts and tighten help.ts typing for tool metadata
- replace hard-coded absolute paths in the MCP server config with ${HOME}-relative strings for portability

## Testing
- pnpm exec tsc -p packages/mcp/tsconfig.json --noEmit
- pnpm --filter @promethean/mcp lint *(fails: existing lint violations in untouched files)*

------
https://chatgpt.com/codex/tasks/task_e_68df6ad32b948324993ca774a68d23e1