### PR TITLE
docs: clarify docops rename state update

### DIFF
--- a/changelog.d/2025.10.09.00.23.52.fixed.md
+++ b/changelog.d/2025.10.09.00.23.52.fixed.md
@@ -1,0 +1,1 @@
+- document DocOps rename state updater to keep LevelDB metadata aligned after merging dev/stealth


### PR DESCRIPTION
## Summary
- document the DocOps rename state updater to explain how LevelDB metadata stays aligned after resolving dev/stealth conflicts
- format the rename pipeline source with the workspace prettier rules
- log the change in the rolling changelog

## Testing
- pnpm --filter @promethean/docops build

------
https://chatgpt.com/codex/tasks/task_e_68e6ffaaa3188324b08a5f2024e495c8