### PR TITLE
Add agents workflow package

### DIFF
--- a/changelog.d/2025.10.03.06.33.23.md
+++ b/changelog.d/2025.10.03.06.33.23.md
@@ -1,0 +1,1 @@
+- add @promethean/agents-workflow package with markdown-driven agent workflows, OpenAI/Ollama providers, and initial tests

--- a/packages/agents-workflow/ava.config.mjs
+++ b/packages/agents-workflow/ava.config.mjs
@@ -1,0 +1,1 @@
+export { default } from "../../config/ava.config.mjs";

--- a/packages/agents-workflow/package.json
+++ b/packages/agents-workflow/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "@promethean/agents-workflow",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "main": "dist/index.cjs",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    },
+    "./*": "./dist/*"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "clean": "rimraf dist",
+    "typecheck": "tsc -p tsconfig.json",
+    "test": "pnpm run build && ava",
+    "lint": "pnpm exec eslint .",
+    "coverage": "pnpm run build && c8 ava",
+    "format": "pnpm exec prettier --write ."
+  },
+  "dependencies": {
+    "@openai/agents": "^0.1.9",
+    "ollama": "^0.5.17",
+    "remark-parse": "11.0.0",
+    "unified": "11.0.5",
+    "unist-util-visit": "5.0.0",
+    "zod": "^3.25.0"
+  },
+  "devDependencies": {
+    "@promethean/test-utils": "workspace:*"
+  },
+  "license": "GPL-3.0-only"
+}

--- a/packages/agents-workflow/src/index.ts
+++ b/packages/agents-workflow/src/index.ts
@@ -1,0 +1,38 @@
+export type {
+  AgentDefinition,
+  AgentFactoryOptions,
+  AgentGraphNode,
+  AgentWorkflowGraph,
+  MarkdownWorkflowDocument,
+  MarkdownWorkflowOptions,
+  ModelReference,
+  ModelResolverMap,
+  ToolDefinition,
+  WorkflowDefinition,
+  WorkflowEdge,
+  WorkflowNode,
+} from "./workflow/types.js";
+export {
+  AgentDefinitionSchema,
+  ModelReferenceSchema,
+  ToolDefinitionSchema,
+} from "./workflow/types.js";
+export { parseMarkdownWorkflows } from "./workflow/markdown.js";
+export {
+  resolveWorkflowDefinitions,
+  createAgentWorkflowGraph,
+  type DefinitionResolutionOptions,
+} from "./workflow/loader.js";
+export {
+  loadAgentWorkflowsFromMarkdown,
+  type WorkflowRuntimeOptions,
+} from "./runtime.js";
+export {
+  createOpenAIModelProvider,
+  registerOpenAIDefaultModelProvider,
+} from "./providers/openai.js";
+export {
+  createOllamaModelProvider,
+  OllamaModelProvider,
+  type OllamaModelProviderOptions,
+} from "./providers/ollama.js";

