### PR TITLE
Allow MCP proxies to set working directories

### DIFF
--- a/changelog.d/2025.10.03.14.45.00.md
+++ b/changelog.d/2025.10.03.14.45.00.md
@@ -1,0 +1,1 @@
+- Allow MCP stdio proxies to configure working directories and propagate the new `cwd` setting through generated configs.

--- a/config/mcp_servers.edn
+++ b/config/mcp_servers.edn
@@ -19,36 +19,42 @@
 
   :npm-helper
   {:command "npx"
-   :args ["-y" "@pinkpixel/npm-helper-mcp"]}
+   :args ["-y" "@pinkpixel/npm-helper-mcp"]
+   :cwd "$HOME/devel/promethean"}
 
   ;; :eslint-official
   ;; {:command "npx"
   ;;  :args ["-y" "@eslint/mcp@latest"]}
 
   :eslint
-  {:command "npx" :args ["-y"
-                         "@uplinq/mcp-eslint"]}
+  {:command "npx"
+   :args ["-y" "@uplinq/mcp-eslint"]
+   :cwd "$HOME/devel/promethean"}
 
   :playwright
   {:command "npx"
-   :args ["@playwright/mcp@latest"]}
+   :args ["@playwright/mcp@latest"]
+   :cwd "$HOME/devel/promethean"}
 
   :ts-ls-lsp
   {:command "npx"
    :args ["tritlo/lsp-mcp"
           "typescript"
           "/home/err/.volta/bin/typescript-language-server"
-          "--stdio"]}
+          "--stdio"]
+   :cwd "$HOME/devel/promethean"}
 
   :serena
   {:command "uvx"
-   :args ["--from" "git+https://github.com/oraios/serena" "serena" "start-mcp-server"]}
+   :args ["--from" "git+https://github.com/oraios/serena" "serena" "start-mcp-server"]
+   :cwd "$HOME/devel/promethean"}
   :haiku-rag
   {:command "uvx"
    :args ["haiku-rag"
           "serve"
           "--stdio"
-          "--db" "/home/err/.local/share/haiku-rag"]}
+          "--db" "/home/err/.local/share/haiku-rag"]
+   :cwd "$HOME/devel/promethean"}
 
   :backseat-driver
   {:command "/home/err/.config/calva/backseat-driver/calva-mcp-server.js"

--- a/packages/clj-hacks/src/clj_hacks/mcp/adapter_codex_toml.clj
+++ b/packages/clj-hacks/src/clj_hacks/mcp/adapter_codex_toml.clj
@@ -68,6 +68,9 @@
 (defn- sanitize-command [c]
   (some-> c strip-quotes))
 
+(defn- sanitize-cwd [c]
+  (some-> c strip-quotes))
+
 (defn- sanitize-args [args]
   (when (seq args)
     (->> args
@@ -84,17 +87,20 @@
                      (let [name (keyword (strip-quotes nm))
                            command (sanitize-command (get kv "command"))
                            args (sanitize-args (get kv "args"))
+                           cwd (sanitize-cwd (get kv "cwd"))
                            entry (cond-> {}
                                     command (assoc :command command)
-                                    (seq args) (assoc :args args))]
+                                    (seq args) (assoc :args args)
+                                    (some? cwd) (assoc :cwd cwd))]
                        [name entry])))}]
     {:mcp mcp :rest rest-string :raw s}))
 
-(defn- render-toml-table [[k {:keys [command args]}]]
+(defn- render-toml-table [[k {:keys [command args cwd]}]]
   (str "[mcp_servers." (format "\"%s\"" (name k)) "]\n"
        "command = " (format "\"%s\"" command) "\n"
        (when (seq args)
          (str "args = [" (str/join ", " (map #(str "\"" % "\"") args)) "]\n"))
+       (when cwd (str "cwd = " (format "\"%s\"" cwd) "\n"))
        "\n"))
 
 (defn write-full [path {:keys [mcp rest]}]

--- a/packages/clj-hacks/test/clj_hacks/mcp/adapter_codex_toml_test.clj
+++ b/packages/clj-hacks/test/clj_hacks/mcp/adapter_codex_toml_test.clj
@@ -8,7 +8,8 @@
    "# header\n"
    "[mcp_servers.\"github\"]\n"
    "command = \"gh\"\n"
-   "args = [\"api\", \"me\"]\n\n"
+   "args = [\"api\", \"me\"]\n"
+   "cwd = \"/tmp/github\"\n\n"
    "[mcp_servers.\"plain\"]\n"
    "command = \"echo\"\n\n"
    "# footer\n"))
@@ -21,6 +22,7 @@
           servers (:mcp-servers mcp)]
       (is (= "gh" (get-in servers [:github :command])))
       (is (= ["api" "me"] (get-in servers [:github :args])))
+      (is (= "/tmp/github" (get-in servers [:github :cwd])))
       (is (= "echo" (get-in servers [:plain :command])))
       (is (string? rest))
       (is (string? raw)))))
