### PR TITLE
Fix kanban init handler and safe rule evaluation

### DIFF
--- a/packages/kanban/src/lib/safe-rule-evaluation.ts
+++ b/packages/kanban/src/lib/safe-rule-evaluation.ts
@@ -245,7 +245,17 @@ const evaluateFunctionDefinition = async (
 ): Promise<boolean> => {
   const { evaluateTransitionRule } = await loadValidationFunctions();
 
-  const ruleFn: unknown = await loadString(`#js(${ruleImpl})`);
+  const trimmed = ruleImpl.trim();
+  if (trimmed.length === 0) {
+    throw new Error('Rule implementation is empty');
+  }
+
+  const source = trimmed.startsWith('(fn') ? trimmed : `(fn [task board] ${trimmed})`;
+  const ruleFn: unknown = await loadString(source);
+
+  if (typeof ruleFn !== 'function') {
+    throw new Error('Rule implementation did not evaluate to a function');
+  }
 
   // Call evaluateTransitionRule function directly with JavaScript objects
   const result = (


### PR DESCRIPTION
## Summary
- add the init command handler back to the CLI command map and scaffold config, board, and starter tasks from the bundled template
- normalize generated paths when writing the template-driven config during `kanban init`
- evaluate inline Clojure rule definitions without the invalid `#js` wrapper so custom rules load correctly

## Testing
- pnpm --filter @promethean-os/kanban lint *(fails: missing packages/kanban/src/lib/task-content/.#ai.ts)*

------
https://chatgpt.com/codex/tasks/task_e_6908e2e900008324bea5aba1b3794ebb