### PR TITLE
Fix GitHub sync build by exposing Kanban exports

### DIFF
--- a/changelog.d/2025.10.08.15.40.41.md
+++ b/changelog.d/2025.10.08.15.40.41.md
@@ -1,0 +1,2 @@
+## Fixed
+- Exposed the kanban board utilities through package exports and updated the GitHub sync logging to restore the workspace build.

--- a/packages/github-sync/src/index.ts
+++ b/packages/github-sync/src/index.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import { loadBoard } from '@promethean/kanban';
-import type { Board, Task } from '@promethean/kanban';
+import type { ColumnData, Task } from '@promethean/kanban';
 
 // GitHub API configuration
 const GITHUB_TOKEN = process.env.GITHUB_TOKEN;
@@ -21,8 +21,8 @@ class GitHubSync {
     }
 
     this.headers = {
-      'Authorization': `token ${GITHUB_TOKEN}`,
-      'Accept': 'application/vnd.github.v3+json',
+      Authorization: `token ${GITHUB_TOKEN}`,
+      Accept: 'application/vnd.github.v3+json',
       'Content-Type': 'application/json',
     };
   }
@@ -31,7 +31,7 @@ class GitHubSync {
     const now = Date.now();
     const timeSinceLastCall = now - lastApiCall;
     if (timeSinceLastCall < MIN_API_INTERVAL) {
-      await new Promise(resolve => setTimeout(resolve, MIN_API_INTERVAL - timeSinceLastCall));
+      await new Promise((resolve) => setTimeout(resolve, MIN_API_INTERVAL - timeSinceLastCall));
     }
     lastApiCall = Date.now();
   }
@@ -43,7 +43,7 @@ class GitHubSync {
       method: 'POST',
       headers: {
         ...this.headers,
-        'Accept': 'application/vnd.github.v3+json',
+        Accept: 'application/vnd.github.v3+json',
       },
       body: JSON.stringify({ query, variables }),
     });
@@ -161,24 +161,34 @@ class GitHubSync {
     return project;
   }
 
-  private async syncColumns(projectId: string, boardColumns: any[], statusFieldId: string) {
+  private async syncColumns(projectId: string, boardColumns: ColumnData[], statusFieldId: string) {
     // This is a simplified version - in practice, you'd need to manage field options
-    console.log(`Syncing ${boardColumns.length} columns with project`);
+    console.log(`Syncing ${boardColumns.length} columns with project ${projectId}`);
+    console.log(`Using status field: ${statusFieldId}`);
     for (const column of boardColumns) {
       console.log(`  - Column: ${column.name} (${column.count} tasks)`);
     }
   }
 
-  private async syncTask(projectId: string, task: Task, statusFieldId: string, columnName: string) {
+  private async syncTask(
+    projectId: string,
+    task: Task,
+    statusFieldId: string | undefined,
+    columnName: string,
+  ) {
     // Use task.title from frontmatter if available, fallback to task metadata
-    const taskTitle = task.title || task.metadata?.title || `Task ${task.uuid}`;
+    const taskTitle = task.title ?? `Task ${task.uuid}`;
 
     // This is a simplified version - in practice, you'd create or update GitHub issues
     // and then add them to the project with appropriate status
     console.log(`Syncing task: "${taskTitle}" to column: ${columnName}`);
+    console.log(`  - Project ID: ${projectId}`);
     console.log(`  - UUID: ${task.uuid}`);
     console.log(`  - Status: ${task.status}`);
-    console.log(`  - Priority: ${task.metadata?.priority || 'Not set'}`);
+    console.log(`  - Priority: ${task.priority ?? 'Not set'}`);
+    if (statusFieldId) {
+      console.log(`  - Status Field ID: ${statusFieldId}`);
+    }
   }
 }
 
@@ -186,7 +196,8 @@ class GitHubSync {
 if (import.meta.url === `file://${process.argv[1]}`) {
   const sync = new GitHubSync();
 
-  sync.syncProjectBoard()
+  sync
+    .syncProjectBoard()
     .then(() => {
       console.log('Project board sync completed successfully');
       process.exit(0);

--- a/packages/kanban/package.json
+++ b/packages/kanban/package.json
@@ -2,6 +2,19 @@
   "name": "@promethean/kanban",
   "version": "0.1.0",
   "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    },
+    "./dist/*": "./dist/*",
+    "./*": "./dist/*"
+  },
+  "files": [
+    "dist"
+  ],
   "bin": {
     "kanban": "dist/index.js"
   },

--- a/packages/kanban/src/index.ts
+++ b/packages/kanban/src/index.ts
@@ -124,3 +124,6 @@ main().catch((error: unknown) => {
   console.error(message);
   process.exit(1);
 });
+
+export { loadBoard, readTasksFolder } from './lib/kanban.js';
+export type { Board, ColumnData, Task } from './lib/types.js';


### PR DESCRIPTION
## Summary
- expose the Kanban board loader and task readers through the package exports so workspace consumers can resolve the module
- update the GitHub sync logging to make use of the kanban types without unused parameters
- record the build repair in the changelog

## Testing
- `pnpm nx run @promethean/github-sync:build`


------
https://chatgpt.com/codex/tasks/task_e_68e683b974908324afa46d62d4de1425