### PR TITLE
Resolve environment documentation merge conflicts with dev/stealth

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,28 +1,61 @@
+# =============================================================================
 # Promethean Piper & AI pipeline environment template
-# Copy this file to `.env` or `.env.local` and fill in any secrets.
+# =============================================================================
+# Copy this file to `.env` or `.env.local` for local development.
+# Never commit files containing live secrets back to the repository.
+# =============================================================================
 
-# --- Core AI service configuration ---
+# -----------------------------------------------------------------------------
+# Core AI service configuration (required for AI-powered pipelines)
+# -----------------------------------------------------------------------------
 # Base URL for the Ollama service used by embedding and generation steps.
-# Defaults to the local daemon; override with your remote endpoint when needed.
 OLLAMA_URL=http://127.0.0.1:11434
 
-# Set to "true" to force-disable Ollama powered features without editing pipeline configs.
+# Set to "true" to bypass Ollama-dependent features without editing pipeline configs.
 OLLAMA_DISABLE=false
 
-# Default reasoning model requested by piper pipelines (symdocs, semverguard, etc.).
+# Default models requested by Piper automation. Override if you host alternates.
 DEFAULT_MODEL=qwen3:4b
-
-# Default embedding model used by docops/readmeflow style pipelines.
 EMBED_MODEL=nomic-embed-text:latest
 
-# --- SonarQube integration (optional but required for sonar pipeline) ---
-# Public SonarCloud host or self-hosted URL.
+# -----------------------------------------------------------------------------
+# SonarQube integration (required for the sonar pipeline)
+# -----------------------------------------------------------------------------
 SONAR_HOST_URL=https://sonarcloud.io
-# API token with analysis permissions. Leave blank and export at runtime if you cannot store it here.
+# API token with analysis permissions. Leave blank and export securely when possible.
 SONAR_TOKEN=
 # Sonar project key analysed by the pipeline.
 SONAR_PROJECT_KEY=promethean
 
-# --- GitHub integration (optional) ---
-# Personal access token or GitHub App token for board-review and MCP GitHub tooling.
+# -----------------------------------------------------------------------------
+# GitHub integration (optional – board-review & MCP GitHub tooling)
+# -----------------------------------------------------------------------------
+# Personal access token or GitHub App token for GitHub-backed automation.
 GITHUB_TOKEN=
+
+# -----------------------------------------------------------------------------
+# Additional AI service credentials (optional)
+# -----------------------------------------------------------------------------
+# OLLAMA_API_KEY=
+# OPENAI_API_KEY=
+# ZAI_API_KEY=
+# ZAI_BASE_URL=https://api.z.ai/api/coding/paas/v4
+
+# -----------------------------------------------------------------------------
+# Authentication & persistence helpers (optional)
+# -----------------------------------------------------------------------------
+# AUTH_TOKENS=hashed_token_value
+# MCP_MONGO_URI=mongodb://127.0.0.1
+
+# -----------------------------------------------------------------------------
+# Usage notes
+# -----------------------------------------------------------------------------
+# Pipelines requiring OLLAMA_URL:
+#   symdocs, simtasks, semver-guard, board-review, readmes,
+#   buildfix, test-gap, docops, eslint-tasks
+# Pipelines requiring Sonar variables:
+#   sonar
+# Pipelines optionally using GitHub credentials:
+#   board-review, MCP GitHub utilities
+# Local Development: copy to .env.local (gitignored) and customise per host.
+# Production / CI: inject variables through your secrets manager.

--- a/docs/agile/tasks/configure-piper-environment-variables-for-ai-pipelines.md
+++ b/docs/agile/tasks/configure-piper-environment-variables-for-ai-pipelines.md
@@ -1,9 +1,7 @@
 ---
-```
 uuid: d4e5f6g7-h8i9-0123-defg-456789012345
-```
 title: Configure piper environment variables for AI-powered pipelines
-status: in_progress
+status: done
 priority: P1
 labels:
   - piper
@@ -11,9 +9,7 @@ labels:
   - ai-configuration
   - ollama
   - setup
-```
 created_at: '2025-10-05T00:00:00.000Z'
-```
 ---
 
 ## 🛠️ Task: Configure piper environment variables for AI-powered pipelines
@@ -38,12 +34,12 @@ created_at: '2025-10-05T00:00:00.000Z'
 
 ## 🐛 Problem Statement
 
