### PR TITLE
Add tasks for pipeline remediation and documentation alignment

### DIFF
--- a/changelog.d/2025.10.07.02.31.30.md
+++ b/changelog.d/2025.10.07.02.31.30.md
@@ -1,0 +1,1 @@
+- Added pipeline reliability and documentation follow-up tasks under `docs/agile/tasks/` based on recent pipeline review findings.

--- a/docs/agile/tasks/Align docops README coverage with pipeline config.md
+++ b/docs/agile/tasks/Align docops README coverage with pipeline config.md
@@ -1,0 +1,33 @@
+---
+uuid: 4e1e4c3c-79e8-4f9e-9ba8-122297198bd3
+title: Align DocOps README coverage with pipeline config
+status: todo
+priority: P3
+labels:
+  - documentation
+  - pipeline
+created_at: '2025-10-07T02:31:07Z'
+---
+## 🛠️ Task: Align DocOps README coverage with pipeline config
+
+### Context
+- The root README pipeline summary omits the `doc-stage` preprocessing step currently required by `pipelines.json`.
+- DocOps reports also reference legacy steps (`doc-references`, `doc-apply-fm`) that no longer exist in configuration.
+- Keeping documentation aligned prevents confusion for operators running or debugging DocOps.
+
+### Definition of Done
+- [ ] Update README pipeline table/section to reflect the current DocOps step sequence (`doc-stage`, `doc-fm`, `doc-index`, `doc-similarity`, `doc-related`, `doc-footer`, `doc-rename`).
+- [ ] Remove or revise any outdated references to DocOps steps in docs/agile/pipelines and related notes.
+- [ ] Add change notes or pointers for maintainers about the preprocessing stage.
+
+### Suggested Plan
+1. Diff the DocOps block in `README.md` against `pipelines.json` to identify mismatches.
+2. Update Markdown descriptions and step ordering accordingly.
+3. Review DocOps-specific documentation (`docs/agile/pipelines/docops.md`, package README) for consistency.
+4. Open follow-up issues if other documents refer to deprecated steps.
+
+### References
+- `README.md`
+- `pipelines.json`
+- `docs/agile/pipelines/docops.md`
+- `scripts/piper-docops.mjs`

--- a/docs/agile/tasks/Convert existing mermaid diagrams into pipeline configs.md
+++ b/docs/agile/tasks/Convert existing mermaid diagrams into pipeline configs.md
@@ -1,0 +1,33 @@
+---
+uuid: 3646ad00-bf96-4744-96ec-ac60066cbedb
+title: Convert existing Mermaid diagrams into pipeline configs
+status: todo
+priority: P4
+labels:
+  - tooling
+  - documentation
+created_at: '2025-10-07T02:31:07Z'
+---
+## 🛠️ Task: Convert existing Mermaid diagrams into pipeline configs
+
+### Context
+- Several documents already contain Mermaid diagrams (e.g., orchestration flows in `promethean-pipelines.md`).
+- Converting these diagrams into executable Piper configs will validate the proposed DSL/compiler approach.
+- Establishing a repeatable conversion flow ensures diagrams and configs stay in sync.
+
+### Definition of Done
+- [ ] Inventory current Mermaid diagrams relevant to pipelines and classify their types (flowchart, timeline, etc.).
+- [ ] For flowchart-style diagrams, demonstrate conversion into the proposed DSL and resulting `pipelines.json` fragments.
+- [ ] Document the tooling/process required for future diagram-to-config conversions, including limitations.
+
+### Suggested Plan
+1. Use `rg` to locate Mermaid code blocks related to pipelines.
+2. Prioritise diagrams that map directly to pipeline steps (e.g., scan → embed → cluster → plan → docs/tasks).
+3. Apply the DSL/compiler prototype to generate config stubs and validate them with Piper.
+4. Capture before/after diagrams and configs in documentation for traceability.
+
+### References
+- `docs/promethean-pipelines.md`
+- README Gantt and flow diagrams
+- Proposed Mermaid DSL compiler design
+- `pipelines.json`

