### PR TITLE
Fix duck-web Nx test wiring

### DIFF
--- a/changelog.d/2025.10.06.20.00.45.md
+++ b/changelog.d/2025.10.06.20.00.45.md
@@ -1,0 +1,1 @@
+- Fix the `@promethean/duck-web:test` Nx target by wiring it to the shared AVA suite under `tests/apps/duck-web` so the throttled sender tests run during CI again.

--- a/packages/duck-web/package.json
+++ b/packages/duck-web/package.json
@@ -8,7 +8,7 @@
     "dev": "vite --open",
     "build": "vite build",
     "preview": "vite preview --open",
-    "test": "ava"
+    "test": "ava ../../tests/apps/duck-web/*.test.js"
   },
   "devDependencies": {
     "typescript": "^5.4.0",

--- a/packages/duck-web/project.json
+++ b/packages/duck-web/project.json
@@ -13,6 +13,12 @@
       "options": {
         "command": "pnpm --filter @promethean/duck-web exec vite build"
       }
+    },
+    "test": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm --filter @promethean/duck-web run test"
+      }
     }
   },
   "tags": []


### PR DESCRIPTION
## Summary
- update the duck-web package test script so Nx runs the shared AVA suite under tests/apps/duck-web
- add an explicit test target to the duck-web project configuration and record the change in changelog.d

## Testing
- pnpm nx run @promethean/duck-web:test

------
https://chatgpt.com/codex/tasks/task_e_68e41c7beec8832486eb0bea449c19e7