### PR TITLE
docs: align task copy with incoming terminology

### DIFF
--- a/changelog.d/2025.10.09.00.30.22.md
+++ b/changelog.d/2025.10.09.00.30.22.md
@@ -1,0 +1,1 @@
+- Aligned remaining task narratives with the Incoming column terminology introduced by the FSM hygiene pass.

--- a/docs/agile/tasks/complete-shared-agent-persistence-migration.md
+++ b/docs/agile/tasks/complete-shared-agent-persistence-migration.md
@@ -6,7 +6,7 @@ priority: P1
 labels: ['agents', 'persistence']
 created_at: '2025-10-07T06:39:18.599Z'
 ---
-Background: The backlog still calls for a `shared/ts/persistence` module, but services continue to maintain bespoke Mongo/Chroma clients. Without a shared DualStore/ContextStore implementation, agent state handling diverges, legacy code lingers, and new services cannot rely on a tested persistence baseline.
+Background: The Incoming column still calls for a `shared/ts/persistence` module, but services continue to maintain bespoke Mongo/Chroma clients. Without a shared DualStore/ContextStore implementation, agent state handling diverges, legacy code lingers, and new services cannot rely on a tested persistence baseline.
 
 Goal: Deliver the shared persistence module, migrate agent services onto it, and retire the old ad-hoc stores with confidence.
 

--- a/docs/agile/tasks/standardize-agent-ecosystem-launchflows.md
+++ b/docs/agile/tasks/standardize-agent-ecosystem-launchflows.md
@@ -6,7 +6,7 @@ priority: P2
 labels: ['agents', 'devx', 'duck']
 created_at: '2025-10-07T06:39:18.599Z'
 ---
-Background: Contributors still rely on outdated Makefile targets to launch agents. The backlog calls for PM2 (or an alternative) baselines, reusable ecosystem declarations (starting with Duck), and documentation that ties `pnpm --filter` scripts to real-world dev flows.
+Background: Contributors still rely on outdated Makefile targets to launch agents. The Incoming column calls for PM2 (or an alternative) baselines, reusable ecosystem declarations (starting with Duck), and documentation that ties `pnpm --filter` scripts to real-world dev flows.
 
 Goal: Ship a consistent launch workflow so every agent (Duck, Cephalon, Discord forwarders, etc.) advertises the same process metadata, tooling, and documentation.
 


### PR DESCRIPTION
## Summary
- update the remaining task backgrounds that referenced the retired backlog column to point to the Incoming column
- note the terminology cleanup in changelog.d

## Testing
- n/a (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68e6ffab9ba483249a734345bcef2230