### PR TITLE
fix: align start dialog mode with bot instance

### DIFF
--- a/changelog.d/2024.07.06.00.00.00.md
+++ b/changelog.d/2024.07.06.00.00.00.md
@@ -1,0 +1,1 @@
+- Respect Bot mode when selecting the start dialog flow to avoid ECS/classic mismatches.

--- a/changelog.d/2025.10.07.05.06.15.md
+++ b/changelog.d/2025.10.07.05.06.15.md
@@ -1,0 +1,1 @@
+- Added a `CEPHALON_MODE` feature flag to switch Cephalon between the ECS orchestrator and legacy `AIAgent` flows, including documentation and tests for the mode selection helpers.

--- a/docs/agile/tasks/cephalon_feature_flag_path_selection.md
+++ b/docs/agile/tasks/cephalon_feature_flag_path_selection.md
@@ -1,7 +1,7 @@
 ---
 uuid: 1f5f505f-155d-4a1b-ba1b-73cb1dd0ea97
 title: cephalon feature flag path selection
-status: todo
+status: in_review
 priority: P3
 labels: []
 created_at: '2025-09-15T02:02:58.509Z'
@@ -13,11 +13,28 @@ Goal: Add a feature flag to select between the classic `AIAgent` flow and the ne
 Why: Codebase is in-between worlds; a flag allows toggling behavior while we complete persistence and context wiring.
 
 Scope:
-- Env var `CEPHALON_MODE` in `services/ts/cephalon/src/index.ts` to choose startup path.
+- Env var `CEPHALON_MODE` in `packages/cephalon/src/index.ts` to choose startup path.
 - Document behavior and defaults; add note in README for temporary nature.
 
 Exit Criteria:
 - Able to switch modes without code edits; both modes functional.
 
 #incoming #cephalon #feature-flag #migration
