### PR TITLE
Refactor kanban CLI runtime and harden UI server

### DIFF
--- a/changelog.d/2025.10.03.07.45.00.md
+++ b/changelog.d/2025.10.03.07.45.00.md
@@ -1,0 +1,3 @@
+- add a `kanban ui` command that serves a dashboard backed by the existing board loaders
+- implement a browser UI for the kanban package with automatic refresh and manual reload controls
+- cover the UI rendering and server endpoints with new ava tests

--- a/docs/agile/tasks/Setup Kanban UI for Kanban package.md
+++ b/docs/agile/tasks/Setup Kanban UI for Kanban package.md
@@ -1,0 +1,30 @@
+---
+uuid: c3366097-0d29-4c8d-b7e1-32de4cf8072e
+title: setup kanban ui for kanban package
+status: in-progress
+priority: P3
+labels:
+  - kanban
+  - ui
+  - framework-core
+created_at: '2025-10-03T07:25:00.000Z'
+---
+## 🎯 Desired Outcome
+A lightweight web UI served from `@promethean/kanban` that visualises the current board using the package's existing loaders, so agents can inspect column WIP without opening Obsidian.
+
+## 📏 Acceptance Criteria
+- `pnpm kanban ui` (or equivalent) serves an HTML dashboard reachable locally.
+- The UI renders all board columns, task counts, and task metadata (title, priority, labels, created timestamp).
+- Data refresh works without reloading the page (manual refresh button and automatic polling acceptable).
+- Coverage via unit tests for the render pipeline and a smoke test for the server endpoint.
+- README documents how to launch the UI.
+
+## 🛠️ Implementation Notes
+- Reuse `loadBoard` to obtain data; expose it through a small HTTP server in `packages/kanban`.
+- Implement UI as a module under `src/frontend/` with zero external dependencies (vanilla web components or DOM helpers).
+- Ship CSS with the UI so it is readable without further tooling.
+- Add AVA tests for HTML rendering and server response.
+
+## ❓ Open Questions / Risks
+- Ensure CLI wiring keeps backward compatibility with existing commands.
+- Confirm that serving compiled frontend assets from `dist/frontend` works under Nx build output.

--- a/packages/kanban/README.md
+++ b/packages/kanban/README.md
@@ -27,6 +27,8 @@ Common workflows:
 - `pnpm kanban sync` – run both directions and surface conflicting cards.
 - `pnpm kanban regenerate` – rebuild the board from the current task folder.
 - `pnpm kanban count --kanban path --tasks path` – quick stats for automation.
+- `pnpm kanban ui --port 4173` – launch an interactive kanban dashboard in the
+  browser (defaults to `http://127.0.0.1:4173`).
 
 Each command emits newline-delimited JSON so downstream tooling can be scripted
 without parsing human output.
@@ -40,6 +42,14 @@ The package also houses the TypeScript utilities that used to live in
   rebalance WIP limits.
 - `pnpm tsx packages/kanban/src/scripts/pending_count.ts` – report the number of
   pending embeddings tracked in MongoDB.
+
+## Web UI
+
+Run `pnpm kanban ui` to start a lightweight HTTP server that renders the
+workspace board as a responsive dashboard. The command respects the same
+configuration flags as other subcommands, so `--kanban`, `--tasks`, `--host`,
+and `--port` work as expected. The page refreshes automatically every minute,
+and you can trigger a manual refresh from the "Refresh" button in the header.
 
 ## Notes
 

