### PR TITLE
Queue piper pipeline timeout task

### DIFF
--- a/changelog.d/2025.10.07.04.57.11.md
+++ b/changelog.d/2025.10.07.04.57.11.md
@@ -1,0 +1,1 @@
+- Queue piper pipeline optimization task at P1 priority and mark it ready for execution once upstream work lands.

--- a/docs/agile/tasks/optimize-piper-pipeline-performance-and-add-timeouts.md
+++ b/docs/agile/tasks/optimize-piper-pipeline-performance-and-add-timeouts.md
@@ -3,8 +3,8 @@
 uuid: e5f6g7h8-i9j0-1234-efgh-567890123456
 ```
 title: Optimize piper pipeline performance and add comprehensive timeouts
-status: todo
-priority: P2
+status: ready
+priority: P1
 labels:
   - piper
   - performance


### PR DESCRIPTION
## Summary
- mark the piper pipeline optimization task as ready with priority P1 so it can be queued once prerequisites land
- log the task queueing update in the changelog for visibility

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68e49ac84a748324a53983fd261c0aa0