### PR TITLE
Fix voice demo transcript formatting and extend CLI coverage

### DIFF
--- a/changelog.d/2025.10.06.19.28.29.md
+++ b/changelog.d/2025.10.06.19.28.29.md
@@ -1,0 +1,1 @@
+- fix CLI transcript formatting to surface transcript text for voice demo logs and extend coverage for CLI streaming options.

--- a/packages/enso-protocol/src/cli.ts
+++ b/packages/enso-protocol/src/cli.ts
@@ -1,24 +1,14 @@
 #!/usr/bin/env node
-import { argv, exit } from "node:process";
-import { randomUUID } from "node:crypto";
-import { ContextRegistry } from "./registry.js";
-import type { ContextInit } from "./types/context.js";
-import {
-  parseConversationArgs,
-  runTwoAgentConversation,
-} from "./conversation.js";
-import { EnsoClient } from "./client.js";
-import {
-  connectWebSocket,
-  type WebSocketConnectionHandle,
-} from "./transport.js";
-import type { HelloCaps } from "./types/privacy.js";
-import type { ChatMessage, ContentPart, TextPart } from "./types/content.js";
-import {
-  createNodeAudioCapture,
-  pumpAudioFrames,
-  type AudioCapture,
-} from "./audio.js";
+import { argv, exit } from 'node:process';
+import { randomUUID } from 'node:crypto';
+import { ContextRegistry } from './registry.js';
+import type { ContextInit } from './types/context.js';
+import { parseConversationArgs, runTwoAgentConversation } from './conversation.js';
+import { EnsoClient } from './client.js';
+import { connectWebSocket, type WebSocketConnectionHandle } from './transport.js';
+import type { HelloCaps } from './types/privacy.js';
+import type { ChatMessage, ContentPart, TextPart } from './types/content.js';
+import { createNodeAudioCapture, pumpAudioFrames, type AudioCapture } from './audio.js';
 
 interface DemoDependencies {
   createClient?: () => EnsoClient;
@@ -45,47 +35,54 @@ export interface CliDependencies {
 const defaultRegistry = new ContextRegistry();
 
 const DEFAULT_HELLO: HelloCaps = {
-  proto: "ENSO-1",
-  caps: ["can.send.text", "can.voice.stream"],
-  agent: { name: "enso-cli", version: "0.0.0" },
+  proto: 'ENSO-1',
+  caps: ['can.send.text', 'can.voice.stream'],
+  agent: { name: 'enso-cli', version: '0.0.0' },
 };
 
 function formatTranscript(payload: unknown): string {
+  if (typeof payload === 'string') {
+    return payload;
+  }
+  if (payload && typeof payload === 'object') {
+    const withText = payload as { text?: unknown };
+    if (typeof withText.text === 'string' && withText.text.length > 0) {
+      return withText.text;
+    }
+  }
   try {
-    return typeof payload === "string" ? payload : JSON.stringify(payload);
+    return JSON.stringify(payload);
   } catch {
     return String(payload);
   }
 }
 
 function partsToText(parts: ContentPart[]): string {
-  const texts = parts
-    .filter((p): p is TextPart => p.kind === "text")
-    .map((p) => p.text);
-  return texts.join(" ");
+  const texts = parts.filter((p): p is TextPart => p.kind === 'text').map((p) => p.text);
+  return texts.join(' ');
 }
 
 function formatChatMessage(msg?: ChatMessage): string {
-  if (!msg) return "";
+  if (!msg) return '';
   const text = partsToText(msg.parts);
   return text || JSON.stringify(msg);
 }
 
 async function runVoiceDemo(
   args: string[],
-  deps: Required<Pick<CliDependencies, "log" | "error">> & {
+  deps: Required<Pick<CliDependencies, 'log' | 'error'>> & {
     demo?: DemoDependencies;
   },
 ): Promise<void> {
   const parsed = (() => {
-    let url: string = "ws://localhost:7766/ws";
+    let url: string = 'ws://localhost:7766/ws';
     let pingIntervalMs: number | undefined;
     for (let i = 0; i < args.length; i += 1) {
       const a = args[i];
-      if (a === "--url" && args[i + 1]) {
+      if (a === '--url' && args[i + 1]) {
         url = String(args[i + 1]);
         i += 1;
-      } else if ((a === "--ping" || a === "--ping-interval") && args[i + 1]) {
+      } else if ((a === '--ping' || a === '--ping-interval') && args[i + 1]) {
         const v = Number(args[i + 1]);
         if (!Number.isNaN(v)) pingIntervalMs = v;
         i += 1;
@@ -102,15 +99,10 @@ async function runVoiceDemo(
     deps.demo?.connect ??
     ((instance, options) => {
       const transportOptions =
-        "pingIntervalMs" in options && options.pingIntervalMs !== undefined
+        'pingIntervalMs' in options && options.pingIntervalMs !== undefined
           ? { pingIntervalMs: options.pingIntervalMs }
           : {};
-      return connectWebSocket(
-        instance,
-        options.url,
-        options.hello,
-        transportOptions,
-      );
+      return connectWebSocket(instance, options.url, options.hello, transportOptions);
     });
   const connection = connectFn(
     client,
@@ -119,18 +111,14 @@ async function runVoiceDemo(
       : { url: parsed.url, hello },
   );
 
-  (deps.log ?? console.log)(
-    `Connecting to ${parsed.url} as stream ${streamId}`,
-  );
-  (deps.log ?? console.log)(
-    "Speak into the microphone or pipe PCM16 audio via stdin.",
-  );
+  (deps.log ?? console.log)(`Connecting to ${parsed.url} as stream ${streamId}`);
+  (deps.log ?? console.log)('Speak into the microphone or pipe PCM16 audio via stdin.');
 
   const transcriptListeners = [
-    client.on("stream:transcript.partial", (env) => {
+    client.on('stream:transcript.partial', (env) => {
       (deps.log ?? console.log)(`[partial] ${formatTranscript(env.payload)}`);
     }),
-    client.on("stream:transcript.final", (env) => {
+    client.on('stream:transcript.final', (env) => {
       (deps.log ?? console.log)(`[final] ${formatTranscript(env.payload)}`);
     }),
   ];
@@ -147,11 +135,9 @@ async function runVoiceDemo(
   });
 
   const agentPromise = new Promise<void>((resolve) => {
-    client.on("event:chat.msg", (env) => {
+    client.on('event:chat.msg', (env) => {
       const payload = env.payload as { message?: ChatMessage } | undefined;
-      (deps.log ?? console.log)(
-        `[agent] ${formatChatMessage(payload?.message)}`,
-      );
+      (deps.log ?? console.log)(`[agent] ${formatChatMessage(payload?.message)}`);
       resolve();
     });
   });
@@ -159,7 +145,7 @@ async function runVoiceDemo(
   const createCapture =
     deps.demo?.createCapture ??
     (async (options: { streamId: string }) => {
-      const { stdin } = await import("node:process");
+      const { stdin } = await import('node:process');
       stdin.resume();
       return createNodeAudioCapture({
         stream: stdin,
@@ -180,7 +166,7 @@ async function runVoiceDemo(
         agentPromise,
         new Promise<void>((resolve) => {
           setTimeout(() => {
-            (deps.log ?? console.log)("[demo] agent reply timeout elapsed");
+            (deps.log ?? console.log)('[demo] agent reply timeout elapsed');
             resolve();
           }, timeoutMs);
         }),
@@ -209,19 +195,19 @@ async function createDemoContext(
 ): Promise<void> {
   if (registry.listSources().length === 0) {
     registry.registerSource({
-      id: { kind: "enso-asset", location: "enso://asset/demo" },
-      owners: [{ userId: "demo" }],
-      discoverability: "visible",
-      availability: { mode: "public" },
-      title: "Demo Asset",
+      id: { kind: 'enso-asset', location: 'enso://asset/demo' },
+      owners: [{ userId: 'demo' }],
+      discoverability: 'visible',
+      availability: { mode: 'public' },
+      title: 'Demo Asset',
     });
   }
   const demo: ContextInit = {
-    name: "demo",
-    owner: { userId: "demo" },
+    name: 'demo',
+    owner: { userId: 'demo' },
     entries: registry.listSources().map((source) => ({
       id: source.id,
-      state: "pinned",
+      state: 'pinned',
       permissions: { readable: true },
     })),
   };
@@ -231,7 +217,7 @@ async function createDemoContext(
 
 function parseServerArgs(args: string[]): { port?: number } {
   return args.reduce<{ port?: number }>((acc, cur, i, arr) => {
-    if (cur === "--port" || cur === "-p") {
+    if (cur === '--port' || cur === '-p') {
       const v = Number(arr[i + 1]);
       if (!Number.isNaN(v)) return { ...acc, port: v };
     }
@@ -252,33 +238,30 @@ Commands:
 `);
 }
 
-export async function runCliCommand(
-  command: string,
-  deps: CliDependencies = {},
-): Promise<void> {
+export async function runCliCommand(command: string, deps: CliDependencies = {}): Promise<void> {
   const registry = deps.registry ?? defaultRegistry;
   const log = deps.log ?? console.log;
   const error = deps.error ?? console.error;
   const exitFn = deps.exit ?? ((code: number) => exit(code));
 
   switch (command) {
-    case "help":
+    case 'help':
       showHelp(log);
       return;
-    case "list-sources":
+    case 'list-sources':
       await listSources(registry, log);
       return;
-    case "create-demo-context":
+    case 'create-demo-context':
       await createDemoContext(registry, log);
       return;
-    case "voice-demo":
+    case 'voice-demo':
       await runVoiceDemo(deps.args ?? [], {
         log,
         error,
         ...(deps.demo ? { demo: deps.demo } : {}),
       });
       return;
-    case "two-agent-chat": {
+    case 'two-agent-chat': {
       const parsed = parseConversationArgs(deps.args ?? []);
       await runTwoAgentConversation({
         ...(parsed.agentNames ? { agentNames: parsed.agentNames } : {}),
@@ -289,13 +272,13 @@ export async function runCliCommand(
       });
       return;
     }
-    case "server": {
+    case 'server': {
       const { port } = parseServerArgs(deps.args ?? []);
       if (port !== undefined) process.env.ENSO_PORT = String(port);
-      await import("./ws-server.js");
+      await import('./ws-server.js');
       log(
         `[enso] ws server boot requested on :${
-          process.env.ENSO_PORT ?? process.env.PORT ?? "7766"
+          process.env.ENSO_PORT ?? process.env.PORT ?? '7766'
         }`,
       );
       return;
@@ -307,7 +290,7 @@ export async function runCliCommand(
 }
 
 async function main(): Promise<void> {
-  const [command = "help", ...args] = argv.slice(2);
+  const [command = 'help', ...args] = argv.slice(2);
   await runCliCommand(command, { args });
 }
 

--- a/packages/enso-protocol/src/tests/cli.spec.ts
+++ b/packages/enso-protocol/src/tests/cli.spec.ts
@@ -1,56 +1,56 @@
-import { randomUUID } from "node:crypto";
-import test from "ava";
-import { ContextRegistry } from "../registry.js";
-import { runCliCommand } from "../cli.js";
-import { EnsoClient } from "../client.js";
-import { createStaticCapture } from "../audio.js";
-import type { HelloCaps } from "../types/privacy.js";
-import { resolveHelloPrivacy } from "../types/privacy.js";
-import type { Envelope } from "../types/envelope.js";
+import { randomUUID } from 'node:crypto';
+import test from 'ava';
+import { ContextRegistry } from '../registry.js';
+import { runCliCommand } from '../cli.js';
+import { EnsoClient } from '../client.js';
+import { createStaticCapture } from '../audio.js';
+import type { HelloCaps } from '../types/privacy.js';
+import { resolveHelloPrivacy } from '../types/privacy.js';
+import type { Envelope } from '../types/envelope.js';
 
 function registerDemoSource(registry: ContextRegistry, location: string) {
   return registry.registerSource({
-    id: { kind: "enso-asset", location },
-    owners: [{ userId: "owner" }],
-    discoverability: "visible",
-    availability: { mode: "public" },
-    title: "Fixture",
-    contentHints: { mime: "text/plain" },
+    id: { kind: 'enso-asset', location },
+    owners: [{ userId: 'owner' }],
+    discoverability: 'visible',
+    availability: { mode: 'public' },
+    title: 'Fixture',
+    contentHints: { mime: 'text/plain' },
   });
 }
 
-test("help command prints usage information", async (t) => {
+test('help command prints usage information', async (t) => {
   const logs: string[] = [];
-  await runCliCommand("help", { log: (message) => logs.push(message) });
-  t.true(logs.some((line) => line.includes("enso-protocol CLI")));
-  t.true(logs.some((line) => line.includes("list-sources")));
+  await runCliCommand('help', { log: (message) => logs.push(message) });
+  t.true(logs.some((line) => line.includes('enso-protocol CLI')));
+  t.true(logs.some((line) => line.includes('list-sources')));
 });
 
-test("list-sources emits JSON describing registered sources", async (t) => {
+test('list-sources emits JSON describing registered sources', async (t) => {
   const registry = new ContextRegistry();
-  registerDemoSource(registry, "enso://asset/alpha");
+  registerDemoSource(registry, 'enso://asset/alpha');
   const logs: string[] = [];
-  await runCliCommand("list-sources", {
+  await runCliCommand('list-sources', {
     registry,
     log: (message) => logs.push(message),
   });
   t.true(logs.length > 0);
   const payload = JSON.parse(logs.at(-1)!);
   t.is(payload.length, 1);
-  t.is(payload[0].id.location, "enso://asset/alpha");
-  t.is(payload[0].title, "Fixture");
+  t.is(payload[0].id.location, 'enso://asset/alpha');
+  t.is(payload[0].title, 'Fixture');
 });
 
-test("create-demo-context seeds a demo source when registry empty", async (t) => {
+test('create-demo-context seeds a demo source when registry empty', async (t) => {
   const registry = new ContextRegistry();
   const logs: string[] = [];
-  await runCliCommand("create-demo-context", {
+  await runCliCommand('create-demo-context', {
     registry,
     log: (message) => logs.push(message),
   });
   t.true(registry.listSources().length > 0);
   const context = JSON.parse(logs.at(-1)!);
-  t.is(context.name, "demo");
+  t.is(context.name, 'demo');
   t.true(Array.isArray(context.entries));
   t.true(context.entries.length > 0);
   const entryLocations = context.entries.map(
@@ -62,13 +62,13 @@ test("create-demo-context seeds a demo source when registry empty", async (t) =>
   );
 });
 
-test("create-demo-context reuses preexisting sources", async (t) => {
+test('create-demo-context reuses preexisting sources', async (t) => {
   const registry = new ContextRegistry();
-  registerDemoSource(registry, "enso://asset/beta");
-  registerDemoSource(registry, "enso://asset/gamma");
+  registerDemoSource(registry, 'enso://asset/beta');
+  registerDemoSource(registry, 'enso://asset/gamma');
   const before = registry.listSources().map((meta) => meta.id.location);
   const logs: string[] = [];
-  await runCliCommand("create-demo-context", {
+  await runCliCommand('create-demo-context', {
     registry,
     log: (message) => logs.push(message),
   });
@@ -82,7 +82,7 @@ test("create-demo-context reuses preexisting sources", async (t) => {
   t.deepEqual(contextLocations.sort(), [...before].sort());
 });
 
-test("voice-demo command streams audio and logs agent output", async (t) => {
+test('voice-demo command streams audio and logs agent output', async (t) => {
   const logs: string[] = [];
   const sent: Envelope[] = [];
   const registry = new ContextRegistry();
@@ -90,14 +90,14 @@ test("voice-demo command streams audio and logs agent output", async (t) => {
   const capture = createStaticCapture([
     {
       streamId,
-      codec: "pcm16le/16000/1",
+      codec: 'pcm16le/16000/1',
       seq: 0,
       pts: 0,
       data: new Uint8Array([1, 2]),
     },
     {
       streamId,
-      codec: "pcm16le/16000/1",
+      codec: 'pcm16le/16000/1',
       seq: 1,
       pts: 20,
       data: new Uint8Array([3, 4]),
@@ -105,27 +105,23 @@ test("voice-demo command streams audio and logs agent output", async (t) => {
     },
   ]);
   const hello: HelloCaps = {
-    proto: "ENSO-1",
-    caps: ["can.send.text", "can.voice.stream"],
-    privacy: { profile: "pseudonymous" },
+    proto: 'ENSO-1',
+    caps: ['can.send.text', 'can.voice.stream'],
+    privacy: { profile: 'pseudonymous' },
   };
   const client = new EnsoClient(registry);
 
-  const makeEnvelope = <T>(
-    type: string,
-    kind: "event" | "stream",
-    payload: T,
-  ): Envelope<T> => ({
+  const makeEnvelope = <T>(type: string, kind: 'event' | 'stream', payload: T): Envelope<T> => ({
     id: randomUUID(),
     ts: new Date().toISOString(),
-    room: "demo",
-    from: "enso-server",
+    room: 'demo',
+    from: 'enso-server',
     kind,
     type,
     payload,
   });
 
-  await runCliCommand("voice-demo", {
+  await runCliCommand('voice-demo', {
     log: (line) => logs.push(line),
     demo: {
       hello,
@@ -144,28 +140,26 @@ test("voice-demo command streams audio and logs agent output", async (t) => {
           emitAccepted: false,
         });
         instance.receive(
-          makeEnvelope("privacy.accepted", "event", {
+          makeEnvelope('privacy.accepted', 'event', {
             profile: privacy.profile,
             wantsE2E: false,
             negotiatedCaps: options.hello.caps,
           }),
         );
         instance.receive(
-          makeEnvelope("presence.join", "event", {
-            session: "demo-session",
+          makeEnvelope('presence.join', 'event', {
+            session: 'demo-session',
             caps: options.hello.caps,
           }),
         );
         setTimeout(() => {
+          instance.receive(makeEnvelope('transcript.partial', 'stream', { text: 'hi' }));
           instance.receive(
-            makeEnvelope("transcript.partial", "stream", { text: "hi" }),
-          );
-          instance.receive(
-            makeEnvelope("chat.msg", "event", {
-              room: "chat",
+            makeEnvelope('chat.msg', 'event', {
+              room: 'chat',
               message: {
-                role: "agent",
-                parts: [{ kind: "text", text: "response" }],
+                role: 'agent',
+                parts: [{ kind: 'text', text: 'response' }],
               },
             }),
           );
@@ -177,27 +171,28 @@ test("voice-demo command streams audio and logs agent output", async (t) => {
       },
       waitForAgentTimeoutMs: 100,
     },
-    args: ["--stream-id", streamId],
+    args: ['--stream-id', streamId, '--url', 'ws://demo.test/ws', '--ping-interval', '25'],
   });
 
-  t.true(sent.some((env) => env.type === "voice.frame"));
-  t.true(logs.some((line) => line.includes("[partial] hi")));
-  t.true(logs.some((line) => line.includes("[agent] response")));
+  t.true(sent.some((env) => env.type === 'voice.frame'));
+  t.true(logs.some((line) => line.includes('[partial] hi')));
+  t.true(logs.some((line) => line.includes('[agent] response')));
+  t.true(logs.some((line) => line.includes('Connecting to ws://demo.test/ws as stream')));
 });
 
-test("unknown command reports error and exits with failure", async (t) => {
+test('unknown command reports error and exits with failure', async (t) => {
   const registry = new ContextRegistry();
   const errors: string[] = [];
-  const exitError = new Error("exit:1");
+  const exitError = new Error('exit:1');
   const exitFn = (() => {
     throw exitError;
   }) as (code: number) => never;
-  const execution = runCliCommand("nope", {
+  const execution = runCliCommand('nope', {
     registry,
     error: (message) => errors.push(message),
     exit: exitFn,
   });
   const thrown = await t.throwsAsync(execution, { is: exitError });
   t.is(thrown, exitError);
-  t.deepEqual(errors, ["Unknown command: nope"]);
+  t.deepEqual(errors, ['Unknown command: nope']);
 });


### PR DESCRIPTION
## Summary
- normalize transcript logging so voice-demo output prints plain text when transcript payloads provide a text field
- expand the voice demo CLI test to cover URL/ping flags and assert the connection log message
- record the change in the changelog

## Testing
- pnpm nx run @promethean/enso-protocol:test

------
https://chatgpt.com/codex/tasks/task_e_68e4145e7ad88324aa69d2006d0ce9c0