--- a/packages/agents-workflow/src/providers/ollama.ts
+++ b/packages/agents-workflow/src/providers/ollama.ts
@@ -1,0 +1,353 @@
+import { randomUUID } from "node:crypto";
+
+import {
+  Usage,
+  assistant,
+  type AgentInputItem,
+  type AssistantMessageItem,
+  type Model,
+  type ModelProvider,
+  type ModelRequest,
+  type ModelResponse,
+  type StreamEvent,
+  type SystemMessageItem,
+  type UserMessageItem,
+} from "@openai/agents";
+import {
+  Ollama as OllamaClient,
+  type ChatRequest,
+  type ChatResponse,
+  type Message,
+  type Tool as OllamaTool,
+} from "ollama";
+
+interface OllamaClientLike {
+  chat(
+    request: ChatRequest & { stream: true },
+  ): Promise<AsyncIterable<ChatResponse>>;
+  chat(request: ChatRequest & { stream?: false }): Promise<ChatResponse>;
+}
+
+export interface OllamaModelProviderOptions {
+  host?: string;
+  defaultModel?: string;
+  client?: OllamaClientLike;
+  requestOptions?: Partial<Omit<ChatRequest, "model" | "messages" | "stream">>;
+}
+
+function isMessageItem(
+  item: AgentInputItem,
+): item is AssistantMessageItem | SystemMessageItem | UserMessageItem {
+  return typeof (item as { role?: unknown }).role === "string";
+}
+
+function flattenEntries(entries: ReadonlyArray<unknown>): string {
+  return entries
+    .map((entry) => {
+      if (!entry || typeof entry !== "object") {
+        return typeof entry === "string" ? entry : "";
+      }
+      if (
+        "text" in (entry as Record<string, unknown>) &&
+        typeof (entry as { text?: unknown }).text === "string"
+      ) {
+        return (entry as { text: string }).text;
+      }
+      if (
+        "refusal" in (entry as Record<string, unknown>) &&
+        typeof (entry as { refusal?: unknown }).refusal === "string"
+      ) {
+        return (entry as { refusal: string }).refusal;
+      }
+      return JSON.stringify(entry);
+    })
+    .filter((segment) => segment.length > 0)
+    .join("\n");
+}
+
+function toMessageContent(
+  item: AssistantMessageItem | SystemMessageItem | UserMessageItem,
+): string {
+  const { content } = item as { content: unknown };
+  if (typeof content === "string") {
+    return content;
+  }
+  if (Array.isArray(content)) {
+    return flattenEntries(content);
+  }
+  return "";
+}
+
+function convertInputToMessages(request: ModelRequest): Message[] {
+  const messages: Message[] = [];
+  if (request.systemInstructions) {
+    messages.push({ role: "system", content: request.systemInstructions });
+  }
+  if (typeof request.input === "string") {
+    messages.push({ role: "user", content: request.input });
+    return messages;
+  }
+  for (const item of request.input) {
+    if (!isMessageItem(item)) {
+      throw new Error(
+        `Ollama provider only supports message conversation items. Unsupported item: ${JSON.stringify(
+          item,
+        )}`,
+      );
+    }
+    messages.push({ role: item.role, content: toMessageContent(item) });
+  }
+  return messages;
+}
+
+function normalizeJsonSchema(
+  schema: unknown,
+): Record<string, unknown> | undefined {
+  if (!schema) {
+    return undefined;
+  }
+  const plain = JSON.parse(JSON.stringify(schema)) as Record<string, unknown>;
+  const required = plain.required;
+  if (Array.isArray(required)) {
+    plain.required = required.map((value) => value.toString());
+  }
+  return plain;
+}
+
+function convertTools(tools: ModelRequest["tools"]): OllamaTool[] | undefined {
+  if (!tools || tools.length === 0) {
+    return undefined;
+  }
+  const result: OllamaTool[] = [];
+  for (const tool of tools) {
+    if (tool.type !== "function") {
+      continue;
+    }
+    result.push({
+      type: "function",
+      function: {
+        name: tool.name,
+        description: tool.description,
+        parameters: normalizeJsonSchema(tool.parameters),
+      },
+    });
+  }
+  return result.length > 0 ? result : undefined;
+}
+
+function convertSettings(
+  settings: ModelRequest["modelSettings"],
+): ChatRequest["options"] | undefined {
+  if (!settings) {
+    return undefined;
+  }
+  const options: Record<string, unknown> = {};
+  if (typeof settings.temperature === "number") {
+    options.temperature = settings.temperature;
+  }
+  if (typeof settings.topP === "number") {
+    options.top_p = settings.topP;
+  }
+  if (typeof settings.frequencyPenalty === "number") {
+    options.repeat_penalty = settings.frequencyPenalty;
+  }
+  if (typeof settings.presencePenalty === "number") {
+    options.presence_penalty = settings.presencePenalty;
+  }
+  if (typeof settings.maxTokens === "number") {
+    options.num_predict = settings.maxTokens;
+  }
+  return Object.keys(options).length > 0
+    ? (options as ChatRequest["options"])
+    : undefined;
+}
+
+function toUsage(response: ChatResponse | undefined): Usage {
+  const inputTokens = response?.prompt_eval_count ?? 0;
+  const outputTokens = response?.eval_count ?? 0;
+  return new Usage({
+    requests: 1,
+    input_tokens: inputTokens,
+    output_tokens: outputTokens,
+    total_tokens: inputTokens + outputTokens,
+  });
+}
+
+function toUsageComponents(response: ChatResponse | undefined): {
+  usage: Usage;
+  payload: {
+    inputTokens: number;
+    outputTokens: number;
+    totalTokens: number;
+    requests?: number;
+    inputTokensDetails?: Record<string, number>;
+    outputTokensDetails?: Record<string, number>;
+  };
+} {
+  const usage = toUsage(response);
+  const payload: {
+    inputTokens: number;
+    outputTokens: number;
+    totalTokens: number;
+    requests?: number;
+    inputTokensDetails?: Record<string, number>;
+    outputTokensDetails?: Record<string, number>;
+  } = {
+    inputTokens: usage.inputTokens,
+    outputTokens: usage.outputTokens,
+    totalTokens: usage.totalTokens,
+  };
+  if (usage.requests) {
+    payload.requests = usage.requests;
+  }
+  if (usage.inputTokensDetails[0]) {
+    payload.inputTokensDetails = usage.inputTokensDetails[0];
+  }
+  if (usage.outputTokensDetails[0]) {
+    payload.outputTokensDetails = usage.outputTokensDetails[0];
+  }
+  return { usage, payload };
+}
+
+class OllamaModel implements Model {
+  constructor(
+    private readonly client: OllamaClientLike,
+    private readonly modelName: string,
+    private readonly defaults?: Partial<
+      Omit<ChatRequest, "model" | "messages" | "stream">
+    >,
+  ) {}
+
+  private buildRequest(request: ModelRequest, stream: boolean): ChatRequest {
+    const base: ChatRequest = {
+      model: this.modelName,
+      messages: convertInputToMessages(request),
+      stream,
+    };
+    if (this.defaults) {
+      for (const [key, value] of Object.entries(this.defaults)) {
+        if (value === undefined) {
+          continue;
+        }
+        if (key === "model" || key === "messages" || key === "stream") {
+          continue;
+        }
+        (base as unknown as Record<string, unknown>)[key] = value;
+      }
+    }
+    const format =
+      request.outputType && request.outputType !== "text"
+        ? request.outputType
+        : undefined;
+    if (format) {
+      (base as unknown as Record<string, unknown>).format = format;
+    }
+    const tools = convertTools(request.tools);
+    if (tools) {
+      base.tools = tools;
+    }
+    const options = convertSettings(request.modelSettings);
+    if (options) {
+      base.options = { ...(base.options ?? {}), ...options };
+    }
+    return base;
+  }
+
+  private toResponse(response: ChatResponse): ModelResponse {
+    const { usage } = toUsageComponents(response);
+    const text = response.message?.content ?? "";
+    return {
+      usage,
+      output: [assistant(text)],
+      responseId: `ollama-${randomUUID()}`,
+      providerData: { raw: response },
+    };
+  }
+
+  async getResponse(request: ModelRequest): Promise<ModelResponse> {
+    const chatRequest = this.buildRequest(request, false) as ChatRequest & {
+      stream?: false;
+    };
+    const response = await this.client.chat(chatRequest);
+    return this.toResponse(response);
+  }
+
+  async *getStreamedResponse(
+    request: ModelRequest,
+  ): AsyncIterable<StreamEvent> {
+    const chatRequest = this.buildRequest(request, true) as ChatRequest & {
+      stream: true;
+    };
+    const stream = await this.client.chat(chatRequest);
+    let aggregated = "";
+    let finalChunk: ChatResponse | undefined;
+    yield { type: "response_started" } satisfies StreamEvent;
+    for await (const chunk of stream) {
+      finalChunk = chunk;
+      const delta = chunk.message?.content ?? "";
+      if (delta) {
+        aggregated += delta;
+        yield { type: "output_text_delta", delta } satisfies StreamEvent;
+      }
+    }
+    const finalResponse =
+      finalChunk ??
+      ({
+        model: this.modelName,
+        created_at: new Date(),
+        message: { role: "assistant", content: aggregated },
+        done: true,
+        done_reason: "stop",
+        total_duration: 0,
+        load_duration: 0,
+        prompt_eval_count: 0,
+        prompt_eval_duration: 0,
+        eval_count: 0,
+        eval_duration: 0,
+      } satisfies ChatResponse);
+    const { payload } = toUsageComponents(finalChunk);
+    const responseId = `ollama-${randomUUID()}`;
+    yield {
+      type: "response_done",
+      response: {
+        id: responseId,
+        usage: payload,
+        output: [assistant(aggregated)],
+        providerData: { raw: finalResponse },
+      },
+    } satisfies StreamEvent;
+  }
+}
+
+export class OllamaModelProvider implements ModelProvider {
+  private readonly client: OllamaClientLike;
+  private readonly defaultModel: string;
+  private readonly requestDefaults?: Partial<
+    Omit<ChatRequest, "model" | "messages" | "stream">
+  >;
+
+  constructor(options: OllamaModelProviderOptions = {}) {
+    this.defaultModel = options.defaultModel ?? "llama3.1";
+    this.requestDefaults = options.requestOptions;
+    this.client =
+      options.client ??
+      new OllamaClient(
+        options.host
+          ? {
+              host: options.host,
+            }
+          : undefined,
+      );
+  }
+
+  async getModel(modelName?: string): Promise<Model> {
+    const target = modelName ?? this.defaultModel;
+    return new OllamaModel(this.client, target, this.requestDefaults);
+  }
+}
+
+export function createOllamaModelProvider(
+  options: OllamaModelProviderOptions = {},
+): OllamaModelProvider {
+  return new OllamaModelProvider(options);
+}

