### PR TITLE
docs: expand utils helper docs

### DIFF
--- a/changelog.d/2024.06.08.12.34.00.md
+++ b/changelog.d/2024.06.08.12.34.00.md
@@ -1,0 +1,1 @@
+- Documented the `retry` utility with TSDoc comments to clarify default behaviour and extension points.

--- a/changelog.d/2025.10.09.00.11.21.md
+++ b/changelog.d/2025.10.09.00.11.21.md
@@ -1,0 +1,1 @@
+- document additional utilities in `@promethean/utils` to clarify usage patterns

--- a/packages/utils/src/retry.ts
+++ b/packages/utils/src/retry.ts
@@ -1,26 +1,54 @@
-import { sleep } from "./sleep.js";
+import { sleep } from './sleep.js';
 
+/**
+ * Configuration values that tune the {@link retry} helper.
+ *
+ * All options are optional so callers can opt-in to only the behaviours they need.
+ * The defaults provide three total attempts with a linear delay that increases by
+ * {@link RetryOptions.delayMs} for each retry.
+ */
 export type RetryOptions = {
-    attempts?: number; // total attempts including the initial one
-    delayMs?: number; // base delay in ms
-    backoff?: (attempt: number) => number; // compute delay before next attempt
-    shouldRetry?: (err: unknown, attempt: number) => boolean; // return false to stop retrying
-    onRetry?: (err: unknown, attempt: number, nextDelayMs: number) => void | Promise<void>;
+  /** Total attempts including the initial invocation. Defaults to `3`. */
+  attempts?: number;
+  /** Base delay in milliseconds used by the default linear backoff strategy. */
+  delayMs?: number;
+  /**
+   * Override the delay calculation. Receives the attempt number (starting at 1) and should
+   * return the number of milliseconds to wait before the next retry.
+   */
+  backoff?: (attempt: number) => number;
+  /**
+   * Decide whether a thrown error should trigger another attempt. Returning `false` short-circuits
+   * the retry loop and immediately rethrows the error.
+   */
+  shouldRetry?: (err: unknown, attempt: number) => boolean;
+  /**
+   * Observe retry attempts. Useful for logging or metrics when retries are triggered.
+   */
+  onRetry?: (err: unknown, attempt: number, nextDelayMs: number) => void | Promise<void>;
 };
 
+/**
+ * Execute an async operation and retry on failure according to the provided {@link RetryOptions}.
+ *
+ * The helper always performs at least one attempt. Between retries it optionally waits for a delay
+ * (using {@link sleep}) that is either computed via the custom {@link RetryOptions.backoff} or by a
+ * simple linear progression based on {@link RetryOptions.delayMs}. Errors that exhaust the configured
+ * attempts, or that are filtered out by {@link RetryOptions.shouldRetry}, are rethrown to the caller.
+ */
 export async function retry<T>(operation: () => Promise<T>, opts: RetryOptions = {}): Promise<T> {
-    const { attempts = 3, delayMs = 100, backoff, shouldRetry, onRetry } = opts;
-    const maxAttempts = Math.max(1, attempts | 0);
-    const run = async (n: number): Promise<T> => {
-        try {
-            return await operation();
-        } catch (err) {
-            if (n >= maxAttempts || (shouldRetry && !shouldRetry(err, n))) throw err;
-            const wait = Math.max(0, (backoff ? backoff(n) : delayMs * n) | 0);
-            if (onRetry) await onRetry(err, n, wait);
-            if (wait > 0) await sleep(wait);
-            return run(n + 1);
-        }
-    };
-    return run(1);
+  const { attempts = 3, delayMs = 100, backoff, shouldRetry, onRetry } = opts;
+  const maxAttempts = Math.max(1, attempts | 0);
+  const run = async (n: number): Promise<T> => {
+    try {
+      return await operation();
+    } catch (err) {
+      if (n >= maxAttempts || (shouldRetry && !shouldRetry(err, n))) throw err;
+      const wait = Math.max(0, (backoff ? backoff(n) : delayMs * n) | 0);
+      if (onRetry) await onRetry(err, n, wait);
+      if (wait > 0) await sleep(wait);
+      return run(n + 1);
+    }
+  };
+  return run(1);
 }

--- a/packages/utils/src/sleep.ts
+++ b/packages/utils/src/sleep.ts
@@ -1,3 +1,10 @@
+/**
+ * Pause execution for the provided number of milliseconds.
+ *
+ * The helper wraps {@link setTimeout} in a promise so async flows can await a
+ * delay without introducing ad-hoc timer management. The promise always
+ * resolves and never rejects.
+ */
 export function sleep(ms: number): Promise<void> {
     return new Promise((resolve) => {
         setTimeout(resolve, ms);

--- a/packages/utils/src/slug.ts
+++ b/packages/utils/src/slug.ts
@@ -37,6 +37,13 @@ const appendSlugChar = (
   };
 };
 
+/**
+ * Convert an arbitrary string into a lower-case kebab-case slug.
+ *
+ * Non alphanumeric characters collapse into single hyphens, leading and
+ * trailing separators are removed, and digits are preserved. Strings composed
+ * entirely of invalid characters return an empty slug.
+ */
 export function slug(s: string): string {
   const { result } = Array.from(s.trim().toLowerCase()).reduce<SlugAccumulator>(
     appendSlugChar,


### PR DESCRIPTION
## Summary
- add TSDoc comments that explain the retry helper defaults and extension hooks
- document the sleep and slug utilities to clarify usage patterns
- record the documentation update in the changelog stream

## Testing
- not run (documentation change only)

------
https://chatgpt.com/codex/tasks/task_e_68e6f7b01084832487ad82d442019d24