--- a/docs/agile/tasks/Define backlog for new automation pipelines.md
+++ b/docs/agile/tasks/Define backlog for new automation pipelines.md
@@ -1,0 +1,33 @@
+---
+uuid: 82c2eb4c-54a4-4f50-90fa-46bbb719c40f
+title: Define backlog for new automation pipelines
+status: todo
+priority: P4
+labels:
+  - pipelines
+  - planning
+created_at: '2025-10-07T02:31:07Z'
+---
+## 🛠️ Task: Define backlog for new automation pipelines
+
+### Context
+- The "menu of new pipelines" note sketches candidates like `apidiff`, `i18npack`, `licscan`, `perf-bench`, `glossary`, `adr-bot`, and `riskmap`.
+- These concepts lack formal task breakdowns, acceptance criteria, or Piper configurations.
+- Capturing a backlog clarifies scope and sequencing for future automation work.
+
+### Definition of Done
+- [ ] Review the pipeline menu note and extract each candidate’s inputs, outputs, and artefact plans.
+- [ ] Create individual task stubs or epics for high-priority pipelines with clear acceptance criteria.
+- [ ] Prioritise the backlog based on impact, dependencies, and resource requirements.
+- [ ] Link tasks to relevant documentation and stakeholders for follow-up.
+
+### Suggested Plan
+1. Summarise the existing pipeline menu content into a structured table (pipeline, purpose, inputs, outputs, status).
+2. Collaborate with stakeholders to rank pipelines and identify prerequisites.
+3. Generate task files or epics within the agile system for top-ranked pipelines.
+4. Document outstanding questions or research needed before implementation.
+
+### References
+- `docs/promethean-pipelines.md` (or equivalent menu note)
+- `pipelines.json`
+- Piper documentation

--- a/docs/agile/tasks/Design mermaid to Piper DSL compiler.md
+++ b/docs/agile/tasks/Design mermaid to Piper DSL compiler.md
@@ -1,0 +1,34 @@
+---
+uuid: 931a7d00-c601-4697-998f-441dffe78f25
+title: Design mermaid to Piper DSL compiler
+status: todo
+priority: P4
+labels:
+  - tooling
+  - pipelines
+created_at: '2025-10-07T02:31:07Z'
+---
+## 🛠️ Task: Design mermaid to Piper DSL compiler
+
+### Context
+- Stakeholders want to author pipelines as non-linear graphs via Mermaid diagrams and compile them into Piper-compatible configs.
+- Target output should be an nbb-compatible ClojureScript DSL that can round-trip to `pipelines.json`.
+- Existing orchestration diagrams (e.g., in `promethean-pipelines.md`) provide seed examples for conversion.
+
+### Definition of Done
+- [ ] Specify a parsing strategy for Mermaid `flowchart`/`graph` syntax to extract nodes, edges, and metadata.
+- [ ] Define the intermediate representation and mapping rules into Piper steps and dependencies.
+- [ ] Produce a DSL design document (nbb ClojureScript) illustrating syntax for pipelines, steps, deps, and annotations.
+- [ ] Outline validation and round-trip testing approach between Mermaid, DSL, and JSON configs.
+
+### Suggested Plan
+1. Survey existing Mermaid parsers or implement a lightweight parser suitable for flowcharts.
+2. Draft an IR capturing nodes, edges, step metadata, and documentation labels.
+3. Design DSL macros/functions mirroring Piper schema, ensuring compatibility with nbb execution.
+4. Document conversion and reverse-generation flow, including tooling requirements and open questions.
+
+### References
+- `docs/promethean-pipelines.md`
+- `pipelines.json`
+- `scripts/` Piper tooling
+- nbb / ClojureScript DSL conventions

--- a/docs/agile/tasks/Expand symdocs and simtasks package documentation.md
+++ b/docs/agile/tasks/Expand symdocs and simtasks package documentation.md
@@ -1,0 +1,33 @@
+---
+uuid: 5f487b0d-4897-4931-b59a-dafe330b9608
+title: Expand symdocs and simtasks package documentation
+status: todo
+priority: P3
+labels:
+  - documentation
+  - packages
+created_at: '2025-10-07T02:31:07Z'
+---
+## 🛠️ Task: Expand symdocs and simtasks package documentation
+
+### Context
+- `@promethean/docops` README provides detailed usage and troubleshooting guidance, but `@promethean/symdocs` and `@promethean/simtasks` still contain "Usage (coming soon)" placeholders.
+- Engineers lack authoritative references when attempting to fix the associated pipelines.
+- Aligning package docs improves onboarding and supports reliability work.
+
+### Definition of Done
+- [ ] Author comprehensive README updates for both packages covering prerequisites, CLI/API usage, cache layout, and troubleshooting.
+- [ ] Include example Piper integrations and environment setup instructions consistent with `pipelines.json`.
+- [ ] Ensure README sections cross-link to pipeline reports and related tasks.
+
+### Suggested Plan
+1. Review existing docops README structure as a template for depth and sections.
+2. Interview pipeline configs and scripts to document actual entrypoints and expected inputs/outputs.
+3. Draft README content for symdocs and simtasks, including testing instructions and known issues.
+4. Solicit review from pipeline maintainers before publishing.
+
+### References
+- `packages/@promethean/docops/README.md`
+- `packages/@promethean/symdocs/README.md`
+- `packages/@promethean/simtasks/README.md`
+- `pipelines.json`