--- a/packages/kanban/src/cli/command-handlers.ts
+++ b/packages/kanban/src/cli/command-handlers.ts
@@ -1,0 +1,269 @@
+import {
+  loadBoard,
+  countTasks,
+  getColumn,
+  getTasksByColumn,
+  findTaskById,
+  findTaskByTitle,
+  updateStatus,
+  moveTask,
+  pullFromTasks,
+  pushToTasks,
+  syncBoardAndTasks,
+  regenerateBoard,
+  indexForSearch,
+  searchTasks,
+} from "../lib/kanban.js";
+import { printJSONL } from "../lib/jsonl.js";
+import { serveKanbanUI } from "../lib/ui-server.js";
+
+type Primitive = string | number | boolean | symbol | null | undefined | bigint;
+
+type DeepReadonly<T> = T extends Primitive
+  ? T
+  : T extends ReadonlyArray<infer U>
+    ? ReadonlyArray<DeepReadonly<U>>
+    : T extends object
+      ? { readonly [K in keyof T]: DeepReadonly<T[K]> }
+      : T;
+
+export type CliContext = Readonly<{
+  readonly boardFile: string;
+  readonly tasksDir: string;
+}>;
+
+export type CommandHandler = (
+  args: ReadonlyArray<string>,
+  context: CliContext,
+) => Promise<void>;
+
+type LoadedBoard = Awaited<ReturnType<typeof loadBoard>>;
+
+type ImmutableLoadedBoard = DeepReadonly<LoadedBoard>;
+
+const requireArg = (value: string | undefined, label: string): string => {
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    if (trimmed.length > 0) {
+      return trimmed;
+    }
+  }
+  console.error(`Missing required ${label}.`);
+  process.exit(2);
+};
+
+const parsePort = (value: string): number => {
+  const trimmed = value.trim();
+  const port = Number.parseInt(trimmed, 10);
+  if (!Number.isInteger(port) || port <= 0 || port > 65_535) {
+    console.error(`Invalid port: ${value}`);
+    process.exit(2);
+  }
+  return port;
+};
+
+type UiOptions = Readonly<{ host?: string; port?: number }>;
+
+const parseUiOptions = (
+  tokens: ReadonlyArray<string>,
+  acc: UiOptions = {},
+): UiOptions => {
+  if (tokens.length === 0) {
+    return acc;
+  }
+  const [head, ...tail] = tokens;
+  const token = head ?? "";
+  if (token.startsWith("--port=")) {
+    const value = token.slice("--port=".length);
+    return parseUiOptions(tail, { ...acc, port: parsePort(value) });
+  }
+  if (token === "--port") {
+    const [next, ...rest] = tail;
+    const port = parsePort(requireArg(next, "port"));
+    return parseUiOptions(rest, { ...acc, port });
+  }
+  if (token.startsWith("--host=")) {
+    const value = token.slice("--host=".length).trim();
+    if (value.length === 0) {
+      console.error("Invalid host value");
+      process.exit(2);
+    }
+    return parseUiOptions(tail, { ...acc, host: value });
+  }
+  if (token === "--host") {
+    const [next, ...rest] = tail;
+    const value = requireArg(next, "host");
+    return parseUiOptions(rest, { ...acc, host: value });
+  }
+  console.error(`Unknown ui option: ${token}`);
+  process.exit(2);
+};
+
+const withBoard = async <T>(
+  context: CliContext,
+  effect: (board: ImmutableLoadedBoard) => Promise<T>,
+): Promise<T> => {
+  const board = await loadBoard(context.boardFile, context.tasksDir);
+  return effect(board as ImmutableLoadedBoard);
+};
+
+const handleCount: CommandHandler = async (args, context) =>
+  withBoard(context, async (board) => {
+    const mutableBoard = board as unknown as LoadedBoard;
+    const count = countTasks(mutableBoard, args[0]);
+    printJSONL({ count });
+  });
+
+const handleGetColumn: CommandHandler = async (args, context) =>
+  withBoard(context, async (board) => {
+    const mutableBoard = board as unknown as LoadedBoard;
+    const column = getColumn(mutableBoard, requireArg(args[0], "column name"));
+    printJSONL(column);
+  });
+
+const handleGetByColumn: CommandHandler = async (args, context) =>
+  withBoard(context, async (board) => {
+    const mutableBoard = board as unknown as LoadedBoard;
+    const tasks = getTasksByColumn(
+      mutableBoard,
+      requireArg(args[0], "column name"),
+    );
+    printJSONL(tasks);
+  });
+
+const handleFind: CommandHandler = async (args, context) =>
+  withBoard(context, async (board) => {
+    const mutableBoard = board as unknown as LoadedBoard;
+    const task = findTaskById(mutableBoard, requireArg(args[0], "task id"));
+    if (task) {
+      printJSONL(task);
+    }
+  });
+
+const handleFindByTitle: CommandHandler = async (args, context) =>
+  withBoard(context, async (board) => {
+    const mutableBoard = board as unknown as LoadedBoard;
+    const title = requireArg(args.join(" ").trim(), "task title");
+    const task = findTaskByTitle(mutableBoard, title);
+    if (task) {
+      printJSONL(task);
+    }
+  });
+
+const handleUpdateStatus: CommandHandler = async (args, context) =>
+  withBoard(context, async (board) => {
+    const mutableBoard = board as unknown as LoadedBoard;
+    const id = requireArg(args[0], "task id");
+    const status = requireArg(args[1], "new status");
+    const updated = await updateStatus(
+      mutableBoard,
+      id,
+      status,
+      context.boardFile,
+    );
+    printJSONL(updated);
+  });
+
+const handleMove =
+  (offset: number): CommandHandler =>
+  async (args, context) =>
+    withBoard(context, async (board) => {
+      const mutableBoard = board as unknown as LoadedBoard;
+      const id = requireArg(args[0], "task id");
+      const result = await moveTask(
+        mutableBoard,
+        id,
+        offset,
+        context.boardFile,
+      );
+      printJSONL(result);
+    });
+
+const handlePull: CommandHandler = async (_args, context) =>
+  withBoard(context, async (board) => {
+    const mutableBoard = board as unknown as LoadedBoard;
+    const result = await pullFromTasks(
+      mutableBoard,
+      context.tasksDir,
+      context.boardFile,
+    );
+    printJSONL(result);
+  });
+
+const handlePush: CommandHandler = async (_args, context) =>
+  withBoard(context, async (board) => {
+    const mutableBoard = board as unknown as LoadedBoard;
+    const result = await pushToTasks(mutableBoard, context.tasksDir);
+    printJSONL(result);
+  });
+
+const handleSync: CommandHandler = async (_args, context) =>
+  withBoard(context, async (board) => {
+    const mutableBoard = board as unknown as LoadedBoard;
+    const result = await syncBoardAndTasks(
+      mutableBoard,
+      context.tasksDir,
+      context.boardFile,
+    );
+    printJSONL(result);
+  });
+
+const handleRegenerate: CommandHandler = async (_args, context) => {
+  const result = await regenerateBoard(context.tasksDir, context.boardFile);
+  printJSONL(result);
+};
+
+const handleIndexForSearch: CommandHandler = async (_args, context) => {
+  const result = await indexForSearch(context.tasksDir);
+  printJSONL(result);
+};
+
+const handleSearch: CommandHandler = async (args, context) =>
+  withBoard(context, async (board) => {
+    const mutableBoard = board as unknown as LoadedBoard;
+    const term = requireArg(args.join(" ").trim(), "search term");
+    const result = await searchTasks(mutableBoard, term);
+    printJSONL(result);
+  });
+
+const handleUi: CommandHandler = async (args, context) => {
+  const options = parseUiOptions(args);
+  await serveKanbanUI({
+    boardFile: context.boardFile,
+    tasksDir: context.tasksDir,
+    host: options.host,
+    port: options.port,
+  });
+};
+
+export const COMMAND_HANDLERS: Readonly<Record<string, CommandHandler>> =
+  Object.freeze({
+    count: handleCount,
+    getColumn: handleGetColumn,
+    getByColumn: handleGetByColumn,
+    find: handleFind,
+    "find-by-title": handleFindByTitle,
+    update_status: handleUpdateStatus,
+    move_up: handleMove(-1),
+    move_down: handleMove(1),
+    pull: handlePull,
+    push: handlePush,
+    sync: handleSync,
+    regenerate: handleRegenerate,
+    indexForSearch: handleIndexForSearch,
+    search: handleSearch,
+    ui: handleUi,
+  });
+
+export const runCommand = async (
+  command: string,
+  args: ReadonlyArray<string>,
+  context: CliContext,
+): Promise<void> => {
+  const handler = COMMAND_HANDLERS[command];
+  if (!handler) {
+    console.error(`Unknown subcommand: ${command}`);
+    process.exit(2);
+  }
+  await handler(args, context);
+};

