### PR TITLE
Fix escaping callback regression in globToRegExp

### DIFF
--- a/packages/security/src/policy.ts
+++ b/packages/security/src/policy.ts
@@ -85,9 +85,7 @@ const GLOB_SPECIALS = /[\\^$+?.()|[\]{}]/g;
 function globToRegExp(pat: string): RegExp {
   const normalized = pat.trim();
   if (normalized.length > 256) throw new NotAllowedError('Pattern too long');
-  const escaped = normalized
-    .replace(GLOB_SPECIALS, (char) => `\\${char}`)
-    .replace(/\*/g, '.*');
+  const escaped = normalized.replace(GLOB_SPECIALS, '\\$&').replace(/\*/g, '.*');
   return new RegExp(`^${escaped}$`);
 }
 


### PR DESCRIPTION
## Summary
- restore regex escape replacement to emit a literal backslash plus the matched character
- ensure provider access glob patterns correctly escape regex metacharacters again

## Testing
- node - <<'NODE' <script verifying escape output>


------
https://chatgpt.com/codex/tasks/task_e_68e5b5c033c8832485b4ae05e2312023