--- a/packages/agents-workflow/src/providers/openai.ts
+++ b/packages/agents-workflow/src/providers/openai.ts
@@ -1,0 +1,17 @@
+import { OpenAIProvider, setDefaultModelProvider } from "@openai/agents";
+
+type OpenAIProviderOptions = ConstructorParameters<typeof OpenAIProvider>[0];
+
+export function createOpenAIModelProvider(
+  options?: OpenAIProviderOptions,
+): OpenAIProvider {
+  return new OpenAIProvider(options);
+}
+
+export function registerOpenAIDefaultModelProvider(
+  options?: OpenAIProviderOptions,
+): OpenAIProvider {
+  const provider = new OpenAIProvider(options);
+  setDefaultModelProvider(provider);
+  return provider;
+}

--- a/packages/agents-workflow/src/runtime.ts
+++ b/packages/agents-workflow/src/runtime.ts
@@ -1,0 +1,34 @@
+import type {
+  AgentWorkflowGraph,
+  AgentFactoryOptions,
+  MarkdownWorkflowDocument,
+  MarkdownWorkflowOptions,
+} from "./workflow/types.js";
+import { parseMarkdownWorkflows } from "./workflow/markdown.js";
+import {
+  createAgentWorkflowGraph,
+  resolveWorkflowDefinitions,
+  type DefinitionResolutionOptions,
+} from "./workflow/loader.js";
+
+export interface WorkflowRuntimeOptions
+  extends MarkdownWorkflowOptions,
+    DefinitionResolutionOptions,
+    AgentFactoryOptions {}
+
+export async function loadAgentWorkflowsFromMarkdown(
+  content: string,
+  options: WorkflowRuntimeOptions = {},
+): Promise<{
+  document: MarkdownWorkflowDocument;
+  graphs: AgentWorkflowGraph[];
+}> {
+  const document = parseMarkdownWorkflows(content, options);
+  const workflows = await resolveWorkflowDefinitions(document, options);
+  const graphs: AgentWorkflowGraph[] = [];
+  for (const workflow of workflows) {
+    const graph = await createAgentWorkflowGraph(workflow, options);
+    graphs.push(graph);
+  }
+  return { document, graphs };
+}

--- a/packages/agents-workflow/src/tests/markdown.test.ts
+++ b/packages/agents-workflow/src/tests/markdown.test.ts
@@ -1,0 +1,87 @@
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import test from "ava";
+
+import {
+  createAgentWorkflowGraph,
+  parseMarkdownWorkflows,
+  resolveWorkflowDefinitions,
+  type AgentWorkflowGraph,
+} from "../index.js";
+
+const MARKDOWN = `# Demo
+
+\`\`\`mermaid workflow
+flowchart TD
+  main["{\\"instructions\\":\\"Lead\\",\\"model\\":{\\"provider\\":\\"openai\\",\\"name\\":\\"gpt-4o-mini\\"}}"]
+  helper[file:./helper.json]
+  reviewer
+  main --> helper
+  helper --> reviewer
+\`\`\`
+
+\`\`\`json agents
+{
+  "agents": {
+    "reviewer": {
+      "instructions": "Review draft",
+      "model": { "provider": "ollama", "name": "llama3" }
+    }
+  }
+}
+\`\`\`
+`;
+
+test("parses markdown workflows and resolves definitions", async (t) => {
+  const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "agents-workflow-"));
+  const helperPath = path.join(tmpDir, "helper.json");
+  await fs.writeFile(
+    helperPath,
+    JSON.stringify(
+      {
+        instructions: "Assist with tasks",
+        model: { provider: "openai", name: "gpt-4o-mini" },
+      },
+      null,
+      2,
+    ),
+    "utf8",
+  );
+
+  const document = parseMarkdownWorkflows(MARKDOWN, {});
+  t.is(document.workflows.length, 1);
+  const workflows = await resolveWorkflowDefinitions(document, {
+    baseDir: tmpDir,
+  });
+  t.true(workflows.length > 0);
+  const workflow = workflows[0]!;
+  t.like(workflow.nodes.find((node) => node.id === "main")?.definition, {
+    instructions: "Lead",
+    model: { provider: "openai", name: "gpt-4o-mini" },
+  });
+  t.like(workflow.nodes.find((node) => node.id === "helper")?.definition, {
+    instructions: "Assist with tasks",
+  });
+  t.like(workflow.nodes.find((node) => node.id === "reviewer")?.definition, {
+    instructions: "Review draft",
+    model: { provider: "ollama", name: "llama3" },
+  });
+
+  const graph: AgentWorkflowGraph = await createAgentWorkflowGraph(workflow, {
+    defaultModel: "gpt-4.1-mini",
+    modelResolvers: {
+      ollama: async (name) => `ollama://${name}`,
+    },
+  });
+
+  const main = graph.nodes.get("main");
+  t.truthy(main);
+  t.is(main?.config.model, "gpt-4o-mini");
+
+  const reviewer = graph.nodes.get("reviewer");
+  t.truthy(reviewer);
+  t.is(reviewer?.config.model, "ollama://llama3");
+  t.is(graph.edges.length, 2);
+});

