### PR TITLE
Fix docops rename step persistence

### DIFF
--- a/changelog.d/2025.10.07.05.00.29.md
+++ b/changelog.d/2025.10.07.05.00.29.md
@@ -1,0 +1,1 @@
+- fix docops rename to update pipeline state after renaming files so downstream steps see new paths

--- a/packages/docops/src/lib/pipeline.ts
+++ b/packages/docops/src/lib/pipeline.ts
@@ -209,7 +209,7 @@ export async function runDocopsStep(
         dir: normalizedArgs.dir,
         ...(files ? { files } : {}),
       };
-      await runRename(opts);
+      await runRename(opts, db, onProgress);
       return;
     }
     default: {


### PR DESCRIPTION
## Summary
- persist renamed file paths back into the DocOps LevelDB so downstream steps resolve the new locations
- pass the database handle through the pipeline when invoking the rename step
- document the change in the changelog

## Testing
- pnpm --filter @promethean/docops build

------
https://chatgpt.com/codex/tasks/task_e_68e49ac1a9f08324a42e3845560cd9d9