### PR TITLE
Restore Windows reserved filename detection in path validator

### DIFF
--- a/packages/security/src/path-validation.ts
+++ b/packages/security/src/path-validation.ts
@@ -38,34 +38,36 @@ export interface PathValidationResult {
 /**
  * Dangerous file patterns that should be blocked
  */
-const DANGEROUS_NAMES = new Set([
-  'CON',
-  'PRN',
-  'AUX',
-  'NUL',
-  'COM1',
-  'COM2',
-  'COM3',
-  'COM4',
-  'COM5',
-  'COM6',
-  'COM7',
-  'COM8',
-  'COM9',
-  'LPT1',
-  'LPT2',
-  'LPT3',
-  'LPT4',
-  'LPT5',
-  'LPT6',
-  'LPT7',
-  'LPT8',
-  'LPT9',
-  '.htaccess',
-  '.htpasswd',
-  'web.config',
-  'php.ini',
-]);
+const DANGEROUS_NAMES = new Set(
+  [
+    'CON',
+    'PRN',
+    'AUX',
+    'NUL',
+    'COM1',
+    'COM2',
+    'COM3',
+    'COM4',
+    'COM5',
+    'COM6',
+    'COM7',
+    'COM8',
+    'COM9',
+    'LPT1',
+    'LPT2',
+    'LPT3',
+    'LPT4',
+    'LPT5',
+    'LPT6',
+    'LPT7',
+    'LPT8',
+    'LPT9',
+    '.htaccess',
+    '.htpasswd',
+    'web.config',
+    'php.ini',
+  ].map((name) => name.toUpperCase()),
+);
 
 const DANGEROUS_PATTERNS = [
   /\.\.[\/\\]/, // Directory traversal
@@ -221,7 +223,7 @@ export async function validatePath(
       }
 
       const fileName = path.basename(normalizedInput);
-      if (DANGEROUS_NAMES.has(fileName.toLowerCase())) {
+      if (DANGEROUS_NAMES.has(fileName.toUpperCase())) {
         return {
           isValid: false,
           error: `Dangerous file name detected: ${fileName}`,


### PR DESCRIPTION
## Summary
- normalize the dangerous name allowlist to uppercase values to restore case-insensitive comparisons
- compare candidate filenames in uppercase so Windows reserved names and sensitive config files are blocked again

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fbb28844ec832491ff223ad03a350c