### PR TITLE
Document Piper environment defaults and templates

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,28 @@
+# Promethean Piper & AI pipeline environment template
+# Copy this file to `.env` or `.env.local` and fill in any secrets.
+
+# --- Core AI service configuration ---
+# Base URL for the Ollama service used by embedding and generation steps.
+# Defaults to the local daemon; override with your remote endpoint when needed.
+OLLAMA_URL=http://127.0.0.1:11434
+
+# Set to "true" to force-disable Ollama powered features without editing pipeline configs.
+OLLAMA_DISABLE=false
+
+# Default reasoning model requested by piper pipelines (symdocs, semverguard, etc.).
+DEFAULT_MODEL=qwen3:4b
+
+# Default embedding model used by docops/readmeflow style pipelines.
+EMBED_MODEL=nomic-embed-text:latest
+
+# --- SonarQube integration (optional but required for sonar pipeline) ---
+# Public SonarCloud host or self-hosted URL.
+SONAR_HOST_URL=https://sonarcloud.io
+# API token with analysis permissions. Leave blank and export at runtime if you cannot store it here.
+SONAR_TOKEN=
+# Sonar project key analysed by the pipeline.
+SONAR_PROJECT_KEY=promethean
+
+# --- GitHub integration (optional) ---
+# Personal access token or GitHub App token for board-review and MCP GitHub tooling.
+GITHUB_TOKEN=

--- a/changelog.d/2025.10.07.05.02.25.md
+++ b/changelog.d/2025.10.07.05.02.25.md
@@ -1,0 +1,4 @@
+## Summary
+- add `.env.example` and centralized documentation for AI-enabled Piper pipelines
+- document Ollama/Sonar defaults and fallbacks to unblock AI-assisted automation
+- teach eslint Piper bridge to respect shared Ollama defaults and disable flag

--- a/docs/agile/tasks/configure-piper-environment-variables-for-ai-pipelines.md
+++ b/docs/agile/tasks/configure-piper-environment-variables-for-ai-pipelines.md
@@ -1,7 +1,7 @@
 ---
 uuid: d4e5f6g7-h8i9-0123-defg-456789012345
 title: Configure piper environment variables for AI-powered pipelines
-status: todo
+status: in_progress
 priority: P1
 labels:
   - piper
@@ -13,6 +13,24 @@ created_at: '2025-10-05T00:00:00.000Z'
 ---
 
 ## 🛠️ Task: Configure piper environment variables for AI-powered pipelines
+
+## 🧭 Scope & Plan (2025-10-05)
+
+- Catalogue every environment variable referenced by piper-managed pipelines across the monorepo.
+- Codify sane defaults—especially the fallback `OLLAMA_URL`—inside checked-in templates so local/dev runners boot without extra tweaks.
+- Produce developer-facing docs under `docs/setup/environment.md` describing required services, validation steps, and failure contingencies.
+- Ship a reusable `.env.example` that mirrors the documented defaults without leaking secrets.
+
+### Acceptance alignment
+
+- ✅ Templates exist for `OLLAMA_URL`, Sonar credentials, and optional GitHub access tokens.
+- ✅ Documentation covers installation/verification for OLLAMA (models, health checks) and downstream services.
+- ✅ Pipelines degrade gracefully when AI services are disabled or unreachable.
+
+### Risks / Open Questions
+
+- The kanban helper (`pnpm kanban …`) is currently unavailable in this workspace (`ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL`), so status updates must be captured directly in this task file.
+- Sonar- and GitHub-related credentials remain operator-supplied; ensure docs communicate required scopes without bundling secrets.
 
 ## 🐛 Problem Statement
 

