### PR TITLE
Fix Nx lint forwarding for shared lint targets

### DIFF
--- a/changelog.d/2025.02.15.12.00.00.md
+++ b/changelog.d/2025.02.15.12.00.00.md
@@ -1,0 +1,3 @@
+## Fixed
+
+- Prevented Nx lint targets from forwarding stray CLI flags to eslint so workspace lint commands succeed again.

--- a/nx.json
+++ b/nx.json
@@ -23,6 +23,11 @@
     },
     "test": {
       "dependsOn": ["build"]
+    },
+    "lint": {
+      "options": {
+        "forwardAllArgs": false
+      }
     }
   },
   "projects": {

--- a/packages/broker/project.json
+++ b/packages/broker/project.json
@@ -1,0 +1,38 @@
+{
+  "name": "@promethean/broker",
+  "root": "packages/broker",
+  "sourceRoot": "packages/broker",
+  "targets": {
+    "build": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm run build",
+        "cwd": "packages/broker"
+      },
+      "outputs": []
+    },
+    "typecheck": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm run typecheck",
+        "cwd": "packages/broker"
+      }
+    },
+    "test": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm run test",
+        "cwd": "packages/broker"
+      }
+    },
+    "lint": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm -w exec eslint .",
+        "cwd": "packages/broker",
+        "forwardAllArgs": false
+      }
+    }
+  },
+  "tags": ["scope:packages"]
+}

--- a/packages/docops-frontend/project.json
+++ b/packages/docops-frontend/project.json
@@ -1,0 +1,41 @@
+{
+  "name": "@promethean/docops-frontend",
+  "root": "packages/docops-frontend",
+  "sourceRoot": "packages/docops-frontend/src",
+  "targets": {
+    "build": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "tsc -b",
+        "cwd": "packages/docops-frontend"
+      },
+      "outputs": ["{projectRoot}/dist"]
+    },
+    "typecheck": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "tsc -p tsconfig.json --noEmit",
+        "cwd": "packages/docops-frontend"
+      }
+    },
+    "test": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "ava",
+        "cwd": "{projectRoot}",
+        "env": {
+          "AVA_PROJECT_ROOT": "."
+        }
+      }
+    },
+    "lint": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm exec eslint .",
+        "cwd": "packages/docops-frontend",
+        "forwardAllArgs": false
+      }
+    }
+  },
+  "tags": ["scope:packages"]
+}

--- a/packages/vision/project.json
+++ b/packages/vision/project.json
@@ -1,0 +1,23 @@
+{
+  "name": "vision-service",
+  "root": "packages/vision",
+  "sourceRoot": "packages/vision",
+  "targets": {
+    "test": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm run test",
+        "cwd": "packages/vision"
+      }
+    },
+    "lint": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm run lint",
+        "cwd": "packages/vision",
+        "forwardAllArgs": false
+      }
+    }
+  },
+  "tags": ["scope:packages"]
+}


### PR DESCRIPTION
## Summary
- stop Nx lint targets from forwarding unexpected CLI flags
- add explicit project configurations for docops-frontend, broker, and vision lint commands
- document the lint pipeline fix in the changelog

## Testing
- pnpm nx run @promethean/platform:lint --paralell
- pnpm nx run @promethean/docops-frontend:lint --paralell

------
https://chatgpt.com/codex/tasks/task_e_68e6f89737688324b534856fe7aafd21