--- a/packages/kanban/src/frontend/kanban-ui.ts
+++ b/packages/kanban/src/frontend/kanban-ui.ts
@@ -1,0 +1,252 @@
+import type { Board } from "../lib/types.js";
+
+import { escapeHtml, renderBoardHtml } from "./render.js";
+import { KANBAN_STYLES } from "./styles.js";
+
+type Primitive = string | number | boolean | symbol | null | undefined | bigint;
+
+type DeepReadonly<T> = T extends Primitive
+  ? T
+  : T extends ReadonlyArray<infer U>
+    ? ReadonlyArray<DeepReadonly<U>>
+    : T extends object
+      ? { readonly [K in keyof T]: DeepReadonly<T[K]> }
+      : T;
+
+type SummaryColumn = {
+  readonly name: string;
+  readonly count: number;
+  readonly limit: number | null;
+};
+
+export type KanbanBoardResponse = DeepReadonly<{
+  board: Board;
+  generatedAt: string;
+  summary: {
+    totalTasks: number;
+    columns: ReadonlyArray<SummaryColumn>;
+  };
+}>;
+
+type UiStatus = "idle" | "loading" | "error";
+
+type UiStatusState = DeepReadonly<{
+  message: string;
+  mode: UiStatus;
+  updatedAt: string | null;
+}>;
+
+type RenderParams = DeepReadonly<{
+  status: UiStatusState;
+  payload: KanbanBoardResponse | null;
+  boardPath: string;
+  tasksPath: string;
+}>;
+
+type ShadowRenderRoot = Readonly<Pick<ShadowRoot, "replaceChildren">>;
+
+type FetchResponse = Readonly<Pick<Response, "ok" | "status" | "json">>;
+
+type RefreshEvent = DeepReadonly<Pick<Event, "target">>;
+
+const REFRESH_INTERVAL_MS = 60_000;
+
+const formatTimestamp = (iso: string): string => {
+  const date = new Date(iso);
+  return Number.isNaN(date.getTime())
+    ? iso
+    : `${date.toLocaleDateString()} ${date.toLocaleTimeString()}`;
+};
+
+const renderMarkup = (params: RenderParams): string => {
+  const updatedAt = params.status.updatedAt;
+  const updatedLabel = updatedAt ? formatTimestamp(updatedAt) : "—";
+  const boardMarkup = params.payload
+    ? renderBoardHtml(params.payload.board)
+    : '<p class="task-empty">Board data unavailable.</p>';
+  const boardLine =
+    params.boardPath.length > 0
+      ? `<p class="muted">Board: <code>${escapeHtml(
+          params.boardPath,
+        )}</code></p>`
+      : "";
+  const tasksLine =
+    params.tasksPath.length > 0
+      ? `<p class="muted">Tasks: <code>${escapeHtml(
+          params.tasksPath,
+        )}</code></p>`
+      : "";
+  return `
+    <style>${KANBAN_STYLES}</style>
+    <div class="kanban-app">
+      <header class="kanban-header">
+        <div>
+          <h1>Promethean Kanban</h1>
+          ${boardLine}
+          ${tasksLine}
+        </div>
+        <div class="kanban-controls">
+          <button type="button" data-action="refresh">Refresh</button>
+          <span class="status" data-state="${escapeHtml(
+            params.status.mode,
+          )}">${escapeHtml(params.status.message)}</span>
+          <time datetime="${escapeHtml(updatedAt ?? "")}">${escapeHtml(
+            updatedLabel,
+          )}</time>
+        </div>
+      </header>
+      <div class="board-container">
+        <div class="kanban-columns" aria-live="polite">${boardMarkup}</div>
+      </div>
+    </div>
+  `;
+};
+
+const renderToShadow = (
+  shadow: ShadowRenderRoot,
+  params: RenderParams,
+): void => {
+  const fragment = document
+    .createRange()
+    .createContextualFragment(renderMarkup(params));
+  shadow.replaceChildren(fragment);
+};
+
+const parseResponse = async (
+  response: FetchResponse,
+): Promise<KanbanBoardResponse> => {
+  if (!response.ok) {
+    throw new Error(`Request failed with status ${response.status}`);
+  }
+  return (await response.json()) as KanbanBoardResponse;
+};
+
+const fetchBoardData = (): Promise<KanbanBoardResponse> =>
+  fetch("/api/board", {
+    headers: { Accept: "application/json" },
+    cache: "no-store",
+  }).then(parseResponse);
+
+const payloadCache = new WeakMap<
+  PrometheanKanbanDashboard,
+  KanbanBoardResponse | null
+>();
+const intervalRegistry = new WeakMap<PrometheanKanbanDashboard, number>();
+
+class PrometheanKanbanDashboard extends HTMLElement {
+  private get boardPath(): string {
+    return this.dataset.boardPath ?? "";
+  }
+
+  private get tasksPath(): string {
+    return this.dataset.tasksPath ?? "";
+  }
+
+  private readonly handleClick = (event: RefreshEvent): void => {
+    const target = event.target;
+    if (
+      target instanceof HTMLButtonElement &&
+      target.dataset.action === "refresh"
+    ) {
+      void this.refresh();
+    }
+  };
+
+  constructor() {
+    super();
+    const shadow = this.attachShadow({ mode: "open" });
+    payloadCache.set(this, null);
+    renderToShadow(shadow, {
+      status: { message: "Ready", mode: "idle", updatedAt: null },
+      payload: null,
+      boardPath: this.boardPath,
+      tasksPath: this.tasksPath,
+    });
+    shadow.addEventListener("click", this.handleClick);
+  }
+
+  connectedCallback(): void {
+    void this.refresh();
+    const intervalId = window.setInterval(() => {
+      void this.refresh();
+    }, REFRESH_INTERVAL_MS);
+    intervalRegistry.set(this, intervalId);
+  }
+
+  disconnectedCallback(): void {
+    const intervalId = intervalRegistry.get(this);
+    if (typeof intervalId === "number") {
+      window.clearInterval(intervalId);
+      intervalRegistry.delete(this);
+    }
+  }
+
+  private renderState(
+    payload: KanbanBoardResponse | null,
+    status: UiStatusState,
+  ): void {
+    if (!this.shadowRoot) return;
+    renderToShadow(this.shadowRoot, {
+      status,
+      payload,
+      boardPath: this.boardPath,
+      tasksPath: this.tasksPath,
+    });
+  }
+
+  private readonly refresh = (): Promise<void> => {
+    const current = payloadCache.get(this) ?? null;
+    this.renderState(current, {
+      message: "Loading…",
+      mode: "loading",
+      updatedAt: current?.generatedAt ?? null,
+    });
+    return fetchBoardData()
+      .then((payload) => {
+        payloadCache.set(this, payload);
+        this.renderState(payload, {
+          message: "Updated",
+          mode: "idle",
+          updatedAt: payload.generatedAt,
+        });
+      })
+      .catch((error: unknown) => {
+        const message =
+          error instanceof Error
+            ? error.message
+            : String(error ?? "unknown error");
+        console.error("[kanban-ui] failed to refresh board", error);
+        this.renderState(current, {
+          message: `Error: ${message}`,
+          mode: "error",
+          updatedAt: current?.generatedAt ?? null,
+        });
+      });
+  };
+}
+
+customElements.define("promethean-kanban-dashboard", PrometheanKanbanDashboard);
+
+const bootstrap = (): void => {
+  const host = document.getElementById("kanban-root");
+  if (!host) {
+    console.warn("[kanban-ui] Missing #kanban-root container");
+    return;
+  }
+  const boardPath = host.dataset.boardPath ?? "";
+  const tasksPath = host.dataset.tasksPath ?? "";
+  const dashboard = document.createElement("promethean-kanban-dashboard");
+  if (boardPath.length > 0) {
+    dashboard.setAttribute("data-board-path", boardPath);
+  }
+  if (tasksPath.length > 0) {
+    dashboard.setAttribute("data-tasks-path", tasksPath);
+  }
+  host.replaceChildren(dashboard);
+};
+
+if (document.readyState === "loading") {
+  document.addEventListener("DOMContentLoaded", bootstrap, { once: true });
+} else {
+  bootstrap();
+}

