### PR TITLE
Fix agent runtime lint issues and update omni-protocol dependency

### DIFF
--- a/changelog.d/2025.10.09.00.35.00.md
+++ b/changelog.d/2025.10.09.00.35.00.md
@@ -1,0 +1,3 @@
+- Hardened `AgentRuntime` generics to remove `any` usage and improved policy tests to rely on concrete capability shapes.
+- Updated omni-protocol dependency declarations to align with the current lockfile for consistent installs.
+

--- a/docs/agile/tasks/resolve_eslint_violations_repo_wide.md
+++ b/docs/agile/tasks/resolve_eslint_violations_repo_wide.md
@@ -2,14 +2,14 @@
 uuid: "137054cb-d7c9-4b0a-9aa9-5ce0425948db"
 title: "Resolve ESLint violations across repository"
 slug: "resolve_eslint_violations_repo_wide"
-status: "todo"
+status: "in_progress"
 priority: "P3"
 labels: ["eslint", "resolve", "violations", "across"]
 created_at: "2025-10-07T20:25:05.643Z"
 estimates:
-  complexity: ""
-  scale: ""
-  time_to_completion: ""
+  complexity: "3"
+  scale: "3"
+  time_to_completion: "1 session"
 ---
 
 
@@ -36,6 +36,22 @@ Multiple packages trigger ESLint errors such as `functional/prefer-immutable-typ
 - [ ] Draft config changes in [[eslint.config.ts]] to address systemic problems.
 - [ ] Refactor code or add utilities where patterns recur.
 - [ ] Create documentation summarizing unresolved or complex rules.
+
+# Session Notes (2025-10-09)
+
+## Clarification & Scope
+- Target a small subset of ESLint errors that block repository linting, focusing on actionable rule violations instead of configuration overhauls.
+- Avoid global rule relaxations; prefer localized refactors in the offending packages.
+
+## Plan
+1. Run linting on the affected package(s) to capture the exact violations.
+2. Refactor code to satisfy the functional lint rules (e.g., eliminate `let`, enforce immutability, prefer pure helpers).
+3. Re-run targeted lint commands to verify the fixes.
+4. Record any remaining blockers or systemic issues for follow-up.
+
+## Risks / Open Questions
+- The repository-level lint run currently fails before reporting violations due to dependency mismatches; may need to update/install dependencies first.
+- Some lint rules may require broader architectural changes; will document if encountered instead of over-scoping this slice.
 
 #Todo #codex-task #doc-this
 

--- a/packages/agent/src/runtime.ts
+++ b/packages/agent/src/runtime.ts
@@ -1,4 +1,7 @@
 export type AgentRuntime = {
-    subscribe(topic: string, handler: (msg: any) => Promise<void>): Promise<void>;
-    publish(topic: string, msg: any): Promise<void>;
+    subscribe<Message>(
+        topic: string,
+        handler: (msg: Message) => Promise<void>,
+    ): Promise<void>;
+    publish<Message>(topic: string, msg: Message): Promise<void>;
 };

--- a/packages/agent/src/tests/policy.test.ts
+++ b/packages/agent/src/tests/policy.test.ts
@@ -51,6 +51,6 @@ test('non-provider caps pass by default', async (t) => {
             kind: 'storage.mongo',
             db: 'db',
             coll: 'messages',
-        } as any),
+        }),
     );
 });

--- a/packages/omni-protocol/package.json
+++ b/packages/omni-protocol/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "@promethean/utils": "workspace:*",
     "zod": "^3.22.4",
-    "zod-to-json-schema": "^3.22.4"
+    "zod-to-json-schema": "^3.23.5"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",


### PR DESCRIPTION
## Summary
- document the scoped lint-remediation plan on `resolve_eslint_violations_repo_wide`
- remove explicit `any` usages in the agent runtime and policy test by introducing generics and concrete capability values
- align `@promethean/omni-protocol`'s `zod-to-json-schema` spec with the existing lockfile and add a changelog note

## Testing
- `pnpm exec eslint packages/agent/src --max-warnings=0 --no-cache -f json`
- `pnpm --filter @promethean/agent exec tsc -b -v`
- `pnpm --filter @promethean/agent test`
- `pnpm install` *(fails: postinstall step exits non-zero after long native builds; see logs for repeating "└─ Failed" message)*

------
https://chatgpt.com/codex/tasks/task_e_68e6f7a1139483248ed2758154152f0b