### PR TITLE
docs: track follow-ups for cephalon test failures

### DIFF
--- a/docs/agile/tasks/Ensure Cephalon chat agent records session id.md
+++ b/docs/agile/tasks/Ensure Cephalon chat agent records session id.md
@@ -1,0 +1,22 @@
+---
+uuid: 74c619d0-d32a-42b8-ad6d-2f2129b57d67
+title: ensure cephalon chat agent records session id
+status: incoming
+priority: P1
+labels: [cephalon, tests]
+created_at: '2025-10-08T02:48:42.625Z'
+---
+The AVA suite for `@promethean/cephalon` fails its evaluation-mode toggle spec because `EnsoChatAgent.getSessionId()` keeps
+returning `undefined` even after the client joins presence. `EnsoClient.receive` already captures the `presence.join`
+payload, but the chat agent never persists that session identifier into its own state.
+
+## Background
+- Evaluation-mode toggles rely on a recorded session id to tag audit events.
+- The regression was observed while running `pnpm nx test @promethean/cephalon`.
+
+## Exit Criteria
+- Copy the session id from the client's presence join envelope into the chat agent.
+- Ensure `getSessionId()` returns the recorded id for evaluation-mode operations.
+- Add or update tests to cover the presence flow.
+
+#incoming #enso #cephalon #tests

--- a/docs/agile/tasks/Handle websocket teardown race in Enso chat agent.md
+++ b/docs/agile/tasks/Handle websocket teardown race in Enso chat agent.md
@@ -1,0 +1,22 @@
+---
+uuid: ad65401b-d6bd-4a26-b9b5-6b0340a98da8
+title: handle websocket teardown race in enso chat agent
+status: incoming
+priority: P1
+labels: [cephalon, reliability]
+created_at: '2025-10-08T02:48:42.625Z'
+---
+`EnsoChatAgent.dispose()` currently awaits `wsHandle.close()`, which rejects with “WebSocket was closed before the connection
+was established” when shutdown runs before the handshake finishes. AVA reports this as an uncaught exception during
+`pnpm nx test @promethean/cephalon`.
+
+## Background
+- The cephalon test suite tears down quickly after starting the agent, so the race reproduces frequently.
+- The websocket handle should tolerate teardown during connection startup.
+
+## Exit Criteria
+- Make `dispose()` resilient to websocket close races (e.g., swallow the specific premature-close error).
+- Ensure teardown always resolves without bubbling an uncaught rejection.
+- Add coverage for disposing the agent before the websocket fully opens.
+
+#incoming #enso #cephalon #stability

--- a/docs/agile/tasks/Restore tool call routing in local Enso server.md
+++ b/docs/agile/tasks/Restore tool call routing in local Enso server.md
@@ -1,0 +1,22 @@
+---
+uuid: 06fd4307-3fcc-496d-b8f1-3df71b2a8922
+title: restore tool call routing in local enso server
+status: incoming
+priority: P1
+labels: [cephalon, tests]
+created_at: '2025-10-08T02:48:42.625Z'
+---
+The local harness for `@promethean/cephalon` spins up an `EnsoServer`, but no router handler forwards `tool.call` envelopes to
+the agent client. Without a handler the router drops those messages, so tests waiting for `tool.result` never observe a
+response and time out.
+
+## Background
+- `pnpm nx test @promethean/cephalon` currently stalls on tool execution specs.
+- Production deployments rely on explicit routing, but the lightweight test harness never implemented it.
+
+## Exit Criteria
+- Register a router handler (or equivalent) so local tool calls reach the agent's `EnsoClient`.
+- Confirm tool invocations emit matching `tool.result` responses under the test harness.
+- Add regression coverage that fails if tool calls are not forwarded.
+
+#incoming #enso #cephalon #tests


### PR DESCRIPTION
## Summary
- add an incoming task to persist the Enso session id in the cephalon chat agent
- add an incoming task to restore local tool call routing for the cephalon test harness
- add an incoming task to harden websocket teardown in the cephalon chat agent

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68e41c7cf3048324864c69bc2ba40e57