+
+## Session Notes (2025-10-09)
+
+### Scope & Plan
+- Parse `CEPHALON_MODE` centrally and expose helpers for consumers.
+- Branch Cephalon bootstrap between ECS (default) and legacy `AIAgent` flows.
+- Document the temporary flag in package README.
+- Cover the mode parsing logic with unit tests and run eslint/tests on touched paths.
+
+### Estimate
+- Complexity: 3 (Fibonacci)
+- Time: 1 session
+
+### Verification
+- [ ] `pnpm --filter @promethean/cephalon test` *(fails: missing `@types/node`/`@types/ava` declarations in the workspace build container)*
+- [ ] `pnpm exec eslint packages/cephalon/src/index.ts packages/cephalon/src/bot.ts packages/cephalon/src/actions/start-dialog.scope.ts packages/cephalon/src/mode.ts packages/cephalon/src/tests/mode.test.ts` *(fails: missing \"`typescript-eslint\"` dependency in lint config; captured for follow-up)*
+
 

--- a/packages/cephalon/README.md
+++ b/packages/cephalon/README.md
@@ -18,6 +18,19 @@ pnpm -w add -D @promethean/cephalon
 // usage example
 ```
 
+## Feature flag: `CEPHALON_MODE`
+
+The Cephalon service is temporarily dual-pathed while the ECS orchestrator rollout completes. Set the
+`CEPHALON_MODE` environment variable before starting the service to choose which execution path boots:
+
+| Value      | Behavior                                                                       |
+| ---------- | ------------------------------------------------------------------------------ |
+| `ecs`      | **Default.** Boots the new ECS orchestrator pipeline and Agent ECS subsystems. |
+| `classic`  | Boots the legacy `AIAgent` pipeline for focused debugging or regression checks. |
+
+Unrecognized values fall back to `ecs`. The flag will be removed once the ECS work fully replaces the
+classic path.
+
 ## Commands
 
 - `build`

--- a/packages/cephalon/src/actions/start-dialog.scope.ts
+++ b/packages/cephalon/src/actions/start-dialog.scope.ts
@@ -1,24 +1,23 @@
-import { randomUUID } from "crypto";
+import { randomUUID } from 'crypto';
 
-import * as discord from "discord.js";
-import { AudioPlayerStatus } from "@discordjs/voice";
-import { createAgentWorld } from "@promethean/agent-ecs/world.js";
-import { OrchestratorSystem } from "@promethean/agent-ecs/systems/orchestrator.js";
-import { enqueueUtterance } from "@promethean/agent-ecs/helpers/enqueueUtterance.js";
-import { AGENT_NAME } from "@promethean/legacy/env.js";
-import { sleep } from "@promethean/utils";
+import * as discord from 'discord.js';
+import { AudioPlayerStatus } from '@discordjs/voice';
+import { createAgentWorld } from '@promethean/agent-ecs/world.js';
+import { OrchestratorSystem } from '@promethean/agent-ecs/systems/orchestrator.js';
+import { enqueueUtterance } from '@promethean/agent-ecs/helpers/enqueueUtterance.js';
+import { AGENT_NAME } from '@promethean/legacy/env.js';
+import { sleep } from '@promethean/utils';
 
-import type { Bot } from "../bot.js";
-import type { FinalTranscript } from "../transcriber.js";
-import { defaultPrompt } from "../prompts.js";
+import type { Bot } from '../bot.js';
+import type { FinalTranscript } from '../transcriber.js';
+import { defaultPrompt } from '../prompts.js';
 import {
   classifyPause,
   estimatePauseDuration,
   seperateSpeechFromThought,
   splitSentances,
-} from "../tokenizers.js";
-import { AIAgent } from "../agent/index.js";
-import { isClassicMode } from "../mode.js";
+} from '../tokenizers.js';
+import { AIAgent } from '../agent/index.js';
 
 export type StartDialogInput = { bot: Bot };
 export type StartDialogOutput = { started: boolean };
@@ -30,7 +29,7 @@ export async function storeAgentMessage(
   startTime = Date.now(),
   endTime = Date.now(),
 ) {
-  const messages = bot.context.getCollection("agent_messages");
+  const messages = bot.context.getCollection('agent_messages');
   return messages.insert({
     text,
     createdAt: Date.now(),
@@ -61,7 +60,7 @@ async function processAgentMessage(bot: Bot, content: string) {
 
   const startTime = Date.now();
   for (const sentence of sentences) {
-    if (sentence.type === "thought") {
+    if (sentence.type === 'thought') {
       const kind = classifyPause(sentence.text);
       const ms = estimatePauseDuration(sentence.text);
       console.log(`[Pause] (${kind}) "${sentence.text}" → sleeping ${ms}ms`);
@@ -74,11 +73,10 @@ async function processAgentMessage(bot: Bot, content: string) {
     const { w, agent, C } = bot.agentWorld as { w: any; agent: number; C: any };
     enqueueUtterance(w, agent, C, {
       id: `${Date.now()}-${randomUUID()}`,
-      group: "agent-speech",
+      group: 'agent-speech',
       priority: 1,
-      bargeIn: "pause",
-      factory: async () =>
-        bot.currentVoiceSession.makeResourceFromText(sentence),
+      bargeIn: 'pause',
+      factory: async () => bot.currentVoiceSession.makeResourceFromText(sentence),
     });
 
     finishedSentences.push(sentence);
@@ -88,21 +86,19 @@ async function processAgentMessage(bot: Bot, content: string) {
 
   await storeAgentMessage(
     bot,
-    finishedSentences.map(({ text }) => text).join(" "),
+    finishedSentences.map(({ text }) => text).join(' '),
     true,
     startTime,
     endTime,
   );
 }
 
-export async function runStartDialog({
-  bot,
-}: StartDialogInput): Promise<StartDialogOutput> {
+export async function runStartDialog({ bot }: StartDialogInput): Promise<StartDialogOutput> {
   if (!bot.currentVoiceSession) return { started: false };
 
   bot.desktop.start();
 
-  if (isClassicMode()) {
+  if (bot.mode === 'classic') {
     return runClassicStartDialog({ bot });
   }
 
@@ -118,7 +114,7 @@ export async function runStartDialog({
       async (text: string) => {
         const msgs = await bot.context.compileContext([text]);
         return msgs.map((m: any) => ({
-          role: m.role as "user" | "assistant" | "system",
+          role: m.role as 'user' | 'assistant' | 'system',
           content: m.content,
         }));
       },
@@ -128,23 +124,20 @@ export async function runStartDialog({
 
   bot.agentWorld.start(50);
 
-  bot.currentVoiceSession.transcriber.on(
-    "transcriptEnd",
-    (tr: FinalTranscript) => {
-      const turnId = w.get(agent, C.Turn)?.id ?? 0;
-      const tf = { text: tr.transcript, ts: Date.now() };
-      w.set(agent, C.TranscriptFinal, tf);
-      bot.bus?.publish({
-        topic: "agent.transcript.final",
-        corrId: randomUUID(),
-        turnId,
-        ts: Date.now(),
-        text: tr.transcript,
-        channelId: bot.currentVoiceSession!.voiceChannelId,
-        userId: tr.user?.id,
-      });
-    },
-  );
+  bot.currentVoiceSession.transcriber.on('transcriptEnd', (tr: FinalTranscript) => {
+    const turnId = w.get(agent, C.Turn)?.id ?? 0;
+    const tf = { text: tr.transcript, ts: Date.now() };
+    w.set(agent, C.TranscriptFinal, tf);
+    bot.bus?.publish({
+      topic: 'agent.transcript.final',
+      corrId: randomUUID(),
+      turnId,
+      ts: Date.now(),
+      text: tr.transcript,
+      channelId: bot.currentVoiceSession!.voiceChannelId,
+      userId: tr.user?.id,
+    });
+  });
 
   const speaking = bot.currentVoiceSession.connection?.receiver.speaking;
   let lastLevel = -1;
@@ -155,35 +148,33 @@ export async function runStartDialog({
     const rv = { ...rv0, level, ts: Date.now() };
     w.set(agent, C.RawVAD, rv);
   };
-  speaking?.on("start", () => onLevel(1));
-  speaking?.on("end", () => onLevel(0));
+  speaking?.on('start', () => onLevel(1));
+  speaking?.on('end', () => onLevel(0));
   bot.currentVoiceSession.transcriber
-    .on("transcriptStart", () => onLevel(1))
-    .on("transcriptEnd", () => onLevel(0));
+    .on('transcriptStart', () => onLevel(1))
+    .on('transcriptEnd', () => onLevel(0));
 
   const qUtter = w.makeQuery({ all: [C.Utterance] });
   bot.currentVoiceSession.getPlayer().on(AudioPlayerStatus.Idle, () => {
     for (const [e, get] of w.iter(qUtter)) {
       const u = get(C.Utterance);
-      if (u?.status === "playing") {
-        w.set(e, C.Utterance, { ...u, status: "done" });
+      if (u?.status === 'playing') {
+        w.set(e, C.Utterance, { ...u, status: 'done' });
       }
     }
   });
 
-  bot.bus?.subscribe("agent.llm.result", (res: any) => {
+  bot.bus?.subscribe('agent.llm.result', (res: any) => {
     if (!bot.agentWorld) return;
-    const text = res?.text ?? res?.reply ?? "";
-    console.log("llm response", text);
+    const text = res?.text ?? res?.reply ?? '';
+    console.log('llm response', text);
     if (!text) return;
     processAgentMessage(bot, text);
   });
 
   // Seed current members and track joins/leaves
   (async () => {
-    const voiceChan = await bot.client.channels.fetch(
-      bot.currentVoiceSession!.voiceChannelId,
-    );
+    const voiceChan = await bot.client.channels.fetch(bot.currentVoiceSession!.voiceChannelId);
     if (voiceChan?.isVoiceBased()) {
       for (const [, member] of voiceChan.members) {
         if (member.user.bot) continue;
@@ -212,15 +203,13 @@ export async function runStartDialog({
   return { started: true };
 }
 
-async function runClassicStartDialog({
-  bot,
-}: StartDialogInput): Promise<StartDialogOutput> {
+async function runClassicStartDialog({ bot }: StartDialogInput): Promise<StartDialogOutput> {
   if (!bot.currentVoiceSession) return { started: false };
   if (!bot.legacyAgent) {
     bot.legacyAgent = new AIAgent({ bot, context: bot.context });
   }
   const agent = bot.legacyAgent;
-  if (agent.state !== "running") {
+  if (agent.state !== 'running') {
     await agent.start();
   }
   return { started: true };

--- a/packages/cephalon/src/bot.ts
+++ b/packages/cephalon/src/bot.ts
@@ -1,6 +1,6 @@
-import { EventEmitter } from "events";
+import { EventEmitter } from 'events';
 
-import * as discord from "discord.js";
+import * as discord from 'discord.js';
 import {
   Client,
   Events,
@@ -8,30 +8,30 @@ import {
   REST,
   Routes,
   type RESTPutAPIApplicationCommandsJSONBody,
-} from "discord.js";
-import { DESKTOP_CAPTURE_CHANNEL_ID } from "@promethean/legacy/env.js";
-import { ContextStore } from "@promethean/persistence/contextStore.js";
-import { createAgentWorld } from "@promethean/agent-ecs/world.js";
-import { AgentBus } from "@promethean/agent-ecs/bus.js";
-import { BrokerClient } from "@promethean/legacy/brokerClient.js";
-import { checkPermission } from "@promethean/legacy";
-import { cleanupChroma } from "@promethean/persistence/maintenance.js";
-import { pushVisionFrame } from "@promethean/agent-ecs";
+} from 'discord.js';
+import { DESKTOP_CAPTURE_CHANNEL_ID } from '@promethean/legacy/env.js';
+import { ContextStore } from '@promethean/persistence/contextStore.js';
+import { createAgentWorld } from '@promethean/agent-ecs/world.js';
+import { AgentBus } from '@promethean/agent-ecs/bus.js';
+import { BrokerClient } from '@promethean/legacy/brokerClient.js';
+import { checkPermission } from '@promethean/legacy';
+import { cleanupChroma } from '@promethean/persistence/maintenance.js';
+import { pushVisionFrame } from '@promethean/agent-ecs';
 
-import { type Interaction } from "./interactions.js";
-import { DesktopCaptureManager } from "./desktop/desktopLoop.js";
+import { type Interaction } from './interactions.js';
+import { DesktopCaptureManager } from './desktop/desktopLoop.js';
 // Avoid compile-time coupling to persistence types
 
-import runForwardAttachments from "./actions/forward-attachments.js";
-import { buildForwardAttachmentsScope } from "./actions/forward-attachments.scope.js";
-import registerLlmHandler from "./actions/register-llm-handler.js";
-import { buildRegisterLlmHandlerScope } from "./actions/register-llm-handler.scope.js";
-import { registerNewStyleCommands } from "./bot/registerCommands.js";
-import { defaultPrompt, defaultState, generatePrompt } from "./prompts.js";
-import { LLMService } from "./llm-service.js";
-import { createEnsoChatAgent, EnsoChatAgent } from "./enso/chat-agent.js";
-import type { CephalonMode } from "./mode.js";
-import type { AIAgent } from "./agent/index.js";
+import runForwardAttachments from './actions/forward-attachments.js';
+import { buildForwardAttachmentsScope } from './actions/forward-attachments.scope.js';
+import registerLlmHandler from './actions/register-llm-handler.js';
+import { buildRegisterLlmHandlerScope } from './actions/register-llm-handler.scope.js';
+import { registerNewStyleCommands } from './bot/registerCommands.js';
+import { defaultPrompt, defaultState, generatePrompt } from './prompts.js';
+import { LLMService } from './llm-service.js';
+import { createEnsoChatAgent, EnsoChatAgent } from './enso/chat-agent.js';
+import type { CephalonMode } from './mode.js';
+import type { AIAgent } from './agent/index.js';
 
 // const VOICE_SERVICE_URL = process.env.VOICE_SERVICE_URL || 'http://localhost:4000';
 
@@ -47,14 +47,8 @@ export type VoiceStateChangeHandler = (
 ) => void;
 
 export class Bot extends EventEmitter {
-  static interactions = new Map<
-    string,
-    discord.RESTPostAPIChatInputApplicationCommandsJSONBody
-  >();
-  static handlers = new Map<
-    string,
-    (bot: Bot, interaction: Interaction) => Promise<any>
-  >();
+  static interactions = new Map<string, discord.RESTPostAPIChatInputApplicationCommandsJSONBody>();
+  static handlers = new Map<string, (bot: Bot, interaction: Interaction) => Promise<any>>();
 
   bus?: AgentBus;
   agentWorld?: ReturnType<typeof createAgentWorld>;
@@ -75,7 +69,7 @@ export class Bot extends EventEmitter {
     super();
     this.token = options.token;
     this.applicationId = options.applicationId;
-    this.mode = options.mode ?? "ecs";
+    this.mode = options.mode ?? 'ecs';
 
     this.desktop = new DesktopCaptureManager();
     this.client = new Client({
@@ -97,19 +91,12 @@ export class Bot extends EventEmitter {
 
   desktop: DesktopCaptureManager;
   async start(options: { enableEcs?: boolean } = {}) {
-    const enableEcs = options.enableEcs ?? this.mode === "ecs";
-    await this.context.createCollection("transcripts", "text", "createdAt");
-    await this.context.createCollection(
-      `discord_messages`,
-      "content",
-      "created_at",
-    );
-    await this.context.createCollection("agent_messages", "text", "createdAt");
-    await this.context.createCollection(
-      "enso_messages",
-      "content",
-      "created_at",
-    );
+    const enableEcs = options.enableEcs ?? this.mode === 'ecs';
+    this.mode = enableEcs ? 'ecs' : 'classic';
+    await this.context.createCollection('transcripts', 'text', 'createdAt');
+    await this.context.createCollection(`discord_messages`, 'content', 'created_at');
+    await this.context.createCollection('agent_messages', 'text', 'createdAt');
+    await this.context.createCollection('enso_messages', 'content', 'created_at');
 
     // Align LLM broker with bus broker if possible
     this.llm = new LLMService({
@@ -119,14 +106,12 @@ export class Bot extends EventEmitter {
     await this.client.login(this.token);
     if (DESKTOP_CAPTURE_CHANNEL_ID) {
       try {
-        const channel = await this.client.channels.fetch(
-          DESKTOP_CAPTURE_CHANNEL_ID,
-        );
+        const channel = await this.client.channels.fetch(DESKTOP_CAPTURE_CHANNEL_ID);
         if (channel?.isTextBased()) {
           this.desktopChannel = channel as discord.TextChannel;
         }
       } catch (e) {
-        console.warn("Failed to set default desktop channel", e);
+        console.warn('Failed to set default desktop channel', e);
       }
     }
     // Register new-style commands alongside decorator-based ones
@@ -136,7 +121,7 @@ export class Bot extends EventEmitter {
 
     if (enableEcs) {
       const broker = new BrokerClient({
-        url: process.env.BROKER_WS_URL || "ws://localhost:7000",
+        url: process.env.BROKER_WS_URL || 'ws://localhost:7000',
       });
       this.bus = new AgentBus(broker);
       const busScope = await buildRegisterLlmHandlerScope(this);
@@ -147,13 +132,13 @@ export class Bot extends EventEmitter {
 
     // --- ENSO chat bridge (optional) ---
     const ensoUrl = process.env.ENSO_WS_URL || undefined;
-    const ensoRoom = process.env.ENSO_CHAT_ROOM || "duck:chat";
+    const ensoRoom = process.env.ENSO_CHAT_ROOM || 'duck:chat';
     const privacy = process.env.DUCK_PRIVACY_PROFILE as any as
-      | "pseudonymous"
-      | "ephemeral"
-      | "persistent"
+      | 'pseudonymous'
+      | 'ephemeral'
+      | 'persistent'
       | undefined;
-    if (ensoUrl || process.env.ENSO_CHAT_ENABLE === "1") {
+    if (ensoUrl || process.env.ENSO_CHAT_ENABLE === '1') {
       try {
         this.ensoChat = createEnsoChatAgent({
           url: ensoUrl,
@@ -161,70 +146,64 @@ export class Bot extends EventEmitter {
           privacyProfile: privacy,
         });
         await this.ensoChat.connect();
-        this.ensoChat.on("message", async (evt: any) => {
+        this.ensoChat.on('message', async (evt: any) => {
           try {
             const message = evt?.message;
             const text = Array.isArray(message?.parts)
-              ? message.parts.find((p: any) => p.kind === "text")?.text || ""
-              : "";
+              ? message.parts.find((p: any) => p.kind === 'text')?.text || ''
+              : '';
             if (!text) return;
             // store inbound text for context (respect ENSO privacy profile)
-            if (privacy !== "ephemeral") {
+            if (privacy !== 'ephemeral') {
               try {
-                const coll = this.context.getCollection("enso_messages");
+                const coll = this.context.getCollection('enso_messages');
                 await coll.insert({
                   content: text,
                   created_at: Date.now(),
                   metadata: {
-                    type: "text",
+                    type: 'text',
                     room: ensoRoom,
                     messageId: message?.id,
-                    userName: message?.role === "assistant" ? "Duck" : "User",
+                    userName: message?.role === 'assistant' ? 'Duck' : 'User',
                   },
                 });
               } catch (e) {
-                console.warn("Failed to store enso message", e);
+                console.warn('Failed to store enso message', e);
               }
             }
             // trigger LLM generation via broker; register-llm-handler will TTS and mirror to ENSO
             if (this.llm) {
-              const userMessage = { role: "user" as const, content: text };
-              const ctx = await this.context.compileContext([
-                defaultPrompt,
-                text,
-              ]);
+              const userMessage = { role: 'user' as const, content: text };
+              const ctx = await this.context.compileContext([defaultPrompt, text]);
               const prompt = `${generatePrompt(
                 defaultPrompt,
                 defaultState,
-              )}\n\nCurrent user message: ${
-                text || "(none)"
-              }\nRespond as Duck.`;
+              )}\n\nCurrent user message: ${text || '(none)'}\nRespond as Duck.`;
               void this.llm.generate({
                 prompt,
                 context: [...ctx, userMessage],
               });
             }
           } catch (e) {
-            console.warn("ENSO message handler failed", e);
+            console.warn('ENSO message handler failed', e);
           }
         });