--- a/packages/kanban/src/frontend/render.ts
+++ b/packages/kanban/src/frontend/render.ts
@@ -1,0 +1,218 @@
+import type { Board, ColumnData, Task } from "../lib/types.js";
+
+type Primitive = string | number | boolean | symbol | null | undefined | bigint;
+
+type DeepReadonly<T> = T extends Primitive
+  ? T
+  : T extends ReadonlyArray<infer U>
+    ? ReadonlyArray<DeepReadonly<U>>
+    : T extends object
+      ? { readonly [K in keyof T]: DeepReadonly<T[K]> }
+      : T;
+
+type ReadonlyEstimates = DeepReadonly<Task["estimates"]> | undefined;
+
+type ReadonlyTask = DeepReadonly<Task>;
+
+type ReadonlyColumn = DeepReadonly<ColumnData>;
+
+type ReadonlyBoard = DeepReadonly<Board>;
+
+export const escapeHtml = (value: string | undefined): string => {
+  if (typeof value !== "string") return "";
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+};
+
+const sanitizeMultiline = (value: string | undefined): string => {
+  if (!value) return "";
+  return value.replace(/\r?\n+/g, " ").trim();
+};
+
+const formatPriority = (
+  priority: ReadonlyTask["priority"],
+): string | undefined => {
+  if (priority === null || typeof priority === "undefined") {
+    return undefined;
+  }
+  if (typeof priority === "number") {
+    return `P${priority}`;
+  }
+  const trimmed = priority.trim();
+  return trimmed.length > 0 ? trimmed.toUpperCase() : undefined;
+};
+
+const formatCreatedAt = (
+  createdAt: ReadonlyTask["created_at"],
+): string | undefined => {
+  if (typeof createdAt !== "string" || createdAt.trim().length === 0) {
+    return undefined;
+  }
+  const date = new Date(createdAt);
+  return Number.isNaN(date.getTime())
+    ? sanitizeMultiline(createdAt)
+    : date.toLocaleString();
+};
+
+const truncate = (value: string, length: number): string =>
+  value.length <= length ? value : `${value.slice(0, length - 1)}…`;
+
+const renderLabels = (labels: ReadonlyArray<string> | undefined): string => {
+  if (!labels || labels.length === 0) {
+    return "";
+  }
+  const chips = labels
+    .filter((label) => typeof label === "string" && label.trim().length > 0)
+    .map((label) => `<span class="task-label">${escapeHtml(label)}</span>`)
+    .join("");
+  return chips.length > 0
+    ? `<div class="task-labels" aria-label="Labels">${chips}</div>`
+    : "";
+};
+
+const renderEstimates = (
+  estimates: ReadonlyEstimates,
+): ReadonlyArray<string> => {
+  if (!estimates) return [];
+  const complexity =
+    typeof estimates.complexity === "number"
+      ? [`C${estimates.complexity}`]
+      : [];
+  const scale =
+    typeof estimates.scale === "number" ? [`S${estimates.scale}`] : [];
+  const time =
+    typeof estimates.time_to_completion === "string"
+      ? (() => {
+          const trimmed = estimates.time_to_completion.trim();
+          return trimmed.length > 0 ? [trimmed] : [];
+        })()
+      : [];
+  return [...complexity, ...scale, ...time];
+};
+
+const renderTaskMeta = (task: ReadonlyTask): string => {
+  const createdDisplay = formatCreatedAt(task.created_at);
+  const estimates = renderEstimates(task.estimates);
+  const segments = [
+    createdDisplay
+      ? `<span class="task-meta-item"><span class="meta-label">Created</span><time datetime="${escapeHtml(
+          task.created_at,
+        )}">${escapeHtml(createdDisplay)}</time></span>`
+      : undefined,
+    task.uuid
+      ? `<span class="task-meta-item"><span class="meta-label">UUID</span><code>${escapeHtml(
+          truncate(task.uuid, 12),
+        )}</code></span>`
+      : undefined,
+    estimates.length > 0
+      ? `<span class="task-meta-item"><span class="meta-label">Est.</span><span>${escapeHtml(
+          estimates.join(" · "),
+        )}</span></span>`
+      : undefined,
+  ].filter((segment): segment is string => typeof segment === "string");
+  return segments.length > 0
+    ? `<div class="task-meta">${segments.join("")}</div>`
+    : "";
+};
+
+const renderTaskContent = (content: ReadonlyTask["content"]): string => {
+  if (typeof content !== "string") {
+    return "";
+  }
+  const trimmed = content.trim();
+  return trimmed.length === 0
+    ? ""
+    : `<p class="task-body">${escapeHtml(truncate(trimmed, 160))}</p>`;
+};
+
+const renderTask = (task: ReadonlyTask): string => {
+  const title =
+    typeof task.title === "string" && task.title.trim().length > 0
+      ? task.title.trim()
+      : task.uuid;
+  const priorityValue = formatPriority(task.priority);
+  const priorityBadge = priorityValue
+    ? `<span class="task-priority" data-priority="${escapeHtml(
+        priorityValue,
+      )}">${escapeHtml(priorityValue)}</span>`
+    : "";
+  const labelsBlock = renderLabels(task.labels);
+  const contentBlock = renderTaskContent(task.content);
+  const metaBlock = renderTaskMeta(task);
+  return `<li class="task-card" data-uuid="${escapeHtml(
+    task.uuid,
+  )}"><header class="task-header"><h3>${escapeHtml(
+    title,
+  )}</h3>${priorityBadge}</header>${labelsBlock}${metaBlock}${contentBlock}</li>`;
+};
+
+const renderTasks = (column: ReadonlyColumn): string =>
+  column.tasks.length === 0
+    ? '<li class="task-empty">No tasks yet.</li>'
+    : column.tasks.map(renderTask).join("");
+
+const renderColumnHeader = (column: ReadonlyColumn): string => {
+  const limit =
+    typeof column.limit === "number" && Number.isFinite(column.limit)
+      ? escapeHtml(String(column.limit))
+      : "";
+  const count = Number.isFinite(column.count)
+    ? column.count
+    : column.tasks.length;
+  const limitLabel = limit.length > 0 ? ` / ${limit}` : "";
+  return `<div class="column-header"><h2>${escapeHtml(
+    column.name,
+  )}</h2><span class="column-count">${escapeHtml(
+    String(count),
+  )}${limitLabel}</span></div>`;
+};
+
+const renderColumn = (column: ReadonlyColumn): string =>
+  `<section class="kanban-column" data-column="${escapeHtml(
+    column.name,
+  )}">${renderColumnHeader(
+    column,
+  )}<ol class="task-list" aria-label="${escapeHtml(
+    column.name,
+  )} tasks">${renderTasks(column)}</ol></section>`;
+
+const summarizeBoard = (
+  board: ReadonlyBoard,
+): Readonly<{
+  readonly totalTasks: number;
+  readonly totalColumns: number;
+}> => ({
+  totalTasks: board.columns.reduce(
+    (acc, column) =>
+      acc +
+      (Number.isFinite(column.count) ? column.count : column.tasks.length),
+    0,
+  ),
+  totalColumns: board.columns.length,
+});
+
+const renderSummary = (board: ReadonlyBoard): string => {
+  const summary = summarizeBoard(board);
+  return `<section class="board-summary"><div class="summary-card"><span class="summary-value">${escapeHtml(
+    String(summary.totalTasks),
+  )}</span><span class="summary-label">Total tasks</span></div><div class="summary-card"><span class="summary-value">${escapeHtml(
+    String(summary.totalColumns),
+  )}</span><span class="summary-label">Columns</span></div></section>`;
+};
+
+export const renderBoardHtml = (board: ReadonlyBoard): string => {
+  const readonlyBoard: ReadonlyBoard = {
+    columns: board.columns.map((column) => ({
+      ...column,
+      tasks: column.tasks.map((task) => ({ ...task }) as ReadonlyTask),
+    })),
+  };
+  const columnsMarkup = readonlyBoard.columns.map(renderColumn).join("");
+  return `${renderSummary(
+    readonlyBoard,
+  )}<section class="kanban-columns">${columnsMarkup}</section>`;
+};

