### PR TITLE
fix: guard nil server specs in MCP JSON adapter

### DIFF
--- a/packages/clj-hacks/src/clj_hacks/mcp/adapter_mcp_json.clj
+++ b/packages/clj-hacks/src/clj_hacks/mcp/adapter_mcp_json.clj
@@ -58,7 +58,8 @@
             server-json->edn)))
 
 (defn- server-spec->json [spec]
-  (let [spec (cond-> spec
+  (let [spec (or spec {})
+        spec (cond-> spec
                 (not (contains? spec :command)) (assoc :command nil))]
     (reduce (fn [acc [edn-key {:keys [key transform include-nil?]}]]
               (if (contains? spec edn-key)


### PR DESCRIPTION
## Summary
- default MCP server specs to an empty map before serializing to JSON
- prevent nil entries from triggering contains? on nil during command handling

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e5c53d917c8324bad2f692df69b50e