--- a/packages/agents-workflow/src/tests/ollama-provider.test.ts
+++ b/packages/agents-workflow/src/tests/ollama-provider.test.ts
@@ -1,0 +1,95 @@
+import test from "ava";
+
+import type { ModelRequest } from "@openai/agents";
+import type { ChatRequest, ChatResponse } from "ollama";
+
+import { createOllamaModelProvider } from "../index.js";
+
+interface RecordedRequest extends ChatRequest {
+  stream?: boolean;
+}
+
+test("ollama provider issues chat requests with expected payload", async (t) => {
+  const calls: RecordedRequest[] = [];
+  const responses: ChatResponse = {
+    model: "test-model",
+    created_at: new Date(),
+    message: { role: "assistant", content: "hello" },
+    done: true,
+    done_reason: "stop",
+    total_duration: 0,
+    load_duration: 0,
+    prompt_eval_count: 4,
+    prompt_eval_duration: 0,
+    eval_count: 6,
+    eval_duration: 0,
+  };
+
+  const client = {
+    async chat(request: ChatRequest & { stream?: boolean }): Promise<any> {
+      calls.push({ ...request });
+      if (request.stream) {
+        async function* generator(): AsyncIterable<ChatResponse> {
+          yield {
+            ...responses,
+            message: { role: "assistant", content: "hel" },
+            done: false,
+          };
+          yield {
+            ...responses,
+            message: { role: "assistant", content: "lo" },
+          };
+        }
+        return generator();
+      }
+      return responses;
+    },
+  };
+
+  const provider = createOllamaModelProvider({ client: client as any });
+  const model = await provider.getModel("test-model");
+
+  const baseRequest = {
+    input: "hi",
+    systemInstructions: "system prompt",
+    modelSettings: { temperature: 0.5 },
+    tools: [],
+    outputType: "text" as const,
+    handoffs: [],
+    tracing: false,
+  } satisfies ModelRequest;
+
+  const result = await model.getResponse(baseRequest);
+  const message = result.output[0];
+  if (!message || !("role" in message) || message.role !== "assistant") {
+    t.fail("expected assistant message output");
+    return;
+  }
+  const contentEntry = Array.isArray(message.content)
+    ? message.content[0]
+    : undefined;
+  if (!contentEntry || contentEntry.type !== "output_text") {
+    t.fail("expected output_text content");
+    return;
+  }
+  t.is(contentEntry.text, "hello");
+  t.is(result.usage.totalTokens, 10);
+
+  const streamEvents: string[] = [];
+  for await (const event of model.getStreamedResponse(baseRequest)) {
+    streamEvents.push(event.type);
+  }
+  t.is(streamEvents[0], "response_started");
+  t.true(
+    streamEvents.slice(1, -1).every((event) => event === "output_text_delta"),
+  );
+  t.is(streamEvents.at(-1), "response_done");
+
+  t.is(calls.length, 2);
+  t.deepEqual(calls[0]!.messages, [
+    { role: "system", content: "system prompt" },
+    { role: "user", content: "hi" },
+  ]);
+  t.is(calls[0]!.options?.temperature, 0.5);
+  t.true(calls[1]!.stream ?? false);
+});

