### PR TITLE
feat(mcp): surface inline stdio proxy definitions

### DIFF
--- a/changelog.d/2025.10.03.20.31.55.md
+++ b/changelog.d/2025.10.03.20.31.55.md
@@ -1,0 +1,1 @@
+- Surface inline MCP stdio proxies in config schema, HTTP transport, UI, and validation tool; add tests for inline and legacy proxy discovery.

--- a/packages/mcp/src/config/load-config.ts
+++ b/packages/mcp/src/config/load-config.ts
@@ -1,8 +1,8 @@
-import fs from "node:fs";
-import path from "node:path";
-import { z } from "zod";
+import fs from 'node:fs';
+import path from 'node:path';
+import { z } from 'zod';
 
-export const CONFIG_FILE_NAME = "promethean.mcp.json";
+export const CONFIG_FILE_NAME = 'promethean.mcp.json';
 
 // Define the root directory for config files
 export const CONFIG_ROOT = process.cwd();
@@ -32,23 +32,37 @@ const EndpointConfig = z.object({
   includeHelp: z.boolean().optional(), // default: true
   meta: ToolsetMeta.optional(),
 });
+const InlineProxy = z
+  .object({
+    name: z.string().min(1),
+    command: z.string().min(1),
+    args: z.array(z.string()).default([]),
+    env: z.record(z.string()).default({}),
+    cwd: z.string().min(1).optional(),
+    httpPath: z.string().min(1),
+  })
+  .strict();
+
 const Config = z.object({
-  transport: z.enum(["stdio", "http"]).default("http"),
+  transport: z.enum(['stdio', 'http']).default('http'),
   tools: z.array(ToolId).default([]),
   includeHelp: z.boolean().optional(), // default: true
   stdioMeta: ToolsetMeta.optional(),
   endpoints: z.record(EndpointConfig).default({}),
   stdioProxyConfig: z.string().min(1).nullable().default(null),
+  stdioProxies: z.array(InlineProxy).default([]),
 });
 
 export const ConfigSchema = Config;
 
 export type AppConfig = z.infer<typeof Config>;
 
+export type InlineProxyConfig = z.infer<typeof InlineProxy>;
+
 export type ConfigSource =
