### PR TITLE
Fix MCP build regression

### DIFF
--- a/packages/mcp/src/core/transports/fastify.ts
+++ b/packages/mcp/src/core/transports/fastify.ts
@@ -26,7 +26,6 @@ import type { StdioHttpProxy } from '../../proxy/stdio-proxy.js';
 import { resolveHttpEndpoints, type EndpointDefinition } from '../resolve-config.js';
 import {
   createEndpointOpenApiDocument,
-  encodeActionPathSegment,
   isZodValidationError,
   toolToActionDefinition,
   type ActionDefinition,

--- a/packages/mcp/src/tests/fastify-transport.integration.test.ts
+++ b/packages/mcp/src/tests/fastify-transport.integration.test.ts
@@ -1,4 +1,3 @@
-
 /* eslint-disable functional/no-let, functional/immutable-data, @typescript-eslint/require-await, @typescript-eslint/no-unused-vars, @typescript-eslint/consistent-type-imports */
 
 /* eslint-disable functional/no-let, functional/immutable-data, @typescript-eslint/require-await, @typescript-eslint/no-unused-vars, @typescript-eslint/consistent-type-imports, @typescript-eslint/no-unsafe-assignment */
@@ -138,7 +137,6 @@ test('fastify transport forwards proxy requests', async (t) => {
     t.is(stdioStarts, 1);
     t.true(forwardedBodies.length >= 1);
 
-
     const parseForwardedBody = (forwarded: unknown): unknown => {
       if (Buffer.isBuffer(forwarded)) {
         return JSON.parse(forwarded.toString('utf8')) as unknown;
@@ -171,6 +169,14 @@ test('fastify transport forwards proxy requests', async (t) => {
 
     t.truthy(initializeRequest);
     t.deepEqual(initializeRequest, {
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'initialize',
+      params: {
+        protocolVersion: '2024-10-01',
+        clientInfo: { name: 'promethean-mcp', version: 'dev' },
+      },
+    });
 
     const forwarded = forwardedBodies[0];
     const parsed = Buffer.isBuffer(forwarded)
@@ -179,7 +185,6 @@ test('fastify transport forwards proxy requests', async (t) => {
         ? JSON.parse(forwarded)
         : forwarded;
     t.deepEqual(parsed, {
-
       jsonrpc: '2.0',
       id: 1,
       method: 'initialize',
@@ -312,7 +317,6 @@ test('fastify registry exposes GPT action routes', async (t) => {
     await transport.stop?.();
   }
 });
-
 
 test('proxied endpoints expose action routes and OpenAPI docs', async (t) => {
   const port = await allocatePort();
@@ -492,5 +496,3 @@ test('proxied endpoints expose action routes and OpenAPI docs', async (t) => {
     await transport.stop?.();
   }
 });
-
-

--- a/packages/mcp/src/tests/openapi.test.ts
+++ b/packages/mcp/src/tests/openapi.test.ts
@@ -20,7 +20,7 @@ test('createEndpointOpenApiDocument describes tool actions', (t) => {
       since: '1.0.0',
       examples: [{ args: { value: 'demo' }, comment: 'Echo a demo value' }],
       notes: 'Returns the provided value under the echoed key.',
-      outputSchema: { result: { type: 'string' } },
+      outputSchema: { result: z.string() },
     },
     invoke: (raw) => {
       const { value } = Schema.parse(raw ?? {});


### PR DESCRIPTION
## Summary
- remove an unused OpenAPI helper import in the Fastify transport
- fix the Fastify transport integration test initialize expectation
- update the OpenAPI unit test to use a valid Zod output schema

## Testing
- pnpm --filter @promethean/mcp build

------
https://chatgpt.com/codex/tasks/task_e_68e32366b3c88324be2c015af7fdf761