--- a/packages/kanban/src/frontend/styles.ts
+++ b/packages/kanban/src/frontend/styles.ts
@@ -1,0 +1,305 @@
+export const KANBAN_STYLES = String.raw`
+  :root {
+    color-scheme: only light;
+    font-family: "Inter", "SF Pro Text", -apple-system, BlinkMacSystemFont,
+      "Segoe UI", sans-serif;
+  }
+
+  body {
+    margin: 0;
+    background: radial-gradient(circle at top, #f8fafc, #e2e8f0);
+    min-height: 100vh;
+    color: #0f172a;
+  }
+
+  .kanban-app {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 2.5rem 1.5rem 3rem;
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+  }
+
+  .kanban-header {
+    display: flex;
+    align-items: flex-end;
+    justify-content: space-between;
+    gap: 1.5rem;
+    flex-wrap: wrap;
+  }
+
+  .kanban-header h1 {
+    margin: 0 0 0.5rem 0;
+    font-size: 2rem;
+    letter-spacing: -0.015em;
+  }
+
+  .muted {
+    color: #475569;
+    margin: 0.25rem 0;
+    font-size: 0.9rem;
+  }
+
+  code {
+    font-family: "JetBrains Mono", "Fira Mono", "SFMono-Regular",
+      ui-monospace, monospace;
+    padding: 0.1rem 0.35rem;
+    border-radius: 6px;
+    background: rgba(15, 23, 42, 0.08);
+  }
+
+  .kanban-controls {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+  }
+
+  button[data-action="refresh"] {
+    appearance: none;
+    border: none;
+    padding: 0.6rem 1rem;
+    border-radius: 9999px;
+    font-weight: 600;
+    background: linear-gradient(135deg, #2563eb, #3b82f6);
+    color: white;
+    box-shadow: 0 8px 16px rgba(37, 99, 235, 0.25);
+    cursor: pointer;
+    transition: transform 0.15s ease, box-shadow 0.15s ease;
+  }
+
+  button[data-action="refresh"]:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 10px 24px rgba(37, 99, 235, 0.28);
+  }
+
+  button[data-action="refresh"]:active {
+    transform: translateY(0);
+    box-shadow: 0 6px 16px rgba(37, 99, 235, 0.22);
+  }
+
+  .status {
+    font-size: 0.9rem;
+    font-weight: 600;
+  }
+
+  .status[data-state="loading"] {
+    color: #0369a1;
+  }
+
+  .status[data-state="idle"] {
+    color: #0f172a;
+  }
+
+  .status[data-state="error"] {
+    color: #dc2626;
+  }
+
+  .board-overview {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    gap: 1rem;
+  }
+
+  .metric {
+    background: white;
+    border-radius: 16px;
+    padding: 1.25rem 1.5rem;
+    box-shadow: 0 18px 35px rgba(15, 23, 42, 0.08);
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+  }
+
+  .metric-value {
+    font-size: 2.1rem;
+    font-weight: 700;
+  }
+
+  .metric-label {
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    font-size: 0.75rem;
+    color: #64748b;
+  }
+
+  .board-container {
+    background: rgba(15, 23, 42, 0.04);
+    border-radius: 18px;
+    padding: 1.5rem;
+    box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.16);
+  }
+
+  .kanban-columns {
+    display: flex;
+    gap: 1.5rem;
+    align-items: flex-start;
+    overflow-x: auto;
+    padding-bottom: 0.5rem;
+  }
+
+  .kanban-columns::-webkit-scrollbar {
+    height: 10px;
+  }
+
+  .kanban-columns::-webkit-scrollbar-thumb {
+    background: rgba(30, 64, 175, 0.35);
+    border-radius: 999px;
+  }
+
+  .kanban-column {
+    flex: 0 0 280px;
+    background: linear-gradient(180deg, rgba(255, 255, 255, 0.92), #fff);
+    border-radius: 20px;
+    padding: 1.1rem;
+    box-shadow: 0 16px 30px rgba(15, 23, 42, 0.1);
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    border: 1px solid rgba(148, 163, 184, 0.18);
+  }
+
+  .column-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+  }
+
+  .column-header h2 {
+    margin: 0;
+    font-size: 1.1rem;
+    color: #1e3a8a;
+  }
+
+  .column-count {
+    font-weight: 600;
+    color: #334155;
+  }
+
+  .task-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.9rem;
+  }
+
+  .task-card {
+    background: white;
+    border-radius: 14px;
+    padding: 0.85rem 1rem;
+    box-shadow: 0 12px 24px rgba(15, 23, 42, 0.08);
+    border: 1px solid rgba(148, 163, 184, 0.25);
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+
+  .task-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 0.5rem;
+  }
+
+  .task-header h3 {
+    margin: 0;
+    font-size: 1rem;
+  }
+
+  .task-priority {
+    font-size: 0.75rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    padding: 0.25rem 0.5rem;
+    border-radius: 999px;
+    background: rgba(190, 242, 100, 0.35);
+    color: #3f6212;
+    font-weight: 700;
+  }
+
+  .task-priority[data-priority="P0"],
+  .task-priority[data-priority="P1"] {
+    background: rgba(248, 113, 113, 0.32);
+    color: #b91c1c;
+  }
+
+  .task-priority[data-priority="P2"] {
+    background: rgba(251, 191, 36, 0.32);
+    color: #b45309;
+  }
+
+  .task-priority[data-priority="P3"],
+  .task-priority[data-priority="P4"] {
+    background: rgba(190, 242, 100, 0.28);
+    color: #3f6212;
+  }
+
+  .task-labels {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.4rem;
+  }
+
+  .task-label {
+    background: rgba(59, 130, 246, 0.18);
+    color: #1d4ed8;
+    padding: 0.2rem 0.5rem;
+    border-radius: 999px;
+    font-size: 0.75rem;
+    font-weight: 600;
+  }
+
+  .task-meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem 0.75rem;
+    font-size: 0.75rem;
+    color: #475569;
+  }
+
+  .meta-label {
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    font-weight: 600;
+    margin-right: 0.25rem;
+    color: #64748b;
+  }
+
+  .task-body {
+    margin: 0;
+    font-size: 0.85rem;
+    line-height: 1.4;
+    color: #1e293b;
+  }
+
+  .task-empty {
+    margin: 0;
+    padding: 0.75rem;
+    background: rgba(148, 163, 184, 0.15);
+    border-radius: 12px;
+    text-align: center;
+    font-size: 0.85rem;
+    color: #475569;
+    font-style: italic;
+  }
+
+  @media (max-width: 768px) {
+    .kanban-app {
+      padding: 1.5rem 1rem 2rem;
+    }
+
+    .kanban-header {
+      align-items: flex-start;
+    }
+
+    .kanban-columns {
+      padding-bottom: 1rem;
+    }
+
+    .kanban-column {
+      flex: 0 0 240px;
+    }
+  }
+`;

--- a/packages/kanban/src/frontend/tests/render.test.ts
+++ b/packages/kanban/src/frontend/tests/render.test.ts
@@ -1,0 +1,78 @@
+import test from "ava";
+
+import { renderBoardHtml } from "../render.js";
+import type { Board } from "../../lib/types.js";
+
+const makeBoard = (overrides?: Partial<Board>): Board => ({
+  columns: [],
+  ...overrides,
+});
+
+test("renderBoardHtml renders columns and tasks", (t) => {
+  const board = makeBoard({
+    columns: [
+      {
+        name: "Todo",
+        count: 1,
+        limit: null,
+        tasks: [
+          {
+            uuid: "abc-123",
+            title: "Implement Kanban UI",
+            status: "Todo",
+            priority: "P1",
+            labels: ["kanban", "ui"],
+            created_at: "2025-10-03T00:00:00.000Z",
+            estimates: { complexity: 2, scale: 3 },
+            content: "Create a small dashboard",
+          },
+        ],
+      },
+    ],
+  });
+  const html = renderBoardHtml(board);
+  t.true(html.includes("Implement Kanban UI"));
+  t.true(html.includes("kanban"));
+  t.true(html.includes("Total tasks"));
+});
+
+test("renderBoardHtml escapes HTML-sensitive content", (t) => {
+  const board = makeBoard({
+    columns: [
+      {
+        name: "<Todo>",
+        count: 1,
+        limit: null,
+        tasks: [
+          {
+            uuid: "uuid-1",
+            title: "<script>bad()</script>",
+            status: "Todo",
+            priority: "P2",
+            labels: ["<alert>"],
+            created_at: "invalid",
+          },
+        ],
+      },
+    ],
+  });
+  const html = renderBoardHtml(board);
+  t.false(html.includes("<script>"));
+  t.true(html.includes("&lt;script&gt;bad()&lt;/script&gt;"));
+  t.true(html.includes("&lt;Todo&gt;"));
+});
+
+test("renderBoardHtml renders placeholder for empty columns", (t) => {
+  const board = makeBoard({
+    columns: [
+      {
+        name: "In Review",
+        count: 0,
+        limit: 2,
+        tasks: [],
+      },
+    ],
+  });
+  const html = renderBoardHtml(board);
+  t.true(html.includes("No tasks yet."));
+});