--- a/docs/agile/tasks/Fix simtasks pipeline orchestration.md
+++ b/docs/agile/tasks/Fix simtasks pipeline orchestration.md
@@ -1,0 +1,34 @@
+---
+uuid: b9a688c4-5860-42e5-bee4-874dfeeaa739
+title: Fix simtasks pipeline orchestration
+status: todo
+priority: P2
+labels:
+  - pipeline
+  - reliability
+created_at: '2025-10-07T02:30:58Z'
+---
+## 🛠️ Task: Fix simtasks pipeline orchestration
+
+### Context
+- Piper reports show all `simtasks` executions failing or being skipped after early step errors.
+- The JSON configuration already enumerates the full pipeline, but package-level implementations remain incomplete.
+- Restoring `simtasks` unlocks automation for simulation task synthesis and ensures parity with DocOps stability.
+
+### Definition of Done
+- [ ] Reproduce the current failure locally and capture logs for each failing step.
+- [ ] Implement the missing functionality or configuration needed for the pipeline to reach completion.
+- [ ] Produce and commit a successful pipeline report in `docs/agile/pipelines/simtasks.md` documenting outputs and follow-ups.
+- [ ] Add regression tests or smoke checks so the pipeline stays green in future runs.
+
+### Suggested Plan
+1. Execute `piper run simtasks` with debug logging to isolate the first failing step.
+2. Inspect `packages/@promethean/simtasks` and its wrapper scripts for missing exports, schema mismatches, or environment requirements.
+3. Patch the implementation, including AJV schemas or LevelDB cache usage, to satisfy the configured steps.
+4. Confirm successful reruns and backfill the Markdown run report.
+
+### References
+- `pipelines.json` (`simtasks` definition)
+- `packages/@promethean/simtasks`
+- Piper cache at `.cache/piper.level`
+- `docs/agile/pipelines/` for report examples

--- a/docs/agile/tasks/Publish missing pipeline run reports.md
+++ b/docs/agile/tasks/Publish missing pipeline run reports.md
@@ -1,0 +1,32 @@
+---
+uuid: 2690e363-4489-4828-bc07-88063262db13
+title: Publish missing pipeline run reports
+status: todo
+priority: P3
+labels:
+  - documentation
+  - pipeline
+created_at: '2025-10-07T02:31:07Z'
+---
+## 🛠️ Task: Publish missing pipeline run reports
+
+### Context
+- Only four Markdown reports exist under `docs/agile/pipelines/`, leaving most automation flows undocumented.
+- Operators currently lack visibility into failure modes for codemods, semver-guard, board-review, sonar, buildfix, test-gap, and eslint-tasks.
+- Publishing reports supports triage and knowledge sharing without rerunning pipelines locally.
+
+### Definition of Done
+- [ ] Execute or replay Piper runs for each undocumented pipeline (codemods, semver-guard, board-review, sonar, buildfix, test-gap, eslint-tasks).
+- [ ] Generate Markdown reports summarising step outcomes, artefacts, and follow-ups in `docs/agile/pipelines/`.
+- [ ] Highlight persistent failures and link to corresponding remediation tasks.
+
+### Suggested Plan
+1. Use Piper `status` or cached run data to gather results for each pipeline.
+2. If no cached results exist, run pipelines in dry-run or targeted mode to collect failure traces.
+3. Leverage the existing report renderer or manual templates to produce Markdown files for each pipeline.
+4. Cross-reference newly created tasks to ensure blockers are tracked.
+
+### References
+- `docs/agile/pipelines/`
+- `pipelines.json`
+- Piper report generation scripts

