### PR TITLE
Normalize MCP HTTP config tool IDs

### DIFF
--- a/changelog.d/2025.10.06.23.59.53.md
+++ b/changelog.d/2025.10.06.23.59.53.md
@@ -1,0 +1,1 @@
+- normalize MCP HTTP endpoint tool IDs so dotted/kebab/camel case config values resolve to the canonical registry names.

--- a/packages/mcp/src/core/resolve-config.ts
+++ b/packages/mcp/src/core/resolve-config.ts
@@ -1,7 +1,7 @@
-import type { AppConfig } from "../config/load-config.js";
+import type { AppConfig } from '../config/load-config.js';
+import { normalizeToolIds } from './tool-ids.js';
 
-const ensureLeadingSlash = (path: string): string =>
-  path.startsWith("/") ? path : `/${path}`;
+const ensureLeadingSlash = (path: string): string => (path.startsWith('/') ? path : `/${path}`);
 
 export type ToolsetMeta = Readonly<{
   title?: string;
@@ -21,61 +21,55 @@ export type EndpointDefinition = Readonly<{
   meta?: ToolsetMeta;
 }>;
 
-export const resolveHttpEndpoints = (
-  config: AppConfig,
-): readonly EndpointDefinition[] => {
-  const entries = Object.entries(config.endpoints ?? {});
-  if (entries.length === 0) {
-    const includeHelp = (config as any).includeHelp;
-    const meta = (config as any).stdioMeta;
+export const resolveHttpEndpoints = (config: AppConfig): readonly EndpointDefinition[] => {
+  const topLevelTools = normalizeToolIds(config.tools);
+  const endpoints = config.endpoints ?? {};
+  const mapped = Object.entries(endpoints).map(([path, cfg]) => {
+    const includeHelp = cfg.includeHelp;
+    const meta = cfg.meta;
+    return {
+      path: ensureLeadingSlash(path),
+      tools: normalizeToolIds(cfg.tools ?? []),
+      ...(includeHelp === undefined ? {} : { includeHelp }),
+      ...(meta === undefined ? {} : { meta }),
+    };
+  });
+
+  if (mapped.length === 0) {
+    const includeHelp = config.includeHelp;
+    const meta = config.stdioMeta;
     return [
       {
-        path: "/mcp",
-        tools: config.tools,
+        path: '/mcp',
+        tools: topLevelTools,
         ...(includeHelp === undefined ? {} : { includeHelp }),
         ...(meta === undefined ? {} : { meta }),
       },
     ];
   }
 
-  const resolved = entries.map(([path, cfg]: any) => {
-    const includeHelp = cfg.includeHelp;
-    const meta = cfg.meta;
-    return {
-      path: ensureLeadingSlash(path),
-      tools: cfg.tools,
-      ...(includeHelp === undefined ? {} : { includeHelp }),
-      ...(meta === undefined ? {} : { meta }),
-    };
-  });
-
   const shouldIncludeLegacyEndpoint =
-    config.tools.length > 0 &&
-    resolved.every((endpoint) => endpoint.path !== "/mcp");
+    topLevelTools.length > 0 && mapped.every((endpoint) => endpoint.path !== '/mcp');
 
-  if (shouldIncludeLegacyEndpoint) {
-    const includeHelp = (config as any).includeHelp;
-    const meta = (config as any).stdioMeta;
-    resolved.unshift({
-      path: "/mcp",
-      tools: config.tools,
-      ...(includeHelp === undefined ? {} : { includeHelp }),
-      ...(meta === undefined ? {} : { meta }),
-    });
-  }
+  const legacyEndpoint = shouldIncludeLegacyEndpoint
+    ? [
+        {
+          path: '/mcp',
+          tools: topLevelTools,
+          ...(config.includeHelp === undefined ? {} : { includeHelp: config.includeHelp }),
+          ...(config.stdioMeta === undefined ? {} : { meta: config.stdioMeta }),
+        },
+      ]
+    : [];
 
-  return resolved;
+  return [...legacyEndpoint, ...mapped];
 };
 
 export const resolveStdioTools = (config: AppConfig): readonly string[] => {
-  if (config.tools.length > 0) return config.tools;
+  if (config.tools.length > 0) return normalizeToolIds(config.tools);
 
-  const collected = new Set<string>();
-  for (const endpoint of Object.values(config.endpoints ?? {})) {
-    for (const tool of (endpoint as any).tools) {
-      collected.add(tool);
-    }
-  }
-
-  return [...collected];
+  const endpoints = config.endpoints ?? {};
+  return Array.from(
+    new Set(Object.values(endpoints).flatMap((endpoint) => normalizeToolIds(endpoint.tools ?? []))),
+  );
 };

--- a/packages/mcp/src/core/tool-ids.ts
+++ b/packages/mcp/src/core/tool-ids.ts
@@ -1,0 +1,25 @@
+const CAMEL_SEGMENT = /([a-z0-9])([A-Z])/g;
+const ACRONYM_BOUNDARY = /([A-Z]+)([A-Z][a-z])/g;
+
+const collapseUnderscores = (value: string): string => value.replace(/__+/g, '_');
+
+/**
+ * Normalize tool identifiers so configuration may use dotted, kebab-case, or camelCase forms.
+ */
+export const normalizeToolId = (id: string): string => {
+  if (!id) return '';
+
+  const replaced = id
+    .replace(/[.]/g, '_')
+    .replace(/-/g, '_')
+    .replace(ACRONYM_BOUNDARY, '$1_$2')
+    .replace(CAMEL_SEGMENT, '$1_$2');
+
+  const collapsed = collapseUnderscores(replaced);
+  return collapsed.toLowerCase();
+};
+
+export const normalizeToolIds = (ids: readonly string[]): readonly string[] =>
+  Array.from(
+    new Set(ids.map(normalizeToolId).filter((value): value is string => value.length > 0)),
+  );

--- a/packages/mcp/src/tests/config.test.ts
+++ b/packages/mcp/src/tests/config.test.ts
@@ -52,6 +52,34 @@ test('resolveHttpEndpoints retains legacy /mcp when endpoints present', (t) => {
   ]);
 });
 
+test('resolveHttpEndpoints normalizes dotted and camelCase tool ids', (t) => {
+  const cfg: AppConfig = {
+    transport: 'http',
+    tools: ['files.viewFile', 'mcp.help'],
+    endpoints: {
+      'github/review': {
+        tools: ['github.review.openPullRequest', 'github.review.submitReview'],
+      },
+      workspace: { tools: ['pnpm.runScript', 'pnpm.install'] },
+    },
+    stdioProxyConfig: null,
+    stdioProxies: [],
+  } as unknown as AppConfig;
+
+  const result = resolveHttpEndpoints(cfg);
+  t.deepEqual(result, [
+    {
+      path: '/mcp',
+      tools: ['files_view_file', 'mcp_help'],
+    },
+    {
+      path: '/github/review',
+      tools: ['github_review_open_pull_request', 'github_review_submit_review'],
+    },
+    { path: '/workspace', tools: ['pnpm_run_script', 'pnpm_install'] },
+  ]);
+});
+
 test('resolveStdioTools prefers top-level tools', (t) => {
   const cfg: AppConfig = {
     transport: 'stdio',
@@ -83,5 +111,24 @@ test('resolveStdioTools unions endpoint tools when top-level empty', (t) => {
   t.deepEqual(
     new Set(result),
     new Set(['github_request', 'files_list_directory', 'files_view_file']),
+  );
+});
+
+test('resolveStdioTools normalizes endpoint tool identifiers', (t) => {
+  const cfg: AppConfig = {
+    transport: 'stdio',
+    tools: [],
+    endpoints: {
+      workspace: { tools: ['pnpm.runScript', 'pnpm.remove'] },
+      process: { tools: ['process.getTaskRunnerConfig', 'process.stop'] },
+    },
+    stdioProxyConfig: null,
+    stdioProxies: [],
+  } as unknown as AppConfig;
+
+  const result = resolveStdioTools(cfg);
+  t.deepEqual(
+    new Set(result),
+    new Set(['pnpm_run_script', 'pnpm_remove', 'process_get_task_runner_config', 'process_stop']),
   );
 });


### PR DESCRIPTION
## Summary
- add a tool-id normalization helper so dotted/kebab/camel case config values resolve to the registry names
- normalize the HTTP and stdio endpoint tool lists during config resolution
- add regression tests and changelog entry covering tool id normalization for HTTP endpoints

## Testing
- pnpm --filter @promethean/mcp test

------
https://chatgpt.com/codex/tasks/task_e_68e4547385288324aeafedb599de9538