--- a/packages/kanban/src/index.ts
+++ b/packages/kanban/src/index.ts
@@ -1,22 +1,10 @@
 #!/usr/bin/env node
-import {
-  loadBoard,
-  countTasks,
-  getColumn,
-  getTasksByColumn,
-  findTaskById,
-  findTaskByTitle,
-  updateStatus,
-  moveTask,
-  pullFromTasks,
-  pushToTasks,
-  syncBoardAndTasks,
-  regenerateBoard,
-  indexForSearch,
-  searchTasks,
-} from "./lib/kanban.js";
-import { printJSONL } from "./lib/jsonl.js";
 import { loadKanbanConfig } from "./board/config.js";
+import {
+  COMMAND_HANDLERS,
+  runCommand,
+  type CliContext,
+} from "./cli/command-handlers.js";
 
 const LEGACY_FLAG_MAP = Object.freeze(
   new Map<string, string>([
@@ -25,52 +13,54 @@ const LEGACY_FLAG_MAP = Object.freeze(
   ]),
 );
 
+const LEGACY_FLAG_ENTRIES = Array.from(LEGACY_FLAG_MAP.entries());
+
+const normalizeLegacyToken = (token: string): string =>
+  LEGACY_FLAG_ENTRIES.reduce((current, [legacy, mapped]) => {
+    if (current === legacy) {
+      return mapped;
+    }
+    if (current.startsWith(`${legacy}=`)) {
+      return `${mapped}=${current.slice(legacy.length + 1)}`;
+    }
+    return current;
+  }, token);
+
 const normalizeLegacyArgs = (
   args: ReadonlyArray<string>,
-): ReadonlyArray<string> =>
-  args.map((token) => {
-    for (const [legacy, current] of LEGACY_FLAG_MAP.entries()) {
-      if (token === legacy) {
-        return current;
-      }
-      if (token.startsWith(`${legacy}=`)) {
-        return `${current}=${token.slice(legacy.length + 1)}`;
-      }
-    }
-    return token;
-  });
+): ReadonlyArray<string> => args.map(normalizeLegacyToken);
+
+const LEGACY_ENV_MAPPINGS = Object.freeze([
+  ["KANBAN_PATH", "KANBAN_BOARD_FILE"],
+  ["TASKS_PATH", "KANBAN_TASKS_DIR"],
+] as const);
 
 const applyLegacyEnv = (
   env: Readonly<NodeJS.ProcessEnv>,
-): NodeJS.ProcessEnv => {
-  const nextEnv: NodeJS.ProcessEnv = { ...env };
-  if (
-    typeof env.KANBAN_PATH === "string" &&
-    typeof env.KANBAN_BOARD_FILE !== "string"
-  ) {
-    nextEnv.KANBAN_BOARD_FILE = env.KANBAN_PATH;
-  }
-  if (
-    typeof env.TASKS_PATH === "string" &&
-    typeof env.KANBAN_TASKS_DIR !== "string"
-  ) {
-    nextEnv.KANBAN_TASKS_DIR = env.TASKS_PATH;
-  }
-  return nextEnv;
-};
-
-const requireArg = (value: string | undefined, label: string): string => {
-  if (typeof value === "string") {
-    const trimmed = value.trim();
-    if (trimmed.length > 0) {
-      return trimmed;
+): Readonly<NodeJS.ProcessEnv> => {
+  const patches = LEGACY_ENV_MAPPINGS.reduce<
+    ReadonlyArray<readonly [string, string]>
+  >((acc, [legacy, modern]) => {
+    const legacyValue = env[legacy];
+    if (typeof legacyValue === "string" && typeof env[modern] !== "string") {
+      return [...acc, [modern, legacyValue] as const];
     }
+    return acc;
+  }, []);
+  if (patches.length === 0) {
+    return { ...env };
   }
-  console.error(`Missing required ${label}.`);
-  process.exit(2);
+  return {
+    ...env,
+    ...Object.fromEntries(patches),
+  };
 };
 
-async function main() {
+const HELP_TEXT =
+  `Usage: kanban [--kanban path] [--tasks path] <subcommand> [args...]\n` +
+  `Subcommands: ${Object.keys(COMMAND_HANDLERS).join(", ")}`;
+
+async function main(): Promise<void> {
   const rawArgs = process.argv.slice(2);
   const normalizedArgs = normalizeLegacyArgs(rawArgs);
   const helpRequested =
@@ -81,129 +71,23 @@ async function main() {
     env: applyLegacyEnv(process.env),
   });
 
-  const [cmd, ...args] = restArgs;
-  const boardFile = config.boardFile;
-  const tasksDir = config.tasksDir;
-
-  if (helpRequested || !cmd) {
-    console.error(
-      `Usage: kanban [--kanban path] [--tasks path] <subcommand> [args...]\n` +
-        `Subcommands: count, getColumn, getByColumn, find, find-by-title, update_status, move_up, move_down, pull, push, sync, regenerate, indexForSearch, search`,
-    );
+  const [command, ...args] = restArgs;
+  if (helpRequested || !command) {
+    console.error(HELP_TEXT);
     process.exit(2);
   }
 
-  switch (cmd) {
-    case "count": {
-      const column = args[0];
-      const board = await loadBoard(boardFile, tasksDir);
-      const n = countTasks(board, column);
-      printJSONL({ count: n });
-      break;
-    }
-    case "getColumn": {
-      const column = requireArg(args[0], "column name");
-      const board = await loadBoard(boardFile, tasksDir);
-      const colData = getColumn(board, column);
-      printJSONL(colData);
-      break;
-    }
-    case "getByColumn": {
-      const column = requireArg(args[0], "column name");
-      const board = await loadBoard(boardFile, tasksDir);
-      const tasks = getTasksByColumn(board, column);
-      printJSONL(tasks);
-      break;
-    }
-    case "find": {
-      const id = requireArg(args[0], "task id");
-      const board = await loadBoard(boardFile, tasksDir);
-      const t = findTaskById(board, id);
-      if (t) printJSONL(t);
-      break;
-    }
-    case "find-by-title": {
-      const joined = args.join(" ").trim();
-      const title = requireArg(
-        joined.length > 0 ? joined : undefined,
-        "task title",
-      );
-      const board = await loadBoard(boardFile, tasksDir);
-      const t = findTaskByTitle(board, title);
-      if (t) printJSONL(t);
-      break;
-    }
-    case "update_status": {
-      const [rawId, rawStatus] = args;
-      const id = requireArg(rawId, "task id");
-      const newStatus = requireArg(rawStatus, "new status");
-      const board = await loadBoard(boardFile, tasksDir);
-      const updated = await updateStatus(board, id, newStatus, boardFile);
-      printJSONL(updated);
-      break;
-    }
-    case "move_up": {
-      const [rawId] = args;
-      const id = requireArg(rawId, "task id");
-      const board = await loadBoard(boardFile, tasksDir);
-      const res = await moveTask(board, id, -1, boardFile);
-      printJSONL(res);
-      break;
-    }
-    case "move_down": {
-      const [rawId] = args;
-      const id = requireArg(rawId, "task id");
-      const board = await loadBoard(boardFile, tasksDir);
-      const res = await moveTask(board, id, +1, boardFile);
-      printJSONL(res);
-      break;
-    }
-    case "pull": {
-      const board = await loadBoard(boardFile, tasksDir);
-      const res = await pullFromTasks(board, tasksDir, boardFile);
-      printJSONL(res);
-      break;
-    }
-    case "push": {
-      const board = await loadBoard(boardFile, tasksDir);
-      const res = await pushToTasks(board, tasksDir);
-      printJSONL(res);
-      break;
-    }
-    case "sync": {
-      const board = await loadBoard(boardFile, tasksDir);
-      const res = await syncBoardAndTasks(board, tasksDir, boardFile);
-      printJSONL(res);
-      break;
-    }
-    case "regenerate": {
-      const res = await regenerateBoard(tasksDir, boardFile);
-      printJSONL(res);
-      break;
-    }
-    case "indexForSearch": {
-      const res = await indexForSearch(tasksDir);
-      printJSONL(res);
-      break;
-    }
-    case "search": {
-      const joined = args.join(" ").trim();
-      const term = requireArg(
-        joined.length > 0 ? joined : undefined,
-        "search term",
-      );
-      const board = await loadBoard(boardFile, tasksDir);
-      const res = await searchTasks(board, term);
-      printJSONL(res);
-      break;
-    }
-    default:
-      console.error(`Unknown subcommand: ${cmd}`);
-      process.exit(2);
-  }
+  const context: CliContext = {
+    boardFile: config.boardFile,
+    tasksDir: config.tasksDir,
+  };
+
+  await runCommand(command, args, context);
 }
 
-main().catch((err) => {
-  console.error(err?.stack || String(err));
+main().catch((error: unknown) => {
+  const message =
+    error instanceof Error ? error.stack ?? error.message : String(error);
+  console.error(message);
   process.exit(1);
 });

--- a/packages/kanban/src/lib/ui-server.ts
+++ b/packages/kanban/src/lib/ui-server.ts
@@ -1,0 +1,276 @@
+import { readFile } from "node:fs/promises";
+import { createServer } from "node:http";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import type { IncomingMessage, ServerResponse } from "node:http";
+
+import { escapeHtml } from "../frontend/render.js";
+
+import { loadBoard } from "./kanban.js";
+type Primitive = string | number | boolean | symbol | null | undefined | bigint;
+
+type DeepReadonlyTuple<T extends ReadonlyArray<unknown>> = {
+  readonly [K in keyof T]: DeepReadonly<T[K]>;
+};
+
+type DeepReadonly<T> = T extends Primitive
+  ? T
+  : T extends (...args: infer A) => infer R
+    ? (...args: DeepReadonlyTuple<A>) => DeepReadonly<R>
+    : T extends ReadonlyArray<infer U>
+      ? ReadonlyArray<DeepReadonly<U>>
+      : T extends object
+        ? { readonly [K in keyof T]: DeepReadonly<T[K]> }
+        : T;
+
+type SummaryColumn = {
+  readonly name: string;
+  readonly count: number;
+  readonly limit: number | null;
+};
+
+type KanbanSummary = {
+  readonly totalTasks: number;
+  readonly columns: ReadonlyArray<SummaryColumn>;
+};
+
+type KanbanBoardPayload = {
+  readonly board: ReadonlyLoadedBoard;
+  readonly generatedAt: string;
+  readonly summary: KanbanSummary;
+};
+
+type KanbanUiServerOptions = {
+  readonly boardFile: string;
+  readonly tasksDir: string;
+  readonly host?: string;
+  readonly port?: number;
+};
+
+type ImmutableSummary = DeepReadonly<KanbanSummary>;
+
+type ImmutablePayload = DeepReadonly<KanbanBoardPayload>;
+
+type ImmutableOptions = DeepReadonly<KanbanUiServerOptions>;
+
+type LoadedBoard = Awaited<ReturnType<typeof loadBoard>>;
+
+type ReadonlyLoadedBoard = DeepReadonly<LoadedBoard>;
+
+type HttpResponse = Readonly<
+  Pick<ServerResponse, "writeHead" | "end"> &
+    Partial<Pick<ServerResponse, "setHeader" | "getHeader">>
+>;
+
+type HttpRequest = Readonly<Pick<IncomingMessage, "method" | "url">>;
+
+type ServerInstance = ReturnType<typeof createServer>;
+
+type ServerControls = Readonly<
+  Pick<ServerInstance, "listen" | "once" | "off" | "close" | "address">
+>;
+
+const FRONTEND_SCRIPT_PATH = fileURLToPath(
+  new URL("../frontend/kanban-ui.js", import.meta.url),
+);
+
+const computeSummary = (board: ReadonlyLoadedBoard): ImmutableSummary => {
+  const columns = board.columns.map((column) => {
+    const count = Number.isFinite(column.count)
+      ? column.count
+      : column.tasks.length;
+    const limit =
+      typeof column.limit === "number" && Number.isFinite(column.limit)
+        ? column.limit
+        : null;
+    return {
+      name: column.name,
+      count,
+      limit,
+    } satisfies SummaryColumn;
+  });
+  const totalTasks = columns.reduce((acc, column) => acc + column.count, 0);
+  return { totalTasks, columns } satisfies ImmutableSummary;
+};
+
+const htmlTemplate = (options: ImmutableOptions): string => {
+  const cwd = process.cwd();
+  const boardPath = path.isAbsolute(options.boardFile)
+    ? path.relative(cwd, options.boardFile) || options.boardFile
+    : options.boardFile;
+  const tasksPath = path.isAbsolute(options.tasksDir)
+    ? path.relative(cwd, options.tasksDir) || options.tasksDir
+    : options.tasksDir;
+  return `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Promethean Kanban</title>
+    <meta name="description" content="Workspace kanban dashboard" />
+  </head>
+  <body>
+    <div
+      id="kanban-root"
+      data-board-path="${escapeHtml(boardPath)}"
+      data-tasks-path="${escapeHtml(tasksPath)}"
+    >
+      <noscript>
+        This dashboard requires JavaScript to render the kanban board.
+      </noscript>
+    </div>
+    <script type="module" src="/assets/kanban-ui.js"></script>
+  </body>
+</html>`;
+};
+
+const send = (
+  res: HttpResponse,
+  status: number,
+  body: string,
+  headers?: Readonly<Record<string, string>>,
+): void => {
+  res.writeHead(status, {
+    "Content-Length": Buffer.byteLength(body, "utf8"),
+    ...headers,
+  });
+  res.end(body, "utf8");
+};
+
+const sendJson = (
+  res: HttpResponse,
+  status: number,
+  payload: unknown,
+): void => {
+  const body = JSON.stringify(payload, null, 2);
+  send(res, status, body, {
+    "Content-Type": "application/json; charset=utf-8",
+    "Cache-Control": "no-store",
+  });
+};
+
+const notFound = (res: HttpResponse): void => {
+  send(res, 404, "Not Found", {
+    "Content-Type": "text/plain; charset=utf-8",
+    "Cache-Control": "no-store",
+  });
+};
+
+const internalError = (res: HttpResponse, error: unknown): void => {
+  console.error("[kanban-ui]", error);
+  send(res, 500, "Internal Server Error", {
+    "Content-Type": "text/plain; charset=utf-8",
+    "Cache-Control": "no-store",
+  });
+};
+
+const handleBoardRequest = (
+  res: HttpResponse,
+  options: ImmutableOptions,
+): Promise<void> =>
+  loadBoard(options.boardFile, options.tasksDir)
+    .then((board) => {
+      const payload: ImmutablePayload = {
+        board: board as ReadonlyLoadedBoard,
+        generatedAt: new Date().toISOString(),
+        summary: computeSummary(board as ReadonlyLoadedBoard),
+      } satisfies ImmutablePayload;
+      sendJson(res, 200, payload);
+    })
+    .catch((error) => {
+      internalError(res, error);
+    });
+
+const handleScriptRequest = (res: HttpResponse): Promise<void> =>
+  readFile(FRONTEND_SCRIPT_PATH, "utf8")
+    .then((script) => {
+      send(res, 200, script, {
+        "Content-Type": "application/javascript; charset=utf-8",
+        "Cache-Control": "no-store",
+      });
+    })
+    .catch((error) => {
+      internalError(res, error);
+    });
+
+const routeRequest = (
+  req: HttpRequest,
+  res: HttpResponse,
+  options: ImmutableOptions,
+): void => {
+  const method = req.method ?? "GET";
+  const url = req.url ?? "/";
+  if (method !== "GET") {
+    notFound(res);
+    return;
+  }
+  if (url === "/" || url.startsWith("/?")) {
+    send(res, 200, htmlTemplate(options), {
+      "Content-Type": "text/html; charset=utf-8",
+      "Cache-Control": "no-store",
+    });
+    return;
+  }
+  if (url.startsWith("/api/board")) {
+    void handleBoardRequest(res, options);
+    return;
+  }
+  if (url.startsWith("/assets/kanban-ui.js")) {
+    void handleScriptRequest(res);
+    return;
+  }
+  notFound(res);
+};
+
+export const createKanbanUiServer = (
+  options: ImmutableOptions,
+): ServerControls => {
+  const server = createServer((req, res) => {
+    routeRequest(req, res, options);
+  });
+
+  return server;
+};
+
+export const serveKanbanUI = async (
+  options: ImmutableOptions,
+): Promise<void> => {
+  const host = options.host ?? "127.0.0.1";
+  const port = options.port ?? 4173;
+  const server = createKanbanUiServer(options);
+  await new Promise<void>((resolve, reject) => {
+    const removeSignalListeners = () => {
+      process.off("SIGINT", stop);
+      process.off("SIGTERM", stop);
+    };
+
+    const onError = (error: Readonly<Error>) => {
+      removeSignalListeners();
+      server.close(() => {
+        reject(error);
+      });
+    };
+
+    const stop = () => {
+      removeSignalListeners();
+      server.close((closeError?: Readonly<Error> | null) => {
+        if (closeError) {
+          reject(closeError);
+          return;
+        }
+        resolve();
+      });
+    };
+
+    server.once("error", onError);
+
+    server.listen(port, host, () => {
+      console.log(
+        `Kanban UI available at http://${host}:${port} (press Ctrl+C to stop)`,
+      );
+    });
+
+    process.once("SIGINT", stop);
+    process.once("SIGTERM", stop);
+  });
+};

--- a/packages/kanban/src/tests/ui-server.test.ts
+++ b/packages/kanban/src/tests/ui-server.test.ts
@@ -1,0 +1,80 @@
+import { writeFile } from "node:fs/promises";
+import path from "node:path";
+
+import test from "ava";
+
+import { createKanbanUiServer } from "../lib/ui-server.js";
+import { makeTask, withTempDir, writeTaskFile } from "../test-utils/helpers.js";
+
+type ServerInstance = ReturnType<typeof createKanbanUiServer>;
+
+type ServerControls = Readonly<
+  Pick<ServerInstance, "listen" | "once" | "off" | "close" | "address">
+>;
+
+type BoardPayload = Readonly<{
+  readonly summary: Readonly<{ readonly totalTasks: number }>;
+  readonly board: Readonly<{
+    readonly columns: ReadonlyArray<
+      Readonly<{ readonly tasks: ReadonlyArray<unknown> }>
+    >;
+  }>;
+}>;
+
+const listenOnRandomPort = async (
+  server: ServerControls,
+): Promise<Readonly<{ readonly baseUrl: string }>> =>
+  new Promise((resolve, reject) => {
+    const onError = (error: Readonly<Error>) => reject(error);
+    server.once("error", onError);
+    server.listen(0, "127.0.0.1", () => {
+      server.off("error", onError);
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        reject(new Error("Unable to determine server address"));
+        return;
+      }
+      resolve({ baseUrl: `http://${address.address}:${address.port}` });
+    });
+  });
+
+const fetchJson = async <T>(url: string): Promise<T> => {
+  const response = await fetch(url, {
+    headers: { Accept: "application/json" },
+  });
+  if (!response.ok) {
+    throw new Error(`Request failed with status ${response.status}`);
+  }
+  return (await response.json()) as T;
+};
+
+test("kanban ui server exposes board payload and html", async (t) => {
+  const dir = await withTempDir(t);
+  const tasksDir = path.join(dir, "tasks");
+  const boardFile = path.join(dir, "board.md");
+  await writeFile(boardFile, "", "utf8");
+  await writeTaskFile(
+    tasksDir,
+    makeTask({
+      uuid: "task-1",
+      title: "Sample task",
+      status: "Todo",
+      slug: "sample-task",
+    }),
+  );
+
+  const server = createKanbanUiServer({ boardFile, tasksDir });
+  const { baseUrl } = await listenOnRandomPort(server);
+  t.teardown(async () => {
+    await new Promise<void>((resolve) => {
+      server.close(() => resolve());
+    });
+  });
+
+  const payload = await fetchJson<BoardPayload>(`${baseUrl}/api/board`);
+  t.is(payload.summary.totalTasks, 1);
+  t.is(payload.board.columns[0]?.tasks.length ?? 0, 1);
+
+  const html = await fetch(`${baseUrl}/`).then((res) => res.text());
+  t.true(html.includes("kanban-ui.js"));
+});


### PR DESCRIPTION
## Summary
- expose a reusable CLI runtime module that normalizes arguments and executes kanban subcommands, keeping handlers pure and reusable
- keep the Promethean kanban dashboard custom element and renderer for the shadow-DOM UI with immutable data contracts
- harden the UI server with deeply immutable payload types, cleaned import order, and safe signal/error handling plus matching test adjustments

## Testing
- `pnpm exec eslint packages/kanban/src/cli/command-handlers.ts`
- `pnpm exec eslint packages/kanban/src/index.ts`
- `pnpm exec eslint packages/kanban/src/lib/ui-server.ts`
- `pnpm exec eslint packages/kanban/src/tests/ui-server.test.ts`
- `pnpm --filter @promethean/kanban build`
- `pnpm --filter @promethean/kanban test`
- `pnpm --filter @promethean/kanban lint` *(fails: package has no lint script)*

------
https://chatgpt.com/codex/tasks/task_e_68df67ee9c3883248e335411e9b79163