### PR TITLE
Capture HTTP transport metadata in MCP schema

### DIFF
--- a/packages/clj-hacks/src/clj_hacks/mcp/adapter_mcp_json.clj
+++ b/packages/clj-hacks/src/clj_hacks/mcp/adapter_mcp_json.clj
@@ -4,6 +4,139 @@
             [cheshire.core :as json]
             [clj-hacks.mcp.core :as core]))
 
+(defn- ->vector [v]
+  (cond
+    (nil? v) nil
+    (vector? v) v
+    (sequential? v) (vec v)
+    :else nil))
+
+(defn- parse-expectations [m]
+  (when (map? m)
+    (let [usage         (->vector (get m "usage"))
+          pitfalls      (->vector (get m "pitfalls"))
+          prerequisites (->vector (get m "prerequisites"))]
+      (-> {}
+          (cond-> (contains? m "usage") (assoc :usage usage))
+          (cond-> (contains? m "pitfalls") (assoc :pitfalls pitfalls))
+          (cond-> (contains? m "prerequisites") (assoc :prerequisites prerequisites))))))
+
+(defn- parse-meta [m]
+  (when (map? m)
+    (let [workflow     (->vector (get m "workflow"))
+          expectations (parse-expectations (get m "expectations"))]
+      (-> {}
+          (cond-> (contains? m "title") (assoc :title (get m "title")))
+          (cond-> (contains? m "description") (assoc :description (get m "description")))
+          (cond-> (contains? m "workflow") (assoc :workflow workflow))
+          (cond-> (contains? m "expectations") (assoc :expectations expectations))))))
+
+(defn- parse-endpoint [spec]
+  (let [tools        (->vector (get spec "tools"))
+        include-help (get spec "includeHelp")
+        meta         (parse-meta (get spec "meta"))]
+    (-> {}
+        (cond-> (contains? spec "tools") (assoc :tools tools))
+        (cond-> (contains? spec "includeHelp") (assoc :include-help? include-help))
+        (cond-> (contains? spec "meta") (assoc :meta meta)))))
+
+(defn- string->endpoint-key [s]
+  (cond
+    (keyword? s) s
+    (string? s) (keyword s)
+    :else (keyword (str s))))
+
+(defn- parse-endpoints [m]
+  (when (map? m)
+    (into (sorted-map)
+          (for [[nm spec] m]
+            [(string->endpoint-key nm)
+             (parse-endpoint spec)]))))
+
+(defn- parse-http [m]
+  (let [transport   (get m "transport")
+        tools       (->vector (get m "tools"))
+        include     (get m "includeHelp")
+        stdio-meta  (parse-meta (get m "stdioMeta"))
+        endpoints   (parse-endpoints (get m "endpoints"))
+        proxy-path  (get m "stdioProxyConfig")]
+    (not-empty
+     (-> {}
+         (cond-> (contains? m "transport") (assoc :transport (some-> transport keyword)))
+         (cond-> (contains? m "tools") (assoc :tools tools))
+         (cond-> (contains? m "includeHelp") (assoc :include-help? include))
+         (cond-> (contains? m "stdioMeta") (assoc :stdio-meta stdio-meta))
+         (cond-> (contains? m "endpoints") (assoc :endpoints endpoints))
+         (cond-> (contains? m "stdioProxyConfig")
+           (assoc :proxy {:config proxy-path}))))))
+
+(defn- expectations->json [m]
+  (when (map? m)
+    (let [usage         (:usage m)
+          pitfalls      (:pitfalls m)
+          prerequisites (:prerequisites m)]
+      (-> {}
+          (cond-> (contains? m :usage) (assoc "usage" (->vector usage)))
+          (cond-> (contains? m :pitfalls) (assoc "pitfalls" (->vector pitfalls)))
+          (cond-> (contains? m :prerequisites)
+            (assoc "prerequisites" (->vector prerequisites)))))))
+
+(defn- meta->json [m]
+  (when (map? m)
+    (let [workflow     (:workflow m)
+          expectations (:expectations m)
+          json-ex      (expectations->json expectations)]
+      (-> {}
+          (cond-> (contains? m :title) (assoc "title" (:title m)))
+          (cond-> (contains? m :description) (assoc "description" (:description m)))
+          (cond-> (contains? m :workflow) (assoc "workflow" (->vector workflow)))
+          (cond-> (contains? m :expectations) (assoc "expectations" json-ex))))))
+
+(defn- endpoint-key->string [k]
+  (cond
+    (string? k) k
+    (keyword? k) (if-let [ns (namespace k)]
+                   (str ns "/" (name k))
+                   (name k))
+    :else (str k)))
+
+(defn- endpoint->json [spec]
+  (let [tools        (:tools spec)
+        include-help (:include-help? spec)
+        meta         (:meta spec)
+        meta-json    (meta->json meta)]
+    (-> {}
+        (cond-> (contains? spec :tools) (assoc "tools" (->vector tools)))
+        (cond-> (contains? spec :include-help?) (assoc "includeHelp" include-help))
+        (cond-> (contains? spec :meta) (assoc "meta" meta-json)))))
+
+(defn- endpoints->json [m]
+  (when (map? m)
+    (into (sorted-map)
+          (for [[nm spec] m]
+            [(endpoint-key->string nm)
+             (endpoint->json spec)]))))
+
+(defn- transport->string [t]
+  (cond
+    (nil? t) nil
+    (keyword? t) (name t)
+    (string? t) t
+    :else (str t)))
+
+(defn- http->json [m]
+  (when (map? m)
+    (let [proxy (:proxy m)
+          proxy-config (:config proxy)]
+      (-> {}
+          (cond-> (contains? m :transport) (assoc "transport" (transport->string (:transport m))))
+          (cond-> (contains? m :tools) (assoc "tools" (->vector (:tools m))))
+          (cond-> (contains? m :include-help?) (assoc "includeHelp" (:include-help? m)))
+          (cond-> (contains? m :stdio-meta) (assoc "stdioMeta" (meta->json (:stdio-meta m))))
+          (cond-> (contains? m :endpoints) (assoc "endpoints" (endpoints->json (:endpoints m))))
+          (cond-> (and proxy (contains? proxy :config))
+            (assoc "stdioProxyConfig" proxy-config))))))
+
 (defn read-full [path]
   (let [m       (json/parse-string (slurp path))
         servers (get m "mcpServers")
@@ -16,8 +149,11 @@
                             (cond-> {:command (get spec "command")}
                               (seq args) (assoc :args (vec args))
                               (some? cwd) (assoc :cwd cwd))])))}