--- a/packages/agents-workflow/src/workflow/loader.ts
+++ b/packages/agents-workflow/src/workflow/loader.ts
@@ -1,0 +1,343 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+
+import type {
+  AgentDefinition,
+  AgentGraphNode,
+  AgentWorkflowGraph,
+  AgentFactoryOptions,
+  MarkdownWorkflowDocument,
+  ResolvedAgentDefinition,
+  WorkflowDefinition,
+  WorkflowNode,
+} from "./types.js";
+import { AgentDefinitionSchema } from "./types.js";
+import type {
+  JsonSchemaDefinition,
+  Model,
+  ModelProvider,
+  ModelSettings,
+  Tool,
+} from "@openai/agents";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function mergeDefinitions(
+  base: Partial<AgentDefinition>,
+  update?: Partial<AgentDefinition>,
+): Partial<AgentDefinition> {
+  if (!update) {
+    return base;
+  }
+  const merged: Partial<AgentDefinition> = {
+    ...base,
+    ...update,
+  };
+  if (base?.modelSettings || update?.modelSettings) {
+    merged.modelSettings = {
+      ...(isRecord(base?.modelSettings)
+        ? (base?.modelSettings as Record<string, unknown>)
+        : {}),
+      ...(isRecord(update?.modelSettings)
+        ? (update?.modelSettings as Record<string, unknown>)
+        : {}),
+    };
+  }
+  if (base?.metadata || update?.metadata) {
+    merged.metadata = {
+      ...(isRecord(base?.metadata)
+        ? (base?.metadata as Record<string, unknown>)
+        : {}),
+      ...(isRecord(update?.metadata)
+        ? (update?.metadata as Record<string, unknown>)
+        : {}),
+    };
+  }
+  if (update?.tools) {
+    merged.tools = update.tools;
+  }
+  return merged;
+}
+
+async function loadReferencedDefinition(
+  reference: string,
+  baseDir: string,
+): Promise<Partial<AgentDefinition>> {
+  const relative = reference.replace(/^(?:ref|file):/iu, "").trim();
+  if (!relative) {
+    throw new Error("Reference path cannot be empty.");
+  }
+  const resolved = path.isAbsolute(relative)
+    ? relative
+    : path.join(baseDir, relative);
+  const content = await readFile(resolved, "utf8");
+  if (/\.jsonc?$/iu.test(relative)) {
+    return JSON.parse(content) as Partial<AgentDefinition>;
+  }
+  return { instructions: content.trim() };
+}
+
+function parseInlineDefinition(label?: string): {
+  definition?: Partial<AgentDefinition>;
+  reference?: string;
+  fallbackInstructions?: string;
+} {
+  if (!label) {
+    return {};
+  }
+  const trimmed = label.trim();
+  if (!trimmed) {
+    return {};
+  }
+  const referenceMatch = trimmed.match(/^(ref|file):(.+)$/iu);
+  if (referenceMatch) {
+    return { reference: referenceMatch[0] };
+  }
+  if (trimmed.startsWith("{") || trimmed.startsWith("[")) {
+    try {
+      const parsed = JSON.parse(trimmed) as Partial<AgentDefinition>;
+      return { definition: parsed };
+    } catch (error) {
+      throw new Error(
+        `Failed to parse inline JSON for node: ${(error as Error).message}`,
+      );
+    }
+  }
+  return { fallbackInstructions: trimmed };
+}
+
+function gatherConfigDefinition(
+  nodeId: string,
+  jsonBlocks: Record<string, unknown>,
+): Partial<AgentDefinition> | undefined {
+  let definition: Partial<AgentDefinition> | undefined;
+  for (const block of Object.values(jsonBlocks)) {
+    if (!isRecord(block)) {
+      continue;
+    }
+    if (isRecord(block.agents) && isRecord(block.agents[nodeId])) {
+      definition = mergeDefinitions(
+        definition ?? {},
+        block.agents[nodeId] as Partial<AgentDefinition>,
+      );
+    }
+    if (isRecord(block[nodeId])) {
+      definition = mergeDefinitions(
+        definition ?? {},
+        block[nodeId] as Partial<AgentDefinition>,
+      );
+    }
+  }
+  return definition;
+}
+
+export interface DefinitionResolutionOptions {
+  baseDir?: string;
+}
+
+async function resolveNodeDefinition(
+  node: WorkflowNode,
+  jsonBlocks: Record<string, unknown>,
+  options: DefinitionResolutionOptions,
+): Promise<{
+  definition: ResolvedAgentDefinition;
+  source: WorkflowNode["source"];
+}> {
+  const baseDir = options.baseDir ?? process.cwd();
+  const inline = parseInlineDefinition(node.label);
+  let definition: Partial<AgentDefinition> = inline.definition ?? {};
+  let source: WorkflowNode["source"];
+
+  if (inline.reference) {
+    const referenced = await loadReferencedDefinition(
+      inline.reference,
+      baseDir,
+    );
+    definition = mergeDefinitions(definition, referenced);
+    source = "reference";
+  }
+
+  const fromConfig = gatherConfigDefinition(node.id, jsonBlocks);
+  if (fromConfig) {
+    definition = mergeDefinitions(definition, fromConfig);
+    if (!source) {
+      source = "config";
+    }
+  }
+
+  if (inline.fallbackInstructions && !definition.instructions) {
+    definition.instructions = inline.fallbackInstructions;
+    if (!source) {
+      source = "inline";
+    }
+  }
+
+  const validated = AgentDefinitionSchema.parse(definition);
+  const instructions = validated.instructions ?? inline.fallbackInstructions;
+  if (!instructions) {
+    throw new Error(`Agent node "${node.id}" is missing instructions.`);
+  }
+
+  return {
+    definition: {
+      ...validated,
+      instructions,
+      name: validated.name ?? node.id,
+    },
+    source: source ?? (inline.definition ? "inline" : undefined),
+  };
+}
+
+export async function resolveWorkflowDefinitions(
+  document: MarkdownWorkflowDocument,
+  options: DefinitionResolutionOptions = {},
+): Promise<WorkflowDefinition[]> {
+  const resolved: WorkflowDefinition[] = [];
+  for (const workflow of document.workflows) {
+    const nodes: WorkflowNode[] = [];
+    for (const node of workflow.nodes) {
+      const { definition, source } = await resolveNodeDefinition(
+        node,
+        document.jsonBlocks,
+        options,
+      );
+      nodes.push({ ...node, definition, source });
+    }
+    resolved.push({ ...workflow, nodes });
+  }
+  return resolved;
+}
+
+async function resolveModel(
+  nodeId: string,
+  definition: AgentDefinition,
+  options: AgentFactoryOptions,
+): Promise<string | Model> {
+  const reference = definition.model;
+  if (!reference) {
+    return options.defaultModel ?? "gpt-4.1-mini";
+  }
+  if (typeof reference === "string") {
+    return reference;
+  }
+  const providerKey = reference.provider;
+  const resolvers = options.modelResolvers ?? {};
+  const resolver = resolvers[providerKey];
+  if (!resolver) {
+    if (providerKey === "openai") {
+      return reference.name;
+    }
+    throw new Error(
+      `No model resolver registered for provider "${providerKey}" (agent "${nodeId}").`,
+    );
+  }
+  if (typeof (resolver as ModelProvider).getModel === "function") {
+    return await (resolver as ModelProvider).getModel(reference.name);
+  }
+  return await (
+    resolver as (
+      name: string,
+      definition: AgentDefinition,
+    ) => Promise<Model | string>
+  )(reference.name, definition);
+}
+
+function resolveTools(
+  definition: AgentDefinition,
+  options: AgentFactoryOptions,
+): Tool[] {
+  if (!definition.tools || definition.tools.length === 0) {
+    return [];
+  }
+  const registry = options.toolRegistry ?? {};
+  const tools: Tool[] = [];
+  for (const toolDef of definition.tools) {
+    if (!toolDef.handler) {
+      continue;
+    }
+    const tool = registry[toolDef.handler];
+    if (!tool) {
+      throw new Error(`No tool registered for handler "${toolDef.handler}".`);
+    }
+    tools.push(tool);
+  }
+  return tools;
+}
+
+function mergeModelSettings(
+  definition: AgentDefinition,
+): ModelSettings | undefined {
+  const explicit = definition.modelSettings as
+    | Record<string, unknown>
+    | undefined;
+  if (!definition.model || typeof definition.model === "string") {
+    return explicit as ModelSettings | undefined;
+  }
+  const providerSettings = isRecord(definition.model.settings)
+    ? (definition.model.settings as Record<string, unknown>)
+    : undefined;
+  if (!providerSettings && !explicit) {
+    return undefined;
+  }
+  return {
+    ...(providerSettings ?? {}),
+    ...(explicit ?? {}),
+  } as ModelSettings;
+}
+
+function resolveOutput(
+  definition: AgentDefinition,
+): JsonSchemaDefinition | "text" | undefined {
+  if (!definition.output) {
+    return undefined;
+  }
+  if (definition.output === "text") {
+    return "text";
+  }
+  return definition.output as JsonSchemaDefinition;
+}
+
+export async function createAgentWorkflowGraph(
+  workflow: WorkflowDefinition,
+  options: AgentFactoryOptions = {},
+): Promise<AgentWorkflowGraph> {
+  const nodes = new Map<string, AgentGraphNode>();
+  for (const node of workflow.nodes) {
+    if (!node.definition) {
+      throw new Error(
+        `Workflow node "${node.id}" is missing a resolved agent definition.`,
+      );
+    }
+    const definition = node.definition;
+    const model = await resolveModel(node.id, definition, options);
+    const modelSettings = mergeModelSettings(definition);
+    const outputType = resolveOutput(definition);
+    const config = {
+      name: definition.name ?? node.id,
+      instructions: definition.instructions,
+      handoffDescription:
+        definition.handoffDescription ?? definition.instructions,
+      model,
+      ...(modelSettings ? { modelSettings } : {}),
+      tools: resolveTools(definition, options),
+      ...(outputType ? { outputType } : {}),
+    } satisfies AgentGraphNode["config"];
+    nodes.set(node.id, {
+      id: node.id,
+      definition: {
+        ...definition,
+        name: definition.name ?? node.id,
+        instructions: definition.instructions,
+      },
+      config,
+    });
+  }
+  return {
+    id: workflow.id,
+    nodes,
+    edges: workflow.edges,
+    metadata: workflow.metadata,
+  };
+}

