### PR TITLE
feat(kanban): share board indexer utilities

### DIFF
--- a/changelog.d/2025.10.03.08.03.26.md
+++ b/changelog.d/2025.10.03.08.03.26.md
@@ -1,0 +1,1 @@
+- expose the kanban board indexer utilities for reuse and add CLI-driven search indexing with tests

--- a/packages/kanban/src/index.ts
+++ b/packages/kanban/src/index.ts
@@ -25,6 +25,7 @@ const { values, positionals } = parseArgs({
     kanban: { type: "string", default: "docs/agile/boards/kanban.md" },
     tasks: { type: "string", default: "docs/agile/tasks" },
     help: { type: "boolean", default: false },
+    write: { type: "boolean", default: false },
   },
   allowPositionals: true,
 });
@@ -143,7 +144,7 @@ async function main() {
       break;
     }
     case "indexForSearch": {
-      const res = await indexForSearch(TASKS);
+      const res = await indexForSearch({ write: values.write });
       printJSONL(res);
       break;
     }

--- a/packages/kanban/src/tests/board.test.ts
+++ b/packages/kanban/src/tests/board.test.ts
@@ -12,7 +12,6 @@ import {
   findTaskByTitle,
   getColumn,
   getTasksByColumn,
-  indexForSearch,
   moveTask,
   pullFromTasks,
   pushToTasks,
@@ -234,10 +233,6 @@ test("regenerate", async (t) => {
   const boardFile = await readFile(boardPath, "utf8");
   t.true(boardFile.startsWith("---\nkanban-plugin: board"));
   t.regex(boardFile, /## Review/);
-});
-
-test("indexForSearch", async (t) => {
-  t.deepEqual(await indexForSearch("."), { started: true });
 });
 
 test("search", async (t) => {

--- a/packages/kanban/src/tests/index-for-search.test.ts
+++ b/packages/kanban/src/tests/index-for-search.test.ts
@@ -1,0 +1,74 @@
+import path from "node:path";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+
+import test from "ava";
+
+import { indexForSearch } from "../lib/kanban.js";
+import { withTempDir } from "../test-utils/helpers.js";
+
+const TASK_BODY = `Plan the integration so all teams know how to use the index.`;
+
+const writeConfig = async (
+  baseDir: string,
+  tasksDir: string,
+  indexFile: string,
+): Promise<string> => {
+  const configPath = path.join(baseDir, "promethean.kanban.json");
+  const payload = {
+    tasksDir,
+    indexFile,
+    exts: [".md"],
+  } as const;
+  await writeFile(configPath, JSON.stringify(payload), "utf8");
+  return configPath;
+};
+
+test("indexForSearch writes JSONL when --write is requested", async (t) => {
+  const tempDir = await withTempDir(t);
+  const tasksDir = path.join(tempDir, "tasks");
+  const indexFile = path.join(tempDir, "index.jsonl");
+  await mkdir(tasksDir, { recursive: true });
+
+  const taskFile = path.join(tasksDir, "kb-1.md");
+  await writeFile(
+    taskFile,
+    `---\nid: KB-1\nuuid: "1234"\ntitle: Document indexing\nstatus: doing\npriority: high\nowner: Ada\nlabels:\n  - search\n  - index\ncreated: "2024-01-01"\nupdated: "2024-01-02"\n---\n\n${TASK_BODY}\n`,
+    "utf8",
+  );
+
+  const configPath = await writeConfig(tempDir, tasksDir, indexFile);
+  const env = Object.freeze({
+    ...process.env,
+    KANBAN_REPO: tempDir,
+    KANBAN_CONFIG: configPath,
+  });
+
+  const result = await indexForSearch({
+    argv: ["indexForSearch", "--write"],
+    env,
+  });
+
+  t.true(result.wrote);
+  t.is(result.count, 1);
+  t.is(result.indexFile, indexFile);
+  t.is(result.lines.length, 1);
+
+  const written = await readFile(indexFile, "utf8");
+  t.is(written, `${result.lines.join("\n")}\n`);
+
+  const parsed = result.lines.map((line) => JSON.parse(line));
+  t.deepEqual(parsed, [
+    {
+      id: "KB-1",
+      title: "Document indexing",
+      status: "doing",
+      priority: "high",
+      owner: "Ada",
+      labels: ["search", "index"],
+      created: "2024-01-01",
+      uuid: "1234",
+      updated: "2024-01-02",
+      path: path.relative(tempDir, taskFile),
+    },
+  ]);
+});


### PR DESCRIPTION
## Summary
- export the board indexer helpers so other modules can reuse the indexing logic
- update `indexForSearch` to load kanban config, reuse the shared indexer, and respect the `--write` flag
- add an AVA test that seeds a temporary repo, runs the search indexer, and verifies the JSONL output

## Testing
- pnpm --filter @promethean/kanban test

------
https://chatgpt.com/codex/tasks/task_e_68df7fd7d9d08324bbe7986a58661615