### PR TITLE
Add MCP manifest refresh automation from EDN

### DIFF
--- a/bb/src/mk/mcp_ops.clj
+++ b/bb/src/mk/mcp_ops.clj
@@ -1,3 +1,69 @@
 (ns mk.mcp-ops
-  "Thin wrapper around clj-hacks MCP operations."
-  (:require [clj-hacks.mcp.ops :as ops :refer :all]))
+  "Thin wrapper around clj-hacks MCP operations plus higher level helpers."
+  (:require [babashka.fs :as fs]
+            [clojure.edn :as edn]
+            [clj-hacks.mcp.core :as core]
+            [clj-hacks.mcp.ops :as ops :refer :all]))
+
+(defn- ensure-base
+  "Resolve the working directory for relative :outputs paths."
+  [edn-path]
+  (or (some-> edn-path fs/path fs/parent str)
+      (str (fs/cwd))))
+
+(defn load-edn
+  "Read EDN configuration from `path`."
+  [path]
+  (edn/read-string (slurp path)))
+
+(defn refresh-outputs!
+  "Push or sync all outputs for `edn-map` relative to `base`.
+
+  Returns {:edn <map> :mode <keyword> :results <vector>} where :edn reflects
+  any updated EDN map when :mode = :sync (since sync-all! can pull remote
+  changes)."
+  ([edn-map base]
+   (refresh-outputs! edn-map base {:mode :push}))
+  ([edn-map base {:keys [mode]}]
+   (let [mode   (or mode :push)
+         outs   (:outputs edn-map)
+         result (cond
+                  (not (seq outs)) {:edn edn-map :mode mode :results []}
+
+                  (= mode :sync)
+                  (let [edn* (ops/sync-all! edn-map base outs)]
+                    {:edn edn* :mode :sync
+                     :results (mapv #(select-keys % [:schema :path]) outs)})
+
+                  (= mode :push)
+                  {:edn edn-map :mode :push
+                   :results (ops/push-all! edn-map base outs)}
+
+                  :else
+                  (throw (ex-info "Unknown refresh mode" {:mode mode})))]
+     result)))
+
+(defn write-edn!
+  "Persist `data` to `path` and refresh :outputs. Accepts {:mode :push|:sync}."
+  ([path data]
+   (write-edn! path data {:mode :push}))
+  ([path data {:keys [mode]}]
+   (core/spit-edn! path data)
+   (let [base            (ensure-base path)
+         {:keys [edn] :as refresh} (refresh-outputs! data base {:mode mode})]
+     (when (and (= (:mode refresh) :sync)
+                (not= edn data))
+       ;; Sync may have pulled new data; persist it immediately.
+       (core/spit-edn! path edn))
+     refresh)))
+
+(defn update-edn!
+  "Load EDN from `path`, apply `f` (plus optional :args vector), write results,
+  and refresh :outputs. Optional {:mode :push|:sync}. Returns the final EDN map."
+  ([path f]
+   (update-edn! path f {:mode :push}))
+  ([path f {:keys [args mode] :or {args [] mode :push}}]
+   (let [current (load-edn path)
+         updated (apply f current args)
+         {:keys [edn]} (write-edn! path updated {:mode mode})]
+     edn)))

--- a/changelog.d/2025.10.05.12.00.00.md
+++ b/changelog.d/2025.10.05.12.00.00.md
@@ -1,0 +1,1 @@
+- Ensure MCP config generators emit `promethean.mcp.json` from EDN and document the refresh workflow.

--- a/packages/clj-hacks/test/clj_hacks/mcp/ops_test.clj
+++ b/packages/clj-hacks/test/clj_hacks/mcp/ops_test.clj
@@ -1,0 +1,32 @@
+(ns clj-hacks.mcp.ops-test
+  (:require [babashka.fs :as fs]
+            [cheshire.core :as json]
+            [clj-hacks.mcp.ops :as ops]
+            [clojure.test :refer [deftest is]]))
+
+(deftest push-all-writes-extended-mcp-json
+  (let [tmp-dir (fs/create-temp-dir {:prefix "mcp-ops-"})
+        manifest (str (fs/path tmp-dir "promethean.mcp.json"))
+        base (str tmp-dir)
+        initial {"transport" "http"
+                 "tools" ["files.view-file"]
+                 "endpoints" {"files" {"tools" ["files.view-file"]}}
+                 "mcpServers" {}}
+        edn {:mcp-servers {:new {:command "echo"
+                                 :args ["hi"]}}
+             :outputs [{:schema :mcp.json :path "./promethean.mcp.json"}]}]
+    (try
+      (fs/create-dirs (fs/parent manifest))
+      (spit manifest (json/generate-string initial {:pretty true}))
+      (ops/push-all! edn base (:outputs edn))
+      (is (fs/exists? manifest))
+      (let [written (json/parse-string (slurp manifest))
+            servers (get written "mcpServers")]
+        (is (= {"new" {"command" "echo" "args" ["hi"]}}
+               servers))
+        (is (= "http" (get written "transport")))
+        (is (= {"files" {"tools" ["files.view-file"]}}
+               (get written "endpoints")))
+        (is (= ["files.view-file"] (get written "tools"))))
+      (finally
+        (fs/delete-tree tmp-dir)))))

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -44,9 +44,11 @@ declared `:http-path` (defaulting to `/<name>/mcp`).
 
 Running with this manifest will expose both the GitHub endpoint defined in JSON and any stdio servers declared in
 `packages/mcp/examples/mcp_servers.edn` on the same Fastify instance. Copy the example to `config/mcp_servers.edn` and
-adjust paths as needed for your machine (the config path is gitignored):
+adjust paths as needed for your machine (the config path is gitignored). Edit the EDN file and regenerate manifests instead of
+touching `promethean.mcp.json` by hand:
 
 ```bash
+bb -m mk.mcp-cli push-all --edn config/mcp_servers.edn
 pnpm --filter @promethean/mcp dev -- --config ./promethean.mcp.json
 ```
 

--- a/packages/mcp/config/mcp_servers.edn
+++ b/packages/mcp/config/mcp_servers.edn
@@ -65,6 +65,9 @@
   ;; Oterm
   {:schema :codex.json :path "/home/err/.local/share/oterm/config.json"}
 
+  ;; Promethean root manifest
+  {:schema :mcp.json  :path "./promethean.mcp.json"}
+
   ;; Emacs MCP package
   ;; doesn't work right.
   ;; we added a thing to parse emacs code with tree sitter to directly manipulate the

--- a/packages/mcp/examples/mcp_servers.edn
+++ b/packages/mcp/examples/mcp_servers.edn
@@ -61,6 +61,9 @@
   ;; Oterm
   {:schema :codex.json :path "${HOME}/.local/share/oterm/config.json"}
 
+  ;; Promethean root manifest
+  {:schema :mcp.json  :path "./promethean.mcp.json"}
+
   ;; Emacs MCP package
   ;; doesn't work right.
   ;; we added a thing to parse emacs code with tree sitter to directly manipulate the


### PR DESCRIPTION
## Summary
- add :mcp.json destinations to MCP EDN configs so generators write the server manifest
- refresh CLI/helpers to push outputs after EDN edits and document the workflow
- cover the new JSON output with a regression test and changelog entry

## Testing
- bb clj-hacks:test

------
https://chatgpt.com/codex/tasks/task_e_68e03075e904832497f4fce7caec00d4