### PR TITLE
Restore elisp AST constructors

### DIFF
--- a/changelog.d/2025.10.06.21.05.37.md
+++ b/changelog.d/2025.10.06.21.05.37.md
@@ -1,0 +1,1 @@
+- Restore original elisp AST constructor names to avoid breaking downstream namespaces.

--- a/packages/clj-hacks/src/elisp/ast.clj
+++ b/packages/clj-hacks/src/elisp/ast.clj
@@ -9,7 +9,7 @@
 ;; AST constructors
 ;; ---------------------------------------------------------------------------
 
-(defn el-symbol
+(defn symbol
   "Create an Elisp symbol node."
   [name]
   (when-not (string? name)
@@ -21,28 +21,28 @@
   [value]
   (str value))
 
-(defn el-list
+(defn list
   "Create a list node with optional metadata."
   [& items]
   (into [:el/list] items))
 
-(defn el-vector
+(defn vector
   "Create a vector node."
   [& items]
   (into [:el/vector] items))
 
-(defn el-cons
+(defn cons
   "Create a dotted pair node."
   [car cdr]
   {:el/type :cons :car car :cdr cdr})
 
 (defn quote [form] {:el/type :quote :form form})
 (defn quasiquote [form] {:el/type :quasiquote :form form})
-(defn el-unquote [form] {:el/type :unquote :form form})
+(defn unquote [form] {:el/type :unquote :form form})
 (defn splice [form] {:el/type :splice :form form})
 (defn function [form] {:el/type :function :form form})
 
-(defn el-comment
+(defn comment
   "Create a comment node. Include trailing newline if needed."
   [text]
   {:el/type :comment :text text})


### PR DESCRIPTION
## Summary
- restore the elisp AST constructor names so downstream namespaces keep compiling
- record the change in the changelog

## Testing
- clojure -M:tasks test *(fails: `clojure` CLI is not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e42cc1a1548324bf8b9cf63d0178c7