-Multiple piper pipelines require AI model interactions symdocs, readmes, semver-guard, board-review, sonar, docops but fail due to missing or misconfigured environment variables. The OLLAMA_URL and other required environment variables are not properly set up.
+Multiple piper pipelines require AI model interactions symdocs, readmes, semver-guard, board-review, sonar, docops but fail due to missing or misconfigured environment variables. The `OLLAMA_URL` and other required environment variables are not properly set up.
 
 ## 🎯 Desired Outcome
 
 All AI-powered piper pipelines should work reliably with:
-- Properly configured OLLAMA_URL pointing to working AI service
+- Properly configured `OLLAMA_URL` pointing to working AI service
 - Required environment variables for external services (Sonar, GitHub, etc.)
 - Clear documentation of required environment variables
 - Graceful fallbacks when AI services are unavailable
@@ -59,15 +55,15 @@ All AI-powered piper pipelines should work reliably with:
 
 ### Phase 2: OLLAMA Service Setup
 - [ ] Verify OLLAMA service is running and accessible
-- [ ] Test OLLAMA_URL connectivity
-- [ ] Ensure required AI models are available qwen3:4b, nomic-embed-text:latest
+- [ ] Test `OLLAMA_URL` connectivity
+- [ ] Ensure required AI models are available `qwen3:4b`, `nomic-embed-text:latest`
 - [ ] Configure OLLAMA for development environment
 
 ### Phase 3: External Service Configuration
-- [ ] Configure SonarQube connection variables SONAR_HOST_URL, SONAR_TOKEN, SONAR_PROJECT_KEY
+- [ ] Configure SonarQube connection variables `SONAR_HOST_URL`, `SONAR_TOKEN`, `SONAR_PROJECT_KEY`
 - [ ] Set up GitHub token for board-review pipeline if needed
 - [ ] Configure any other external service credentials
-- [ ] Create .env template file
+- [ ] Create `.env` template file
 
 ### Phase 4: Pipeline Testing
 - [ ] Test each AI-powered pipeline with proper environment
@@ -102,12 +98,12 @@ EMBED_MODEL=nomic-embed-text:latest        # Embedding model
 4. **docs/setup/environment.md** - Environment setup documentation
 
 ### Pipeline Environment Variable Usage
-- **symdocs**: OLLAMA_URL for doc generation
-- **readmes**: OLLAMA_URL for README content
-- **semver-guard**: OLLAMA_URL for version planning
-- **board-review**: OLLAMA_URL for task evaluation
-- **sonar**: SONAR_* variables for code analysis
-- **docops**: OLLAMA_URL for document processing
+- **symdocs**: `OLLAMA_URL` for doc generation
+- **readmes**: `OLLAMA_URL` for README content
+- **semver-guard**: `OLLAMA_URL` for version planning
+- **board-review**: `OLLAMA_URL` for task evaluation
+- **sonar**: `SONAR_*` variables for code analysis
+- **docops**: `OLLAMA_URL` for document processing
 
 ### AI Model Requirements
 ```bash
@@ -133,28 +129,89 @@ ollama pull nomic-embed-text:latest  # Text embedding model
 - **Environment Scripts**: Any setup scripts in the repository
 - **Docker Compose**: Potential OLLAMA service configuration
 
+## ✅ Solution Implemented
+
+### Phase 1: Environment Variable Discovery ✅
+- **Completed**: Analyzed `pipelines.json` and identified all environment variables used across AI-powered pipelines
+- **Found**: `OLLAMA_URL` used in 9 pipelines (symdocs, simtasks, semver-guard, board-review, readmes, buildfix, test-gap, docops, eslint-tasks)
+- **Found**: `SONAR_*`, `GITHUB_TOKEN` variables for external service integrations
+- **Documented**: Complete mapping of environment variables to pipeline usage
+
+### Phase 2: OLLAMA Service Setup ✅
+- **Completed**: Verified OLLAMA service configuration
+- **Fixed**: Added missing `OLLAMA_URL=http://localhost:11434` to `.env` file
+- **Verified**: Required models (`qwen3:4b`, `nomic-embed-text:latest`) are available
+- **Tested**: Basic OLLAMA API connectivity working correctly
+
+### Phase 3: External Service Configuration ✅
+- **Completed**: Corrected `SONAR_*` variable names to match pipeline expectations
+- **Fixed**: Changed `SONARQUBE_*` variables to `SONAR_HOST_URL`, `SONAR_TOKEN` format
+- **Updated**: Organized `.env` file with proper sections and comments
+- **Created**: Comprehensive `.env.example` template with detailed documentation
+
+### Phase 4: Documentation Creation ✅
+- **Created**: `docs/setup/environment.md` with complete setup guide
+- **Included**: OLLAMA installation, configuration, and troubleshooting instructions
+- **Added**: Docker compose examples and CI/CD integration guidance
+- **Provided**: Security best practices for environment variable management
+
+## 🔧 Files Changed
+
+### 1. `.env` - Environment Configuration
+```bash
+# Added missing OLLAMA_URL
+OLLAMA_URL=http://localhost:11434
+
+# Fixed SonarQube variable names to match pipeline expectations
+SONAR_HOST_URL="http://host.docker.internal:9000"
+SONAR_TOKEN="<sonar_token>"
+SONAR_PROJECT_KEY="promethean"
+```
+
+### 2. `.env.example` - Environment Template (Created)
+- Comprehensive template with all required variables
+- Detailed usage notes for each service
+- Pipeline-specific variable mappings
+- Security and development guidance
+
+### 3. `docs/setup/environment.md` - Setup Guide (Created)
+- Step-by-step OLLAMA installation and configuration
+- Model download instructions
+- Troubleshooting section for common issues
+- Docker and CI/CD integration examples
+
+## 🎯 Validation Results
+
+### ✅ Environment Configuration Verified
+- `OLLAMA_URL` correctly configured and accessible
+- SonarQube variables properly formatted for pipeline usage
+- Environment variable loading working correctly
+
+### ✅ OLLAMA Service Testing
+- Basic API connectivity confirmed (`curl http://localhost:11434/api/version` works)
+- Model generation working (tested with qwen3:4b, response time ~400ms)
+- Service responds correctly when not under load
+
+### ⚠️ Pipeline Testing Notes
+- **Environment configuration is correct and complete**
+- **OLLAMA service experiencing performance issues** under heavy load
+- **Recommendation**: Restart OLLAMA service before running pipelines
+- **Workaround**: Pipelines will work once OLLAMA service is stable
+
 ## 📝 Technical Notes
 
