### PR TITLE
Add backlog tasks for Duck, Enso, and agent platform

### DIFF
--- a/changelog.d/2025.10.07.06.39.52.md
+++ b/changelog.d/2025.10.07.06.39.52.md
@@ -1,0 +1,1 @@
+- Added backlog tasks covering Duck voice streaming hardening, ENSO guardrail payload typing, shared agent persistence, and standardized launch workflows.

--- a/docs/agile/tasks/complete-shared-agent-persistence-migration.md
+++ b/docs/agile/tasks/complete-shared-agent-persistence-migration.md
@@ -1,0 +1,27 @@
+---
+uuid: 1325fde4-1aab-485d-aca6-53f180883740
+title: complete shared agent persistence migration
+status: todo
+priority: P1
+labels: ['agents', 'persistence']
+created_at: '2025-10-07T06:39:18.599Z'
+---
+Background: The backlog still calls for a `shared/ts/persistence` module, but services continue to maintain bespoke Mongo/Chroma clients. Without a shared DualStore/ContextStore implementation, agent state handling diverges, legacy code lingers, and new services cannot rely on a tested persistence baseline.
+
+Goal: Deliver the shared persistence module, migrate agent services onto it, and retire the old ad-hoc stores with confidence.
+
+Scope:
+- Stand up `shared/ts/persistence` with DualStore/ContextStore ports, adapters, and AVA coverage (unit + integration fakes).
+- Update each agent service to depend on the shared module, removing local persistence wrappers and wiring migrations where data moves.
+- Refresh service-level `AGENTS.md` docs to point at the shared module and outline usage patterns.
+- Provide a rollout checklist documenting migration order, verification steps, and fallback procedures.
+
+Out of Scope:
+- Introducing new storage backends beyond the supported MongoDB/LevelDB pairing.
+- Reworking unrelated agent capabilities (e.g., ECS loops) except for necessary persistence wiring adjustments.
+
+Exit Criteria:
+- `shared/ts/persistence` builds and ships with passing tests and published docs.
+- All agent services compile against the shared module without referencing legacy persistence files.
+- Legacy persistence directories are removed or archived with deprecation notes.
+- Rollout documentation and changelog entries reflect the migration completion and highlight any service-specific nuances.

--- a/docs/agile/tasks/publish-enso-guardrail-rationale-payload.md
+++ b/docs/agile/tasks/publish-enso-guardrail-rationale-payload.md
@@ -1,0 +1,27 @@
+---
+uuid: 387b3ee0-c4f3-4c53-9b77-048e5490c9ca
+title: publish enso guardrail rationale payload
+status: todo
+priority: P1
+labels: ['enso', 'protocol', 'guardrails']
+created_at: '2025-10-07T06:39:18.599Z'
+---
+Background: The ENSO protocol docs and SDK still describe `act.rationale` as a loosely typed payload, even though Cephalon emits rich guardrail metadata during Duck evaluations. Without a canonical `ActRationalePayload` type and migration guidance, downstream producers/consumers are blocked from adopting the telemetry and the transport chapter risks drifting from the actual TypeScript union.
+
+Goal: Align the ENSO transport spec, SDK (`packages/enso-protocol`), and service implementations around a typed guardrail rationale payload with clear migration steps.
+
+Scope:
+- Extend `packages/enso-protocol` with a first-class `ActRationalePayload` type, regenerate the `EnsoEvent` union, and document the schema in the transport chapter.
+- Produce upgrade notes for Cephalon, the ENSO gateway, and any other guardrail publishers/consumers (e.g., Morganna evaluators) covering event renames, metadata expectations, and backward-compatibility shims.
+- Add AVA tests verifying that the new payload serializes/deserializes cleanly and that deprecated fields (if any) trigger warnings.
+- Update `docs/enso` design chapters to reflect the new telemetry contract and link to migration instructions.
+
+Out of Scope:
+- Adding new guardrail event families beyond `act.rationale`.
+- Rewriting unrelated ENSO SDK areas like assets or context bundles.
+
+Exit Criteria:
+- `packages/enso-protocol` builds cleanly with the new payload type and exports matching documentation.
+- Consumers (Cephalon, gateway) compile with the updated payload and emit/handle rationale metadata without type casts.
+- Documentation changes land alongside a migration checklist summarizing adoption steps and compatibility considerations.
+- A changelog entry captures the payload addition and any deprecations.