--- a/packages/agents-workflow/src/workflow/markdown.ts
+++ b/packages/agents-workflow/src/workflow/markdown.ts
@@ -1,0 +1,93 @@
+import { unified } from "unified";
+import remarkParse from "remark-parse";
+
+import { parseMermaidGraph } from "./mermaid.js";
+import type {
+  MarkdownWorkflowDocument,
+  MarkdownWorkflowOptions,
+} from "./types.js";
+
+type HeadingNode = {
+  type: string;
+  children?: Array<{ value?: string }>;
+};
+
+type CodeNode = {
+  type: "code";
+  lang?: string;
+  meta?: string | null;
+  value: string;
+};
+
+type MarkdownNode =
+  | HeadingNode
+  | CodeNode
+  | { type: string; [key: string]: unknown };
+
+function headingText(node: HeadingNode): string {
+  return (node.children ?? [])
+    .map((child) => (typeof child.value === "string" ? child.value : ""))
+    .join("")
+    .trim();
+}
+
+function parseJson(value: string, label: string): unknown {
+  const text = value.trim();
+  if (!text) {
+    return {};
+  }
+  try {
+    return JSON.parse(text);
+  } catch (error) {
+    throw new Error(
+      `Failed to parse JSON block "${label}": ${(error as Error).message}`,
+    );
+  }
+}
+
+export function parseMarkdownWorkflows(
+  content: string,
+  _options: MarkdownWorkflowOptions = {},
+): MarkdownWorkflowDocument {
+  const tree = unified().use(remarkParse).parse(content) as {
+    children?: MarkdownNode[];
+  };
+  const workflows = [] as MarkdownWorkflowDocument["workflows"];
+  const jsonBlocks: Record<string, unknown> = {};
+
+  let currentHeading: string | undefined;
+  let workflowIndex = 0;
+  let jsonIndex = 0;
+
+  for (const node of tree.children ?? []) {
+    if (node.type === "heading") {
+      currentHeading = headingText(node as HeadingNode);
+      continue;
+    }
+    if (node.type !== "code") {
+      continue;
+    }
+    const code = node as CodeNode;
+    const lang = code.lang?.toLowerCase();
+    if (lang === "mermaid") {
+      workflowIndex += 1;
+      const id = (
+        code.meta?.trim() ||
+        currentHeading ||
+        `workflow-${workflowIndex}`
+      ).toString();
+      const graph = parseMermaidGraph(code.value, id);
+      graph.metadata = currentHeading ? { heading: currentHeading } : undefined;
+      workflows.push(graph);
+    } else if (
+      lang &&
+      (lang === "json" || lang === "jsonc" || lang === "application/json")
+    ) {
+      jsonIndex += 1;
+      const key = code.meta?.trim() || `config-${jsonIndex}`;
+      jsonBlocks[key] = parseJson(code.value, key);
+    }
+  }
+
+  return { workflows, jsonBlocks };
+}

--- a/packages/agents-workflow/src/workflow/mermaid.ts
+++ b/packages/agents-workflow/src/workflow/mermaid.ts
@@ -1,0 +1,107 @@
+import type {
+  WorkflowDefinition,
+  WorkflowEdge,
+  WorkflowNode,
+} from "./types.js";
+
+const NODE_REGEX =
+  /^(?<id>[A-Za-z0-9_]+)\s*(?:\((?<round>[^)]*)\)|\[(?<square>[^\]]*)\]|\{(?<curly>[^}]*)\}|"(?<quoted>[^"]*)"|\s+"(?<standalone>[^"]*)")?/;
+const EDGE_REGEX =
+  /^(?<from>[A-Za-z0-9_]+)\s*--[->]+\s*(?:\|(?<label>[^|]+)\|\s*)?(?<to>[A-Za-z0-9_]+)/;
+
+const COMMENT_PREFIX = "%%";
+const DIRECTIVE_REGEX = /^(?:graph|flowchart|classDef|linkStyle|style)\b/i;
+
+function decodeLabel(raw: string | undefined): string | undefined {
+  if (!raw) {
+    return undefined;
+  }
+  const text = raw
+    .replace(/&quot;/gu, '"')
+    .replace(/\\n/gu, "\n")
+    .replace(/\\"/gu, '"');
+  const trimmed = text.trim();
+  if (trimmed.startsWith('"') && trimmed.endsWith('"')) {
+    return trimmed.slice(1, -1);
+  }
+  return trimmed;
+}
+
+function parseNode(line: string): WorkflowNode | undefined {
+  const trimmed = line.trim();
+  if (
+    !trimmed ||
+    trimmed.startsWith(COMMENT_PREFIX) ||
+    DIRECTIVE_REGEX.test(trimmed)
+  ) {
+    return undefined;
+  }
+  const match = trimmed.match(NODE_REGEX);
+  if (!match || !match.groups || !match.groups.id) {
+    return undefined;
+  }
+  const { id, round, square, curly, quoted, standalone } = match.groups;
+  const rawLabel = round ?? square ?? curly ?? quoted ?? standalone;
+  const label = decodeLabel(rawLabel);
+  return { id, label };
+}
+
+function parseEdge(line: string): WorkflowEdge | undefined {
+  const trimmed = line.trim();
+  if (
+    !trimmed ||
+    trimmed.startsWith(COMMENT_PREFIX) ||
+    DIRECTIVE_REGEX.test(trimmed)
+  ) {
+    return undefined;
+  }
+  const match = trimmed.match(EDGE_REGEX);
+  if (!match || !match.groups || !match.groups.from || !match.groups.to) {
+    return undefined;
+  }
+  const { from, to, label } = match.groups;
+  return {
+    from,
+    to,
+    label: label?.trim(),
+  };
+}
+
+export function parseMermaidGraph(
+  source: string,
+  id = "workflow",
+): WorkflowDefinition {
+  const nodes = new Map<string, WorkflowNode>();
+  const edges: WorkflowEdge[] = [];
+
+  for (const rawLine of source.split("\n")) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith(COMMENT_PREFIX)) {
+      continue;
+    }
+    const node = parseNode(line);
+    if (node) {
+      if (!nodes.has(node.id)) {
+        nodes.set(node.id, node);
+      } else if (node.label && !nodes.get(node.id)?.label) {
+        nodes.set(node.id, node);
+      }
+    }
+    const edge = parseEdge(line);
+    if (edge) {
+      edges.push(edge);
+      if (!nodes.has(edge.from)) {
+        nodes.set(edge.from, { id: edge.from });
+      }
+      if (!nodes.has(edge.to)) {
+        nodes.set(edge.to, { id: edge.to });
+      }
+    }
+  }
+
+  return {
+    id,
+    nodes: Array.from(nodes.values()),
+    edges,
+  };
+}

