### PR TITLE
Add timeout guard for Codex build steps

### DIFF
--- a/changelog.d/2025.10.06.20.01.40.md
+++ b/changelog.d/2025.10.06.20.01.40.md
@@ -1,0 +1,1 @@
+- add configurable timeout for codex maintenance/setup build steps to avoid blocking runs

--- a/run/codex_maintenance.sh
+++ b/run/codex_maintenance.sh
@@ -7,12 +7,15 @@ RUN_TS="${RUN_TS:-$(date -u +"%Y.%m.%d.%H.%M.%S")}"
 # bring in describe() (creates $RUN_DIR = $ART_ROOT/describe/$RUN_TS)
 ART_ROOT="$ART_ROOT" RUN_TS="$RUN_TS" source "$(dirname "$0")/describe.sh"
 
+# ---------- knobs ----------
+BUILD_TIMEOUT_SECS="${BUILD_TIMEOUT_SECS:-1200}"
+
 # ---------- steps (never fail outward) ----------
 describe env-dump            bash -lc '(set -o posix; set)'
 describe pnpm-install        pnpm install --no-frozen-lockfile
 
 
-describe pnpm-build        pnpm -r --no-bail build
+TIMEOUT_SECS="$BUILD_TIMEOUT_SECS" describe pnpm-build        pnpm -r --no-bail build
 
 # ESLint artifacts (human + machine)
 # describe eslint-stylish      pnpm exec eslint --cache -f stylish .

--- a/run/setup_codex_dev_env.sh
+++ b/run/setup_codex_dev_env.sh
@@ -7,6 +7,9 @@ ART_ROOT="${ART_ROOT:-docs/reports/codex_cloud}"
 RUN_TS="${RUN_TS:-$(date -u +"%Y.%m.%d.%H.%M.%S")}"
 ART_ROOT="$ART_ROOT" RUN_TS="$RUN_TS" source "$(dirname "$0")/describe.sh"
 
+# ---------- knobs ----------
+BUILD_TIMEOUT_SECS="${BUILD_TIMEOUT_SECS:-1200}"
+
 # ---------- base/tooling ----------
 describe env-dump               bash -lc '(set -o posix; set)'
 
@@ -40,7 +43,7 @@ describe setup-playwright       bash -lc '"./run/setup_playwright.sh"'
 # ./run/standup_ollama_nohup.sh
 
 
-describe pnpm-build           pnpm -r --no-bail build
+TIMEOUT_SECS="$BUILD_TIMEOUT_SECS" describe pnpm-build           pnpm -r --no-bail build
 # fi
 
 # describe eslint-stylish         pnpm exec eslint --cache


### PR DESCRIPTION
## Summary
- add a configurable timeout knob that can be overridden via BUILD_TIMEOUT_SECS
- wrap the pnpm build step in the maintenance and setup scripts so it aborts after the timeout instead of blocking the run

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e41da044d483248e63d111b8d22f0c