### PR TITLE
Clarify ignored error handling in Fastify transport

### DIFF
--- a/changelog.d/2025.10.06.01.26.11.md
+++ b/changelog.d/2025.10.06.01.26.11.md
@@ -1,0 +1,1 @@
+- Clarified ignored-error comments in the Fastify transport to explain why JSON parsing and proxy shutdown failures are safe to skip.

--- a/packages/mcp/src/core/transports/fastify.ts
+++ b/packages/mcp/src/core/transports/fastify.ts
@@ -912,7 +912,7 @@ export const fastifyTransport = (opts?: { port?: number; host?: string }): Trans
               try {
                 await response.json();
               } catch {
-                /* ignore */
+                // The proxy doesn't return JSON on every request; ignore parse failures.
               }
             };
 
@@ -1364,7 +1364,7 @@ export const fastifyTransport = (opts?: { port?: number; host?: string }): Trans
             try {
               await proxy.stop();
             } catch {
-              /* ignore */
+              // Best-effort shutdown so cleanup errors don't hide the root failure.
             }
           }),
         );


### PR DESCRIPTION
## Summary
- explain why JSON parsing errors can be ignored when initializing proxy sessions
- document why proxy shutdown failures are tolerated during cleanup

## Testing
- no tests were run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e3186a47808324a4d59e39929a7723