### PR TITLE
fix(docops): sync rename sequencing

### DIFF
--- a/changelog.d/2025.10.07.05.01.21.md
+++ b/changelog.d/2025.10.07.05.01.21.md
@@ -1,0 +1,1 @@
+- fix: update DocOps rename step to sync LevelDB mappings and reorder pipeline so footers runs after rename, preventing ENOENT failures.

--- a/docs/agile/tasks/fix-docops-pipeline-file-reference-management-and-sequencing.md
+++ b/docs/agile/tasks/fix-docops-pipeline-file-reference-management-and-sequencing.md
@@ -42,13 +42,13 @@ The docops pipeline should:
 
 ### Phase 1: File Reference Tracking
 - [ ] Investigate how file references are passed between pipeline steps
-- [ ] Implement proper file rename tracking system
+- [x] Implement proper file rename tracking system
 - [ ] Add file mapping metadata between steps
 - [ ] Create file reference validation logic
 
 ### Phase 2: Pipeline Sequencing Fix
-- [ ] Fix step dependency order for file operations
-- [ ] Ensure `doc-rename` and `doc-footer` steps coordinate properly
+- [x] Fix step dependency order for file operations
+- [x] Ensure `doc-rename` and `doc-footer` steps coordinate properly
 - [ ] Add error handling for missing or renamed files
 - [ ] Implement rollback capability for failed file operations
 
@@ -114,6 +114,10 @@ await pipeline.setStepData('doc-rename', {
   processedFiles: renameResults.files
 });
 ```
+
+**Update 2025-10-07:** The sequencing fix now ensures `doc-rename` finishes
+before `doc-footer`, and the rename step writes the new absolute path to the
+DocOps `docs` sublevel so downstream steps resolve the renamed files directly.
 
 #### 2. File Reference Resolution
 ```typescript

--- a/packages/docops/README.md
+++ b/packages/docops/README.md
@@ -5,7 +5,7 @@ DocOps is a modular documentation pipeline that parses, embeds, queries, relates
 ## Features
 
 - Pure functions with dependency injection (LevelDB, Chroma)
-- Steps: frontmatter → embed → query → relations → footers → rename
+- Steps: frontmatter → embed → query → relations → rename → footers
 - Preview endpoint to see expected frontmatter without writing
 - Web Components UI for per-step runs and full pipeline
 - Streaming progress via Server-Sent Events (SSE)
