### PR TITLE
fix: align apply-patch Nx test runner with shared AVA config

### DIFF
--- a/changelog.d/2025.10.06.19.58.43.md
+++ b/changelog.d/2025.10.06.19.58.43.md
@@ -1,0 +1,1 @@
+- Align Nx test runner for @promethean/apply-patch with the shared AVA configuration to ensure consistent execution.

--- a/packages/apply-patch/project.json
+++ b/packages/apply-patch/project.json
@@ -21,7 +21,7 @@
     "test": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "ava",
+        "command": "pnpm exec ava --config ../../config/ava.config.mjs",
         "cwd": "{projectRoot}",
         "env": {
           "AVA_PROJECT_ROOT": "."


### PR DESCRIPTION
## Summary
- run the @promethean/apply-patch Nx test target through `pnpm exec ava` with the shared configuration for consistent execution
- document the change in the changelog

## Testing
- pnpm nx test @promethean/apply-patch

------
https://chatgpt.com/codex/tasks/task_e_68e41c7e7918832498ffb3f9cc22f00b