### PR TITLE
Fix kanban CLI imports for inline subcommands

### DIFF
--- a/changelog.d/2024.04.27.12.00.00.md
+++ b/changelog.d/2024.04.27.12.00.00.md
@@ -1,0 +1,1 @@
+- Fix kanban CLI subcommands by importing board helpers directly and sharing argument validation.

--- a/packages/kanban/src/index.ts
+++ b/packages/kanban/src/index.ts
@@ -1,17 +1,30 @@
 #!/usr/bin/env node
-import { loadKanbanConfig } from "./board/config.js";
+import { loadKanbanConfig } from './board/config.js';
+import { COMMAND_HANDLERS } from './cli/command-handlers.js';
 import {
-  COMMAND_HANDLERS,
-  runCommand,
-  type CliContext,
-} from "./cli/command-handlers.js";
-import { processSync } from "./process/sync.js";
-import { docguard } from "./process/docguard.js";
+  countTasks,
+  findTaskById,
+  findTaskByTitle,
+  getColumn,
+  getTasksByColumn,
+  indexForSearch,
+  loadBoard,
+  moveTask,
+  pullFromTasks,
+  pushToTasks,
+  regenerateBoard,
+  searchTasks,
+  syncBoardAndTasks,
+  updateStatus,
+} from './lib/kanban.js';
+import { printJSONL } from './lib/jsonl.js';
+import { processSync } from './process/sync.js';
+import { docguard } from './process/docguard.js';
 
 const LEGACY_FLAG_MAP = Object.freeze(
   new Map<string, string>([
-    ["--kanban", "--board-file"],
-    ["--tasks", "--tasks-dir"],
+    ['--kanban', '--board-file'],
+    ['--tasks', '--tasks-dir'],
   ]),
 );
 
@@ -28,27 +41,25 @@ const normalizeLegacyToken = (token: string): string =>
     return current;
   }, token);
 
-const normalizeLegacyArgs = (
-  args: ReadonlyArray<string>,
-): ReadonlyArray<string> => args.map(normalizeLegacyToken);
+const normalizeLegacyArgs = (args: ReadonlyArray<string>): ReadonlyArray<string> =>
+  args.map(normalizeLegacyToken);
 
 const LEGACY_ENV_MAPPINGS = Object.freeze([
-  ["KANBAN_PATH", "KANBAN_BOARD_FILE"],
-  ["TASKS_PATH", "KANBAN_TASKS_DIR"],
+  ['KANBAN_PATH', 'KANBAN_BOARD_FILE'],
+  ['TASKS_PATH', 'KANBAN_TASKS_DIR'],
 ] as const);
 
