### PR TITLE
Add Emacs install step and layer manifest checks

### DIFF
--- a/.emacs/layers/codex-hub/packages.el
+++ b/.emacs/layers/codex-hub/packages.el
@@ -1,4 +1,4 @@
-;;; packages.el --- codex-hub layer packages file for Spacemacs.
+;;; packages.el --- codex-hub layer packages file for Spacemacs -*- lexical-binding: t; -*-
 ;;
 ;; Copyright (c) 2012-2025 Sylvain Benner & Contributors
 ;;
@@ -66,5 +66,7 @@ Each entry is either:
       - The symbol `local' directs Spacemacs to load the file at
         `./local/PACKAGE/PACKAGE.el'
 
-      - A list beginning with the symbol `recipe' is a melpa
-        recipe.  See: https://github.com/milkypostman/melpa#recipe-format")
+    - A list beginning with the symbol `recipe' is a melpa
+      recipe.  See: https://github.com/milkypostman/melpa#recipe-format")
+
+;;; packages.el ends here

--- a/.emacs/layers/err-commonlisp/packages.el
+++ b/.emacs/layers/err-commonlisp/packages.el
@@ -1,4 +1,4 @@
-;;; packages.el --- err-commonlisp layer packages file for Spacemacs.
+;;; packages.el --- err-commonlisp layer packages file for Spacemacs -*- lexical-binding: t; -*-
 ;;
 ;; Copyright (c) 2012-2025 Sylvain Benner & Contributors
 ;;
@@ -111,3 +111,5 @@ Each entry is either:
       ((error line-start (file-name) ":" line ":" column ": " (message) line-end))
       :modes (common-lisp-mode))
     (add-to-list 'flycheck-checkers 'common-lisp-sblint)))
+
+;;; packages.el ends here

--- a/.emacs/layers/err-core/packages.el
+++ b/.emacs/layers/err-core/packages.el
@@ -1,4 +1,4 @@
-;;; packages.el --- err-core layer packages file for Spacemacs.
+;;; packages.el --- err-core layer packages file for Spacemacs -*- lexical-binding: t; -*-
 ;;
 ;; Copyright (c) 2012-2025 Sylvain Benner & Contributors
 ;;
@@ -227,3 +227,5 @@
           (c++-mode . c++-ts-mode)
           (python-mode . python-ts-mode)
           (yaml-mode . yaml-ts-mode))))
+
+;;; packages.el ends here

--- a/.emacs/layers/err-ts/packages.el
+++ b/.emacs/layers/err-ts/packages.el
@@ -1,4 +1,4 @@
-;;; packages.el --- err-ts layer packages file for Spacemacs.
+;;; packages.el --- err-ts layer packages file for Spacemacs -*- lexical-binding: t; -*-
 ;;
 ;; Copyright (c) 2012-2025 Sylvain Benner & Contributors
 ;;
@@ -117,3 +117,5 @@ Each entry is either:
 ;;   (with-eval-after-load 'flycheck
 ;;     (flycheck-add-mode 'typescript-tslint 'typescript-ts-mode)
 ;;     (flycheck-add-mode 'javascript-eslint 'typescript-ts-mode)))
+
+;;; packages.el ends here

--- a/.emacs/layers/llm/packages.el
+++ b/.emacs/layers/llm/packages.el
@@ -97,3 +97,5 @@
   (use-package gptel-quick
     :after gptel
     :commands (gptel-quick)))
+
+;;; packages.el ends here

--- a/.emacs/layers/obsidian/packages.el
+++ b/.emacs/layers/obsidian/packages.el
@@ -1,4 +1,4 @@
-;;; packages.el --- obsidian layer packages file for Spacemacs.
+;;; packages.el --- obsidian layer packages file for Spacemacs -*- lexical-binding: t; -*-
 ;;
 ;; Copyright (c) 2012-2025 Sylvain Benner & Contributors
 ;;
@@ -63,3 +63,5 @@
         "on" #'obsidian-daily-note
         "ot" #'obsidian-tag-insert
         "os" #'obsidian-search))))
+
+;;; packages.el ends here

