### PR TITLE
Install global shadow-cljs and nbb via Clojure installer

### DIFF
--- a/changelog.d/2025.10.08.02.03.00.md
+++ b/changelog.d/2025.10.08.02.03.00.md
@@ -1,0 +1,1 @@
+- Fix `run/install-clojure.sh` to respect root/sudo detection and run non-interactively when rerun.

--- a/changelog.d/2025.10.08.02.52.02.md
+++ b/changelog.d/2025.10.08.02.52.02.md
@@ -1,0 +1,1 @@
+- Ensure the Clojure installer provisions global shadow-cljs and nbb CLIs alongside Babashka.


### PR DESCRIPTION
## Summary
- ensure the Clojure install script checks for npm so it can add JavaScript tooling
- add helpers that install the shadow-cljs and nbb CLIs globally with resilient version reporting
- record the installer enhancements in the changelog

## Testing
- ./run/install-clojure.sh >/tmp/install.log && tail -n 20 /tmp/install.log

------
https://chatgpt.com/codex/tasks/task_e_68e5c41ad18483248baed63db634aaa0