### PR TITLE
Normalize kanban tasks to FSM statuses

### DIFF
--- a/changelog.d/2025.10.07.04.48.51.md
+++ b/changelog.d/2025.10.07.04.48.51.md
@@ -1,0 +1,4 @@
+## Docs: align kanban tasks with FSM flow
+
+- Normalized kanban task statuses from `backlog` to `incoming` per FSM guidance.
+- Cross-linked board tooling refactor task with FSM hygiene checklist to keep automation consistent.

--- a/docs/agile/tasks/add-tsdoc-support.md
+++ b/docs/agile/tasks/add-tsdoc-support.md
@@ -1,6 +1,6 @@
 ---
 title: "Add TSDoc support to the project"
-status: backlog
+status: incoming
 priority: P2
 tags: [documentation, typescript, build-system]
 uuid: tsdoc-support-001

--- a/docs/agile/tasks/boardrev-confidence-calibration.md
+++ b/docs/agile/tasks/boardrev-confidence-calibration.md
@@ -1,7 +1,7 @@
 ---
 uuid: $(uuidgen)
 title: Add confidence calibration and historical accuracy tracking
-status: backlog
+status: incoming
 priority: P2
 labels: [enhancement, boardrev, accuracy, metrics]
 created_at: 2025-10-06T12:00:00Z

--- a/docs/agile/tasks/boardrev-continuous-monitoring.md
+++ b/docs/agile/tasks/boardrev-continuous-monitoring.md
@@ -1,7 +1,7 @@
 ---
 uuid: $(uuidgen)
 title: Add continuous monitoring and real-time updates to boardrev
-status: backlog
+status: incoming
 priority: P1
 labels: [enhancement, boardrev, monitoring, automation]
 created_at: 2025-10-06T12:00:00Z

--- a/docs/agile/tasks/boardrev-enhanced-context-analysis.md
+++ b/docs/agile/tasks/boardrev-enhanced-context-analysis.md
@@ -1,7 +1,7 @@
 ---
 uuid: $(uuidgen)
 title: Enhance boardrev context analysis with weighted factors
-status: backlog
+status: incoming
 priority: P2
 labels: [enhancement, boardrev, analysis, accuracy]
 created_at: 2025-10-06T12:00:00Z

--- a/docs/agile/tasks/boardrev-incremental-updates.md
+++ b/docs/agile/tasks/boardrev-incremental-updates.md
@@ -1,7 +1,7 @@
 ---
 uuid: $(uuidgen)
 title: Add incremental updates to boardrev indexing
-status: backlog
+status: incoming
 priority: P1
 labels: [enhancement, boardrev, performance]
 created_at: 2025-10-06T12:00:00Z

--- a/docs/agile/tasks/boardrev-interactive-task-management.md
+++ b/docs/agile/tasks/boardrev-interactive-task-management.md
@@ -1,7 +1,7 @@
 ---
 uuid: $(uuidgen)
 title: Add interactive task management and auto-updates to boardrev
-status: backlog
+status: incoming
 priority: P2
 labels: [enhancement, boardrev, automation, management]
 created_at: 2025-10-06T12:00:00Z

--- a/docs/agile/tasks/boardrev-multi-model-evaluation.md
+++ b/docs/agile/tasks/boardrev-multi-model-evaluation.md
@@ -1,7 +1,7 @@
 ---
 uuid: $(uuidgen)
 title: Implement multi-model evaluation for boardrev
-status: backlog
+status: incoming
 priority: P2
 labels: [enhancement, boardrev, ai, evaluation]
 created_at: 2025-10-06T12:00:00Z

--- a/docs/agile/tasks/boardrev-piper-integration.md
+++ b/docs/agile/tasks/boardrev-piper-integration.md
@@ -1,7 +1,7 @@
 ---
 uuid: $(uuidgen)
 title: Integrate boardrev with piper pipeline system
-status: backlog
+status: incoming
 priority: P2
 labels: [enhancement, boardrev, infrastructure]
 created_at: 2025-10-06T12:00:00Z

--- a/docs/agile/tasks/boardrev-vector-db.md
+++ b/docs/agile/tasks/boardrev-vector-db.md
@@ -1,7 +1,7 @@
 ---
 uuid: $(uuidgen)
 title: Replace LevelDB with vector database for boardrev
-status: backlog
+status: incoming
 priority: P2
 labels: [enhancement, boardrev, performance]
 created_at: 2025-10-06T12:00:00Z

--- a/docs/agile/tasks/enhance-clj-hacks-claude-code-mcp.md
+++ b/docs/agile/tasks/enhance-clj-hacks-claude-code-mcp.md
@@ -2,7 +2,7 @@
 title: Enhance clj-hacks for Claude Code MCP server configs
 uuid: 5386dc78-da5b-4dfa-bef3-f82094c4c58a
 created: 2025-10-06T20:06:54-05:00
-status: backlog
+status: incoming
 priority: P2
 owner:
 labels:

--- a/docs/agile/tasks/kanban-crud-commands.md
+++ b/docs/agile/tasks/kanban-crud-commands.md
@@ -1,6 +1,6 @@
 ---
 title: "Add CRUD subcommands to kanban CLI"
-status: backlog
+status: incoming
 priority: P2
 tags: [kanban, cli, enhancement, crud]
 uuid: kanban-crud-001

--- a/docs/agile/tasks/move-board-tools-into-kanban-package.md
+++ b/docs/agile/tasks/move-board-tools-into-kanban-package.md
@@ -12,6 +12,7 @@ Move the TypeScript utilities under `tools/board/` into the maintained `@prometh
 - [x] Inspect the legacy `tools/board/*` entrypoints and data contracts.
 - [x] Relocate the scripts into a `packages/kanban/src/board` directory, exporting them as part of the package build.
 - [x] Update documentation and any hard-coded paths or references to the old location.
+- [ ] Coordinate with hygiene task `kanban-fsm-update-001` so the relocated tooling honours the FSM status map used by the board automation.
 - [ ] Ensure `@promethean/kanban` builds cleanly and lint passes on touched files. *(Blocked: `tsc -p tsconfig.json` currently fails in `src/lib/types.ts` and `src/lib/jsonl.ts`.)*
 
 ## Definition of Done

--- a/docs/agile/tasks/update-kanban-statuses-to-fsm.md
+++ b/docs/agile/tasks/update-kanban-statuses-to-fsm.md
@@ -30,3 +30,4 @@ All tasks with status "backlog" should be moved to "incoming" to follow the FSM 
 - [ ] Verify board regeneration shows proper FSM column flow
 - [ ] Update any task templates or documentation to use FSM statuses
 - [ ] Test that WIP limits work correctly with new status flow
+- [ ] Confirm the board tooling inside `@promethean/kanban` reads the relocated scripts and respects the FSM statuses (see task `8a791d5f-757a-4154-bba2-e14886da4c30`).

--- a/docs/agile/tasks/upgrade-symdocs-documentation.md
+++ b/docs/agile/tasks/upgrade-symdocs-documentation.md
@@ -1,7 +1,7 @@
 ---
 uuid: a2b3c4d5-e6f7-8901-bcde-f23456789012
 title: Upgrade symdocs to generate meaningful API documentation
-status: backlog
+status: incoming
 priority: P2
 labels: [symdocs, documentation, enhancement, ai, pipeline]
 created_at: 2025-10-06T23:45:00.000Z


### PR DESCRIPTION
## Summary
- update kanban task docs to use the FSM "incoming" status instead of the deprecated "backlog" state
- cross-link the board tooling refactor with the FSM hygiene checklist to keep automation aligned

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e49aa88aa08324ab9c56e10420ecd3