-        console.log("ENSO chat bridge enabled:", ensoUrl || "local");
+        console.log('ENSO chat bridge enabled:', ensoUrl || 'local');
       } catch (e) {
-        console.warn("Failed to enable ENSO chat bridge", e);
+        console.warn('Failed to enable ENSO chat bridge', e);
       }
     }
     // --- end ENSO chat bridge ---
 
     this.client
       .on(Events.InteractionCreate, async (interaction) => {
-        if (!interaction.inCachedGuild() || !interaction.isChatInputCommand())
-          return;
+        if (!interaction.inCachedGuild() || !interaction.isChatInputCommand()) return;
         if (!Bot.interactions.has(interaction.commandName)) {
-          await interaction.reply("Unknown command");
+          await interaction.reply('Unknown command');
           return;
         }
         if (!checkPermission(interaction.user.id, interaction.commandName)) {
-          await interaction.reply("Permission denied");
+          await interaction.reply('Permission denied');
           return;
         }
         try {
@@ -264,20 +243,20 @@ export class Bot extends EventEmitter {
   async forwardAttachments(message: discord.Message) {
     if (message.author?.bot) return;
     const imageAttachments = [...message.attachments.values()].filter(
-      (att) => att.contentType?.startsWith("image/"),
+      (att) => att.contentType?.startsWith('image/'),
     );
     if (!imageAttachments.length) return;
 
-    if (process.env.NODE_ENV !== "test") {
+    if (process.env.NODE_ENV !== 'test') {
       let collection: any | null = null;
       try {
-        collection = this.context.getCollection("discord_messages");
+        collection = this.context.getCollection('discord_messages');
       } catch {
         try {
           collection = await this.context.createCollection(
-            "discord_messages",
-            "content",
-            "created_at",
+            'discord_messages',
+            'content',
+            'created_at',
           );
         } catch (e) {
           console.warn(e);
@@ -290,7 +269,7 @@ export class Bot extends EventEmitter {
               content: att.url,
               created_at: message.createdTimestamp,
               metadata: {
-                type: "image",
+                type: 'image',
                 messageId: message.id,
                 channelId: message.channelId,
                 userId: message.author.id,
@@ -312,7 +291,7 @@ export class Bot extends EventEmitter {
       const { w, agent, C } = this.agentWorld;
       for (const att of imageAttachments) {
         const ref = {
-          type: "url" as const,
+          type: 'url' as const,
           url: att.url,
           ...(att.contentType ? { mime: att.contentType } : {}),
         };
@@ -327,7 +306,7 @@ export class Bot extends EventEmitter {
     try {
       await this.captureChannel.send({ files });
     } catch (e: any) {
-      console.warn("Failed to forward attachments", e);
+      console.warn('Failed to forward attachments', e);
     }
   }
 }

--- a/packages/cephalon/src/index.ts
+++ b/packages/cephalon/src/index.ts
@@ -3,12 +3,15 @@ import { AGENT_NAME } from "@promethean/legacy/env.js";
 import { HeartbeatClient } from "@promethean/legacy/heartbeat/index.js";
 
 import { Bot } from "./bot.js";
+import { getCephalonMode, isEcsMode } from "./mode.js";
 
 async function main() {
-  console.log("Starting", AGENT_NAME, "Cephalon");
+  const mode = getCephalonMode();
+  console.log(`Starting ${AGENT_NAME} Cephalon (${mode} mode)`);
   const bot = new Bot({
     token: process.env.DISCORD_TOKEN as string,
     applicationId: process.env.DISCORD_CLIENT_USER_ID as string,
+    mode,
   });
   const hb = new HeartbeatClient();
   try {
@@ -18,7 +21,7 @@ async function main() {
     process.exit(1);
   }
   hb.start();
-  await bot.start();
+  await bot.start({ enableEcs: isEcsMode() });
   console.log(`Cephalon started for ${AGENT_NAME}`);
 }
 

--- a/packages/cephalon/src/mode.ts
+++ b/packages/cephalon/src/mode.ts
@@ -1,0 +1,31 @@
+export type CephalonMode = "classic" | "ecs";
+
+const DEFAULT_MODE: CephalonMode = "ecs";
+const WARNED_VALUES = new Set<string>();
+
+function normalizeMode(value: string | undefined): CephalonMode {
+  if (!value) return DEFAULT_MODE;
+  const normalized = value.trim().toLowerCase();
+  if (normalized === "classic" || normalized === "ecs") {
+    return normalized;
+  }
+  if (!WARNED_VALUES.has(normalized)) {
+    console.warn(
+      `Unknown CEPHALON_MODE "${value}". Falling back to "${DEFAULT_MODE}" mode.`,
+    );
+    WARNED_VALUES.add(normalized);
+  }
+  return DEFAULT_MODE;
+}
+
+export function getCephalonMode(): CephalonMode {
+  return normalizeMode(process.env.CEPHALON_MODE);
+}
+
+export function isClassicMode(): boolean {
+  return getCephalonMode() === "classic";
+}
+
+export function isEcsMode(): boolean {
+  return getCephalonMode() === "ecs";
+}

--- a/packages/cephalon/src/tests/mode.test.ts
+++ b/packages/cephalon/src/tests/mode.test.ts
@@ -1,0 +1,35 @@
+import test from "ava";
+
+import {
+  getCephalonMode,
+  isClassicMode,
+  isEcsMode,
+} from "../mode.js";
+
+test.beforeEach(() => {
+  delete process.env.CEPHALON_MODE;
+});
+
+test.afterEach(() => {
+  delete process.env.CEPHALON_MODE;
+});
+
+test.serial("defaults to ecs mode", (t) => {
+  t.is(getCephalonMode(), "ecs");
+  t.true(isEcsMode());
+  t.false(isClassicMode());
+});
+
+test.serial("honors classic mode", (t) => {
+  process.env.CEPHALON_MODE = "classic";
+  t.is(getCephalonMode(), "classic");
+  t.true(isClassicMode());
+  t.false(isEcsMode());
+});
+
+test.serial("invalid values fall back to ecs", (t) => {
+  process.env.CEPHALON_MODE = "bogus";
+  t.is(getCephalonMode(), "ecs");
+  t.true(isEcsMode());
+  t.false(isClassicMode());
+});


### PR DESCRIPTION
## Summary
- persist the resolved ECS/classic mode on the Bot instance when starting
- gate the start dialog flow on the Bot mode instead of the global environment flag
- record the adjustment in the changelog

## Testing
- not run (workspace missing dependencies noted in base PR)


------
https://chatgpt.com/codex/tasks/task_e_68e4b62b70a48324a2aa46b51b811973