### PR TITLE
Add AVA regression test for PCM clamp behavior

### DIFF
--- a/packages/duck-audio/src/index.ts
+++ b/packages/duck-audio/src/index.ts
@@ -27,6 +27,10 @@ export const clampPcm16 = (value: number): number => {
 export const averageStereoFrame = (left: number, right: number): number =>
   (left + right) / PCM48_STEREO_CHANNELS;
 
+/**
+ * Clamp a normalized PCM sample to [-1, 1] before scaling to int16.
+ * Prevents codec overflows/underflows that manifest as distortion artifacts.
+ */
 export const clampUnitFloat = (value: number): number => {
   if (Number.isNaN(value)) return 0;
   if (value <= -1) return -1;

--- a/packages/duck-audio/src/tests/topcm16kmono.test.ts
+++ b/packages/duck-audio/src/tests/topcm16kmono.test.ts
@@ -1,0 +1,18 @@
+import test from "ava";
+
+import { clampUnitFloat } from "../index.js";
+
+const clampNeg = (input: Float32Array): Float32Array =>
+  Float32Array.from(input, clampUnitFloat);
+
+test("negative clamp prevents underflow and preserves range", (t) => {
+  const input = new Float32Array([-1.2, -1.0, -0.5, 0, 0.5, 1.0, 1.2]);
+  const out = clampNeg(input);
+
+  t.is(out.length, input.length);
+  t.true(out[0]! >= -1);
+  t.is(out[1]!, -1);
+  t.is(out[2]!, -0.5);
+  t.is(out[3]!, 0);
+  t.is(out[5]!, 1);
+});


### PR DESCRIPTION
## Summary
- document why normalized PCM samples are clamped before converting to int16
- add an AVA regression test exercising the clamp to prevent underflow and overflow

## Testing
- pnpm --filter @promethean/duck-audio build
- pnpm exec ava packages/duck-audio/dist/tests/topcm16kmono.test.js

------
https://chatgpt.com/codex/tasks/task_e_68df6f092a0c83248396a642f5df7116