--- a/packages/agents-workflow/src/workflow/types.ts
+++ b/packages/agents-workflow/src/workflow/types.ts
@@ -1,0 +1,112 @@
+import type {
+  JsonSchemaDefinition,
+  Model,
+  ModelProvider,
+  ModelSettings,
+  Tool,
+} from "@openai/agents";
+import { z } from "zod";
+
+export const ModelReferenceSchema = z.union([
+  z.string().min(1, "model name cannot be empty"),
+  z.object({
+    provider: z.string().min(1, "model provider cannot be empty"),
+    name: z.string().min(1, "model name cannot be empty"),
+    options: z.record(z.unknown()).optional(),
+    settings: z.record(z.unknown()).optional(),
+  }),
+]);
+
+export type ModelReference = z.infer<typeof ModelReferenceSchema>;
+
+export const ToolDefinitionSchema = z.object({
+  name: z.string().min(1, "tool name cannot be empty"),
+  description: z.string().optional(),
+  parameters: z.record(z.unknown()).optional(),
+  strict: z.boolean().optional(),
+  handler: z.string().optional(),
+  metadata: z.record(z.unknown()).optional(),
+});
+
+export const AgentDefinitionSchema = z.object({
+  name: z.string().optional(),
+  instructions: z.string().optional(),
+  handoffDescription: z.string().optional(),
+  model: ModelReferenceSchema.optional(),
+  modelSettings: z.record(z.unknown()).optional(),
+  output: z.union([z.literal("text"), z.record(z.unknown())]).optional(),
+  tools: z.array(ToolDefinitionSchema).optional(),
+  metadata: z.record(z.unknown()).optional(),
+});
+
+export type AgentDefinition = z.infer<typeof AgentDefinitionSchema>;
+export type ToolDefinition = z.infer<typeof ToolDefinitionSchema>;
+
+export type ResolvedAgentDefinition = AgentDefinition & {
+  name: string;
+  instructions: string;
+};
+
+export interface WorkflowNode {
+  id: string;
+  label?: string;
+  definition?: ResolvedAgentDefinition;
+  source?: "inline" | "reference" | "config";
+}
+
+export interface WorkflowEdge {
+  from: string;
+  to: string;
+  label?: string;
+}
+
+export interface WorkflowDefinition {
+  id: string;
+  nodes: WorkflowNode[];
+  edges: WorkflowEdge[];
+  metadata?: Record<string, unknown>;
+}
+
+export interface MarkdownWorkflowDocument {
+  workflows: WorkflowDefinition[];
+  jsonBlocks: Record<string, unknown>;
+}
+
+export interface ResolvedAgentConfig {
+  name: string;
+  instructions: string;
+  handoffDescription: string;
+  model: string | Model;
+  modelSettings?: ModelSettings;
+  tools: Tool[];
+  outputType?: JsonSchemaDefinition | "text";
+}
+
+export interface AgentGraphNode {
+  id: string;
+  definition: ResolvedAgentDefinition;
+  config: ResolvedAgentConfig;
+}
+
+export interface AgentWorkflowGraph {
+  id: string;
+  nodes: Map<string, AgentGraphNode>;
+  edges: WorkflowEdge[];
+  metadata?: Record<string, unknown>;
+}
+
+export interface ModelResolverMap {
+  [provider: string]:
+    | ModelProvider
+    | ((name: string, definition: AgentDefinition) => Promise<Model | string>);
+}
+
+export interface AgentFactoryOptions {
+  defaultModel?: string;
+  modelResolvers?: ModelResolverMap;
+  toolRegistry?: Record<string, Tool>;
+}
+
+export interface MarkdownWorkflowOptions {
+  baseDir?: string;
+}

--- a/packages/agents-workflow/tsconfig.json
+++ b/packages/agents-workflow/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../config/tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "composite": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*"],
+  "references": []
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -392,6 +392,31 @@ importers:
         specifier: ^8.5.9
         version: 8.18.1
 
+  packages/agents-workflow:
+    dependencies:
+      '@openai/agents':
+        specifier: ^0.1.9
+        version: 0.1.9(ws@8.18.3)(zod@3.25.76)
+      ollama:
+        specifier: ^0.5.17
+        version: 0.5.18
+      remark-parse:
+        specifier: 11.0.0
+        version: 11.0.0
+      unified:
+        specifier: 11.0.5
+        version: 11.0.5
+      unist-util-visit:
+        specifier: 5.0.0
+        version: 5.0.0
+      zod:
+        specifier: ^3.25.0
+        version: 3.25.76
+    devDependencies:
+      '@promethean/test-utils':
+        specifier: workspace:*
+        version: link:../test-utils
+
   packages/alias-rewrite:
     dependencies:
       '@promethean/naming':
@@ -2247,7 +2272,7 @@ importers:
         version: link:../utils
       chromadb:
         specifier: ^1.8.1
-        version: 1.10.5(encoding@0.1.13)(ollama@0.5.18)
+        version: 1.10.5(encoding@0.1.13)(ollama@0.5.18)(openai@5.23.2(ws@8.18.3)(zod@3.25.76))
 
   packages/indexer-service:
     dependencies:
@@ -3745,7 +3770,7 @@ importers:
         version: 3.0.1(ajv@8.17.1)
       chromadb:
         specifier: ^1.8.1