--- a/docs/agile/tasks/Refresh pipeline notes for LevelDB caches and Piper redesign.md
+++ b/docs/agile/tasks/Refresh pipeline notes for LevelDB caches and Piper redesign.md
@@ -1,0 +1,33 @@
+---
+uuid: 4f810709-9a6d-4677-812f-c8dc3bfa4d28
+title: Refresh pipeline notes for LevelDB caches and Piper redesign
+status: todo
+priority: P3
+labels:
+  - documentation
+  - pipeline
+created_at: '2025-10-07T02:31:07Z'
+---
+## 🛠️ Task: Refresh pipeline notes for LevelDB caches and Piper redesign
+
+### Context
+- `docs/notes/promethean-ci-cd-pipeline.md` still describes pipelines emitting JSON artefacts, predating the LevelDB cache migration and Piper orchestration.
+- Current runs persist LevelDB state and use Piper fingerprinting, causing confusion for operators referencing outdated docs.
+- Updating the notes aligns onboarding material with actual runtime behaviour.
+
+### Definition of Done
+- [ ] Audit `docs/notes/promethean-ci-cd-pipeline.md` (and related notes) for outdated references to artefact formats or orchestration flow.
+- [ ] Document the current Piper lifecycle, cache layout (`.cache/piper.level`), and dependency requirements (e.g., Ollama models).
+- [ ] Note any remaining deltas or TODOs for future automation enhancements.
+
+### Suggested Plan
+1. Compare the note’s described pipeline outputs with the actual files generated during DocOps runs.
+2. Update sections on artefacts, caching, and orchestrator behaviour to reflect the LevelDB-backed design.
+3. Cross-link to Piper package documentation for deeper implementation details.
+4. Flag any areas needing follow-up tasks (e.g., diagrams, CLI references).
+
+### References
+- `docs/notes/promethean-ci-cd-pipeline.md`
+- `docs/agile/pipelines/docops.md`
+- `.cache/piper.level` structure
+- Piper README / package docs

--- a/docs/agile/tasks/Restore symdocs pipeline execution.md
+++ b/docs/agile/tasks/Restore symdocs pipeline execution.md
@@ -1,0 +1,34 @@
+---
+uuid: aeed625c-0cb1-490d-aa15-19b39d96fc3e
+title: Restore symdocs pipeline execution in Piper
+status: todo
+priority: P2
+labels:
+  - pipeline
+  - reliability
+created_at: '2025-10-07T02:30:45Z'
+---
+## 🛠️ Task: Restore symdocs pipeline execution in Piper
+
+### Context
+- Recent pipeline health review shows every `symdocs` run aborts while DocOps succeeds.
+- Piper orchestrator already has `symdocs` wired in `pipelines.json`, so the failures stem from missing step implementations or misconfigured wrappers.
+- Stabilising `symdocs` unblocks downstream doc intelligence flows and brings parity with the working DocOps run.
+
+### Definition of Done
+- [ ] Identify and document the failing `symdocs` step(s) with reproducible logs.
+- [ ] Implement or repair the corresponding package runners so the pipeline completes end-to-end in Piper.
+- [ ] Capture a successful pipeline report under `docs/agile/pipelines/symdocs.md` (or equivalent) with current artefacts.
+- [ ] Update fingerprints or cache hints if needed so subsequent runs skip cleanly when inputs unchanged.
+
+### Suggested Plan
+1. Re-run `symdocs` via Piper with verbose logging and inspect `.cache/piper.level` entries for error signatures.
+2. Audit `scripts/piper-symdocs` (or package entrypoints) to confirm exported handlers match `pipelines.json` step schema.
+3. Patch missing implementations or configuration (AJV schemas, env variables, concurrency guards) and add regression tests where practical.
+4. Re-run the pipeline to confirm success, then publish the Markdown report.
+
+### References
+- `pipelines.json` (`symdocs` definition)
+- `packages/@promethean/symdocs` sources and README
+- `scripts/` Piper bridge scripts for symdocs
+- `docs/agile/pipelines/` for existing report format


### PR DESCRIPTION
## Summary
- capture follow-up work to restore failing symdocs and simtasks pipelines
- add documentation and reporting tasks to align pipeline references with current configs
- outline planning work for mermaid-driven pipeline DSL and future automation backlog

## Testing
- pre-commit (Ensure Piper build Succeeds)


------
https://chatgpt.com/codex/tasks/task_e_68e476ba27b88324824e646608ba89a1