### PR TITLE
Fix regex for filename space-number detection

### DIFF
--- a/packages/scar/src/core/corruption-detector.ts
+++ b/packages/scar/src/core/corruption-detector.ts
@@ -284,7 +284,11 @@ export class CorruptionDetector {
     }
 
     // Space and number in extension
-    if (/^(.+)\s+\d+\.(md|txt|json|yaml|yml)$/.test(filename)) {
+    const extensionMatch = filename.match(/\.(md|txt|json|yaml|yml)$/);
+    if (
+      extensionMatch !== null &&
+      /\s+\d+$/.test(filename.slice(0, -extensionMatch[0].length))
+    ) {
       corruptions.push({
         type: ScarType.FILENAME_CORRUPTION,
         severity: ScarSeverity.HIGH,


### PR DESCRIPTION
## Summary
- replace the filename space/number corruption check with safe string logic to avoid backtracking

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fbb293ef5083249f995fdf9538315f