-const applyLegacyEnv = (
-  env: Readonly<NodeJS.ProcessEnv>,
-): Readonly<NodeJS.ProcessEnv> => {
-  const patches = LEGACY_ENV_MAPPINGS.reduce<
-    ReadonlyArray<readonly [string, string]>
-  >((acc, [legacy, modern]) => {
-    const legacyValue = env[legacy];
-    if (typeof legacyValue === "string" && typeof env[modern] !== "string") {
-      return [...acc, [modern, legacyValue] as const];
-    }
-    return acc;
-  }, []);
+const applyLegacyEnv = (env: Readonly<NodeJS.ProcessEnv>): Readonly<NodeJS.ProcessEnv> => {
+  const patches = LEGACY_ENV_MAPPINGS.reduce<ReadonlyArray<readonly [string, string]>>(
+    (acc, [legacy, modern]) => {
+      const legacyValue = env[legacy];
+      if (typeof legacyValue === 'string' && typeof env[modern] !== 'string') {
+        return [...acc, [modern, legacyValue] as const];
+      }
+      return acc;
+    },
+    [],
+  );
   if (patches.length === 0) {
     return { ...env };
   }
@@ -58,15 +69,23 @@ const applyLegacyEnv = (
   };
 };
 
-const HELP_TEXT =
-  `Usage: kanban [--kanban path] [--tasks path] <subcommand> [args...]\n` +
-  `Subcommands: ${Object.keys(COMMAND_HANDLERS).join(", ")}`;
+const requireArg = (value: string | undefined, label: string): string => {
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (trimmed.length > 0) {
+      return trimmed;
+    }
+  }
+  console.error(`Missing required ${label}.`);
+  process.exit(2);
+};
+
+const SUBCOMMANDS = Object.freeze([...Object.keys(COMMAND_HANDLERS), 'process_sync', 'doccheck']);
 
 async function main(): Promise<void> {
   const rawArgs = process.argv.slice(2);
   const normalizedArgs = normalizeLegacyArgs(rawArgs);
-  const helpRequested =
-    normalizedArgs.includes("--help") || normalizedArgs.includes("-h");
+  const helpRequested = normalizedArgs.includes('--help') || normalizedArgs.includes('-h');
 
   const { config, restArgs } = await loadKanbanConfig({
     argv: normalizedArgs,
@@ -79,7 +98,7 @@ async function main(): Promise<void> {
 
   const usage =
     `Usage: kanban [--kanban path] [--tasks path] <subcommand> [args...]\n` +
-    `Subcommands: count, getColumn, getByColumn, find, find-by-title, update_status, move_up, move_down, pull, push, sync, regenerate, indexForSearch, search, process_sync, doccheck`;
+    `Subcommands: ${SUBCOMMANDS.join(', ')}`;
 
   if (helpRequested || !cmd) {
     console.error(usage);
@@ -87,110 +106,104 @@ async function main(): Promise<void> {
   }
 
   switch (cmd) {
-    case "count": {
+    case 'count': {
       const column = args[0];
       const board = await loadBoard(boardFile, tasksDir);
       const n = countTasks(board, column);
       printJSONL({ count: n });
       break;
     }
-    case "getColumn": {
-      const column = requireArg(args[0], "column name");
+    case 'getColumn': {
+      const column = requireArg(args[0], 'column name');
       const board = await loadBoard(boardFile, tasksDir);
       const colData = getColumn(board, column);
       printJSONL(colData);
       break;
     }
-    case "getByColumn": {
-      const column = requireArg(args[0], "column name");
+    case 'getByColumn': {
+      const column = requireArg(args[0], 'column name');
       const board = await loadBoard(boardFile, tasksDir);
       const tasks = getTasksByColumn(board, column);
       printJSONL(tasks);
       break;
     }
-    case "find": {
-      const id = requireArg(args[0], "task id");
+    case 'find': {
+      const id = requireArg(args[0], 'task id');
       const board = await loadBoard(boardFile, tasksDir);
       const t = findTaskById(board, id);
       if (t) printJSONL(t);
       break;
     }
-    case "find-by-title": {
-      const joined = args.join(" ").trim();
-      const title = requireArg(
-        joined.length > 0 ? joined : undefined,
-        "task title",
-      );
+    case 'find-by-title': {
+      const joined = args.join(' ').trim();
+      const title = requireArg(joined.length > 0 ? joined : undefined, 'task title');
       const board = await loadBoard(boardFile, tasksDir);
       const t = findTaskByTitle(board, title);
       if (t) printJSONL(t);
       break;
     }
-    case "update_status": {
+    case 'update_status': {
       const [rawId, rawStatus] = args;
-      const id = requireArg(rawId, "task id");
-      const newStatus = requireArg(rawStatus, "new status");
+      const id = requireArg(rawId, 'task id');
+      const newStatus = requireArg(rawStatus, 'new status');
       const board = await loadBoard(boardFile, tasksDir);
       const updated = await updateStatus(board, id, newStatus, boardFile);
       printJSONL(updated);
       break;
     }
-    case "move_up": {
+    case 'move_up': {
       const [rawId] = args;
-      const id = requireArg(rawId, "task id");
+      const id = requireArg(rawId, 'task id');
       const board = await loadBoard(boardFile, tasksDir);
       const res = await moveTask(board, id, -1, boardFile);
       printJSONL(res);
       break;
     }
-    case "move_down": {
+    case 'move_down': {
       const [rawId] = args;
-      const id = requireArg(rawId, "task id");
+      const id = requireArg(rawId, 'task id');
       const board = await loadBoard(boardFile, tasksDir);
       const res = await moveTask(board, id, +1, boardFile);
       printJSONL(res);
       break;
     }
-    case "pull": {
+    case 'pull': {
       const board = await loadBoard(boardFile, tasksDir);
       const res = await pullFromTasks(board, tasksDir, boardFile);
       printJSONL(res);
       break;
     }
-    case "push": {
+    case 'push': {
       const board = await loadBoard(boardFile, tasksDir);
       const res = await pushToTasks(board, tasksDir);
       printJSONL(res);
       break;
     }
-    case "sync": {
+    case 'sync': {
       const board = await loadBoard(boardFile, tasksDir);
       const res = await syncBoardAndTasks(board, tasksDir, boardFile);
       printJSONL(res);
       break;
     }
-    case "regenerate": {
+    case 'regenerate': {
       const res = await regenerateBoard(tasksDir, boardFile);
       printJSONL(res);
       break;
     }
-    case "indexForSearch": {
+    case 'indexForSearch': {
       const res = await indexForSearch(tasksDir);
       printJSONL(res);
       break;
     }
-    case "search": {
-      const joined = args.join(" ").trim();
-      const term = requireArg(
-        joined.length > 0 ? joined : undefined,
-        "search term",
-      );
+    case 'search': {
+      const joined = args.join(' ').trim();
+      const term = requireArg(joined.length > 0 ? joined : undefined, 'search term');
       const board = await loadBoard(boardFile, tasksDir);
       const res = await searchTasks(board, term);
       printJSONL(res);
       break;
     }
-    case "process_sync": {
+    case 'process_sync': {
       const res = await processSync({
         processFile: process.env.KANBAN_PROCESS_FILE,
         owner: process.env.GITHUB_OWNER,
@@ -200,9 +213,14 @@ async function main(): Promise<void> {
       printJSONL(res);
       break;
     }
-    case "doccheck": {
+    case 'doccheck': {
       const pr = args[0] || process.env.PR_NUMBER;
-      await docguard({ pr, owner: process.env.GITHUB_OWNER, repo: process.env.GITHUB_REPO, token: process.env.GITHUB_TOKEN });
+      await docguard({
+        pr,
+        owner: process.env.GITHUB_OWNER,
+        repo: process.env.GITHUB_REPO,
+        token: process.env.GITHUB_TOKEN,
+      });
       break;
     }
     default:
@@ -213,8 +231,7 @@ async function main(): Promise<void> {
 }
 
 main().catch((error: unknown) => {
-  const message =
-    error instanceof Error ? error.stack ?? error.message : String(error);
+  const message = error instanceof Error ? error.stack ?? error.message : String(error);
   console.error(message);
   process.exit(1);
 });


### PR DESCRIPTION
## Summary
- import kanban board helper functions and JSONL printer used by the inline CLI switch
- add a shared argument validator and dynamic subcommand list for help output
- record the CLI fix in the changelog entry for this release

## Testing
- pnpm nx run @promethean/kanban:build

------
https://chatgpt.com/codex/tasks/task_e_68e007712fa083248a5e323203c87d11