### PR TITLE
Limit Codex build steps to Nx affected runs with fallback

### DIFF
--- a/changelog.d/2025.10.06.21.06.13.md
+++ b/changelog.d/2025.10.06.21.06.13.md
@@ -1,0 +1,1 @@
+- Limit Codex maintenance/dev environment build steps to 20 minutes by adding an Nx-affected build wrapper with pnpm fallback.

--- a/run/codex_build.sh
+++ b/run/codex_build.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+log() {
+  printf '[codex_build] %s\n' "$*" >&2
+}
+
+resolve_git_commit() {
+  local ref="$1"
+  if git rev-parse --verify "${ref}^{commit}" >/dev/null 2>&1; then
+    return 0
+  fi
+  return 1
+}
+
+select_base() {
+  local candidate
+  local requested="${NX_BASE:-}"
+  if [[ -n "$requested" ]]; then
+    if resolve_git_commit "$requested" >/dev/null; then
+      echo "$requested"
+      return 0
+    fi
+    log "WARN: requested NX_BASE='$requested' not found; falling back to auto-detect."
+  fi
+  for candidate in origin/main origin/master main master HEAD^; do
+    if resolve_git_commit "$candidate" >/dev/null; then
+      echo "$candidate"
+      return 0
+    fi
+  done
+  if first_commit=$(git rev-list --max-parents=0 HEAD 2>/dev/null | tail -n 1); then
+    echo "$first_commit"
+    return 0
+  fi
+  echo HEAD
+}
+
+select_head() {
+  local requested="${NX_HEAD:-HEAD}"
+  if resolve_git_commit "$requested" >/dev/null; then
+    echo "$requested"
+    return 0
+  fi
+  log "WARN: requested NX_HEAD='$requested' not found; defaulting to HEAD."
+  echo HEAD
+}
+
+run_nx_affected() {
+  local nx_base nx_head parallel
+  nx_base="$(select_base)"
+  nx_head="$(select_head)"
+  parallel="${NX_PARALLEL:-3}"
+
+  local cmd=(pnpm exec nx affected --target=build "--parallel=${parallel}" --output-style=static --base "$nx_base" --head "$nx_head")
+
+  log "info: attempting Nx affected build (base=${nx_base} head=${nx_head} parallel=${parallel})."
+  if "${cmd[@]}"; then
+    return 0
+  fi
+
+  local rc=$?
+  log "WARN: Nx affected build failed with rc=${rc}; falling back to recursive pnpm build."
+  return 1
+}
+
+run_recursive_build() {
+  log "info: running fallback pnpm recursive build."
+  pnpm -r --no-bail build
+}
+
+main() {
+  if run_nx_affected; then
+    exit 0
+  fi
+  run_recursive_build
+}
+
+main "$@"

--- a/run/codex_maintenance.sh
+++ b/run/codex_maintenance.sh
@@ -15,7 +15,7 @@ describe env-dump            bash -lc '(set -o posix; set)'
 describe pnpm-install        pnpm install --no-frozen-lockfile
 
 
-TIMEOUT_SECS="$BUILD_TIMEOUT_SECS" describe pnpm-build        pnpm -r --no-bail build
+TIMEOUT_SECS="$BUILD_TIMEOUT_SECS" describe nx-affected-build  ./run/codex_build.sh
 
 # ESLint artifacts (human + machine)
 # describe eslint-stylish      pnpm exec eslint --cache -f stylish .

--- a/run/setup_codex_dev_env.sh
+++ b/run/setup_codex_dev_env.sh
@@ -43,7 +43,7 @@ describe setup-playwright       bash -lc '"./run/setup_playwright.sh"'
 # ./run/standup_ollama_nohup.sh
 
 
-TIMEOUT_SECS="$BUILD_TIMEOUT_SECS" describe pnpm-build           pnpm -r --no-bail build
+TIMEOUT_SECS="$BUILD_TIMEOUT_SECS" describe nx-affected-build     ./run/codex_build.sh
 # fi
 
 # describe eslint-stylish         pnpm exec eslint --cache


### PR DESCRIPTION
## Summary
- add a shared `run/codex_build.sh` helper that attempts an Nx affected build and falls back to the previous recursive pnpm build
- update Codex maintenance and setup scripts to invoke the helper under a 20-minute timeout instead of running the full workspace build
- record the change in the Codex changelog

## Testing
- not run (scripts would trigger a full workspace build)


------
https://chatgpt.com/codex/tasks/task_e_68e42c60266883248ca1c280eb88fdb9