### PR TITLE
fix(nx): align markdown-graph test target with package script

### DIFF
--- a/changelog.d/2025.10.07.00.00.00.md
+++ b/changelog.d/2025.10.07.00.00.00.md
@@ -1,0 +1,1 @@
+- Aligned the @promethean/markdown-graph Nx test target with the package test runner so Ava finds the compiled graph tests.

--- a/docs/agile/tasks/fix-nx-task-markdown-graph-test.md
+++ b/docs/agile/tasks/fix-nx-task-markdown-graph-test.md
@@ -1,0 +1,30 @@
+---
+uuid: a4764fc6-ff3e-4ad9-97f6-7cce0b813b44
+title: Fix nx task @promethean/markdown-graph:test
+status: in_progress
+priority: P1
+labels: []
+created_at: '2025-10-07T00:00:00.000Z'
+---
+# Description
+
+Address failures when running the Nx test target for `@promethean/markdown-graph`.
+
+## Requirements/Definition of done
+
+- `pnpm nx test @promethean/markdown-graph` succeeds without errors.
+- Any new tests cover the regression if feasible.
+- Document follow-up items if the root cause cannot be fully resolved.
+
+## Tasks
+
+- [x] Reproduce the failing Nx test target.
+- [x] Implement the fix for the test target.
+- [ ] Add or update automated tests if necessary.
+- [ ] Document the change in changelog.d.
+
+## Notes
+
+Initial creation for the current session.
+
+2025-10-07: Nx test target updated to invoke the package's scripted test command so Ava picks up compiled JS tests.

--- a/packages/markdown-graph/project.json
+++ b/packages/markdown-graph/project.json
@@ -21,11 +21,8 @@
     "test": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "ava",
-        "cwd": "{projectRoot}",
-        "env": {
-          "AVA_PROJECT_ROOT": "."
-        }
+        "command": "pnpm run test",
+        "cwd": "{projectRoot}"
       }
     },
     "lint": {


### PR DESCRIPTION
## Summary
- update the @promethean/markdown-graph Nx test target to run the package test script so Ava picks up the compiled JS suite
- add a changelog entry and track the work in the kanban task list

## Testing
- pnpm nx test @promethean/markdown-graph

------
https://chatgpt.com/codex/tasks/task_e_68e4147ee670832496b7d7442b73fe11