@@ -28,7 +30,7 @@
 (deftest write-full-renders-tables
   (let [tmp  (fs/create-temp-file {:prefix "mcp-toml-out-" :suffix ".toml"})
         path (str tmp)
-        data {:mcp {:mcp-servers {:x {:command "cmd" :args ["a" "b"]}
+        data {:mcp {:mcp-servers {:x {:command "cmd" :args ["a" "b"] :cwd "/tmp/x"}
                                   :y {:command "yo"}}}
               :rest "# preserved"}]
     (adapter/write-full path data)
@@ -36,5 +38,6 @@
       (is (re-find #"\[mcp_servers.\"x\"\]" s))
       (is (re-find #"command = \"cmd\"" s))
       (is (re-find #"args = \[\"a\", \"b\"\]" s))
+      (is (re-find #"cwd = \"/tmp/x\"" s))
       (is (re-find #"\[mcp_servers.\"y\"\]" s))
       (is (re-find #"command = \"yo\"" s)))))

--- a/packages/clj-hacks/test/clj_hacks/mcp/adapter_mcp_json_test.clj
+++ b/packages/clj-hacks/test/clj_hacks/mcp/adapter_mcp_json_test.clj
@@ -11,13 +11,13 @@
                     "{\n"
                     "  \"foo\": 1,\n"
                     "  \"mcpServers\": {\n"
-                    "    \"foo\": { \"command\": \"echo\", \"args\": [\"a\", \"b\"] },\n"
+                    "    \"foo\": { \"command\": \"echo\", \"args\": [\"a\", \"b\"], \"cwd\": \"/tmp/foo\" },\n"
                     "    \"bar\": { \"command\": \"run\" }\n"
                     "  }\n"
                     "}"))
         {:keys [mcp rest]} (adapter/read-full path)]
     (is (map? mcp))
-    (is (= #{{:command "echo" :args ["a" "b"]}
+    (is (= #{{:command "echo" :args ["a" "b"] :cwd "/tmp/foo"}
              {:command "run"}}
            (set (vals (:mcp-servers mcp)))))
     (is (map? rest))))
@@ -25,9 +25,11 @@
 (deftest write-full-writes-valid-json
   (let [tmp-out  (fs/create-temp-file {:prefix "mcp-json-out-" :suffix ".json"})
         path-out (str tmp-out)
-        data     {:mcp {:mcp-servers {:foo {:command "echo" :args ["a" "b"]}
+        data     {:mcp {:mcp-servers {:foo {:command "echo" :args ["a" "b"] :cwd "/tmp/foo"}
                                       :bar {:command "run"}}}
                    :rest {"foo" 1}}]
     (adapter/write-full path-out data)
     (is (fs/exists? path-out))
-    (is (string? (slurp path-out)))))
+    (let [out (slurp path-out)]
+      (is (string? out))
+      (is (re-find #"\"cwd\"\s*:\s*\"/tmp/foo\"" out)))))

--- a/packages/mcp/test/proxy.config.test.ts
+++ b/packages/mcp/test/proxy.config.test.ts
@@ -1,0 +1,29 @@
+import { mkdtemp, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import test from "ava";
+
+import { loadStdioServerSpecs } from "../src/proxy/config.js";
+
+test("loadStdioServerSpecs respects cwd and scoped package args", async (t) => {
+  const tmp = await mkdtemp(path.join(os.tmpdir(), "mcp-proxy-config-"));
+  const configPath = path.join(tmp, "servers.edn");
+  await writeFile(
+    configPath,
+    `{:mcp-servers {:scoped {:command "echo"
+                              :args ["@pinkpixel/npm-helper-mcp" "./relative"]
+                              :cwd "./nested"}}}`,
+    "utf8",
+  );
+
+  const specs = await loadStdioServerSpecs(configPath);
+
+  t.is(specs.length, 1);
+  const [spec] = specs;
+  t.is(spec.cwd, path.resolve(tmp, "nested"));
+  t.deepEqual(spec.args, [
+    "@pinkpixel/npm-helper-mcp",
+    path.resolve(tmp, "relative"),
+  ]);
+});

--- a/packages/mcp/test/tsconfig.json
+++ b/packages/mcp/test/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": "../"
+  },
+  "include": ["../src/**/*.ts", "./**/*.ts"]
+}

--- a/packages/mcp/tsconfig.eslint.json
+++ b/packages/mcp/tsconfig.eslint.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": ["src/**/*.ts", "test/**/*.ts"]
+}


### PR DESCRIPTION
## Summary
- allow the stdio proxy loader to normalize scoped npm arguments, enforce `:mcp-servers` detection, and accept configured working directories
- cover the new cwd behaviour with an Ava test and dedicated tsconfig files so eslint can type-check proxy tests
- propagate the `cwd` field through clj-hacks adapters, extend the default MCP server map, and record the change in the changelog

## Testing
- pnpm --filter @promethean/mcp test
- clojure -M:test *(fails: clojure executable not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e00391bea48324be7744e1c3ccddef