-        rest    (dissoc m "mcpServers")]
-    {:mcp mcp :rest rest}))
+        http    (parse-http m)
+        rest    (apply dissoc m ["mcpServers" "transport" "tools" "includeHelp"
+                                 "stdioMeta" "endpoints" "stdioProxyConfig"])]
+    {:mcp (cond-> mcp http (assoc :http http))
+     :rest rest}))
 
 (defn write-full [path {:keys [mcp rest]}]
   (let [existing (if (fs/exists? path)
@@ -30,6 +166,9 @@
                         [(name k) (cond-> {"command" command}
                                     (seq args) (assoc "args" (vec args))
                                     (some? cwd) (assoc "cwd" cwd))]))
-        out     (assoc m* "mcpServers" servers)]
+        http    (http->json (:http mcp))
+        cleaned (apply dissoc (assoc m* "mcpServers" servers)
+                       ["transport" "tools" "includeHelp" "stdioMeta" "endpoints" "stdioProxyConfig"])
+        out     (merge cleaned (or http {}))]
     (core/ensure-parent! path)
     (spit path (json/generate-string out {:pretty true}))))

--- a/packages/clj-hacks/src/clj_hacks/mcp/core.clj
+++ b/packages/clj-hacks/src/clj_hacks/mcp/core.clj
@@ -52,9 +52,12 @@
 
 ;; ----- canonical model -----
 (defn canonical?
-  "True when `m` looks like {:mcp-servers {...}}."
+  "True when `m` looks like {:mcp-servers {...} :http {...?}}."
   [m]
-  (and (map? m) (map? (:mcp-servers m))))
+  (and (map? m)
+       (map? (:mcp-servers m))
+       (let [http (:http m)]
+         (or (nil? http) (map? http)))))
 
 ;; ----- merges (maps only) -----
 (defn deep-merge

--- a/packages/clj-hacks/test/clj_hacks/mcp/adapter_mcp_json_test.clj
+++ b/packages/clj-hacks/test/clj_hacks/mcp/adapter_mcp_json_test.clj
@@ -1,15 +1,35 @@
 (ns clj-hacks.mcp.adapter-mcp-json-test
   (:require [babashka.fs :as fs]
+            [cheshire.core :as json]
             [clj-hacks.mcp.adapter-mcp-json :as adapter]
             [clojure.test :refer [deftest is]]))
 
-(deftest read-full-parses-mcpServers
+(deftest read-full-parses-http-config
   (let [tmp  (fs/create-temp-file {:prefix "mcp-json-" :suffix ".json"})
         path (str tmp)
         _    (spit path
                    (str
                     "{\n"
                     "  \"foo\": 1,\n"
+                    "  \"transport\": \"http\",\n"
+                    "  \"tools\": [\"files.view-file\"],\n"
+                    "  \"includeHelp\": false,\n"
+                    "  \"stdioMeta\": {\n"
+                    "    \"title\": \"Default\",\n"
+                    "    \"workflow\": [\"inspect\"],\n"
+                    "    \"expectations\": { \"usage\": [\"call mcp.toolset\"] }\n"
+                    "  },\n"
+                    "  \"endpoints\": {\n"
+                    "    \"files\": {\n"
+                    "      \"tools\": [\"files.view-file\"],\n"
+                    "      \"includeHelp\": true,\n"
+                    "      \"meta\": {\n"
+                    "        \"description\": \"Read files\",\n"
+                    "        \"expectations\": { \"pitfalls\": [\"binary\"] }\n"
+                    "      }\n"
+                    "    }\n"
+                    "  },\n"
+                    "  \"stdioProxyConfig\": \"./config/mcp_servers.edn\",\n"
                     "  \"mcpServers\": {\n"
                     "    \"foo\": { \"command\": \"echo\", \"args\": [\"a\", \"b\"], \"cwd\": \"/tmp/foo\" },\n"
                     "    \"bar\": { \"command\": \"run\" }\n"
@@ -20,16 +40,58 @@
     (is (= #{{:command "echo" :args ["a" "b"] :cwd "/tmp/foo"}
              {:command "run"}}
            (set (vals (:mcp-servers mcp)))))
-    (is (map? rest))))
+    (is (= {:transport :http
+            :tools ["files.view-file"]
+            :include-help? false
+            :stdio-meta {:title "Default"
+                         :workflow ["inspect"]
+                         :expectations {:usage ["call mcp.toolset"]}}
+            :endpoints {:files {:tools ["files.view-file"]
+                                :include-help? true
+                                :meta {:description "Read files"
+                                       :expectations {:pitfalls ["binary"]}}}}
+            :proxy {:config "./config/mcp_servers.edn"}}
+           (:http mcp)))
+    (is (= {"foo" 1} rest))))
 
 (deftest write-full-writes-valid-json
   (let [tmp-out  (fs/create-temp-file {:prefix "mcp-json-out-" :suffix ".json"})
         path-out (str tmp-out)
         data     {:mcp {:mcp-servers {:foo {:command "echo" :args ["a" "b"] :cwd "/tmp/foo"}
-                                      :bar {:command "run"}}}
+                                      :bar {:command "run"}}
+                        :http {:transport :http
+                               :tools ["files.view-file"]
+                               :include-help? true
+                               :stdio-meta {:title "Default"
+                                            :expectations {:usage ["workflow"]}}
+                               :endpoints {:files {:tools ["files.view-file"]}}
+                               :proxy {:config "./config/mcp_servers.edn"}}}
                    :rest {"foo" 1}}]
     (adapter/write-full path-out data)
     (is (fs/exists? path-out))
-    (let [out (slurp path-out)]
-      (is (string? out))
-      (is (re-find #"\"cwd\"\s*:\s*\"/tmp/foo\"" out)))))
+    (let [out (json/parse-string (slurp path-out))]
+      (is (= "http" (get out "transport")))
+      (is (= ["files.view-file"] (get out "tools")))
+      (is (= true (get out "includeHelp")))
+      (is (= "Default" (get-in out ["stdioMeta" "title"])))
+      (is (= ["files.view-file"] (get-in out ["endpoints" "files" "tools"])))
+      (is (= "./config/mcp_servers.edn" (get out "stdioProxyConfig"))))))
+
+(deftest http-config-round-trips
+  (let [tmp-out  (fs/create-temp-file {:prefix "mcp-json-rt-" :suffix ".json"})
+        path-out (str tmp-out)
+        canonical {:mcp {:mcp-servers {:foo {:command "echo"}}
+                         :http {:transport :http
+                                :tools ["a" "b"]
+                                :include-help? false
+                                :stdio-meta {:title "Stdio" :workflow []}
+                                :endpoints {:alpha {:tools ["a"]
+                                                    :include-help? true
+                                                    :meta {:title "Alpha"
+                                                           :expectations {:usage ["call a"]}}}}
+                                :proxy {:config "./config/servers.edn"}}}
+                    :rest {}}]
+    (adapter/write-full path-out canonical)
+    (let [{:keys [mcp]} (adapter/read-full path-out)]
+      (is (= {:foo {:command "echo"}} (:mcp-servers mcp)))
+      (is (= (:http (:mcp canonical)) (:http mcp))))))


### PR DESCRIPTION
## Summary
- extend the canonical MCP schema to include structured HTTP transport data
- map HTTP manifest fields in the JSON adapter and add regression coverage for round-tripping
- document the EDN `:http` representation for configuring endpoints and proxies

## Testing
- clojure -M:test *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e0305b5020832490e4b9ddd056c43f