### PR TITLE
fix: align voice service AVA configuration

### DIFF
--- a/changelog.d/2025.10.06.19.23.38.md
+++ b/changelog.d/2025.10.06.19.23.38.md
@@ -1,0 +1,1 @@
+- Fix @promethean/voice-service Nx test target by adopting the shared AVA configuration.

--- a/packages/voice/ava.config.mjs
+++ b/packages/voice/ava.config.mjs
@@ -1,0 +1,1 @@
+export { default } from '../../config/ava.config.mjs';

--- a/packages/voice/package.json
+++ b/packages/voice/package.json
@@ -4,9 +4,9 @@
   "type": "module",
   "main": "dist/index.js",
   "scripts": {
-    "build": "tsc",
-    "test": "cross-env TS_NODE_TRANSPILE_ONLY=1 ava --config ../../../config/ava.config.mjs \"tests/**/*.ts\" \"src/tests/**/*.ts\"",
-    "coverage": "cross-env TS_NODE_TRANSPILE_ONLY=1 c8 ava \"tests/**/*.ts\" \"src/tests/**/*.ts\"",
+    "build": "tsc -b",
+    "test": "pnpm run build && ava --config ../../config/ava.config.mjs",
+    "coverage": "pnpm run build && c8 ava --config ../../config/ava.config.mjs",
     "lint": "pnpm exec eslint . || true",
     "format": "pnpm exec prettier --write ."
   },
@@ -21,20 +21,6 @@
   },
   "devDependencies": {
     "@promethean/pm2-helpers": "workspace:*",
-    "@types/express": "^4.17.21",
-    "cross-env": "^10.0.0"
-  },
-  "ava": {
-    "extensions": {
-      "ts": "module"
-    },
-    "files": [
-      "tests/**/*.ts",
-      "src/tests/**/*.ts"
-    ],
-    "nodeArguments": [
-      "--loader",
-      "ts-node/esm"
-    ]
+    "@types/express": "^4.17.21"
   }
 }


### PR DESCRIPTION
## Summary
- add a local ava.config.mjs that forwards to the shared workspace configuration
- simplify the @promethean/voice-service npm scripts to use the shared AVA setup and remove the redundant per-package config
- document the fix in the changelog for visibility

## Testing
- pnpm nx test @promethean/voice-service
- pnpm exec eslint packages/voice/ava.config.mjs


------
https://chatgpt.com/codex/tasks/task_e_68e41461d86c8324b73f68826ec8bae3