-        version: 1.10.5(encoding@0.1.13)(ollama@0.5.18)
+        version: 1.10.5(encoding@0.1.13)(ollama@0.5.18)(openai@5.23.2(ws@8.18.3)(zod@3.25.76))
       dotenv:
         specifier: ^17.2.1
         version: 17.2.1
@@ -5751,6 +5776,29 @@ packages:
 
   '@open-draft/until@2.1.0':
     resolution: {integrity: sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==}
+
+  '@openai/agents-core@0.1.8':
+    resolution: {integrity: sha512-6tNFU/oR7EXzYyv6E6xuCVaVFr9ixO3zsPRGb1d+67obGN2V9QftbfXkYN8bobIaVgI7FD5i4d9VQQesL8Odkg==}
+    peerDependencies:
+      zod: ^3.25.40
+    peerDependenciesMeta:
+      zod:
+        optional: true
+
+  '@openai/agents-openai@0.1.9':
+    resolution: {integrity: sha512-NNca4HSLDQ9J/xVM05+rzS6QvPN4bscZmZTIgPix1V5wFs8buiDd5sR1jFkEXZ3HppFhm2P8cndV2Ab46it2zw==}
+    peerDependencies:
+      zod: ^3.25.40
+
+  '@openai/agents-realtime@0.1.8':
+    resolution: {integrity: sha512-i9+0G3P640l8LmBkDanJ+YvVTfMnQvLvjqj3h7TnVBjNiXBeFi1G5uaCae5e/xH+igciKgvS8VyQ/Mftel0BQg==}
+    peerDependencies:
+      zod: ^3.25.40
+
+  '@openai/agents@0.1.9':
+    resolution: {integrity: sha512-f0MLi8N9tVqJqxR3oJj7XmXq0roE+lllRaBG3MeMNP0edOC99+Le/24u3lM7HE6/FyqaCdrRuEbv9QEEf0RDkA==}
+    peerDependencies:
+      zod: ^3.25.40
 
   '@opentelemetry/api@1.9.0':
     resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
@@ -10179,6 +10227,18 @@ packages:
     resolution: {integrity: sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==}
     engines: {node: '>=12'}
 
+  openai@5.23.2:
+    resolution: {integrity: sha512-MQBzmTulj+MM5O8SKEk/gL8a7s5mktS9zUtAkU257WjvobGc9nKcBuVwjyEEcb9SI8a8Y2G/mzn3vm9n1Jlleg==}
+    hasBin: true
+    peerDependencies:
+      ws: ^8.18.0
+      zod: ^3.23.8
+    peerDependenciesMeta:
+      ws:
+        optional: true
+      zod:
+        optional: true
+
   openapi-types@12.1.3:
     resolution: {integrity: sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==}
 
@@ -12462,7 +12522,7 @@ snapshots:
     dependencies:
       '@chroma-core/ai-embeddings-common': 0.1.7
       chromadb: 3.0.14
-      ollama: 0.5.17
+      ollama: 0.5.18
       testcontainers: 10.28.0
     transitivePeerDependencies:
       - bare-buffer
@@ -13329,6 +13389,53 @@ snapshots:
       outvariant: 1.4.3
 
   '@open-draft/until@2.1.0': {}
+
+  '@openai/agents-core@0.1.8(ws@8.18.3)(zod@3.25.76)':
+    dependencies:
+      debug: 4.4.3
+      openai: 5.23.2(ws@8.18.3)(zod@3.25.76)
+    optionalDependencies:
+      '@modelcontextprotocol/sdk': 1.17.5
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - supports-color
+      - ws
+
+  '@openai/agents-openai@0.1.9(ws@8.18.3)(zod@3.25.76)':
+    dependencies:
+      '@openai/agents-core': 0.1.8(ws@8.18.3)(zod@3.25.76)
+      debug: 4.4.3
+      openai: 5.23.2(ws@8.18.3)(zod@3.25.76)
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - supports-color
+      - ws
+
+  '@openai/agents-realtime@0.1.8(zod@3.25.76)':
+    dependencies:
+      '@openai/agents-core': 0.1.8(ws@8.18.3)(zod@3.25.76)
+      '@types/ws': 8.18.1
+      debug: 4.4.3
+      ws: 8.18.3
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  '@openai/agents@0.1.9(ws@8.18.3)(zod@3.25.76)':
+    dependencies:
+      '@openai/agents-core': 0.1.8(ws@8.18.3)(zod@3.25.76)
+      '@openai/agents-openai': 0.1.9(ws@8.18.3)(zod@3.25.76)
+      '@openai/agents-realtime': 0.1.8(zod@3.25.76)
+      debug: 4.4.3
+      openai: 5.23.2(ws@8.18.3)(zod@3.25.76)
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - ws
 
   '@opentelemetry/api@1.9.0': {}
 
@@ -15062,12 +15169,13 @@ snapshots:
   chromadb-js-bindings-win32-x64-msvc@1.0.5:
     optional: true
 
-  chromadb@1.10.5(encoding@0.1.13)(ollama@0.5.18):
+  chromadb@1.10.5(encoding@0.1.13)(ollama@0.5.18)(openai@5.23.2(ws@8.18.3)(zod@3.25.76)):
     dependencies:
       cliui: 8.0.1
       isomorphic-fetch: 3.0.0(encoding@0.1.13)
     optionalDependencies:
       ollama: 0.5.18
+      openai: 5.23.2(ws@8.18.3)(zod@3.25.76)
     transitivePeerDependencies:
       - encoding
 
@@ -18845,6 +18953,11 @@ snapshots:
       define-lazy-prop: 2.0.0
       is-docker: 2.2.1
       is-wsl: 2.2.0
+
+  openai@5.23.2(ws@8.18.3)(zod@3.25.76):
+    optionalDependencies:
+      ws: 8.18.3
+      zod: 3.25.76
 
   openapi-types@12.1.3: {}
 


### PR DESCRIPTION
## Summary
- add a new @promethean/agents-workflow package that wraps the OpenAI SDK
- support loading agent workflows from Markdown + Mermaid with optional file/JSON config
- provide Ollama model provider implementation and AVA coverage for parsing and provider plumbing

## Testing
- pnpm --filter @promethean/agents-workflow test

------
https://chatgpt.com/codex/tasks/task_e_68df67c097f483248aa3b2df0a1e2336