### PR TITLE
Fix stream package TypeScript build errors

### DIFF
--- a/changelog.d/2024.06.08.12.00.00.md
+++ b/changelog.d/2024.06.08.12.00.00.md
@@ -1,0 +1,4 @@
+fix(stream): stub ollama types for type checking
+
+- declare minimal ollama client types for the stream package
+- tighten tests to use typed chat requests and adjust watcher error handling

--- a/packages/stream/src/ollama.d.ts
+++ b/packages/stream/src/ollama.d.ts
@@ -1,0 +1,28 @@
+declare module 'ollama' {
+    export type MessageRole = 'system' | 'user' | 'assistant' | (string & {});
+
+    export type Message = {
+        readonly role: MessageRole;
+        readonly content: string;
+    };
+
+    export type ChatRequest = {
+        readonly model: string;
+        readonly messages?: ReadonlyArray<Message>;
+        readonly stream?: boolean;
+    };
+
+    export type ChatResponse = {
+        readonly message: {
+            readonly content: string;
+        };
+    };
+
+    export interface OllamaClient {
+        chat(request: ChatRequest): Promise<ChatResponse>;
+    }
+
+    const client: OllamaClient;
+
+    export default client;
+}

--- a/packages/stream/src/tests/title.test.ts
+++ b/packages/stream/src/tests/title.test.ts
@@ -19,7 +19,7 @@ const withChatStub = (
     handler: (request: ChatRequest & { readonly stream?: false }) => Promise<ChatResponse>,
 ): GenerateTwitchStreamTitleOptions => ({
     client: {
-        chat: ((request) => {
+        chat: ((request: ChatRequest) => {
             if (request.stream === true) {
                 throw new Error('streaming responses are not supported in this test stub');
             }
@@ -78,7 +78,7 @@ test.serial('generateTwitchStreamTitle preserves legacy model string parameter',
     const originalChat = ollama.chat;
 
     try {
-        (ollama as { chat: ChatFunction }).chat = (async ({ model }) => {
+        (ollama as { chat: ChatFunction }).chat = (async ({ model }: ChatRequest) => {
             t.is(model, customModel);
             return {
                 message: { content: 'Legacy compatible stream' },
@@ -95,7 +95,7 @@ test.serial('generateTwitchStreamTitle preserves legacy model string parameter',
         instanceOf: TypeError,
     });
 
-    const options = withChatStub(async ({ model }) => {
+    const options = withChatStub(async ({ model }: ChatRequest) => {
         t.is(model, 'gemma3:latest');
         return {
             message: { content: 'Object options still work' },

--- a/packages/stream/src/title.ts
+++ b/packages/stream/src/title.ts
@@ -128,11 +128,9 @@ export function watchContextAndGenerate(
     store: TitleStore,
     options: WatchContextAndGenerateOptions | string = {},
 ): void {
-    emitter.on('context', async () => {
-        try {
-            await generateAndStoreTitle(source, store, options);
-        } catch (error) {
+    emitter.on('context', () => {
+        void generateAndStoreTitle(source, store, options).catch((error: unknown) => {
             console.error('title generation failed', error);
-        }
+        });
     });
 }


### PR DESCRIPTION
## Summary
- add local Ollama module type declarations so the stream package typechecks
- tighten stream title tests to use typed chat requests and avoid implicit anys
- adjust the watcher helper to handle async failures without returning a promise and record the change log entry

## Testing
- pnpm --filter @promethean/stream build

------
https://chatgpt.com/codex/tasks/task_e_68e57d0757908324b0d6f102e1e835db