-  | Readonly<{ type: "file"; path: string }>
-  | Readonly<{ type: "env" }>
-  | Readonly<{ type: "default" }>;
+  | Readonly<{ type: 'file'; path: string }>
+  | Readonly<{ type: 'env' }>
+  | Readonly<{ type: 'default' }>;
 
 export type LoadedConfig = Readonly<{
   config: AppConfig;
@@ -56,7 +70,7 @@ export type LoadedConfig = Readonly<{
 }>;
 
 const readJsonFileSync = (p: string): unknown => {
-  const raw = fs.readFileSync(p, "utf8");
+  const raw = fs.readFileSync(p, 'utf8');
   return JSON.parse(raw);
 };
 
@@ -78,38 +92,30 @@ const findUpSync = (start: string, fileName: string): string | null => {
   return null;
 };
 
-const getArgValue = (
-  argv: string[],
-  flag: string,
-  short: string,
-): string | undefined => {
+const getArgValue = (argv: string[], flag: string, short: string): string | undefined => {
   const idx = argv.indexOf(flag);
   if (idx >= 0 && argv[idx + 1]) return argv[idx + 1];
   const sidx = argv.indexOf(short);
   if (sidx >= 0 && argv[sidx + 1]) return argv[sidx + 1];
   // support --config=path
   const eq = argv.find((a) => a.startsWith(`${flag}=`));
-  if (eq) return eq.split("=", 2)[1];
+  if (eq) return eq.split('=', 2)[1];
   return undefined;
 };
 
-const normalizeConfig = (input: unknown): AppConfig =>
-  Config.parse(input ?? {});
+const normalizeConfig = (input: unknown): AppConfig => Config.parse(input ?? {});
 
 export const findConfigPath = (cwd: string = process.cwd()): string | null =>
   findUpSync(cwd, CONFIG_FILE_NAME);
 
-export const resolveConfigPath = (
-  filePath: string,
-  baseDir: string = CONFIG_ROOT,
-): string => {
+export const resolveConfigPath = (filePath: string, baseDir: string = CONFIG_ROOT): string => {
   if (path.isAbsolute(filePath)) {
     return path.normalize(filePath);
   }
   const base = fs.realpathSync(baseDir);
   const candidate = path.normalize(path.resolve(base, filePath));
   const relative = path.relative(base, candidate);
-  if (relative.startsWith("..") || path.isAbsolute(relative)) {
+  if (relative.startsWith('..') || path.isAbsolute(relative)) {
     throw new Error(`Refusing to access path outside of ${base}: ${candidate}`);
   }
   return candidate;
@@ -135,7 +141,7 @@ export const saveConfigFile = (
   const target = resolveConfigPath(filePath, baseDir);
   const normalized = normalizeConfig(config);
   ensureDirectory(target);
-  fs.writeFileSync(target, JSON.stringify(normalized, null, 2), "utf8");
+  fs.writeFileSync(target, JSON.stringify(normalized, null, 2), 'utf8');
   return normalized;
 };
 
@@ -146,11 +152,11 @@ export const loadConfigWithSource = (
 ): LoadedConfig => {
   const fromFile = (filePath: string): LoadedConfig => ({
     config: loadConfigFromFile(filePath, cwd),
-    source: { type: "file", path: filePath },
+    source: { type: 'file', path: filePath },
   });
 
   // 1) explicit file
-  const explicit = getArgValue(argv, "--config", "-c");
+  const explicit = getArgValue(argv, '--config', '-c');
   if (explicit) {
     const abs = path.resolve(cwd, explicit);
     return fromFile(abs);
@@ -168,17 +174,17 @@ export const loadConfigWithSource = (
       const raw = JSON.parse(env.MCP_CONFIG_JSON);
       return {
         config: normalizeConfig(raw),
-        source: { type: "env" },
+        source: { type: 'env' },
       };
     } catch (e) {
-      throw new Error("Invalid MCP_CONFIG_JSON: " + (e as Error).message);
+      throw new Error('Invalid MCP_CONFIG_JSON: ' + (e as Error).message);
     }
   }
 
   // 4) defaults
   return {
     config: createDefaultConfig(),
-    source: { type: "default" },
+    source: { type: 'default' },
   };
 };
 

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -13,34 +13,32 @@ import {
   tddCoverage,
   tddPropertyCheck,
   tddMutationScore,
-} from "./tools/tdd.js";
+} from './tools/tdd.js';
 import {
   loadConfigWithSource,
   type AppConfig,
   CONFIG_FILE_NAME,
-} from "./config/load-config.js";
-import { buildRegistry } from "./core/registry.js";
-import { createMcpServer } from "./core/mcp-server.js";
-import { fastifyTransport } from "./core/transports/fastify.js";
-import { stdioTransport } from "./core/transports/stdio.js";
-import { githubRequestTool } from "./tools/github/request.js";
-import { githubGraphqlTool } from "./tools/github/graphql.js";
-import { githubRateLimitTool } from "./tools/github/rate-limit.js";
-import { githubContentsWrite } from "./tools/github/contents.js";
-import {
-  githubWorkflowGetJobLogs,
-  githubWorkflowGetRunLogs,
-} from "./tools/github/workflows.js";
+  type InlineProxyConfig,
+} from './config/load-config.js';
+import { buildRegistry } from './core/registry.js';
+import { createMcpServer } from './core/mcp-server.js';
+import { fastifyTransport } from './core/transports/fastify.js';
+import { stdioTransport } from './core/transports/stdio.js';
+import { githubRequestTool } from './tools/github/request.js';
+import { githubGraphqlTool } from './tools/github/graphql.js';
+import { githubRateLimitTool } from './tools/github/rate-limit.js';
+import { githubContentsWrite } from './tools/github/contents.js';
+import { githubWorkflowGetJobLogs, githubWorkflowGetRunLogs } from './tools/github/workflows.js';
 import {
   githubPrGet,
   githubPrFiles,
   githubPrResolvePosition,
-} from "./tools/github/pull-request-data.js";
+} from './tools/github/pull-request-data.js';
 import {
   githubPrReviewStart,
   githubPrReviewCommentInline,
   githubPrReviewSubmit,
-} from "./tools/github/pull-request-review.js";
+} from './tools/github/pull-request-review.js';
 import {
   githubReviewCheckoutBranch,
   githubReviewCommit,
@@ -54,8 +52,8 @@ import {
   githubReviewRevertCommits,
   githubReviewSubmitComment,
   githubReviewSubmitReview,
-} from "./tools/github/code-review.js";
-import { githubApplyPatchTool } from "./tools/github/apply-patch.js";
+} from './tools/github/code-review.js';
+import { githubApplyPatchTool } from './tools/github/apply-patch.js';
 import {
   filesListDirectory,
   filesTreeDirectory,
@@ -110,8 +108,12 @@ import {
   ollamaRemoveJob,
 } from './tools/ollama.js';
 
-import { help as helpTool, toolset as toolsetTool, endpoints as endpointsTool } from "./tools/help.js";
-import { validateConfig as validateConfigTool } from "./tools/validate-config.js";
+import {
+  help as helpTool,
+  toolset as toolsetTool,
+  endpoints as endpointsTool,
+} from './tools/help.js';
+import { validateConfig as validateConfigTool } from './tools/validate-config.js';
 
 type ToolSummary = Readonly<{
   id: string;
@@ -189,81 +191,78 @@ const toolCatalog = new Map<string, ToolFactory>([
   ['ollama.startConversation', ollamaStartConversation],
   ['ollama.getQueue', ollamaGetQueue],
   ['ollama.removeJob', ollamaRemoveJob],
-  ["apply_patch", applyPatchTool],
-  ["github.request", githubRequestTool],
-  ["github.graphql", githubGraphqlTool],
-  ["github.rate-limit", githubRateLimitTool],
-  ["github.contents.write", githubContentsWrite],
-  ["github.workflow.getRunLogs", githubWorkflowGetRunLogs],
-  ["github.workflow.getJobLogs", githubWorkflowGetJobLogs],
-  ["github.apply_patch", githubApplyPatchTool],
-  ["github.pr.get", githubPrGet],
-  ["github.pr.files", githubPrFiles],
-  ["github.pr.resolvePosition", githubPrResolvePosition],
-  ["github.pr.review.start", githubPrReviewStart],
-  ["github.pr.review.commentInline", githubPrReviewCommentInline],
-  ["github.pr.review.submit", githubPrReviewSubmit],
-  ["github.review.openPullRequest", githubReviewOpenPullRequest],
-  ["github.review.getComments", githubReviewGetComments],
-  ["github.review.getReviewComments", githubReviewGetReviewComments],
-  ["github.review.submitComment", githubReviewSubmitComment],
-  [
-    "github.review.requestChangesFromCodex",
-    githubReviewRequestChangesFromCodex,
-  ],
-  ["github.review.submitReview", githubReviewSubmitReview],
-  ["mcp.help", helpTool],
-  ["mcp.toolset", toolsetTool],
-  ["mcp.endpoints", endpointsTool],
-  ["github.review.getActionStatus", githubReviewGetActionStatus],
-  ["github.review.commit", githubReviewCommit],
-  ["github.review.push", githubReviewPush],
-  ["github.review.checkoutBranch", githubReviewCheckoutBranch],
-  ["mcp.validate-config", validateConfigTool],
-  ["github.review.createBranch", githubReviewCreateBranch],
-  ["github.review.revertCommits", githubReviewRevertCommits],
-  ["files.list-directory", filesListDirectory],
-  ["files.tree-directory", filesTreeDirectory],
-  ["files.view-file", filesViewFile],
-  ["files.write-content", filesWriteFileContent],
-  ["files.write-lines", filesWriteFileLines],
-  ["files.search", filesSearch],
-  ["process.getTaskRunnerConfig", processGetTaskRunnerConfig],
-  ["process.updateTaskRunnerConfig", processUpdateTaskRunnerConfig],
-  ["process.enqueueTask", processEnqueueTask],
-  ["process.stop", processStopTask],
-  ["process.getQueue", processGetQueue],
-  ["process.getStdout", processGetStdout],
-  ["process.getStderr", processGetStderr],
-  ["exec.run", execRunTool],
-  ["exec.list", execListTool],
-  ["pnpm.install", pnpmInstall],
-  ["pnpm.add", pnpmAdd],
-  ["pnpm.remove", pnpmRemove],
-  ["pnpm.runScript", pnpmRunScript],
-  ["nx.generatePackage", nxGeneratePackage],
-  ["tdd.scaffoldTest", tddScaffoldTest],
-  ["tdd.changedFiles", tddChangedFiles],
-  ["tdd.runTests", tddRunTests],
-  ["tdd.startWatch", tddStartWatch],
-  ["tdd.getWatchChanges", tddGetWatchChanges],
-  ["tdd.stopWatch", tddStopWatch],
-  ["tdd.coverage", tddCoverage],
-  ["tdd.propertyCheck", tddPropertyCheck],
-  ["tdd.mutationScore", tddMutationScore],
-  ["kanban.get-board", kanbanGetBoard],
-  ["kanban.get-column", kanbanGetColumn],
-  ["kanban.find-task", kanbanFindTaskById],
-  ["kanban.find-task-by-title", kanbanFindTaskByTitle],
-  ["kanban.update-status", kanbanUpdateStatus],
-  ["kanban.move-task", kanbanMoveTask],
-  ["kanban.sync-board", kanbanSyncBoard],
-  ["kanban.search", kanbanSearchTasks],
-  ["discord.send-message", discordSendMessage],
-  ["discord.list-messages", discordListMessages],
-  ["sandbox.create", sandboxCreateTool],
-  ["sandbox.list", sandboxListTool],
-  ["sandbox.delete", sandboxDeleteTool],
+  ['apply_patch', applyPatchTool],
+  ['github.request', githubRequestTool],
+  ['github.graphql', githubGraphqlTool],
+  ['github.rate-limit', githubRateLimitTool],
+  ['github.contents.write', githubContentsWrite],
+  ['github.workflow.getRunLogs', githubWorkflowGetRunLogs],
+  ['github.workflow.getJobLogs', githubWorkflowGetJobLogs],
+  ['github.apply_patch', githubApplyPatchTool],
+  ['github.pr.get', githubPrGet],
+  ['github.pr.files', githubPrFiles],
+  ['github.pr.resolvePosition', githubPrResolvePosition],
+  ['github.pr.review.start', githubPrReviewStart],
+  ['github.pr.review.commentInline', githubPrReviewCommentInline],
+  ['github.pr.review.submit', githubPrReviewSubmit],
+  ['github.review.openPullRequest', githubReviewOpenPullRequest],
+  ['github.review.getComments', githubReviewGetComments],
+  ['github.review.getReviewComments', githubReviewGetReviewComments],
+  ['github.review.submitComment', githubReviewSubmitComment],
+  ['github.review.requestChangesFromCodex', githubReviewRequestChangesFromCodex],
+  ['github.review.submitReview', githubReviewSubmitReview],
+  ['mcp.help', helpTool],
+  ['mcp.toolset', toolsetTool],
+  ['mcp.endpoints', endpointsTool],
+  ['github.review.getActionStatus', githubReviewGetActionStatus],
+  ['github.review.commit', githubReviewCommit],
+  ['github.review.push', githubReviewPush],
+  ['github.review.checkoutBranch', githubReviewCheckoutBranch],
+  ['mcp.validate-config', validateConfigTool],
+  ['github.review.createBranch', githubReviewCreateBranch],
+  ['github.review.revertCommits', githubReviewRevertCommits],
+  ['files.list-directory', filesListDirectory],
+  ['files.tree-directory', filesTreeDirectory],
+  ['files.view-file', filesViewFile],
+  ['files.write-content', filesWriteFileContent],
+  ['files.write-lines', filesWriteFileLines],
+  ['files.search', filesSearch],
+  ['process.getTaskRunnerConfig', processGetTaskRunnerConfig],
+  ['process.updateTaskRunnerConfig', processUpdateTaskRunnerConfig],
+  ['process.enqueueTask', processEnqueueTask],
+  ['process.stop', processStopTask],
+  ['process.getQueue', processGetQueue],
+  ['process.getStdout', processGetStdout],
+  ['process.getStderr', processGetStderr],
+  ['exec.run', execRunTool],
+  ['exec.list', execListTool],
+  ['pnpm.install', pnpmInstall],
+  ['pnpm.add', pnpmAdd],
+  ['pnpm.remove', pnpmRemove],
+  ['pnpm.runScript', pnpmRunScript],
+  ['nx.generatePackage', nxGeneratePackage],
+  ['tdd.scaffoldTest', tddScaffoldTest],
+  ['tdd.changedFiles', tddChangedFiles],
+  ['tdd.runTests', tddRunTests],
+  ['tdd.startWatch', tddStartWatch],
+  ['tdd.getWatchChanges', tddGetWatchChanges],
+  ['tdd.stopWatch', tddStopWatch],
+  ['tdd.coverage', tddCoverage],
+  ['tdd.propertyCheck', tddPropertyCheck],
+  ['tdd.mutationScore', tddMutationScore],
+  ['kanban.get-board', kanbanGetBoard],
+  ['kanban.get-column', kanbanGetColumn],
+  ['kanban.find-task', kanbanFindTaskById],
+  ['kanban.find-task-by-title', kanbanFindTaskByTitle],
+  ['kanban.update-status', kanbanUpdateStatus],
+  ['kanban.move-task', kanbanMoveTask],
+  ['kanban.sync-board', kanbanSyncBoard],
+  ['kanban.search', kanbanSearchTasks],
+  ['discord.send-message', discordSendMessage],
+  ['discord.list-messages', discordListMessages],
+  ['sandbox.create', sandboxCreateTool],
+  ['sandbox.list', sandboxListTool],
+  ['sandbox.delete', sandboxDeleteTool],
 ]);
 
 const env = process.env;
@@ -273,9 +272,7 @@ const mkCtx = () => ({
   now: () => new Date(),
 });
 
-const collectToolSummaries = (
-  ctx: ReturnType<typeof mkCtx>,
-): readonly ToolSummary[] =>
+const collectToolSummaries = (ctx: ReturnType<typeof mkCtx>): readonly ToolSummary[] =>
   Array.from(toolCatalog.entries()).map(([id, factory]) => {
     const tool = factory(ctx);
     return {
@@ -292,9 +289,10 @@ const ensureMetaTools = (
 ): readonly string[] => {
   if (!includeHelp) return ids;
   const need: string[] = [];
-  if (toolCatalog.has("mcp.help") && !ids.includes("mcp.help")) need.push("mcp.help");
-  if (toolCatalog.has("mcp.toolset") && !ids.includes("mcp.toolset")) need.push("mcp.toolset");
-  if (toolCatalog.has("mcp.endpoints") && !ids.includes("mcp.endpoints")) need.push("mcp.endpoints");
+  if (toolCatalog.has('mcp.help') && !ids.includes('mcp.help')) need.push('mcp.help');
+  if (toolCatalog.has('mcp.toolset') && !ids.includes('mcp.toolset')) need.push('mcp.toolset');
+  if (toolCatalog.has('mcp.endpoints') && !ids.includes('mcp.endpoints'))
+    need.push('mcp.endpoints');
   return need.length ? [...ids, ...need] : ids;
 };
 
@@ -384,19 +382,36 @@ const loadConfiguredProxies = async (
 
 export type HttpTransportConfig = Readonly<{
   endpoints: readonly EndpointDefinition[];
-  stdioProxies: readonly StdioServerSpec[];
+  inlineProxySpecs: readonly StdioServerSpec[];
+  legacyProxySpecs: readonly StdioServerSpec[];
 }>;
+
+const ensureLeadingSlash = (value: string): string => (value.startsWith('/') ? value : `/${value}`);
+
+const toStdioServerSpec = (proxy: InlineProxyConfig): StdioServerSpec => ({
+  name: proxy.name,
+  command: proxy.command,
+  args: [...proxy.args],
+  env: { ...proxy.env },
+  cwd: proxy.cwd,
+  httpPath: ensureLeadingSlash(proxy.httpPath),
+});
 
 export const loadHttpTransportConfig = async (
   cfg: Readonly<AppConfig>,
 ): Promise<HttpTransportConfig> => {
   const endpoints = resolveHttpEndpoints(cfg);
+  const inlineSpecs = (cfg.stdioProxies ?? []).map(toStdioServerSpec);
+  if (inlineSpecs.length > 0) {
+    return { endpoints, inlineProxySpecs: inlineSpecs, legacyProxySpecs: [] };
+  }
+
   if (!cfg.stdioProxyConfig) {
-    return { endpoints, stdioProxies: [] };
+    return { endpoints, inlineProxySpecs: [], legacyProxySpecs: [] };
   }
 
   const stdioProxies = await loadStdioServerSpecs(cfg.stdioProxyConfig);
-  return { endpoints, stdioProxies };
+  return { endpoints, inlineProxySpecs: [], legacyProxySpecs: stdioProxies };
 };
 
 export const main = async (): Promise<void> => {
@@ -408,26 +423,41 @@ export const main = async (): Promise<void> => {
     const httpConfig = await loadHttpTransportConfig(cfg);
     (ctx as any).__allEndpoints = httpConfig.endpoints;
     (ctx as any).__allToolIds = Array.from(toolCatalog.keys());
-    const registryDescriptors: HttpEndpointDescriptor[] =
-      httpConfig.endpoints.map((endpoint) => {
-        const factories = selectFactories(
-          ensureMetaTools(endpoint.tools, endpoint.includeHelp !== false),
-        );
-        const registry = buildRegistry(factories, ctx);
-        ctx.__registryList = () => registry.list();
-        ctx.__endpointDef = endpoint;
-        ctx.__allEndpoints = httpConfig.endpoints;
-        return {
-          path: endpoint.path,
-          kind: "registry" as const,
-          handler: createMcpServer(registry.list()),
-        } satisfies HttpEndpointDescriptor;
-      });
+    const registryDescriptors: HttpEndpointDescriptor[] = httpConfig.endpoints.map((endpoint) => {
+      const factories = selectFactories(
+        ensureMetaTools(endpoint.tools, endpoint.includeHelp !== false),
+      );
+      const registry = buildRegistry(factories, ctx);
+      ctx.__registryList = () => registry.list();
+      ctx.__endpointDef = endpoint;
+      ctx.__allEndpoints = httpConfig.endpoints;
+      return {
+        path: endpoint.path,
+        kind: 'registry' as const,
+        handler: createMcpServer(registry.list()),
+      } satisfies HttpEndpointDescriptor;
+    });
 
-    const proxiesFromConfig = httpConfig.stdioProxies.map(instantiateProxy);
+    const inlineProxySpecs = httpConfig.inlineProxySpecs;
+    const inlineProxies = inlineProxySpecs.map(instantiateProxy);
+    const legacyProxySpecs = inlineProxySpecs.length > 0 ? [] : httpConfig.legacyProxySpecs;
+    const legacyProxies = legacyProxySpecs.map(instantiateProxy);
     const fallbackProxies =
-      proxiesFromConfig.length > 0 ? [] : await loadConfiguredProxies(env, cwd);
-    const stdioProxies = proxiesFromConfig.length > 0 ? proxiesFromConfig : fallbackProxies;
+      inlineProxySpecs.length > 0 || legacyProxySpecs.length > 0
+        ? []
+        : await loadConfiguredProxies(env, cwd);
+    const stdioProxies =
+      inlineProxies.length > 0
+        ? inlineProxies
+        : legacyProxies.length > 0
+          ? legacyProxies
+          : fallbackProxies;
+
+    (ctx as any).__proxySources = {
+      inline: inlineProxySpecs,
+      config: legacyProxySpecs,
+      fallback: fallbackProxies.map((proxy) => proxy.spec),
+    } as const;
 
     const proxyDescriptors: HttpEndpointDescriptor[] = stdioProxies.map((proxy) => ({
       path: proxy.spec.httpPath,
@@ -439,16 +469,31 @@ export const main = async (): Promise<void> => {
 
     const transport = fastifyTransport();
     const defaultConfigPath = path.resolve(process.cwd(), CONFIG_FILE_NAME);
-    const configPath = source.type === "file" ? source.path : defaultConfigPath;
+    const configPath = source.type === 'file' ? source.path : defaultConfigPath;
     const toolSummaries = collectToolSummaries(ctx);
 
     const summaryParts = [
       `${registryDescriptors.length} endpoint${registryDescriptors.length === 1 ? '' : 's'}`,
     ];
-    if (stdioProxies.length > 0) {
-      summaryParts.push(`${stdioProxies.length} prox${stdioProxies.length === 1 ? 'y' : 'ies'}`);
+    if (inlineProxySpecs.length > 0) {
+      summaryParts.push(
+        `${inlineProxySpecs.length} inline prox${inlineProxySpecs.length === 1 ? 'y' : 'ies'}`,
+      );
+    } else if (legacyProxySpecs.length > 0) {
+      summaryParts.push(
+        `${legacyProxySpecs.length} prox${
+          legacyProxySpecs.length === 1 ? 'y' : 'ies'
+        } from stdioProxyConfig`,
+      );
     }
-    console.log(`[mcp] transport = http (${summaryParts.join(", ")})`);
+    if (fallbackProxies.length > 0) {
+      summaryParts.push(
+        `${fallbackProxies.length} prox${
+          fallbackProxies.length === 1 ? 'y' : 'ies'
+        } from legacy fallback`,
+      );
+    }
+    console.log(`[mcp] transport = http (${summaryParts.join(', ')})`);
     await transport.start(descriptors, {
       ui: {
         availableTools: toolSummaries,
@@ -461,21 +506,19 @@ export const main = async (): Promise<void> => {
     return;
   }
 
-  const toolIds = ensureMetaTools(
-    resolveStdioTools(cfg),
-    (cfg as any).includeHelp !== false,
-  );
+  const toolIds = ensureMetaTools(resolveStdioTools(cfg), (cfg as any).includeHelp !== false);
   const factories = selectFactories(toolIds);
   const registry = buildRegistry(factories, ctx);
   ctx.__registryList = () => registry.list();
   ctx.__endpointDef = {
-    path: "/mcp",
+    path: '/mcp',
     tools: toolIds,
     includeHelp: (cfg as any).includeHelp,
     meta: (cfg as any).stdioMeta,
   };
   ctx.__allEndpoints = resolveHttpEndpoints(cfg);
   ctx.__allToolIds = Array.from(toolCatalog.keys());
+  (ctx as any).__proxySources = { inline: [], config: [], fallback: [] } as const;
   const server = createMcpServer(registry.list());
   const transport = stdioTransport();
   console.log('[mcp] transport = stdio');

--- a/packages/mcp/src/tests/config.test.ts
+++ b/packages/mcp/src/tests/config.test.ts
@@ -1,85 +1,87 @@
-import test from "ava";
-import {
-  resolveHttpEndpoints,
-  resolveStdioTools,
-} from "../core/resolve-config.js";
-import type { AppConfig } from "../config/load-config.js";
+import test from 'ava';
+import { resolveHttpEndpoints, resolveStdioTools } from '../core/resolve-config.js';
+import type { AppConfig } from '../config/load-config.js';
 
-test("resolveHttpEndpoints falls back to /mcp with top-level tools", (t) => {
+test('resolveHttpEndpoints falls back to /mcp with top-level tools', (t) => {
   const cfg: AppConfig = {
-    transport: "http",
-    tools: ["files.view-file"],
+    transport: 'http',
+    tools: ['files.view-file'],
     endpoints: {},
     stdioProxyConfig: null,
+    stdioProxies: [],
   };
 
   const result = resolveHttpEndpoints(cfg);
-  t.deepEqual(result, [{ path: "/mcp", tools: ["files.view-file"] }]);
+  t.deepEqual(result, [{ path: '/mcp', tools: ['files.view-file'] }]);
 });
 
-test("resolveHttpEndpoints normalizes endpoint paths", (t) => {
+test('resolveHttpEndpoints normalizes endpoint paths', (t) => {
   const cfg: AppConfig = {
-    transport: "http",
+    transport: 'http',
     tools: [],
     endpoints: {
-      "github/mcp": { tools: ["github.request"] },
-      "/fs/mcp": { tools: ["files.list-directory"] },
+      'github/mcp': { tools: ['github.request'] },
+      '/fs/mcp': { tools: ['files.list-directory'] },
     },
     stdioProxyConfig: null,
+    stdioProxies: [],
   };
 
   const result = resolveHttpEndpoints(cfg);
   t.deepEqual(result, [
-    { path: "/github/mcp", tools: ["github.request"] },
-    { path: "/fs/mcp", tools: ["files.list-directory"] },
+    { path: '/github/mcp', tools: ['github.request'] },
+    { path: '/fs/mcp', tools: ['files.list-directory'] },
   ]);
 });
 
-test("resolveHttpEndpoints retains legacy /mcp when endpoints present", (t) => {
+test('resolveHttpEndpoints retains legacy /mcp when endpoints present', (t) => {
   const cfg: AppConfig = {
-    transport: "http",
-    tools: ["files.view-file"],
+    transport: 'http',
+    tools: ['files.view-file'],
     endpoints: {
-      "github/mcp": { tools: ["github.request"] },
+      'github/mcp': { tools: ['github.request'] },
     },
     stdioProxyConfig: null,
+    stdioProxies: [],
   };
 
   const result = resolveHttpEndpoints(cfg);
   t.deepEqual(result, [
-    { path: "/mcp", tools: ["files.view-file"] },
-    { path: "/github/mcp", tools: ["github.request"] },
+    { path: '/mcp', tools: ['files.view-file'] },
+    { path: '/github/mcp', tools: ['github.request'] },
   ]);
 });
 
-test("resolveStdioTools prefers top-level tools", (t) => {
+test('resolveStdioTools prefers top-level tools', (t) => {
   const cfg: AppConfig = {
-    transport: "stdio",
-    tools: ["files.view-file"],
+    transport: 'stdio',
+    tools: ['files.view-file'],
     endpoints: {
-      "github/mcp": { tools: ["github.request"] },
+      'github/mcp': { tools: ['github.request'] },
     },
     stdioProxyConfig: null,
+    stdioProxies: [],
   };
 
   const result = resolveStdioTools(cfg);
-  t.deepEqual(result, ["files.view-file"]);
+  t.deepEqual(result, ['files.view-file']);
 });
 
-test("resolveStdioTools unions endpoint tools when top-level empty", (t) => {
+test('resolveStdioTools unions endpoint tools when top-level empty', (t) => {
   const cfg: AppConfig = {
-    transport: "stdio",
+    transport: 'stdio',
     tools: [],
     endpoints: {
-      "github/mcp": { tools: ["github.request"] },
-      "fs/mcp": { tools: ["files.list-directory", "files.view-file"] },
+      'github/mcp': { tools: ['github.request'] },
+      'fs/mcp': { tools: ['files.list-directory', 'files.view-file'] },
     },
     stdioProxyConfig: null,
+    stdioProxies: [],
   };
 
   const result = resolveStdioTools(cfg);
   t.deepEqual(
     new Set(result),
-    new Set(["github.request", "files.list-directory", "files.view-file"]),
+    new Set(['github.request', 'files.list-directory', 'files.view-file']),
   );
 });

--- a/packages/mcp/src/tests/http-config.test.ts
+++ b/packages/mcp/src/tests/http-config.test.ts
@@ -1,47 +1,89 @@
-import { mkdtempSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
-import path from "node:path";
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
 
-import test from "ava";
+import test from 'ava';
 
-import { loadConfig } from "../config/load-config.js";
-import { loadHttpTransportConfig } from "../index.js";
+import { loadConfig } from '../config/load-config.js';
+import { loadHttpTransportConfig } from '../index.js';
 
 const serialize = (value: unknown) => JSON.stringify(value, null, 2);
 
-test("loadHttpTransportConfig merges JSON endpoints with stdio proxies", async (t) => {
-  const dir = mkdtempSync(path.join(tmpdir(), "mcp-http-"));
-  const configPath = path.join(dir, "promethean.mcp.json");
-  const ednPath = path.join(dir, "servers.edn");
-
-  const edn =
-    '{:mcp-servers {:proxy {:command "./bin/server.sh" :args ["--stdio"] :http-path "/proxy"}}}';
-  writeFileSync(ednPath, edn, "utf8");
+test('loadHttpTransportConfig prefers inline stdio proxies over legacy path', async (t) => {
+  const dir = mkdtempSync(path.join(tmpdir(), 'mcp-http-inline-'));
+  const configPath = path.join(dir, 'promethean.mcp.json');
+  const missingPath = path.join(dir, 'missing.edn');
 
   const jsonConfig = {
-    transport: "http",
-    tools: ["files.view-file"],
+    transport: 'http',
+    tools: ['files.view-file'],
     endpoints: {
-      "analytics/api": { tools: ["github.request"] },
+      'analytics/api': { tools: ['github.request'] },
     },
-    stdioProxyConfig: ednPath,
+    stdioProxyConfig: missingPath,
+    stdioProxies: [
+      {
+        name: 'inline-proxy',
+        command: './bin/server.sh',
+        httpPath: 'inline',
+      },
+    ],
   } as const;
-  writeFileSync(configPath, serialize(jsonConfig), "utf8");
+  writeFileSync(configPath, serialize(jsonConfig), 'utf8');
 
   const env = Object.create(null) as NodeJS.ProcessEnv;
-  const cfg = loadConfig(env, ["node", "test", "--config", configPath], dir);
+  const cfg = loadConfig(env, ['node', 'test', '--config', configPath], dir);
 
   const httpConfig = await loadHttpTransportConfig(cfg);
 
   t.deepEqual(
     httpConfig.endpoints.map((endpoint) => endpoint.path),
-    ["/mcp", "/analytics/api"],
+    ['/mcp', '/analytics/api'],
   );
-  t.deepEqual(httpConfig.endpoints[0]?.tools, ["files.view-file"]);
+  t.deepEqual(httpConfig.endpoints[0]?.tools, ['files.view-file']);
 
-  t.is(httpConfig.stdioProxies.length, 1);
-  const proxy = httpConfig.stdioProxies[0]!;
-  t.is(proxy.name, "proxy");
-  t.true(proxy.command.endsWith(path.join("bin", "server.sh")));
-  t.is(proxy.httpPath, "/proxy");
+  t.is(httpConfig.inlineProxySpecs.length, 1);
+  const inlineProxy = httpConfig.inlineProxySpecs[0]!;
+  t.is(inlineProxy.name, 'inline-proxy');
+  t.is(inlineProxy.command, './bin/server.sh');
+  t.is(inlineProxy.httpPath, '/inline');
+  t.is(httpConfig.legacyProxySpecs.length, 0);
+});
+
+test('loadHttpTransportConfig loads stdio proxies from legacy config path', async (t) => {
+  const dir = mkdtempSync(path.join(tmpdir(), 'mcp-http-'));
+  const configPath = path.join(dir, 'promethean.mcp.json');
+  const ednPath = path.join(dir, 'servers.edn');
+
+  const edn =
+    '{:mcp-servers {:proxy {:command "./bin/server.sh" :args ["--stdio"] :http-path "/proxy"}}}';
+  writeFileSync(ednPath, edn, 'utf8');
+
+  const jsonConfig = {
+    transport: 'http',
+    tools: ['files.view-file'],
+    endpoints: {
+      'analytics/api': { tools: ['github.request'] },
+    },
+    stdioProxyConfig: ednPath,
+  } as const;
+  writeFileSync(configPath, serialize(jsonConfig), 'utf8');
+
+  const env = Object.create(null) as NodeJS.ProcessEnv;
+  const cfg = loadConfig(env, ['node', 'test', '--config', configPath], dir);
+
+  const httpConfig = await loadHttpTransportConfig(cfg);
+
+  t.deepEqual(
+    httpConfig.endpoints.map((endpoint) => endpoint.path),
+    ['/mcp', '/analytics/api'],
+  );
+  t.deepEqual(httpConfig.endpoints[0]?.tools, ['files.view-file']);
+
+  t.is(httpConfig.inlineProxySpecs.length, 0);
+  t.is(httpConfig.legacyProxySpecs.length, 1);
+  const proxy = httpConfig.legacyProxySpecs[0]!;
+  t.is(proxy.name, 'proxy');
+  t.true(proxy.command.endsWith(path.join('bin', 'server.sh')));
+  t.is(proxy.httpPath, '/proxy');
 });

--- a/packages/mcp/src/tests/validate-config.test.ts
+++ b/packages/mcp/src/tests/validate-config.test.ts
@@ -1,9 +1,9 @@
-import test from "ava";
-import { z } from "zod";
+import test from 'ava';
+import { z } from 'zod';
 
-import type { EndpointDefinition } from "../core/resolve-config.js";
-import type { ToolContext } from "../core/types.js";
-import { validateConfig } from "../tools/validate-config.js";
+import type { EndpointDefinition } from '../core/resolve-config.js';
+import type { ToolContext } from '../core/types.js';
+import { validateConfig } from '../tools/validate-config.js';
 
 type ValidateResult = Readonly<{
   ok: boolean;
@@ -14,6 +14,12 @@ type ValidateResult = Readonly<{
     errorCount: number;
     warningCount: number;
     workflowIssues: number;
+    proxies: Readonly<{
+      inline: number;
+      config: number;
+      fallback: number;
+      active: number;
+    }>;
   }>;
 }>;
 
@@ -26,45 +32,58 @@ const ResultSchema = z.object({
     errorCount: z.number(),
     warningCount: z.number(),
     workflowIssues: z.number(),
+    proxies: z.object({
+      inline: z.number(),
+      config: z.number(),
+      fallback: z.number(),
+      active: z.number(),
+    }),
   }),
 }) satisfies z.ZodType<ValidateResult>;
 
 type TestContext = ToolContext & {
   readonly __allEndpoints: readonly EndpointDefinition[];
   readonly __allToolIds: readonly string[];
+  readonly __proxySources: Readonly<{
+    inline: readonly any[];
+    config: readonly any[];
+    fallback: readonly any[];
+  }>;
 };
 
 const mkCtx = (
   endpoints: readonly EndpointDefinition[],
   allToolIds: readonly string[],
+  proxySources: TestContext['__proxySources'] = { inline: [], config: [], fallback: [] },
 ): TestContext => ({
   env: {},
   fetch: () => Promise.resolve({ ok: true } as Response),
   now: () => new Date(),
   __allEndpoints: endpoints,
   __allToolIds: allToolIds,
+  __proxySources: proxySources,
 });
 
-test("validate-config returns ok when workflows match exposed tools", async (t) => {
+test('validate-config returns ok when workflows match exposed tools', async (t) => {
   const endpoints: EndpointDefinition[] = [
     {
-      path: "/files",
-      tools: ["files.search", "files.view-file"],
+      path: '/files',
+      tools: ['files.search', 'files.view-file'],
       includeHelp: true,
       meta: {
-        title: "Filesystem",
-        description: "Search and inspect workspace files.",
-        workflow: ["files.search → files.view-file"],
+        title: 'Filesystem',
+        description: 'Search and inspect workspace files.',
+        workflow: ['files.search → files.view-file'],
       },
     },
   ];
   const ctx = mkCtx(endpoints, [
-    "files.search",
-    "files.view-file",
-    "apply_patch",
-    "mcp.help",
-    "mcp.toolset",
-    "mcp.endpoints",
+    'files.search',
+    'files.view-file',
+    'apply_patch',
+    'mcp.help',
+    'mcp.toolset',
+    'mcp.endpoints',
   ]);
   const tool = validateConfig(ctx);
   const result = ResultSchema.parse(await tool.invoke(undefined));
@@ -72,47 +91,89 @@ test("validate-config returns ok when workflows match exposed tools", async (t) 
   t.deepEqual(result.errors, []);
   t.deepEqual(result.warnings, []);
   t.is(result.summary.workflowIssues, 0);
+  t.deepEqual(result.summary.proxies, {
+    inline: 0,
+    config: 0,
+    fallback: 0,
+    active: 0,
+  });
 });
 
-test("validate-config flags unknown workflow tool ids", async (t) => {
+test('validate-config summary reports proxy sources', async (t) => {
+  const ctx = mkCtx([], [], {
+    inline: [
+      {
+        name: 'inline',
+        command: 'cmd',
+        args: [],
+        env: {},
+        httpPath: '/inline',
+      },
+    ],
+    config: [],
+    fallback: [
+      {
+        name: 'fallback',
+        command: 'cmd',
+        args: [],
+        env: {},
+        httpPath: '/fallback',
+      },
+    ],
+  });
+  const tool = validateConfig(ctx);
+  const result = ResultSchema.parse(await tool.invoke(undefined));
+  t.is(result.summary.proxies.inline, 1);
+  t.is(result.summary.proxies.config, 0);
+  t.is(result.summary.proxies.fallback, 1);
+  t.is(result.summary.proxies.active, 1);
+});
+
+test('validate-config flags unknown workflow tool ids', async (t) => {
   const endpoints: EndpointDefinition[] = [
     {
-      path: "/files",
-      tools: ["files.view-file"],
+      path: '/files',
+      tools: ['files.view-file'],
       includeHelp: true,
       meta: {
-        title: "Filesystem",
-        description: "Read files.",
-        workflow: ["files.view-file → files.apply"],
+        title: 'Filesystem',
+        description: 'Read files.',
+        workflow: ['files.view-file → files.apply'],
       },
     },
   ];
-  const ctx = mkCtx(endpoints, ["files.view-file"]);
+  const ctx = mkCtx(endpoints, ['files.view-file']);
   const tool = validateConfig(ctx);
   const result = ResultSchema.parse(await tool.invoke(undefined));
   t.false(result.ok);
-  t.true(result.errors.some((msg) => msg.includes("files.apply")), result.errors.join("\n"));
+  t.true(
+    result.errors.some((msg) => msg.includes('files.apply')),
+    result.errors.join('\n'),
+  );
   t.is(result.summary.workflowIssues, 1);
 });
 
-test("validate-config detects workflow references missing from endpoint", async (t) => {
+test('validate-config detects workflow references missing from endpoint', async (t) => {
   const endpoints: EndpointDefinition[] = [
     {
-      path: "/files",
-      tools: ["files.view-file"],
+      path: '/files',
+      tools: ['files.view-file'],
       includeHelp: true,
       meta: {
-        title: "Filesystem",
-        description: "Read files.",
-        workflow: ["Consult docs", "files.search"],
+        title: 'Filesystem',
+        description: 'Read files.',
+        workflow: ['Consult docs', 'files.search'],
       },
     },
   ];
-  const ctx = mkCtx(endpoints, ["files.view-file", "files.search"]);
+  const ctx = mkCtx(endpoints, ['files.view-file', 'files.search']);
   const tool = validateConfig(ctx);
   const result = ResultSchema.parse(await tool.invoke(undefined));
   t.false(result.ok);
-  t.true(result.errors.some((msg) => msg.includes("files.search")), result.errors.join("\n"));
-  t.true(result.warnings.some((msg) => msg.includes("does not reference any tool ids")));
+  t.true(
+    result.errors.some((msg) => msg.includes('files.search')),
+    result.errors.join('\n'),
+  );
+  t.true(result.warnings.some((msg) => msg.includes('does not reference any tool ids')));
   t.is(result.summary.workflowIssues, 2);
 });


### PR DESCRIPTION
## Summary
- add an inline stdio proxy array to the MCP config schema and prefer it ahead of the legacy EDN file loader
- surface inline proxy definitions in the HTTP bootstrap log, UI editor, and validate-config tool output
- extend the MCP unit tests to cover inline proxy usage and the legacy fallback path

## Testing
- pnpm --dir packages/mcp run test *(fails: TypeScript build in package requires optional workspace dependencies such as esmock, fflate, and @promethean/discord)*

------
https://chatgpt.com/codex/tasks/task_e_68e0306651b88324a79f324da59db726