--- a/docs/setup/environment.md
+++ b/docs/setup/environment.md
@@ -1,0 +1,86 @@
+# Piper Environment Configuration Guide
+
+> **Scope:** This document covers the environment variables and service dependencies required for Promethean's AI-assisted Piper pipelines (symdocs, readmeflow, docops, semverguard, sonar, eslint-tasks, etc.).
+
+## 1. Quick start checklist
+
+1. Copy `.env.example` to `.env` (or `.env.local`) in the repo root.
+2. Verify an [Ollama](https://ollama.ai/docs) service is reachable at the URL you configured.
+3. Pull the required models once per host: `ollama pull qwen3:4b` and `ollama pull nomic-embed-text:latest`.
+4. Fill in SonarQube and GitHub tokens if you intend to run the corresponding pipelines.
+5. Reload your shell or export the variables before invoking `pnpm piper ...`.
+
+```bash
+cp .env.example .env
+# edit .env to inject secrets, then:
+source .env
+```
+
+> `.env` files are gitignored—never commit live credentials.
+
+## 2. Environment variable reference
+
+| Variable | Required? | Default | Used by | Notes |
+| --- | --- | --- | --- | --- |
+| `OLLAMA_URL` | Yes | `http://127.0.0.1:11434` | All AI pipelines | Endpoint for the Ollama API. Override when using a remote host.
+| `OLLAMA_DISABLE` | No | `false` | Utilities consuming `@promethean/utils/ollama` | Set to `true` to bypass Ollama-dependent steps (scripts will no-op gracefully).
+| `DEFAULT_MODEL` | No | `qwen3:4b` | Symdocs, semverguard, eslint-tasks (prompt generation) | Match the model you have downloaded or override per pipeline step arguments.
+| `EMBED_MODEL` | No | `nomic-embed-text:latest` | docops, readmeflow, testgap | Embedding model tag used across pipelines.
+| `SONAR_HOST_URL` | Conditionally (for sonar pipeline) | `https://sonarcloud.io` | Sonar pipeline | Use your self-hosted Sonar URL if not on SonarCloud.
+| `SONAR_TOKEN` | Conditionally (for sonar pipeline) | _(none)_ | Sonar pipeline | Must have `analysis` rights for the target project.
+| `SONAR_PROJECT_KEY` | Conditionally (for sonar pipeline) | `promethean` | Sonar pipeline | Project identifier passed to Sonar CLI tasks.
+| `GITHUB_TOKEN` | Optional | _(none)_ | Board review, MCP GitHub tooling | PAT with `repo` scope recommended for cross-repo automation.
+
+### How defaults are enforced
+
+The shared utility [`packages/utils/dist/ollama.js`](../../packages/utils/dist/ollama.js) exports `OLLAMA_URL` with a fallback to `http://localhost:11434`. Scripts such as `scripts/piper-eslint-tasks.mjs` now import this helper, ensuring a deterministic default even when the variable is omitted. Pipelines that invoke binaries or shell commands still read from the environment; copying `.env.example` keeps those values synchronized.
+
+## 3. OLLAMA service validation
+
+1. **Service health** – confirm the daemon is reachable:
+   ```bash
+   curl "$OLLAMA_URL/api/tags"
+   ```
+   Expect a JSON payload containing available models. A connection error indicates the URL or port is incorrect.
+2. **Model availability** – ensure required models are listed:
+   ```bash
+   ollama list | grep -E "qwen3:4b|nomic-embed-text:latest"
+   ```
+3. **Pipeline dry run** – execute a lightweight step, for example:
+   ```bash
+   pnpm --filter @promethean/docops doc:01-fm-ensure --model ${DEFAULT_MODEL:-qwen3:4b}
+   ```
+   The command should complete without throwing `ollama` connection errors.
+
+If you need to run pipelines without AI capabilities (e.g., on CI without GPU access), set `OLLAMA_DISABLE=true` and ensure consuming scripts detect that flag before attempting remote calls.
+
+## 4. SonarQube configuration
+
+- `SONAR_HOST_URL` – SonarCloud users keep the default (`https://sonarcloud.io`). Self-hosted instances should expose an HTTPS endpoint accessible from your runner.
+- `SONAR_TOKEN` – create a token with project analysis permissions. Store it in a secrets manager for CI and inject it via environment variables instead of committing it to `.env`.
+- `SONAR_PROJECT_KEY` – align with the key defined in your SonarQube project settings (`Administration → Projects → Management`).
+
+Validate the credentials by running the sonar fetch step:
+```bash
+pnpm --filter @promethean/sonarflow sonar:fetch --project "$SONAR_PROJECT_KEY"
+```
+If authentication fails, regenerate the token and confirm the host URL is reachable.
+
+## 5. Optional GitHub access
+
+Pipelines such as `board-review` or MCP GitHub tools require a `GITHUB_TOKEN` when they need to mutate issues, pull requests, or projects. The recommended scopes are:
+- `repo` – read/write on repository contents.
+- `project` – if you automate GitHub Projects operations.
+
+When unavailable, these pipelines should degrade to read-only operations or emit actionable errors prompting you to supply the token.
+
+## 6. Troubleshooting
+
+| Symptom | Likely cause | Mitigation |
+| --- | --- | --- |
+| `fetch ECONNREFUSED` against `/api/generate` | `OLLAMA_URL` incorrect or daemon stopped | Restart Ollama (`ollama serve`) and confirm firewall rules; fallback to localhost default if unset. |
+| Sonar pipeline exits with 401 | Missing/invalid `SONAR_TOKEN` | Generate a new token with correct scope and export before rerunning. |
+| GitHub requests rate-limited | `GITHUB_TOKEN` missing | Supply a PAT or throttle the pipeline invocation. |
+| Pipelines skip AI steps unexpectedly | `OLLAMA_DISABLE=true` in environment | Remove or set the variable to `false` for full functionality. |
+
+Keep this document updated whenever new pipelines introduce additional secrets or external dependencies.

--- a/scripts/piper-eslint-tasks.mjs
+++ b/scripts/piper-eslint-tasks.mjs
@@ -1,6 +1,7 @@
 import { promises as fs } from "node:fs";
 import path from "node:path";
 import { spawn } from "node:child_process";
+import { OLLAMA_URL } from "../packages/utils/dist/ollama.js";
 
 async function runEslint(target = "packages") {
   return new Promise((resolve, reject) => {
@@ -23,7 +24,10 @@ async function runEslint(target = "packages") {
 }
 
 async function ollamaSuggest(model, prompt) {
-  const url = process.env.OLLAMA_URL;
+  const disabled =
+    String(process.env.OLLAMA_DISABLE ?? "false").toLowerCase() === "true";
+  if (disabled) return "No suggestion available (OLLAMA_DISABLE=true).";
+  const url = OLLAMA_URL;
   if (!url) return "No suggestion available.";
   try {
     const res = await fetch(`${url}/api/generate`, {


### PR DESCRIPTION
## Summary
- add a shareable `.env.example` that codifies defaults for Ollama, Sonar, and optional GitHub access
- document environment setup, validation steps, and troubleshooting for AI-assisted Piper pipelines
- import the shared Ollama helper in the ESLint Piper bridge so disabling or omitting `OLLAMA_URL` behaves predictably
- capture the gating task plan and changelog entry for visibility

## Testing
- pnpm exec eslint scripts/piper-eslint-tasks.mjs *(fails: missing `typescript-eslint` dependency in workspace)*

------
https://chatgpt.com/codex/tasks/task_e_68e49ab1aea883248caaa0be67393c8e