### PR TITLE
Add task for daemon confirmation telemetry planning

### DIFF
--- a/changelog.d/2025.10.07.04.53.31.md
+++ b/changelog.d/2025.10.07.04.53.31.md
@@ -1,0 +1,1 @@
+- Added a kanban task to plan confirmation telemetry and optimization trigger tracking for daemon/condition workflows described in `system/README.md`.

--- a/docs/agile/tasks/capture-confirmation-telemetry-for-daemon-optimization.md
+++ b/docs/agile/tasks/capture-confirmation-telemetry-for-daemon-optimization.md
@@ -1,0 +1,61 @@
+---
+uuid: 7a86d12d-27f8-42ce-ae96-661ebfd7012d
+title: capture confirmation telemetry for daemon optimization
+status: todo
+priority: P2
+labels:
+  - framework-core
+  - telemetry
+created_at: '2025-10-07T04:53:22.789Z'
+---
+#Todo
+
+## 🛠️ Description
+
+Add instrumentation to observe how often daemon/condition-based smart units achieve their goals, capturing both immediate and asynchronous user confirmations as outlined in `system/README.md`.
+
+## Description
+- **What changed?** Introduce a telemetry capture plan for confirmation events and optimization triggers tied to daemon/condition workflows, ensuring repeated runs and conversions to structured formats are tracked.
+- **Where is the impact?** Applies to Promethean system orchestration, specifically smart unit lifecycle handling described in `system/README.md` (daemon, condition, trigger sections).
+- **Why now?** Telemetry is needed to validate optimization readiness and user approvals before converting markdown units into structured representations.
+- **Supporting context** `system/README.md`
+
+## Goals
+- Document confirmation telemetry requirements for daemon/condition workflows, including immediate and asynchronous approvals.
+- Define metrics/events needed to identify when optimization triggers should fire.
+- Outline data sinks or dashboards for reviewing confirmation and optimization performance.
+
+## Requirements
+- [ ] Capture scenarios for synchronous and asynchronous confirmation flows.
+- [ ] Specify events required to detect repeated execution leading to optimization attempts.
+- [ ] Document storage/reporting expectations for telemetry consumers.
+- [ ] Record risks or open questions around instrumenting existing daemons and conditions.
+
+## Subtasks
+1. Audit current daemon/condition execution path for available confirmation signals.
+2. Design telemetry schema/events that align with optimization trigger lifecycle.
+3. Propose monitoring dashboard or alerting workflow for optimization readiness.
+
+Estimate: 3
+
+---
+
+## 🔗 Related Epics
+
+- [[kanban]]
+
+---
+
+## ⛓️ Blocked By
+
+- None
+
+## ⛓️ Blocks
+
+- None
+
+---
+
+## 🔍 Relevant Links
+
+- `system/README.md`


### PR DESCRIPTION
## Summary
- add a kanban task detailing telemetry requirements for daemon/condition confirmation flows in system/README.md
- document goals, requirements, and subtasks for capturing optimization trigger signals
- record the addition in the changelog for visibility

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e49ad339b48324884a3a2a33cc0d02