--- a/docs/agile/tasks/stabilize-duck-voice-streaming-pipeline.md
+++ b/docs/agile/tasks/stabilize-duck-voice-streaming-pipeline.md
@@ -1,0 +1,27 @@
+---
+uuid: 9a2e9225-9cbf-4ee0-ae5f-cdc6e525bbd3
+title: stabilize duck voice streaming pipeline
+status: todo
+priority: P2
+labels: ['duck', 'audio', 'enso']
+created_at: '2025-10-07T06:39:18.599Z'
+---
+Background: Duck's revival plan calls for reliable, low-latency voice delivery through the ENSO gateway. The current web client still ships a brittle AudioWorklet, the PCM16 → 16 kHz conversion path lacks shared constants, and we have no automated validation of the throttled RTC sender before traffic hits the websocket bridge.
+
+Goal: Finish the reliability pass so Duck's browser client can stream audio predictably into ENSO and the gateway has guardrails for malformed frames.
+
+Scope:
+- Refactor `apps/duck-web` to inject transport dependencies (`openWs`, throttled RTC sender) for easier testing and to isolate blob vs. live streaming modes.
+- Repair the AudioWorklet microphone pipeline so PCM16 capture, downsampling, and clamping use the shared helpers from `@promethean/duck-audio`.
+- Clamp `frameDurationMs` at the gateway boundary per the voice forwarder README task and add unit tests for out-of-range frame rejection.
+- Document the full audio path (browser → ENSO → Cephalon) including feature flags (`DUCK_USE_BLOBS`, `STT_TTS_ENABLED`) so QA can rehearse manual microphone tests on macOS/Linux.
+
+Out of Scope:
+- Shipping new TTS/STT providers; this task focuses on transport stability.
+- Rewriting Cephalon persona logic beyond what's required for audio ingress.
+
+Exit Criteria:
+- `apps/duck-web` exposes injectable transport factories and has green AVA coverage for the microphone/RTC sender.
+- The ENSO gateway rejects or clamps invalid frame durations with tests demonstrating the boundary behavior.
+- Documentation under `docs/duck` (or equivalent) explains how to start the voice pipeline, enumerate flags, and validate audio end-to-end.
+- Manual QA notes capture at least one verified microphone streaming session on macOS and one on Linux.

--- a/docs/agile/tasks/standardize-agent-ecosystem-launchflows.md
+++ b/docs/agile/tasks/standardize-agent-ecosystem-launchflows.md
@@ -1,0 +1,27 @@
+---
+uuid: ab4b2c51-91e6-4880-9390-30609209389c
+title: standardize agent ecosystem launch flows
+status: todo
+priority: P2
+labels: ['agents', 'devx', 'duck']
+created_at: '2025-10-07T06:39:18.599Z'
+---
+Background: Contributors still rely on outdated Makefile targets to launch agents. The backlog calls for PM2 (or an alternative) baselines, reusable ecosystem declarations (starting with Duck), and documentation that ties `pnpm --filter` scripts to real-world dev flows.
+
+Goal: Ship a consistent launch workflow so every agent (Duck, Cephalon, Discord forwarders, etc.) advertises the same process metadata, tooling, and documentation.
+
+Scope:
+- Decide on a process manager baseline (PM2 or replacement), produce canonical ecosystem config examples, and codify them under `scripts/` or a new shared package.
+- Inventories each agent package's `dev`/`start` scripts, aligning them with `pnpm --filter` workflows and ensuring docs reference the correct commands.
+- Generate or update `AGENTS.md` stubs (potentially via automation) so every service inherits the same launch section, environment variable expectations, and health checks.
+- Document the combined workflow in `docs/agents/` including quickstart tables for Duck, ENSO gateway, Cephalon, and supporting tooling.
+
+Out of Scope:
+- Refactoring agent business logic unrelated to launch orchestration.
+- Building CI deployment pipelines (focus is on developer ergonomics and local ops).
+
+Exit Criteria:
+- A shared process manager configuration (or equivalent) exists with working examples for Duck and at least one additional agent.
+- Agent package scripts (`pnpm --filter ...`) are verified and documented; stale Makefile references are removed or updated.
+- `AGENTS.md` files across agent services share the standardized launch template.
+- Docs include an end-to-end launch guide linking to ecosystem declarations and troubleshooting tips.


### PR DESCRIPTION
## Summary
- add a Duck voice streaming stabilization task covering transport fixes, documentation, and manual QA
- add an ENSO guardrail rationale payload typing task to align SDK and docs
- add shared agent persistence and launch workflow tasks to unify platform workstreams

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68e49bed23908324bffa65e3728ce2b6