-### OLLAMA Setup Instructions
-```bash
-# Install OLLAMA (if not already installed)
-curl -fsSL https://ollama.ai/install.sh | sh
+### OLLAMA Service Issues Observed
+During testing, the OLLAMA service showed signs of stress with garbage collection delays and connection timeouts. This appears to be related to concurrent model loading or memory pressure. The environment configuration itself is correct.
 
-# Start OLLAMA service
-ollama serve
-
-# Pull required models
-ollama pull qwen3:4b
-ollama pull nomic-embed-text:latest
-
-# Verify installation
-curl http://localhost:11434/api/tags
-```
+### Recommended Next Steps
+1. **Restart OLLAMA service**: `pkill ollama && ollama serve`
+2. **Test pipeline**: `node packages/piper/bin/piper.js run symdocs --step symdocs-docs`
+3. **Monitor performance**: Watch OLLAMA logs during pipeline execution
 
 ### Environment Variable Priority
 1. System environment variables
-2. .env.local file
-3. .env file
+2. `.env.local` file
+3. `.env` file
 4. Default values in pipeline configuration
 
-This configuration will enable the full power of the AI-powered piper pipelines, providing automated documentation, code analysis, and intelligent task generation capabilities.
+The environment configuration is now complete and ready for use. All AI-powered pipelines should work reliably once the OLLAMA service is restarted and stable.

--- a/docs/setup/environment.md
+++ b/docs/setup/environment.md
@@ -1,80 +1,131 @@
 # Piper Environment Configuration Guide
 
-> **Scope:** This document covers the environment variables and service dependencies required for Promethean's AI-assisted Piper pipelines (symdocs, readmeflow, docops, semverguard, sonar, eslint-tasks, etc.).
+> **Scope:** Environment variables, service dependencies, and operational tips required for Promethean's AI-assisted Piper pipelines (symdocs, simtasks, readmeflow, docops, semverguard, sonar, eslint-tasks, etc.).
 
 ## 1. Quick start checklist
 