--- a/.emacs/layers/prom-unique/packages.el
+++ b/.emacs/layers/prom-unique/packages.el
@@ -2,3 +2,5 @@
 
 
 (defconst prom-unique-packages '())
+
+;;; packages.el ends here

--- a/.emacs/layers/promethean-vterm/packages.el
+++ b/.emacs/layers/promethean-vterm/packages.el
@@ -1,4 +1,4 @@
-;;; packages.el --- promethean-vterm layer packages file for Spacemacs.
+;;; packages.el --- promethean-vterm layer packages file for Spacemacs -*- lexical-binding: t; -*-
 ;;
 ;; Copyright (c) 2012-2025 Sylvain Benner & Contributors
 ;;
@@ -91,3 +91,5 @@
       (vterm-previous-prompt 0)
       (beginning-of-line))
     (define-key vterm-mode-map (kbd "C-a") #'promethean/vterm-bol)))
+
+;;; packages.el ends here

--- a/.emacs/layers/promethean/packages.el
+++ b/.emacs/layers/promethean/packages.el
@@ -18,3 +18,5 @@
   (load (expand-file-name "hy.el" promethean--layer-dir)))
 (defun promethean/init-promethean-sibilant-mode ()
   (load (expand-file-name "sibilant.el" promethean--layer-dir)))
+
+;;; packages.el ends here

--- a/.emacs/layers/semantic-search/packages.el
+++ b/.emacs/layers/semantic-search/packages.el
@@ -142,3 +142,5 @@
 
 ;; (defun semantic-search/init-vecdb ()
 ;;   (use-package vecdb :defer t)) ;; GNU ELPA; vector DB interface
+
+;;; packages.el ends here

--- a/changelog.d/2025.10.05.04.18.55.md
+++ b/changelog.d/2025.10.05.04.18.55.md
@@ -1,0 +1,4 @@
+## Added
+- Ensure Codex dev environment installs Emacs for layer testing.
+- Introduced automated checks for Emacs layer package manifests.
+- Standardized layer package headers and footers for lexical binding.

--- a/run/setup_codex_dev_env.sh
+++ b/run/setup_codex_dev_env.sh
@@ -16,6 +16,7 @@ describe uvx-precommit-install  uvx pre-commit install
 # OS deps
 describe apt-update             bash -lc 'export DEBIAN_FRONTEND=noninteractive; apt-get update -y'
 describe apt-build-tools        bash -lc 'apt-get install -y build-essential python3 make g++ pkg-config'
+describe apt-emacs              bash -lc 'export DEBIAN_FRONTEND=noninteractive; apt-get install -y emacs-nox'
 
 
 # native toolchain + node-gyp helpers

--- a/tests/emacsLayers.test.js
+++ b/tests/emacsLayers.test.js
@@ -1,0 +1,57 @@
+import test from 'ava';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, '..');
+const layersDir = path.join(repoRoot, '.emacs', 'layers');
+
+async function getLayerEntries() {
+  const entries = await fs.readdir(layersDir, { withFileTypes: true });
+  return entries.filter((entry) => entry.isDirectory());
+}
+
+test('each Emacs layer defines a packages.el manifest', async (t) => {
+  const layers = await getLayerEntries();
+
+  t.true(layers.length > 0, 'expected at least one Emacs layer to exist');
+
+  await Promise.all(
+    layers.map(async (layer) => {
+      const manifestPath = path.join(layersDir, layer.name, 'packages.el');
+      try {
+        await fs.access(manifestPath);
+        t.pass(`${layer.name} exposes packages.el`);
+      } catch (error) {
+        t.fail(`${layer.name} is missing packages.el: ${error.message}`);
+        throw error;
+      }
+    }),
+  );
+});
+
+test('Emacs layer manifests opt into lexical binding and terminate with sentinel', async (t) => {
+  const layers = await getLayerEntries();
+
+  await Promise.all(
+    layers.map(async (layer) => {
+      const manifestPath = path.join(layersDir, layer.name, 'packages.el');
+      const contents = await fs.readFile(manifestPath, 'utf8');
+      const lines = contents.split(/\r?\n/);
+      const header = lines[0] ?? '';
+
+      t.regex(
+        header,
+        /lexical-binding:\s*t/,
+        `${layer.name}/packages.el should enable lexical-binding in the file header`,
+      );
+
+      const trimmed = contents.trimEnd();
+      t.true(
+        trimmed.endsWith(';;; packages.el ends here'),
+        `${layer.name}/packages.el should finish with the standard footer comment`,
+      );
+    }),
+  );
+});


### PR DESCRIPTION
## Summary
- ensure the Codex dev environment installs emacs-nox so layer configuration tests can run
- add Ava coverage that verifies each Emacs layer manifest opts into lexical binding and ends with the standard footer
- update existing Emacs layer package manifests to satisfy the new checks

## Testing
- pnpm exec ava tests/emacsLayers.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e1ef08ab3c8324b2b7772223f03a87