@@ -42,8 +42,12 @@ await runEmbed({ dir: 'docs/unique', embedModel, collection: 'docs-cosine' }, db
 await runQuery({ embedModel, collection: 'docs-cosine', k: 16, force: true }, db, coll);
 await runRelations({ docsDir: 'docs/unique', docThreshold: 0.78, refThreshold: 0.85 }, db);
 await runFooters({ dir: 'docs/unique', anchorStyle: 'block' }, db);
-await runRename({ dir: 'docs/unique' });
+await runRename({ dir: 'docs/unique' }, db);
 ```
+
+Providing the DocOps database to `runRename` keeps pipeline metadata in sync with
+the latest on-disk filenames so subsequent steps (like `runFooters`) can resolve
+files that were renamed earlier in the run.
 
 ## APIs
 

--- a/packages/docops/src/06-rename.ts
+++ b/packages/docops/src/06-rename.ts
@@ -8,9 +8,18 @@ import type { IndexedFile } from "@promethean/file-indexer";
 
 import { parseArgs, slugify, extnamePrefer } from "./utils.js";
 import type { Front } from "./types.js";
+import type { DBs } from "./db.js";
 // CLI
 
 export type RenameOptions = { dir: string; dryRun?: boolean; files?: string[] };
+export type RenameProgress = {
+  step: "rename";
+  done: number;
+  total?: number;
+};
+export type RenameResult = {
+  renamed: Array<{ from: string; to: string; uuid?: string }>;
+};
 let ROOT = path.resolve("docs/unique");
 let DRY = false;
 
@@ -23,7 +32,34 @@ async function exists(p: string) {
   }
 }
 
-export async function runRename(opts: RenameOptions) {
+const updateDocPath = async (
+  db: DBs | undefined,
+  fm: Front,
+  target: string,
+) => {
+  if (!db?.docs || !fm.uuid) return;
+  const uuid = fm.uuid;
+  try {
+    const prev = await db.docs.get(uuid);
+    const title = prev?.title ?? fm.title ?? fm.filename ?? path.basename(target);
+    await db.docs.put(uuid, {
+      path: target,
+      title,
+    });
+  } catch {
+    const title = fm.title ?? fm.filename ?? path.basename(target);
+    await db.docs.put(uuid, {
+      path: target,
+      title,
+    });
+  }
+};
+
+export async function runRename(
+  opts: RenameOptions,
+  db?: DBs,
+  onProgress?: (p: RenameProgress) => void,
+): Promise<RenameResult> {
   ROOT = path.resolve(opts.dir);
   DRY = Boolean(opts.dryRun);
   const exts = new Set([".md", ".mdx", ".txt"]);
@@ -31,6 +67,8 @@ export async function runRename(opts: RenameOptions) {
     opts.files && opts.files.length
       ? new Set(opts.files.map((p) => path.resolve(p)))
       : null;
+  const renamed: RenameResult["renamed"] = [];
+  let processed = 0;
   await scanFiles({
     root: ROOT,
     exts,
@@ -47,7 +85,12 @@ export async function runRename(opts: RenameOptions) {
       const want = slugify(fm.filename) + extnamePrefer(abs);
       const dir = path.dirname(abs);
       const currentBase = path.basename(abs);
-      if (currentBase === want) return;
+      processed++;
+      if (currentBase === want) {
+        await updateDocPath(db, fm, abs);
+        onProgress?.({ step: "rename", done: processed });
+        return;
+      }
 
       let target = path.join(dir, want);
       let i = 1;
@@ -59,10 +102,14 @@ export async function runRename(opts: RenameOptions) {
       if (DRY) console.log(`Would rename: ${abs} -> ${target}`);
       else {
         await fs.rename(abs, target);
+        await updateDocPath(db, fm, target);
       }
+      renamed.push({ from: abs, to: target, uuid: fm.uuid });
+      onProgress?.({ step: "rename", done: processed });
     },
   });
   console.log("06-rename: done.");
+  return { renamed };
 }
 const isDirect =
   !!process.argv[1] && pathToFileURL(process.argv[1]).href === import.meta.url;

--- a/packages/docops/src/index.ts
+++ b/packages/docops/src/index.ts
@@ -4,7 +4,12 @@ export { runEmbed, type EmbedOptions } from "./02-embed.js";
 export { runQuery, type QueryOptions } from "./03-query.js";
 export { runRelations, type RelationsOptions } from "./04-relations.js";
 export { runFooters, type FootersOptions } from "./05-footers.js";
-export { runRename, type RenameOptions } from "./06-rename.js";
+export {
+  runRename,
+  type RenameOptions,
+  type RenameProgress,
+  type RenameResult,
+} from "./06-rename.js";
 export { computePreview } from "./preview-front.js";
 export {
   checkDuplicateFragments,

--- a/packages/docops/src/lib/pipeline.ts
+++ b/packages/docops/src/lib/pipeline.ts
@@ -209,7 +209,7 @@ export async function runDocopsStep(
         dir: normalizedArgs.dir,
         ...(files ? { files } : {}),
       };
-      await runRename(opts);
+      await runRename(opts, db, (p) => onProgress?.(p));
       return;
     }
     default: {
@@ -265,8 +265,8 @@ export async function servePipeline(
     "embed",
     "query",
     "relations",
-    "footers",
     "rename",
+    "footers",
   ];
   send(`Starting pipeline in ${args.dir}`);
   try {

--- a/packages/docops/src/tests/rename.db-update.test.ts
+++ b/packages/docops/src/tests/rename.db-update.test.ts
@@ -1,0 +1,87 @@
+import * as path from "node:path";
+import * as fs from "node:fs/promises";
+
+import test from "ava";
+
+import { runRename } from "../06-rename.js";
+import { runFooters } from "../05-footers.js";
+import { openDB } from "../db.js";
+
+const exists = async (p: string) => {
+  try {
+    await fs.stat(p);
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+const withTmp = async (fn: (dir: string) => Promise<void>) => {
+  const dir = path.join(
+    process.cwd(),
+    "test-tmp",
+    `${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  );
+  await fs.mkdir(dir, { recursive: true });
+  try {
+    await fn(dir);
+  } finally {
+    await fs.rm(dir, { recursive: true, force: true });
+  }
+};
+
+test.serial("runRename updates doc path mapping for renamed files", async (t) => {
+  await withTmp(async (dir) => {
+    const docsDir = path.join(dir, "docs/labeled");
+    await fs.mkdir(docsDir, { recursive: true });
+    const original = path.join(docsDir, "2025.09.18.16.46.24.md");
+    const uuid = "rename-test-uuid";
+    const frontmatter = [
+      "---",
+      `uuid: ${uuid}`,
+      "filename: Example Doc",
+      "title: Example Doc",
+      "references: []",
+      "related_to_uuid: []",
+      "---",
+      "",
+      "Body",
+      "",
+    ].join("\n");
+    await fs.writeFile(original, frontmatter, "utf8");
+
+    const dbPath = path.join(dir, ".cache/docops.level");
+    const db = await openDB(dbPath);
+    try {
+      await db.docs.put(uuid, { path: original, title: "Example Doc" });
+
+      await runRename({ dir: docsDir }, db);
+
+      const renamedPath = path.join(docsDir, "example-doc.md");
+      t.false(await exists(original));
+      t.true(await exists(renamedPath));
+
+      const record = await db.docs.get(uuid).catch(() => undefined);
+      if (!record) {
+        t.fail("expected renamed document to be persisted in docs DB");
+        return;
+      }
+      t.is(path.normalize(record.path), path.normalize(renamedPath));
+
+      await runFooters(
+        {
+          dir: docsDir,
+          anchorStyle: "none",
+          includeRelated: false,
+          includeSources: false,
+        },
+        db,
+      );
+
+      const updated = await fs.readFile(renamedPath, "utf8");
+      t.regex(updated, /GENERATED-SECTIONS:DO-NOT-EDIT-BELOW/);
+    } finally {
+      await db.root.close();
+    }
+  });
+});

--- a/pipelines.json
+++ b/pipelines.json
@@ -821,7 +821,7 @@
         },
         {
           "id": "doc-footer",
-          "deps": ["doc-related"],
+          "deps": ["doc-rename"],
           "js": {
             "module": "scripts/piper-docops.mjs",
             "export": "footers",


### PR DESCRIPTION
## Summary
- persist DocOps rename results back into the LevelDB docs catalog and expose progress/result types
- run the rename step before footers in both the Piper pipeline and DocOps server pipeline flow
- document the new flow, tick the sequencing task checklist, and add a regression test covering rename + footers

## Testing
- pnpm exec eslint packages/docops/src/06-rename.ts packages/docops/src/lib/pipeline.ts packages/docops/src/index.ts packages/docops/src/tests/rename.db-update.test.ts *(fails: functional lint rules triggered in existing files)*
- pnpm --filter @promethean/docops test -- --match "rename" --timeout 10m *(fails: missing optional dev dependency `esmock` and subsequent SIGINT)*

------
https://chatgpt.com/codex/tasks/task_e_68e49af54d948324bab97849efb16baf