### PR TITLE
Add stability metadata to MCP tools

### DIFF
--- a/packages/mcp/src/core/types.ts
+++ b/packages/mcp/src/core/types.ts
@@ -17,6 +17,8 @@ export type ToolSpec = Readonly<{
   // IMPORTANT: the SDK expects a ZodRawShape (a flat object of fields), not a z.object(...)
   inputSchema?: ZodRawShape;
   outputSchema?: ZodRawShape;
+  stability?: "stable" | "experimental" | "deprecated";
+  since?: string;
   // New: agent-facing hints.
   examples?: ReadonlyArray<ToolExample>;
   notes?: string;

--- a/packages/mcp/src/tools/apply-patch.ts
+++ b/packages/mcp/src/tools/apply-patch.ts
@@ -5,7 +5,7 @@ import { resolve as resolvePath } from "node:path";
 import { z } from "zod";
 
 import { getMcpRoot } from "../files.js";
-import type { ToolFactory } from "../core/types.js";
+import type { ToolFactory, ToolSpec } from "../core/types.js";
 
 const isUniversalDiff = (value: string): boolean =>
   /^(?:Index: |diff --git|---\s)/m.test(value);
@@ -93,7 +93,9 @@ export const applyPatchTool: ToolFactory = (ctx) => {
     description:
       "Apply a universal diff patch to the MCP sandbox using git apply.",
     inputSchema: shape,
-  } as const;
+    stability: "stable",
+    since: "0.1.0",
+  } satisfies ToolSpec;
 
   const invoke = async (raw: unknown) => {
     const argsParsed = Schema.parse(raw);

--- a/packages/mcp/src/tools/discord.ts
+++ b/packages/mcp/src/tools/discord.ts
@@ -1,7 +1,12 @@
 import { z } from "zod";
 import { DiscordRestProxy } from "@promethean/discord";
 
-import type { Tool, ToolContext, ToolFactory } from "../core/types.js";
+import type {
+  Tool,
+  ToolContext,
+  ToolFactory,
+  ToolSpec,
+} from "../core/types.js";
 
 const RestResponseSchema = z
   .object({
@@ -124,7 +129,9 @@ const createSendMessageTool = (
     description:
       "Send a message to a Discord channel. Provide content or embeds and the Discord space URN.",
     inputSchema: shape,
-  };
+    stability: "experimental",
+    since: "0.1.0",
+  } satisfies ToolSpec;
 
   const proxy = proxyFactory();
 
@@ -169,7 +176,9 @@ const createListMessagesTool = (
     description:
       "List recent messages from a Discord channel with optional pagination parameters.",
     inputSchema: ListSchemaShape,
-  };
+    stability: "experimental",
+    since: "0.1.0",
+  } satisfies ToolSpec;
 
   const proxy = proxyFactory();
 

--- a/packages/mcp/src/tools/exec.ts
+++ b/packages/mcp/src/tools/exec.ts
@@ -4,7 +4,7 @@ import { spawn } from "node:child_process";
 
 import { z } from "zod";
 
-import type { ToolFactory } from "../core/types.js";
+import type { ToolFactory, ToolSpec } from "../core/types.js";
 import {
   loadApprovedExecConfig,
   type ApprovedExecCommand,
@@ -255,7 +255,9 @@ export const execRunTool: ToolFactory = (ctx) => {
       args: ExecInputSchema.shape.args,
       timeoutMs: ExecInputSchema.shape.timeoutMs,
     } as const,
-  } as const;
+    stability: "stable",
+    since: "0.1.0",
+  } satisfies ToolSpec;
 
   const invoke = async (raw: unknown) => {
     const parsed = ExecInputSchema.parse(raw);
@@ -289,7 +291,9 @@ export const execListTool: ToolFactory = (ctx) => {
   const spec = {
     name: "exec.list",
     description: "List approved shell commands and their metadata.",
-  } as const;
+    stability: "stable",
+    since: "0.1.0",
+  } satisfies ToolSpec;
 
   const invoke = async () =>
     config.commands.map((command) => ({

--- a/packages/mcp/src/tools/files.ts
+++ b/packages/mcp/src/tools/files.ts
@@ -8,7 +8,7 @@ import {
   writeFileContent,
   writeFileLines,
 } from "../files.js";
-import type { ToolFactory } from "../core/types.js";
+import type { ToolFactory, ToolSpec } from "../core/types.js";
 
 // Unified sandbox-root resolver
 // If MCP_ROOT_PATH isn't set, default to CWD at runtime.
@@ -24,12 +24,18 @@ export const filesListDirectory: ToolFactory = () => {
     name: "files.list-directory",
     description: "List files and directories within the sandbox root.",
     inputSchema: shape,
-    outputSchema: { ok: true, base: ".", entries: [{ name: "src", path: "src", type: "dir" }] } as any,
+    outputSchema: {
+      ok: true,
+      base: ".",
+      entries: [{ name: "src", path: "src", type: "dir" }],
+    } as any,
     examples: [
       { args: { rel: "packages" }, comment: "List the packages/ folder" },
       { args: { rel: ".", includeHidden: true }, comment: "Include dotfiles" },
     ],
-  } as const;
+    stability: "stable",
+    since: "0.1.0",
+  } satisfies ToolSpec;
 
   const invoke = async (raw: unknown) => {
     const args = Schema.parse(raw);
@@ -55,9 +61,14 @@ export const filesTreeDirectory: ToolFactory = () => {
     inputSchema: shape,
     outputSchema: { ok: true, base: ".", tree: [] } as any,
     examples: [
-      { args: { rel: "packages/mcp", depth: 2 }, comment: "Two-level tree of MCP package" },
+      {
+        args: { rel: "packages/mcp", depth: 2 },
+        comment: "Two-level tree of MCP package",
+      },
     ],
-  } as const;
+    stability: "stable",
+    since: "0.1.0",
+  } satisfies ToolSpec;
 
   const invoke = async (raw: unknown) => {
     const args = Schema.parse(raw);
@@ -83,11 +94,23 @@ export const filesViewFile: ToolFactory = () => {
     name: "files.view-file",
     description: "View a file by path, with line-context selection.",
     inputSchema: shape,
-    outputSchema: { path: "README.md", totalLines: 0, startLine: 1, endLine: 1, focusLine: 1, snippet: "" } as any,
+    outputSchema: {
+      path: "README.md",
+      totalLines: 0,
+      startLine: 1,
+      endLine: 1,
+      focusLine: 1,
+      snippet: "",
+    } as any,
     examples: [
-      { args: { relOrFuzzy: "packages/mcp/src/index.ts", line: 1, context: 40 }, comment: "View file head with context" },
+      {
+        args: { relOrFuzzy: "packages/mcp/src/index.ts", line: 1, context: 40 },
+        comment: "View file head with context",
+      },
     ],
-  } as const;
+    stability: "stable",
+    since: "0.1.0",
+  } satisfies ToolSpec;
   const invoke = async (raw: unknown) => {
     const args = Schema.parse(raw);
     const { relOrFuzzy: rel, line, context } = args;
@@ -108,9 +131,14 @@ export const filesWriteFileContent: ToolFactory = () => {
     inputSchema: shape,
     outputSchema: { path: "path/to/file" } as any,
     examples: [
-      { args: { filePath: "tmp/notes.txt", content: "hello" }, comment: "Create or replace a text file" },
+      {
+        args: { filePath: "tmp/notes.txt", content: "hello" },
+        comment: "Create or replace a text file",
+      },
     ],
-  } as const;
+    stability: "stable",
+    since: "0.1.0",
+  } satisfies ToolSpec;
   const invoke = async (raw: unknown) => {
     const args = Schema.parse(raw);
     const { filePath, content } = args;
@@ -132,9 +160,18 @@ export const filesWriteFileLines: ToolFactory = () => {
     inputSchema: shape,
     outputSchema: { path: "path/to/file" } as any,
     examples: [
-      { args: { filePath: "README.md", lines: ["", "## New Section"], startLine: 10 }, comment: "Insert section at line 10" },
+      {
+        args: {
+          filePath: "README.md",
+          lines: ["", "## New Section"],
+          startLine: 10,
+        },
+        comment: "Insert section at line 10",
+      },
     ],
-  } as const;
+    stability: "stable",
+    since: "0.1.0",
+  } satisfies ToolSpec;
   const invoke = async (raw: unknown) => {
     const args = Schema.parse(raw);
     const { filePath, lines, startLine } = args;

--- a/packages/mcp/src/tools/github/apply-patch.ts
+++ b/packages/mcp/src/tools/github/apply-patch.ts
@@ -6,7 +6,7 @@ import { buffer } from "node:stream/consumers";
 
 import { z } from "zod";
 
-import type { ToolFactory } from "../../core/types.js";
+import type { ToolFactory, ToolSpec } from "../../core/types.js";
 
 type ToolCtx = Parameters<ToolFactory>[0];
 
@@ -357,7 +357,9 @@ export const githubApplyPatchTool: ToolFactory = (ctx) => {
       description:
         "Apply a unified diff to a GitHub branch by committing the changes via createCommitOnBranch.",
       inputSchema: inputSchema.shape,
-    },
+      stability: "experimental",
+      since: "0.1.0",
+    } satisfies ToolSpec,
     invoke: async (raw: unknown) => {
       if (!token) {
         throw new Error(

--- a/packages/mcp/src/tools/github/code-review.ts
+++ b/packages/mcp/src/tools/github/code-review.ts
@@ -2,7 +2,7 @@ import { execFile, type ExecFileOptions } from "node:child_process";
 import { promisify } from "node:util";
 import { z } from "zod";
 
-import type { ToolContext, ToolFactory } from "../../core/types.js";
+import type { ToolContext, ToolFactory, ToolSpec } from "../../core/types.js";
 
 const execFileAsync = promisify(execFile);
 const GIT_EXEC_OPTS: ExecFileOptions & { encoding: "utf8" } = {
@@ -172,7 +172,9 @@ export const githubReviewOpenPullRequest: ToolFactory = (ctx) => {
       description:
         "Open a new pull request targeting a base branch with the provided title and body.",
       inputSchema: shape,
-    },
+      stability: "experimental",
+      since: "0.1.0",
+    } satisfies ToolSpec,
     invoke: async (raw: unknown) => {
       const args = Schema.parse(raw);
       const client = createGithubGraphqlClient(ctx);
@@ -248,7 +250,9 @@ export const githubReviewGetComments: ToolFactory = (ctx) => {
       description:
         "List issue comments on a pull request with pagination support.",
       inputSchema: shape,
-    },
+      stability: "experimental",
+      since: "0.1.0",
+    } satisfies ToolSpec,
     invoke: async (raw: unknown) => {
       const args = Schema.parse(raw);
       const client = createGithubGraphqlClient(ctx);
@@ -350,7 +354,9 @@ export const githubReviewGetReviewComments: ToolFactory = (ctx) => {
       description:
         "Fetch review thread comments (diff comments) for a pull request.",
       inputSchema: shape,
-    },
+      stability: "experimental",
+      since: "0.1.0",
+    } satisfies ToolSpec,
     invoke: async (raw: unknown) => {
       const args = Schema.parse(raw);
       const client = createGithubGraphqlClient(ctx);
@@ -440,7 +446,9 @@ export const githubReviewSubmitComment: ToolFactory = (ctx) => {
       name: "github.review.submitComment",
       description: "Submit an issue-level comment on a pull request.",
       inputSchema: shape,
-    },
+      stability: "experimental",
+      since: "0.1.0",
+    } satisfies ToolSpec,
     invoke: async (raw: unknown) => {
       const args = Schema.parse(raw);
       const client = createGithubGraphqlClient(ctx);
@@ -529,7 +537,9 @@ export const githubReviewRequestChangesFromCodex: ToolFactory = (ctx) => {
       description:
         "Request changes from Codex by posting an issue-level pull request comment tagging @codex.",
       inputSchema: shape,
-    },
+      stability: "experimental",
+      since: "0.1.0",
+    } satisfies ToolSpec,
     invoke: async (raw: unknown) => {
       const args = Schema.parse(raw);
       const client = createGithubGraphqlClient(ctx);
@@ -618,7 +628,9 @@ export const githubReviewSubmitReview: ToolFactory = (ctx) => {
       description:
         "Create a pull request review with optional summary body and inline comments.",
       inputSchema: shape,
-    },
+      stability: "experimental",
+      since: "0.1.0",
+    } satisfies ToolSpec,
     invoke: async (raw: unknown) => {
       const args = Schema.parse(raw);
       const client = createGithubGraphqlClient(ctx);
@@ -733,7 +745,9 @@ export const githubReviewGetActionStatus: ToolFactory = (ctx) => {
       description:
         "Fetch the latest workflow and check status for the most recent pull request commit.",
       inputSchema: shape,
-    },
+      stability: "experimental",
+      since: "0.1.0",
+    } satisfies ToolSpec,
     invoke: async (raw: unknown) => {
       const args = Schema.parse(raw);
       const client = createGithubGraphqlClient(ctx);
@@ -835,7 +849,9 @@ export const githubReviewCommit: ToolFactory = () => {
       description:
         "Create a git commit. Optionally stage specific paths or use --all/--allow-empty.",
       inputSchema: shape,
-    },
+      stability: "experimental",
+      since: "0.1.0",
+    } satisfies ToolSpec,
     invoke: async (raw: unknown) => {
       const args = Schema.parse(raw);
       const cwd = ensureCwd(args.cwd);
@@ -867,7 +883,9 @@ export const githubReviewPush: ToolFactory = () => {
       description:
         "Push the current branch to the specified remote with optional upstream/force settings.",
       inputSchema: shape,
-    },
+      stability: "experimental",
+      since: "0.1.0",
+    } satisfies ToolSpec,
     invoke: async (raw: unknown) => {
       const args = Schema.parse(raw);
       const cwd = ensureCwd(args.cwd);
@@ -892,7 +910,9 @@ export const githubReviewCheckoutBranch: ToolFactory = () => {
       name: "github.review.checkoutBranch",
       description: "Check out an existing git branch.",
       inputSchema: shape,
-    },
+      stability: "experimental",
+      since: "0.1.0",
+    } satisfies ToolSpec,
     invoke: async (raw: unknown) => {
       const args = Schema.parse(raw);
       const cwd = ensureCwd(args.cwd);
@@ -915,7 +935,9 @@ export const githubReviewCreateBranch: ToolFactory = () => {
       description:
         "Create and check out a new git branch optionally from a specific start point.",
       inputSchema: shape,
-    },
+      stability: "experimental",
+      since: "0.1.0",
+    } satisfies ToolSpec,
     invoke: async (raw: unknown) => {
       const args = Schema.parse(raw);
       const cwd = ensureCwd(args.cwd);
@@ -939,7 +961,9 @@ export const githubReviewRevertCommits: ToolFactory = () => {
       name: "github.review.revertCommits",
       description: "Revert one or more commits using git revert.",
       inputSchema: shape,
-    },
+      stability: "experimental",
+      since: "0.1.0",
+    } satisfies ToolSpec,
     invoke: async (raw: unknown) => {
       const args = Schema.parse(raw);
       const cwd = ensureCwd(args.cwd);

--- a/packages/mcp/src/tools/github/contents.ts
+++ b/packages/mcp/src/tools/github/contents.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 
-import type { ToolFactory } from "../../core/types.js";
+import type { ToolFactory, ToolSpec } from "../../core/types.js";
 
 import { isBase64String, normalizeGithubPayload } from "./base64.js";
 
@@ -119,7 +119,9 @@ export const githubContentsWrite: ToolFactory = (ctx) => {
     description:
       "Create or update a file via the GitHub contents API with automatic base64 encoding.",
     inputSchema: GithubContentsInputShape,
-  } as const;
+    stability: "experimental",
+    since: "0.1.0",
+  } satisfies ToolSpec;
 
   const invoke = async (raw: unknown) => {
     const args = GithubContentsSchema.parse(raw);

--- a/packages/mcp/src/tools/github/graphql.ts
+++ b/packages/mcp/src/tools/github/graphql.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import type { ToolFactory } from "../../core/types.js";
+import type { ToolFactory, ToolSpec } from "../../core/types.js";
 
 export const githubGraphqlTool: ToolFactory = (ctx) => {
   const endpoint =
@@ -17,7 +17,9 @@ export const githubGraphqlTool: ToolFactory = (ctx) => {
       name: "github_graphql",
       description: "Post a GraphQL query to GitHub.",
       inputSchema: shape, // <— shape, not z.object(...)
-    },
+      stability: "experimental",
+      since: "0.1.0",
+    } satisfies ToolSpec,
     invoke: async (raw: unknown) => {
       const args = Schema.parse(raw);
       const res = await ctx.fetch(endpoint, {

--- a/packages/mcp/src/tools/github/rate-limit.ts
+++ b/packages/mcp/src/tools/github/rate-limit.ts
@@ -1,4 +1,4 @@
-import type { ToolFactory } from "../../core/types.js";
+import type { ToolFactory, ToolSpec } from "../../core/types.js";
 
 export const githubRateLimitTool: ToolFactory = (ctx) => {
   const base = ctx.env.GITHUB_BASE_URL ?? "https://api.github.com";
@@ -8,7 +8,9 @@ export const githubRateLimitTool: ToolFactory = (ctx) => {
     spec: {
       name: "github_rate_limit",
       description: "Get GitHub REST /rate_limit snapshot.",
-    },
+      stability: "experimental",
+      since: "0.1.0",
+    } satisfies ToolSpec,
     invoke: async () => {
       const res = await ctx.fetch(new URL("/rate_limit", base), {
         headers: {

--- a/packages/mcp/src/tools/github/request.ts
+++ b/packages/mcp/src/tools/github/request.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import type { ReadonlyDeep } from "type-fest";
 
-import type { ToolContext, ToolFactory } from "../../core/types.js";
+import type { ToolContext, ToolFactory, ToolSpec } from "../../core/types.js";
 
 import { normalizeGithubPayload } from "./base64.js";
 
@@ -189,11 +189,19 @@ export const githubRequestTool: ToolFactory = (ctx) => {
         comment: "Fetch repo metadata",
       },
       {
-        args: { method: "GET", path: "/repos/riatzukiza/promethean/issues", paginate: true, perPage: 100, maxPages: 3 },
+        args: {
+          method: "GET",
+          path: "/repos/riatzukiza/promethean/issues",
+          paginate: true,
+          perPage: 100,
+          maxPages: 3,
+        },
         comment: "Stream issues with pagination",
       },
     ],
-  } as const;
+    stability: "experimental",
+    since: "0.1.0",
+  } satisfies ToolSpec;
 
   const invoke = async (raw: unknown) => {
     const args = Schema.parse(raw);

--- a/packages/mcp/src/tools/github/workflows.ts
+++ b/packages/mcp/src/tools/github/workflows.ts
@@ -2,7 +2,7 @@ import { strFromU8, unzipSync } from "fflate";
 import { z } from "zod";
 import type { ReadonlyDeep } from "type-fest";
 
-import type { ToolContext, ToolFactory } from "../../core/types.js";
+import type { ToolContext, ToolFactory, ToolSpec } from "../../core/types.js";
 
 const DEFAULT_API_VERSION = "2022-11-28";
 const DEFAULT_BASE_URL = "https://api.github.com";
@@ -129,7 +129,9 @@ export const githubWorkflowGetRunLogs: ToolFactory = (ctx) => {
       description:
         "Download and extract the log files for a GitHub Actions workflow run.",
       inputSchema: shape,
-    },
+      stability: "experimental",
+      since: "0.1.0",
+    } satisfies ToolSpec,
     invoke: async (raw: unknown) => {
       const args = Schema.parse(raw);
       const base = ctx.env.GITHUB_BASE_URL ?? DEFAULT_BASE_URL;
@@ -161,7 +163,9 @@ export const githubWorkflowGetJobLogs: ToolFactory = (ctx) => {
       description:
         "Download and extract the log files for a GitHub Actions workflow job.",
       inputSchema: shape,
-    },
+      stability: "experimental",
+      since: "0.1.0",
+    } satisfies ToolSpec,
     invoke: async (raw: unknown) => {
       const args = Schema.parse(raw);
       const base = ctx.env.GITHUB_BASE_URL ?? DEFAULT_BASE_URL;

--- a/packages/mcp/src/tools/kanban.ts
+++ b/packages/mcp/src/tools/kanban.ts
@@ -14,7 +14,7 @@ import {
 } from "@promethean/kanban/dist/lib/kanban.js";
 import type { Board } from "@promethean/kanban/dist/lib/types.js";
 
-import type { ToolFactory } from "../core/types.js";
+import type { ToolFactory, ToolSpec } from "../core/types.js";
 
 type PathOverrides = Readonly<{
   boardFile?: string;
@@ -71,7 +71,9 @@ export const kanbanGetBoard: ToolFactory = (ctx) => {
     description:
       "Load the kanban board defined by the repository configuration.",
     inputSchema: basePathSchema,
-  } as const;
+    stability: "experimental",
+    since: "0.1.0",
+  } satisfies ToolSpec;
 
   const invoke = async (raw: unknown) => {
     const args = Schema.parse(raw ?? {});
@@ -94,7 +96,9 @@ export const kanbanGetColumn: ToolFactory = (ctx) => {
       ...basePathSchema,
       column: z.string(),
     },
-  } as const;
+    stability: "experimental",
+    since: "0.1.0",
+  } satisfies ToolSpec;
 
   const invoke = async (raw: unknown) => {
     const args = Schema.parse(raw ?? {});
@@ -117,7 +121,9 @@ export const kanbanFindTaskById: ToolFactory = (ctx) => {
       ...basePathSchema,
       uuid: z.string().min(1),
     },
-  } as const;
+    stability: "experimental",
+    since: "0.1.0",
+  } satisfies ToolSpec;
 
   const invoke = async (raw: unknown) => {
     const args = Schema.parse(raw ?? {});
@@ -141,7 +147,9 @@ export const kanbanFindTaskByTitle: ToolFactory = (ctx) => {
       ...basePathSchema,
       title: z.string().min(1),
     },
-  } as const;
+    stability: "experimental",
+    since: "0.1.0",
+  } satisfies ToolSpec;
 
   const invoke = async (raw: unknown) => {
     const args = Schema.parse(raw ?? {});
@@ -168,7 +176,9 @@ export const kanbanUpdateStatus: ToolFactory = (ctx) => {
       uuid: z.string().min(1),
       status: z.string().min(1),
     },
-  } as const;
+    stability: "experimental",
+    since: "0.1.0",
+  } satisfies ToolSpec;
 
   const invoke = async (raw: unknown) => {
     const args = Schema.parse(raw ?? {});
@@ -197,7 +207,9 @@ export const kanbanMoveTask: ToolFactory = (ctx) => {
       uuid: z.string().min(1),
       delta: z.number().int().min(-100).max(100),
     },
-  } as const;
+    stability: "experimental",
+    since: "0.1.0",
+  } satisfies ToolSpec;
 
   const invoke = async (raw: unknown) => {
     const args = Schema.parse(raw ?? {});
@@ -217,7 +229,9 @@ export const kanbanSyncBoard: ToolFactory = (ctx) => {
     description:
       "Pull updates from task files into the board and push board ordering back to task files.",
     inputSchema: basePathSchema,
-  } as const;
+    stability: "experimental",
+    since: "0.1.0",
+  } satisfies ToolSpec;
 
   const invoke = async (raw: unknown) => {
     const args = Schema.parse(raw ?? {});
@@ -241,7 +255,9 @@ export const kanbanSearchTasks: ToolFactory = (ctx) => {
       ...basePathSchema,
       query: z.string().min(1),
     },
-  } as const;
+    stability: "experimental",
+    since: "0.1.0",
+  } satisfies ToolSpec;
 
   const invoke = async (raw: unknown) => {
     const args = Schema.parse(raw ?? {});

--- a/packages/mcp/src/tools/nx.ts
+++ b/packages/mcp/src/tools/nx.ts
@@ -4,7 +4,7 @@ import { promisify } from "node:util";
 import { z } from "zod";
 
 import { getMcpRoot } from "../files.js";
-import type { ToolContext, ToolFactory } from "../core/types.js";
+import type { ToolContext, ToolFactory, ToolSpec } from "../core/types.js";
 
 const execFileAsync = promisify(execFile);
 
@@ -204,7 +204,9 @@ const createTool = (
     description:
       "Generate a new workspace package using the Nx tools:package generator.",
     inputSchema: shape,
-  } as const;
+    stability: "experimental",
+    since: "0.1.0",
+  } satisfies ToolSpec;
 
   const invoke = async (raw: unknown) => {
     const parsed = Schema.parse(raw);

--- a/packages/mcp/src/tools/pnpm.ts
+++ b/packages/mcp/src/tools/pnpm.ts
@@ -4,7 +4,12 @@ import { promisify } from "node:util";
 import { z } from "zod";
 
 import { getMcpRoot } from "../files.js";
-import type { Tool, ToolContext, ToolFactory } from "../core/types.js";
+import type {
+  Tool,
+  ToolContext,
+  ToolFactory,
+  ToolSpec,
+} from "../core/types.js";
 
 const execFileAsync = promisify(execFile);
 
@@ -202,7 +207,9 @@ const createInstallTool = (
     description:
       "Run pnpm install at the workspace root or limited to filtered packages.",
     inputSchema: installShape,
-  } as const;
+    stability: "stable",
+    since: "0.1.0",
+  } satisfies ToolSpec;
 
   const invoke = async (raw: unknown) => {
     const { filter, frozenLockfile, offline, force, ignoreScripts } =
@@ -231,7 +238,9 @@ const createAddTool = (
     description:
       "Add dependencies via pnpm, optionally scoped to specific workspace packages.",
     inputSchema: addShape,
-  } as const;
+    stability: "stable",
+    since: "0.1.0",
+  } satisfies ToolSpec;
 
   const invoke = async (raw: unknown) => {
     const { dependencies, filter, dev, optional, peer, exact } =
@@ -261,7 +270,9 @@ const createRemoveTool = (
     description:
       "Remove dependencies via pnpm, optionally scoped to workspace filters.",
     inputSchema: removeShape,
-  } as const;
+    stability: "stable",
+    since: "0.1.0",
+  } satisfies ToolSpec;
 
   const invoke = async (raw: unknown) => {
     const { dependencies, filter } = Schema.parse(raw);
@@ -284,7 +295,9 @@ const createRunScriptTool = (
     description:
       "Execute a pnpm script, optionally filtered to specific workspace packages.",
     inputSchema: runScriptShape,
-  } as const;
+    stability: "stable",
+    since: "0.1.0",
+  } satisfies ToolSpec;
 
   const invoke = async (raw: unknown) => {
     const { script, args: extraArgs, filter } = Schema.parse(raw);

--- a/packages/mcp/src/tools/process-manager.ts
+++ b/packages/mcp/src/tools/process-manager.ts
@@ -4,7 +4,7 @@ import path from "node:path";
 
 import { z } from "zod";
 
-import type { ToolFactory } from "../core/types.js";
+import type { ToolFactory, ToolSpec } from "../core/types.js";
 
 const DEFAULT_MAX_RUNNING = 1;
 const DEFAULT_TERMINATE_GRACE_MS = 5_000;
@@ -613,7 +613,9 @@ export const processGetTaskRunnerConfig: ToolFactory = () => ({
   spec: {
     name: "process.getTaskRunnerConfig",
     description: "Return the current task runner configuration.",
-  },
+    stability: "experimental",
+    since: "0.1.0",
+  } satisfies ToolSpec,
   invoke: async () => ({ config: runner.getConfig() }),
 });
 
@@ -630,7 +632,9 @@ export const processUpdateTaskRunnerConfig: ToolFactory = () => {
         key: Schema.shape.key,
         value: Schema.shape.value,
       },
-    },
+      stability: "experimental",
+      since: "0.1.0",
+    } satisfies ToolSpec,
     invoke: async (raw: unknown) => {
       const { key, value } = Schema.parse(raw);
       const config = runner.updateConfig(key, value);
@@ -649,7 +653,9 @@ export const processEnqueueTask: ToolFactory = () => ({
       args: z.array(z.string()).optional(),
       opts: EnqueueSchema.shape.opts.optional(),
     },
-  },
+    stability: "experimental",
+    since: "0.1.0",
+  } satisfies ToolSpec,
   invoke: async (raw: unknown) => {
     const parsed = EnqueueSchema.parse(raw);
     const task = runner.createTask({
@@ -681,7 +687,9 @@ export const processStopTask: ToolFactory = () => {
         tail: Schema.shape.tail,
         signal: Schema.shape.signal,
       },
-    },
+      stability: "experimental",
+      since: "0.1.0",
+    } satisfies ToolSpec,
     invoke: async (raw: unknown) => {
       const { handle, tail, signal } = Schema.parse(raw);
       const result = await runner.stopTask(handle, tail, signal);
@@ -690,7 +698,7 @@ export const processStopTask: ToolFactory = () => {
   };
 };
 
-const buildLogSpec = (name: string) => ({
+const buildLogSpec = (name: string): ToolSpec => ({
   name,
   description: "Retrieve task output with pagination or explicit line ranges.",
   inputSchema: {
@@ -700,6 +708,8 @@ const buildLogSpec = (name: string) => ({
     startLine: z.number().optional(),
     count: z.number().optional(),
   },
+  stability: "experimental",
+  since: "0.1.0",
 });
 
 export const processGetStdout: ToolFactory = () => ({
@@ -742,7 +752,9 @@ export const processGetQueue: ToolFactory = () => ({
   spec: {
     name: "process.getQueue",
     description: "Return waiting, running, and completed task summaries.",
-  },
+    stability: "experimental",
+    since: "0.1.0",
+  } satisfies ToolSpec,
   invoke: async () => runner.getQueue(),
 });
 

--- a/packages/mcp/src/tools/sandboxes.ts
+++ b/packages/mcp/src/tools/sandboxes.ts
@@ -5,7 +5,7 @@ import {
   listSandboxes,
   removeSandbox,
 } from "../github/sandboxes/git.js";
-import type { ToolFactory } from "../core/types.js";
+import type { ToolFactory, ToolSpec } from "../core/types.js";
 
 const sandboxIdPattern = /^[A-Za-z0-9][A-Za-z0-9._-]*$/u;
 const refPattern = /^[A-Za-z0-9][A-Za-z0-9._:/-]*$/u;
@@ -49,7 +49,9 @@ export const sandboxCreateTool: ToolFactory = () => {
     description:
       "Create a git worktree-based sandbox rooted under .sandboxes/<id>.",
     inputSchema: createShape,
-  } as const;
+    stability: "experimental",
+    since: "0.1.0",
+  } satisfies ToolSpec;
 
   const invoke = async (raw: unknown) => {
     const input = Schema.parse(raw);
@@ -65,7 +67,9 @@ export const sandboxListTool: ToolFactory = () => {
     name: "sandbox.list",
     description: "List sandboxes created as git worktrees under .sandboxes.",
     inputSchema: listShape,
-  } as const;
+    stability: "experimental",
+    since: "0.1.0",
+  } satisfies ToolSpec;
 
   const invoke = async (raw: unknown) => {
     const input = Schema.parse(raw);
@@ -81,7 +85,9 @@ export const sandboxDeleteTool: ToolFactory = () => {
     name: "sandbox.delete",
     description: "Remove a git worktree sandbox by sandboxId.",
     inputSchema: removeShape,
-  } as const;
+    stability: "experimental",
+    since: "0.1.0",
+  } satisfies ToolSpec;
 
   const invoke = async (raw: unknown) => {
     const input = Schema.parse(raw);

--- a/packages/mcp/src/tools/tdd.ts
+++ b/packages/mcp/src/tools/tdd.ts
@@ -5,7 +5,7 @@ import { execFile, type ExecFileOptions, spawn } from "node:child_process";
 import { promisify } from "node:util";
 
 import { z } from "zod";
-import type { ToolFactory } from "../core/types.js";
+import type { ToolFactory, ToolSpec } from "../core/types.js";
 import { minimatch } from "minimatch";
 import fc from "fast-check";
 import { Stryker } from "@stryker-mutator/core";
@@ -83,7 +83,9 @@ export const tddScaffoldTest: ToolFactory = () => {
     description:
       "Create or append a test file next to a module (unit or property-test template).",
     inputSchema: shape,
-  } as const;
+    stability: "experimental",
+    since: "0.1.0",
+  } satisfies ToolSpec;
   const invoke = async (raw: unknown) => {
     const { modulePath, testName, template = "unit" } = Schema.parse(raw);
     const dir = path.dirname(modulePath);
@@ -131,7 +133,9 @@ export const tddChangedFiles: ToolFactory = () => {
     description:
       "List files changed vs a git base ref, filtered by glob patterns.",
     inputSchema: shape,
-  } as const;
+    stability: "experimental",
+    since: "0.1.0",
+  } satisfies ToolSpec;
   const invoke = async (raw: unknown) => {
     const { base, patterns } = Schema.parse(raw);
     const { stdout } = await execFileAsync(
@@ -159,17 +163,20 @@ export const tddRunTests: ToolFactory = () => {
   const spec = {
     name: "tdd.runTests",
     description:
-    description: "Run AVA via npx with JSON (or TAP) output and return aggregated results. For long-running watchers, use tdd.startWatch/tdd.getWatchChanges instead.",
+      "Run AVA via npx with JSON (or TAP) output and return aggregated results. For long-running watchers, use tdd.startWatch/tdd.getWatchChanges instead.",
+    inputSchema: shape,
     outputSchema: { passed: 0, failed: 0, durationMs: 0, failures: [] } as any,
     examples: [
       { args: {}, comment: "Run all tests with JSON output" },
-      { args: { files: ["packages/mcp/dist/**/*.test.js"] }, comment: "Target compiled MCP tests" },
+      {
+        args: { files: ["packages/mcp/dist/**/*.test.js"] },
+        comment: "Target compiled MCP tests",
+      },
       { args: { match: ["*schema*"] }, comment: "Filter by AVA title glob" },
-    // description moved above
     ],
-      "Run AVA via npx with JSON (or TAP) output and return aggregated results. For long-running watchers, use tdd.startWatch/tdd.getWatchChanges instead.",
-    inputSchema: shape,
-  } as const;
+    stability: "experimental",
+    since: "0.1.0",
+  } satisfies ToolSpec;
   const invoke = async (raw: unknown) => {
     const { files, match, tap, watch: w } = Schema.parse(raw);
     if (w) {
@@ -209,7 +216,9 @@ export const tddStartWatch: ToolFactory = () => {
     description:
       "Start an AVA --watch process and stream output via getWatchChanges.",
     inputSchema: shape,
-  } as const;
+    stability: "experimental",
+    since: "0.1.0",
+  } satisfies ToolSpec;
   const invoke = async (raw: unknown) => {
     return watch.start(Schema.parse(raw));
   };
@@ -221,7 +230,9 @@ export const tddGetWatchChanges: ToolFactory = () => {
     name: "tdd.getWatchChanges",
     description: "Get incremental stdout/stderr from the running watch.",
     inputSchema: {},
-  } as const;
+    stability: "experimental",
+    since: "0.1.0",
+  } satisfies ToolSpec;
   const invoke = async () => watch.getChanges();
   return { spec, invoke } as any;
 };
@@ -231,7 +242,9 @@ export const tddStopWatch: ToolFactory = () => {
     name: "tdd.stopWatch",
     description: "Stop the running watch process.",
     inputSchema: {},
-  } as const;
+    stability: "experimental",
+    since: "0.1.0",
+  } satisfies ToolSpec;
   const invoke = async () => watch.stop();
   return { spec, invoke } as any;
 };
@@ -253,7 +266,9 @@ export const tddCoverage: ToolFactory = () => {
     description:
       "Run c8+AVA to produce coverage summary; enforce optional thresholds.",
     inputSchema: shape,
-  } as const;
+    stability: "experimental",
+    since: "0.1.0",
+  } satisfies ToolSpec;
   const invoke = async (raw: unknown) => {
     const { include, thresholds } = Schema.parse(raw);
     const args = [
@@ -298,7 +313,9 @@ export const tddPropertyCheck: ToolFactory = () => {
     description:
       "Dynamically import a module export that builds a fast-check property and assert it.",
     inputSchema: shape,
-  } as const;
+    stability: "experimental",
+    since: "0.1.0",
+  } satisfies ToolSpec;
   const invoke = async (raw: unknown) => {
     const { propertyModule, propertyExport, runs } = Schema.parse(raw);
     const mod = await import(pathToFileURL(propertyModule).href);
@@ -323,7 +340,9 @@ export const tddMutationScore: ToolFactory = () => {
     description:
       "Run Stryker mutation testing and return the score (fail if below minScore).",
     inputSchema: shape,
-  } as const;
+    stability: "experimental",
+    since: "0.1.0",
+  } satisfies ToolSpec;
   const invoke = async (raw: unknown) => {
     const { files, minScore } = Schema.parse(raw);
     const stryker = new Stryker({


### PR DESCRIPTION
## Summary
- add stability and since fields to the MCP ToolSpec and surface them in the help/toolset meta tools
- annotate each public tool specification with stability and provenance metadata for downstream consumers

## Testing
- `pnpm exec eslint --max-warnings=0 $(git diff --name-only | grep '\.ts$')` *(fails: pre-existing lint violations in untouched code paths)*

------
https://chatgpt.com/codex/tasks/task_e_68df7f66f60c83248a82f5444c2e8107