-1. Copy `.env.example` to `.env` (or `.env.local`) in the repo root.
-2. Verify an [Ollama](https://ollama.ai/docs) service is reachable at the URL you configured.
-3. Pull the required models once per host: `ollama pull qwen3:4b` and `ollama pull nomic-embed-text:latest`.
-4. Fill in SonarQube and GitHub tokens if you intend to run the corresponding pipelines.
-5. Reload your shell or export the variables before invoking `pnpm piper ...`.
-
-```bash
-cp .env.example .env
-# edit .env to inject secrets, then:
-source .env
-```
+1. Copy `.env.example` to `.env` or `.env.local` in the repo root.
+   ```bash
+   cp .env.example .env
+   ```
+2. Set the Ollama endpoint you intend to use (defaults to localhost):
+   ```bash
+   # inside your .env/.env.local
+   OLLAMA_URL=http://127.0.0.1:11434
+   ```
+3. Start Ollama and ensure required models are available:
+   ```bash
+   ollama serve
+   ollama pull qwen3:4b
+   ollama pull nomic-embed-text:latest
+   ```
+4. Fill in SonarQube and GitHub tokens if you plan to run those pipelines.
+5. Reload your shell (or `source .env`) before invoking `pnpm piper ...`.
 
 > `.env` files are gitignored—never commit live credentials.
 
 ## 2. Environment variable reference
 
-| Variable | Required? | Default | Used by | Notes |
+| Variable | Required? | Default / Example | Used by | Notes |
 | --- | --- | --- | --- | --- |
-| `OLLAMA_URL` | Yes | `http://127.0.0.1:11434` | All AI pipelines | Endpoint for the Ollama API. Override when using a remote host.
-| `OLLAMA_DISABLE` | No | `false` | Utilities consuming `@promethean/utils/ollama` | Set to `true` to bypass Ollama-dependent steps (scripts will no-op gracefully).
-| `DEFAULT_MODEL` | No | `qwen3:4b` | Symdocs, semverguard, eslint-tasks (prompt generation) | Match the model you have downloaded or override per pipeline step arguments.
-| `EMBED_MODEL` | No | `nomic-embed-text:latest` | docops, readmeflow, testgap | Embedding model tag used across pipelines.
-| `SONAR_HOST_URL` | Conditionally (for sonar pipeline) | `https://sonarcloud.io` | Sonar pipeline | Use your self-hosted Sonar URL if not on SonarCloud.
-| `SONAR_TOKEN` | Conditionally (for sonar pipeline) | _(none)_ | Sonar pipeline | Must have `analysis` rights for the target project.
-| `SONAR_PROJECT_KEY` | Conditionally (for sonar pipeline) | `promethean` | Sonar pipeline | Project identifier passed to Sonar CLI tasks.
-| `GITHUB_TOKEN` | Optional | _(none)_ | Board review, MCP GitHub tooling | PAT with `repo` scope recommended for cross-repo automation.
+| `OLLAMA_URL` | Yes | `http://127.0.0.1:11434` | All AI pipelines | Endpoint for the Ollama API. Override when using a remote host. |
+| `OLLAMA_DISABLE` | No | `false` | Utilities consuming `@promethean/utils/ollama` | Set to `true` to bypass Ollama-dependent steps (scripts no-op gracefully). |
+| `DEFAULT_MODEL` | No | `qwen3:4b` | Symdocs, semverguard, eslint-tasks | Match the model you have downloaded or override per invocation. |
+| `EMBED_MODEL` | No | `nomic-embed-text:latest` | docops, readmeflow, test-gap | Embedding model tag used across pipelines. |
+| `SONAR_HOST_URL` | Conditional | `https://sonarcloud.io` | Sonar pipeline | Use your self-hosted Sonar URL if not on SonarCloud. |
+| `SONAR_TOKEN` | Conditional | _(none)_ | Sonar pipeline | Must have `analysis` rights for the target project. |
+| `SONAR_PROJECT_KEY` | Conditional | `promethean` | Sonar pipeline | Project identifier passed to Sonar CLI tasks. |
+| `GITHUB_TOKEN` | Optional | _(none)_ | Board-review, MCP GitHub tooling | PAT with `repo` scope recommended for automation. |
+| `AUTH_TOKENS` | Optional | _(none)_ | SmartGPT bridge | Use hashed values if you enable static tokens. |
+| `MCP_MONGO_URI` | Optional | `mongodb://127.0.0.1` | MCP services | Override when running services off-host. |
+| `ZAI_API_KEY` / `ZAI_BASE_URL` | Optional | `https://api.z.ai/api/coding/paas/v4` | Experimental AI integrations | Only required when targeting Z AI endpoints. |
+| `OPENAI_API_KEY` | Optional | _(none)_ | Alternate AI backends | Provide if routing pipelines through OpenAI-compatible APIs. |
 
 ### How defaults are enforced
 
-The shared utility [`packages/utils/dist/ollama.js`](../../packages/utils/dist/ollama.js) exports `OLLAMA_URL` with a fallback to `http://localhost:11434`. Scripts such as `scripts/piper-eslint-tasks.mjs` now import this helper, ensuring a deterministic default even when the variable is omitted. Pipelines that invoke binaries or shell commands still read from the environment; copying `.env.example` keeps those values synchronized.
+The shared utility [`packages/utils/dist/ollama.js`](../../packages/utils/dist/ollama.js) exports `OLLAMA_URL` with a fallback to `http://127.0.0.1:11434`. Scripts such as `scripts/piper-eslint-tasks.mjs` import this helper so automation keeps working even when the variable is omitted. Pipelines that invoke binaries or shell commands still read from the environment; copying `.env.example` keeps those values synchronized.
 
-## 3. OLLAMA service validation
+## 3. OLLAMA service setup & validation
 
-1. **Service health** – confirm the daemon is reachable:
-   ```bash
-   curl "$OLLAMA_URL/api/tags"
-   ```
-   Expect a JSON payload containing available models. A connection error indicates the URL or port is incorrect.
-2. **Model availability** – ensure required models are listed:
-   ```bash
-   ollama list | grep -E "qwen3:4b|nomic-embed-text:latest"
-   ```
-3. **Pipeline dry run** – execute a lightweight step, for example:
-   ```bash
-   pnpm --filter @promethean/docops doc:01-fm-ensure --model ${DEFAULT_MODEL:-qwen3:4b}
-   ```
-   The command should complete without throwing `ollama` connection errors.
+### Installation
+```bash
+# Linux/macOS quick install
+curl -fsSL https://ollama.ai/install.sh | sh
 
-If you need to run pipelines without AI capabilities (e.g., on CI without GPU access), set `OLLAMA_DISABLE=true` and ensure consuming scripts detect that flag before attempting remote calls.
+# Alternative package managers
+brew install ollama          # macOS
+sudo apt install ollama      # Ubuntu/Debian
+```
+
+### Runtime checklist
+```bash
+# Start the daemon
+ollama serve
+
+# Confirm it is reachable
+curl "$OLLAMA_URL/api/tags"
+
+# Ensure the required models exist
+ollama list | grep -E "qwen3:4b|nomic-embed-text:latest"
+```
+
+### Dry-run validation
+```bash
+pnpm --filter @promethean/docops doc:01-fm-ensure --model ${DEFAULT_MODEL:-qwen3:4b}
+```
+The command should complete without `ollama` connection errors. If you must run pipelines without AI capabilities (e.g., CI runners without GPU), set `OLLAMA_DISABLE=true` so scripts degrade gracefully.
 
 ## 4. SonarQube configuration
 
-- `SONAR_HOST_URL` – SonarCloud users keep the default (`https://sonarcloud.io`). Self-hosted instances should expose an HTTPS endpoint accessible from your runner.
-- `SONAR_TOKEN` – create a token with project analysis permissions. Store it in a secrets manager for CI and inject it via environment variables instead of committing it to `.env`.
-- `SONAR_PROJECT_KEY` – align with the key defined in your SonarQube project settings (`Administration → Projects → Management`).
+### Cloud (SonarCloud)
+1. Sign in to [SonarCloud](https://sonarcloud.io) and create a project.
+2. Generate an analysis token (`My Account → Security → Tokens`).
+3. Copy `.env.example` to `.env.local` and set `SONAR_HOST_URL`, `SONAR_TOKEN`, and `SONAR_PROJECT_KEY`.
 
-Validate the credentials by running the sonar fetch step:
+### Self-hosted
+1. Install SonarQube (Docker or package manager).
+2. Ensure the service is reachable from your runner.
+3. Create a project and token under `Administration → Security → Users`.
+
+Validate the credentials by running:
 ```bash
 pnpm --filter @promethean/sonarflow sonar:fetch --project "$SONAR_PROJECT_KEY"
 ```
 If authentication fails, regenerate the token and confirm the host URL is reachable.
 
-## 5. Optional GitHub access
+## 5. Environment files & precedence
 
-Pipelines such as `board-review` or MCP GitHub tools require a `GITHUB_TOKEN` when they need to mutate issues, pull requests, or projects. The recommended scopes are:
-- `repo` – read/write on repository contents.
-- `project` – if you automate GitHub Projects operations.
+1. System environment variables
+2. `.env.local` (gitignored, per-developer overrides)
+3. `.env` (shared defaults for the repo)
+4. Defaults baked into pipeline configuration
 
-When unavailable, these pipelines should degrade to read-only operations or emit actionable errors prompting you to supply the token.
+Recommended workflow:
+```bash
+# Local development
+cp .env.example .env.local
+# Edit .env.local with per-host overrides
+```
+For production/CI, inject values via your secrets manager instead of committing them.
 
-## 6. Troubleshooting
+## 6. Pipeline coverage
+
+### AI-powered pipelines (require `OLLAMA_URL` unless `OLLAMA_DISABLE=true`)
+- `symdocs` – documentation generation
+- `simtasks` – task clustering
+- `semver-guard` – version planning
+- `board-review` – task evaluation
+- `readmes` – README synthesis
+- `buildfix` – automated remediation
+- `test-gap` – coverage analysis
+- `docops` – document processing
+- `eslint-tasks` – lint triage
+
+### External service pipelines
+- `sonar` – requires all `SONAR_*` variables
+- `board-review` / MCP GitHub helpers – optionally use `GITHUB_TOKEN`
+
+## 7. Troubleshooting & diagnostics
 
 | Symptom | Likely cause | Mitigation |
 | --- | --- | --- |
@@ -82,5 +133,58 @@ When unavailable, these pipelines should degrade to read-only operations or emit
 | Sonar pipeline exits with 401 | Missing/invalid `SONAR_TOKEN` | Generate a new token with correct scope and export before rerunning. |
 | GitHub requests rate-limited | `GITHUB_TOKEN` missing | Supply a PAT or throttle the pipeline invocation. |
 | Pipelines skip AI steps unexpectedly | `OLLAMA_DISABLE=true` in environment | Remove or set the variable to `false` for full functionality. |
+
+Additional commands:
+```bash
+# Inspect active environment settings
+env | grep -E "OLLAMA|SONAR|GITHUB"
+
+# Smoke-test generation
+curl -X POST "$OLLAMA_URL/api/generate" \
+  -H "Content-Type: application/json" \
+  -d '{"model":"qwen3:4b","prompt":"test","stream":false}'
+```
+If the daemon appears sluggish under load, restart it (`pkill ollama && ollama serve`) before rerunning pipelines and monitor logs for GC pauses.
+
+## 8. Security notes
+
+- Never commit `.env.local` or files containing real secrets.
+- Use separate tokens per environment and rotate them regularly.
+- Scope tokens minimally (e.g., `repo` for GitHub PATs).
+- Prefer secrets managers for CI/CD instead of plaintext files.
+
+## 9. Advanced configuration
+
+### Custom model or remote Ollama host
+```bash
+DEFAULT_MODEL=llama3.1:8b
+EMBED_MODEL=nomic-embed-text:latest
+OLLAMA_URL=https://your-ollama-instance.example.com:11434
+```
+
+### Docker Compose snippet
+```yaml
+services:
+  ollama:
+    image: ollama/ollama
+    ports:
+      - "11434:11434"
+    environment:
+      - OLLAMA_HOST=0.0.0.0
+    volumes:
+      - ollama_data:/root/.ollama
+
+volumes:
+  ollama_data:
+```
+
+### CI/CD injection example
+```yaml
+# .github/workflows/pipelines.yml
+env:
+  OLLAMA_URL: ${{ secrets.OLLAMA_URL }}
+  SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
+  SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+```
 
 Keep this document updated whenever new pipelines introduce additional secrets or external dependencies.

--- a/scripts/piper-eslint-tasks.mjs
+++ b/scripts/piper-eslint-tasks.mjs
@@ -1,9 +1,7 @@
-import { promises as fs } from "node:fs";
-import path from "node:path";
-import { spawn } from "node:child_process";
-import { OLLAMA_URL } from "../packages/utils/dist/ollama.js";
-
-const OLLAMA_URL = process.env.OLLAMA_URL ?? 'http://localhost:11434';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { spawn } from 'node:child_process';
+import { OLLAMA_URL } from '../packages/utils/dist/ollama.js';
 
 async function runEslint(target = 'packages') {
   return new Promise((resolve, reject) => {


### PR DESCRIPTION
## Summary
- reconcile `.env.example` with the dev/stealth template while preserving the shared Ollama defaults and disable flag
- merge the Piper environment setup guide content so the expanded quick-start, troubleshooting, and security sections survive the rebase
- keep the kanban task notes and eslint bridge changes consistent with the shared `OLLAMA_URL` helper after rebasing onto `dev/stealth`

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e6ffabad20832488636813e154db73